### PR TITLE
Remove the sentence about DockerHub account

### DIFF
--- a/docs/source/getting_started/run_mspass_with_docker.rst
+++ b/docs/source/getting_started/run_mspass_with_docker.rst
@@ -16,7 +16,6 @@ Download MsPASS Container
 -------------------------
 
 The MsPASS container image is built and hosted on Docker Hub `here <https://hub.docker.com/r/wangyinz/mspass>`__.
-You may want to create an account and sign in your Docker following `this <https://docs.docker.com/docker-id/>`__ instruction. 
 Once you have docker setup properly, use the following command in a terminal to pull the MsPASS image from Docker Hub to your local machine:
 
 .. code-block:: 


### PR DESCRIPTION
As I understand it, DockerHub account is not required to use Docker and MsPASS. The following sentence may give users wrong impression that a docker hub account is necessary. I think it should be removed from the "Get Started" section to lower the barrier for new users.

> You may want to create an account and sign in your Docker following this instruction.
