### PR TITLE
Bugfix db ensemble data

### DIFF
--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -286,6 +286,8 @@ PYBIND11_MODULE(seismic, m) {
         throw py::value_error("transform expects a 3x3 matrix");
       self.transform(static_cast<double(*)[3]>(info.ptr));
     },"Applies an arbitrary transformation matrix to the data")
+    .def("cardinal ",&CoreSeismogram::cardinal,"Returns true if components are cardinal")
+    .def("orthogonal ",&CoreSeismogram::orthogonal,"Returns true if components are orthogonal")
     .def("free_surface_transformation",&CoreSeismogram::free_surface_transformation,"Apply free surface transformation operator to data")
     .def_property("tmatrix",
       [](const CoreSeismogram &self){

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -287,7 +287,7 @@ PYBIND11_MODULE(seismic, m) {
       self.transform(static_cast<double(*)[3]>(info.ptr));
     },"Applies an arbitrary transformation matrix to the data")
     .def("free_surface_transformation",&CoreSeismogram::free_surface_transformation,"Apply free surface transformation operator to data")
-    .def_property("transformation_matrix",
+    .def_property("tmatrix",
       [](const CoreSeismogram &self){
         dmatrix tm = self.get_transformation_matrix();
         auto v = static_cast<Publicdmatrix&>(tm).ary;
@@ -430,13 +430,8 @@ PYBIND11_MODULE(seismic, m) {
         to go back and forth from obspy trace objects. */
         bts.set_tref(TimeReferenceType::UTC);
         ProcessingHistory emptyph;
-        double *dptr;
-        vector<double> sbuf;
-        sbuf.reserve(npts);   // A standard efficiency trick for std::vector
-        /* Initialize dptr here for clarity instead of putting it inside the
-        initialization block of the for loop - clearer to me anyway */
-        dptr=(double*)(info.ptr);
-        for(size_t i=0;i<npts;++i,++dptr) sbuf.push_back(*dptr);
+        vector<double> sbuf(npts);
+        memcpy(&sbuf[0], info.ptr, npts*sizeof(double));
         auto v = new TimeSeries(bts,md,emptyph,sbuf);
         return v;
       }))

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -286,8 +286,8 @@ PYBIND11_MODULE(seismic, m) {
         throw py::value_error("transform expects a 3x3 matrix");
       self.transform(static_cast<double(*)[3]>(info.ptr));
     },"Applies an arbitrary transformation matrix to the data")
-    .def("cardinal ",&CoreSeismogram::cardinal,"Returns true if components are cardinal")
-    .def("orthogonal ",&CoreSeismogram::orthogonal,"Returns true if components are orthogonal")
+    .def("cardinal",&CoreSeismogram::cardinal,"Returns true if components are cardinal")
+    .def("orthogonal",&CoreSeismogram::orthogonal,"Returns true if components are orthogonal")
     .def("free_surface_transformation",&CoreSeismogram::free_surface_transformation,"Apply free surface transformation operator to data")
     .def_property("tmatrix",
       [](const CoreSeismogram &self){

--- a/data/yaml/mspass.yaml
+++ b/data/yaml/mspass.yaml
@@ -29,94 +29,94 @@ Database:
   wf_TimeSeries:
     default: wf
     data_type: TimeSeries
-    schema: &wf_TimeSeries
-      _id:
-        type: ObjectID
-        concept: ObjectId used to define a data object
-        constraint: required
-      npts:
-        type: int
-        concept: Number of data samples
-        aliases: [nsamp, wfdisc.nsamp]
-        constraint: required
-      delta:
-        type: double
-        concept: Data sample interval in seconds
-        aliases: [dt]
-        constraint: required
-      sampling_rate:
-        type: double
-        concept: Data sampling frequency in Hz=1/s
-        constraint: optional
-      starttime:
-        type: double
-        concept: Time of first sample of data (epoch time or relative to some other time mark)
-        aliases: [t0, time]
-        constraint: required
-      starttime_shift:
-        type: double
-        concept:  Time shift applied to define relative time of 0.0
-        aliases:  t0shift
-        constraint: required
-      utc_convertible:
-        type:  bool
-        concept:  When true starttime_shift can be used to convert relative time to UTC.
-        constraint: required
-      time_standard:
-        type: string
-        concept: Defines time standard for meaning of t0 (default should be UTC)
-        constraint: required
-      calib:
-        type: double
-        concept: Nominal conversion factor for changing sample data to ground motion units.
-        constraint: normal
-      storage_mode:
-        type: string
-        concept: The storage mode of the saved data ('file', 'url' or 'gridfs')
-        constraint: required
-      format:
-        type: string
-        concept: The file format of the saved data (e.g., 'MSEED', 'SAC', ...).
-        constraint: optional
-      dir:
-        type: string
-        concept: Directory path to an external file (always used with dfile)
-        aliases: [file.dir, wfdisc.dir, wfprocess.dir]
-        constraint: optional
-      dfile:
-        type: string
-        concept: External data file name.
-        aliases: [file.dfile, wfdisc.dfile, wfprocess.dfile]
-        constraint: optional
-      foff:
-        type: int
-        concept: Offset in bytes from beginning of a file to first data sample.
-        aliases: [file.foff, wfdisc.foff, wfprocess.foff]
-        constraint: optional
-      url:
-        type: string
-        concept: Url to external data file.
-        constraint: optional
-      gridfs_id:
-        type: ObjectID
-        concept: The _id of data file in the fs.files collection.
-        constraint: optional
-      site_id:
-        reference: site
-        constraint: xref_key
+    schema:
       channel_id:
         reference: channel
         constraint: xref_key
-      source_id:
-        reference: source
-        constraint: xref_key
-      history_object_id:
-        reference: history_object
-        constraint: xref_key
-      elog_id:
-        # type: list
-        reference: elog
-        constraint: xref_key
+      <<: &wf_TimeSeries
+        _id:
+          type: ObjectID
+          concept: ObjectId used to define a data object
+          constraint: required
+        npts:
+          type: int
+          concept: Number of data samples
+          aliases: [nsamp, wfdisc.nsamp]
+          constraint: required
+        delta:
+          type: double
+          concept: Data sample interval in seconds
+          aliases: [dt]
+          constraint: required
+        sampling_rate:
+          type: double
+          concept: Data sampling frequency in Hz=1/s
+          constraint: optional
+        starttime:
+          type: double
+          concept: Time of first sample of data (epoch time or relative to some other time mark)
+          aliases: [t0, time]
+          constraint: required
+        starttime_shift:
+          type: double
+          concept:  Time shift applied to define relative time of 0.0
+          aliases:  t0shift
+          constraint: required
+        utc_convertible:
+          type:  bool
+          concept:  When true starttime_shift can be used to convert relative time to UTC.
+          constraint: required
+        time_standard:
+          type: string
+          concept: Defines time standard for meaning of t0 (default should be UTC)
+          constraint: required
+        calib:
+          type: double
+          concept: Nominal conversion factor for changing sample data to ground motion units.
+          constraint: normal
+        storage_mode:
+          type: string
+          concept: The storage mode of the saved data ('file', 'url' or 'gridfs')
+          constraint: required
+        format:
+          type: string
+          concept: The file format of the saved data (e.g., 'MSEED', 'SAC', ...).
+          constraint: optional
+        dir:
+          type: string
+          concept: Directory path to an external file (always used with dfile)
+          aliases: [file.dir, wfdisc.dir, wfprocess.dir]
+          constraint: optional
+        dfile:
+          type: string
+          concept: External data file name.
+          aliases: [file.dfile, wfdisc.dfile, wfprocess.dfile]
+          constraint: optional
+        foff:
+          type: int
+          concept: Offset in bytes from beginning of a file to first data sample.
+          aliases: [file.foff, wfdisc.foff, wfprocess.foff]
+          constraint: optional
+        url:
+          type: string
+          concept: Url to external data file.
+          constraint: optional
+        gridfs_id:
+          type: ObjectID
+          concept: The _id of data file in the fs.files collection.
+          constraint: optional
+        source_id:
+          reference: source
+          constraint: xref_key
+        site_id:
+          reference: site
+          constraint: xref_key
+        history_object_id:
+          reference: history_object
+          constraint: xref_key
+        elog_id:
+          reference: elog
+          constraint: xref_key
 
   wf_Seismogram:
     data_type: Seismogram
@@ -126,10 +126,21 @@ Database:
         type: list
         concept: Three-component data's transformation matrix
         constraint: required
-      channel_id:
-        type: list
-        reference: channel
+      cardinal:
+        type: bool
+        concept: When true the data stored are orthogonal and in cardinal (ENZ) geographic directions.
+        constraint: required
+      orthogonal:
+        type: bool
+        concept: When true the transformation matrix is orthogonal (inverse can then be constructed from transpose instead of inversion). 
+        constraint: required
+      site_id:
+        concept: Linking id to site collection
+        reference: site
         constraint: xref_key
+      channel_id_list:
+        type: list
+        constraint: optional
 
   wf_miniseed:
     data_type: TimeSeries
@@ -176,6 +187,10 @@ Database:
       chan:
         reference: channel
         constraint: normal
+      channel_id:
+        reference: channel
+        constraint: xref_key
+
   site:
     schema:
       _id:
@@ -369,8 +384,8 @@ Database:
         reference: wf_TimeSeries
         constraint: xref_key
       alg_id:
-        type: string
         concept: ObjectId used to define a unique algorithm(alg_name + parameters)
+        reference: history_global
         constraint: xref_key
       alg_name:
         type: string
@@ -523,9 +538,6 @@ Metadata:
         collection: wf_Seismogram
         readonly: false
       site_id:
-        collection: wf_Seismogram
-        readonly: false
-      channel_id:
         collection: wf_Seismogram
         readonly: false
       source_id:

--- a/data/yaml/mspass_lite.yaml
+++ b/data/yaml/mspass_lite.yaml
@@ -2,7 +2,7 @@ Database:
   wf_TimeSeries:
     default: wf
     data_type: TimeSeries
-    schema: 
+    schema:
       chan:
         type: string
         concept: channel name (e.g. HHZ, BHE, etc.) - normally a SEED channel code
@@ -99,7 +99,6 @@ Database:
           reference: history_object
           constraint: xref_key
         elog_id:
-          type: list
           reference: elog
           constraint: xref_key
 
@@ -110,6 +109,14 @@ Database:
       tmatrix:
         type: list
         concept: Three-component data's transformation matrix
+        constraint: required
+      cardinal:
+        type: bool
+        concept: When true the data stored are orthogonal and in cardinal (ENZ) geographic directions.
+        constraint: required
+      orthogonal:
+        type: bool
+        concept: When true the transformation matrix is orthogonal (inverse can then be constructed from transpose instead of inversion). 
         constraint: required
 
   history_global:
@@ -165,8 +172,8 @@ Database:
         reference: wf_TimeSeries
         constraint: xref_key
       alg_id:
-        type: string
         concept: ObjectId used to define a unique algorithm(alg_name + parameters)
+        reference: history_global
         constraint: xref_key
       alg_name:
         type: string

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1793,19 +1793,18 @@ class Database(pymongo.database.Database):
                 object_type, wf_collection), 'Fatal')
 
         # if objectid_list is a cursor, convert the cursor to a list
-        member_list = []
-        for i in objectid_list:
-            member_list.append(i)
+        if type(objectid_list) is pymongo.cursor.Cursor:
+            objectid_list = list(objectid_list)
 
         if object_type is TimeSeries:
-            ensemble = TimeSeriesEnsemble(len(member_list))
+            ensemble = TimeSeriesEnsemble(len(objectid_list))
         else:
-            ensemble = SeismogramEnsemble(len(member_list))
+            ensemble = SeismogramEnsemble(len(objectid_list))
         # Here we post the ensemble metdata - see docstring notes on this feature
         for k in ensemble_metadata:
             ensemble[k]=ensemble_metadata[k]
 
-        for i in member_list:
+        for i in objectid_list:
             data = self.read_data(i, mode=mode, normalize=normalize, load_history=load_history, exclude_keys=exclude_keys, collection=wf_collection,
                                 data_tag=data_tag, alg_name=alg_name, alg_id=alg_id)
             if data:

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1793,9 +1793,9 @@ class Database(pymongo.database.Database):
                 object_type, wf_collection), 'Fatal')
 
         if object_type is TimeSeries:
-            ensemble = TimeSeriesEnsemble(len(objectid_list))
+            ensemble = TimeSeriesEnsemble(len(list(objectid_list)))
         else:
-            ensemble = SeismogramEnsemble(len(objectid_list))
+            ensemble = SeismogramEnsemble(len(list(objectid_list)))
         # Here we post the ensemble metdata - see docstring notes on this feature
         for k in ensemble_metadata:
             ensemble[k]=ensemble_metadata[k]
@@ -2185,6 +2185,13 @@ class Database(pymongo.database.Database):
         else:
             mspass_object['utc_convertible'] = True
             mspass_object['time_standard'] = 'UTC'
+        # If it is a seismogram, we need to update the tmatrix in the metadata to be consistent with the internal tmatrix
+        if isinstance(mspass_object, Seismogram):
+            t_matrix = mspass_object.tmatrix
+            mspass_object.tmatrix = t_matrix
+            # also update the cardinal and orthogonal attributes
+            mspass_object['cardinal'] = mspass_object.cardinal()
+            mspass_object['orthogonal'] = mspass_object.orthogonal()
 
     def _save_history(self, mspass_object, alg_name=None, alg_id=None, collection=None):
         """

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1793,7 +1793,7 @@ class Database(pymongo.database.Database):
                 object_type, wf_collection), 'Fatal')
 
         # if objectid_list is a cursor, convert the cursor to a list
-        if type(objectid_list) is pymongo.cursor.Cursor:
+        if isinstance(objectid_list, pymongo.cursor.Cursor):
             objectid_list = list(objectid_list)
 
         if object_type is TimeSeries:

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1759,7 +1759,7 @@ class Database(pymongo.database.Database):
         common arguments are used.
 
         :param objectid_list: a :class:`list` of :class:`bson.objectid.ObjectId`,
-          of the ids defining the ensemble members.
+          of the ids defining the ensemble members or a :class:`pymongo.cursor.Cursor`
         :param ensemble_metadata:  is a dict or dict like container containing
           metadata to be stored in the ensemble's Metadata (common to the group)
           container.  A common choice would be to post the query used to
@@ -1792,15 +1792,20 @@ class Database(pymongo.database.Database):
             raise MsPASSError('only TimeSeries and Seismogram are supported, but {} is requested. Please check the data_type of {} collection.'.format(
                 object_type, wf_collection), 'Fatal')
 
+        # if objectid_list is a cursor, convert the cursor to a list
+        member_list = []
+        for i in objectid_list:
+            member_list.append(i)
+
         if object_type is TimeSeries:
-            ensemble = TimeSeriesEnsemble(len(list(objectid_list)))
+            ensemble = TimeSeriesEnsemble(len(member_list))
         else:
-            ensemble = SeismogramEnsemble(len(list(objectid_list)))
+            ensemble = SeismogramEnsemble(len(member_list))
         # Here we post the ensemble metdata - see docstring notes on this feature
         for k in ensemble_metadata:
             ensemble[k]=ensemble_metadata[k]
 
-        for i in objectid_list:
+        for i in member_list:
             data = self.read_data(i, mode=mode, normalize=normalize, load_history=load_history, exclude_keys=exclude_keys, collection=wf_collection,
                                 data_tag=data_tag, alg_name=alg_name, alg_id=alg_id)
             if data:

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -397,6 +397,20 @@ class TestDatabase():
         with pytest.raises(MsPASSError, match="Can not find the record with _id: {} in wf_TimeSeries collection under pedantic mode.".format(non_exist_id)):
             self.db.update_metadata(pedantic_ts, mode='pedantic')
 
+        # test tmatrix attribute when update seismogram
+        test_seis = get_live_seismogram()
+        logging_helper.info(test_seis, '1', 'deepcopy')
+        non_fatal_error_cnt = self.db.update_metadata(test_seis, mode='promiscuous')
+        res = self.db['wf_Seismogram'].find_one({'_id': test_seis['_id']})
+        assert res
+        assert '_id' in test_seis
+        assert promiscuous_ts.live
+        assert non_fatal_error_cnt == 0
+        assert res['site_id'] == test_seis['site_id']
+        assert 'cardinal' in res and res['cardinal']
+        assert 'orthogonal' in res and res['orthogonal']
+        assert res['tmatrix'] == [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+
     def test_save_read_data(self):
         # new object
         # read data

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -410,6 +410,15 @@ class TestDatabase():
         assert 'cardinal' in res and res['cardinal']
         assert 'orthogonal' in res and res['orthogonal']
         assert res['tmatrix'] == [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+        # change tmatrix
+        logging_helper.info(test_seis, '2', 'update_metadata')
+        test_seis.tmatrix = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+        non_fatal_error_cnt = self.db.update_metadata(test_seis, mode='promiscuous')
+        res = self.db['wf_Seismogram'].find_one({'_id': test_seis['_id']})
+        assert promiscuous_ts.live
+        assert non_fatal_error_cnt == 0
+        assert res
+        assert res['tmatrix'] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
     def test_save_read_data(self):
         # new object
@@ -541,7 +550,7 @@ class TestDatabase():
 
         # test read exclude parameter
         assert '_id' in promiscuous_seis2
-        assert 'channel_id' in promiscuous_seis2
+        assert 'channel_id' not in promiscuous_seis2
         assert 'source_depth' in promiscuous_seis2
         assert '_id' not in exclude_promiscuous_seis2
         assert 'channel_id' not in exclude_promiscuous_seis2
@@ -556,7 +565,6 @@ class TestDatabase():
                 assert promiscuous_seis[key] == promiscuous_seis2[key]
         assert 'test' not in promiscuous_seis2
         assert 'extra2' not in promiscuous_seis2
-        assert promiscuous_seis['channel_id'] == promiscuous_seis2['channel_id']
 
         res = self.db['site'].find_one({'_id': promiscuous_seis['site_id']})
         assert promiscuous_seis2['site_lat'] == res['lat']

--- a/python/tests/db/test_schema.py
+++ b/python/tests/db/test_schema.py
@@ -158,7 +158,7 @@ class TestSchema():
 
     def test_keys(self):
         for k in self.dbschema.wf_TimeSeries.keys():
-            if k != 'test':
+            if k != 'test' and k != 'channel_id':
                 assert k in self.dbschema.wf_Seismogram.keys()
 
     def test_type(self):
@@ -192,13 +192,13 @@ class TestSchema():
 
     def test_DBSchemaDefinition_required_keys(self):
         assert self.dbschema.wf_TimeSeries.required_keys() == ['_id','npts','delta','starttime','starttime_shift','utc_convertible','time_standard','storage_mode']
-        assert self.dbschema.wf_Seismogram.required_keys() == ['_id','npts','delta','starttime','starttime_shift','utc_convertible','time_standard','storage_mode','tmatrix']
+        assert self.dbschema.wf_Seismogram.required_keys() == ['_id','npts','delta','starttime','starttime_shift','utc_convertible','time_standard','storage_mode','tmatrix','cardinal','orthogonal']
         assert self.dbschema.site.required_keys() == ['_id','lat','lon','elev']
         assert self.dbschema.source.required_keys() == ['_id','lat','lon','depth','time']
 
     def test_DBSchemaDefinition_xref_keys(self):
-        assert self.dbschema.wf_TimeSeries.xref_keys() == ['site_id','channel_id','source_id','history_object_id','elog_id']
-        assert self.dbschema.wf_Seismogram.xref_keys() == ['site_id','channel_id','source_id','history_object_id','elog_id']
+        assert self.dbschema.wf_TimeSeries.xref_keys() == ['source_id', 'site_id', 'history_object_id', 'elog_id', 'channel_id']
+        assert self.dbschema.wf_Seismogram.xref_keys() == ['source_id', 'site_id', 'history_object_id', 'elog_id']
         assert self.dbschema.site.xref_keys() == []
         assert self.dbschema.source.xref_keys() == []
 
@@ -210,10 +210,10 @@ class TestSchema():
         self.mdschema.TimeSeries.set_collection('channel_id', 'dummy')
         assert self.mdschema.TimeSeries.collection('channel_id') == 'dummy'
 
-        assert self.mdschema.TimeSeries.type('channel_id') == ObjectId
-        self.mdschema.TimeSeries.set_collection('channel_id', 'wf_Seismogram', self.dbschema)
-        assert self.mdschema.TimeSeries.collection('channel_id') == 'wf_Seismogram'
-        assert self.mdschema.TimeSeries.type('channel_id') == list
+        assert self.mdschema.TimeSeries.type('site_id') == ObjectId
+        self.mdschema.TimeSeries.set_collection('site_id', 'wf_Seismogram', self.dbschema)
+        assert self.mdschema.TimeSeries.collection('site_id') == 'wf_Seismogram'
+        assert self.mdschema.TimeSeries.type('site_id') == ObjectId
         
         with pytest.raises(MsPASSError, match='not defined'):
             self.mdschema.TimeSeries.set_collection('test100','wf_Seismogram')

--- a/python/tests/helper.py
+++ b/python/tests/helper.py
@@ -31,7 +31,6 @@ def get_live_seismogram():
     seis['delta'] = 0.1
     seis['calib'] = 0.1
     seis['site_id'] = bson.objectid.ObjectId()
-    seis['channel_id'] = [bson.objectid.ObjectId()]
     seis['source_id'] = bson.objectid.ObjectId()
     seis.data = dmatrix(3, ts_size)
     for i in range(3):

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -417,40 +417,40 @@ def test_CoreSeismogram():
     # test metadata constructor
     md['tmatrix'] = np.random.rand(3, 3)
     cseis = _CoreSeismogram(md, False)
-    assert (cseis.transformation_matrix == md['tmatrix']).all()
+    assert (cseis.tmatrix == md['tmatrix']).all()
     md['tmatrix'] = dmatrix(np.random.rand(3, 3))
     cseis = _CoreSeismogram(md, False)
-    assert (cseis.transformation_matrix == md['tmatrix']).all()
+    assert (cseis.tmatrix == md['tmatrix']).all()
     md['tmatrix'] = np.random.rand(9)
     cseis = _CoreSeismogram(md, False)
-    assert (cseis.transformation_matrix == md['tmatrix'].reshape(3, 3)).all()
+    assert (cseis.tmatrix == md['tmatrix'].reshape(3, 3)).all()
     md['tmatrix'] = np.random.rand(1, 9)
     cseis = _CoreSeismogram(md, False)
-    assert (cseis.transformation_matrix == md['tmatrix'].reshape(3, 3)).all()
+    assert (cseis.tmatrix == md['tmatrix'].reshape(3, 3)).all()
     md['tmatrix'] = np.random.rand(9, 1)
     cseis = _CoreSeismogram(md, False)
-    assert (cseis.transformation_matrix == md['tmatrix'].reshape(3, 3)).all()
+    assert (cseis.tmatrix == md['tmatrix'].reshape(3, 3)).all()
 
     md['tmatrix'] = np.random.rand(3, 3).tolist()
     cseis = _CoreSeismogram(md, False)
-    assert np.isclose(cseis.transformation_matrix,
+    assert np.isclose(cseis.tmatrix,
                       np.array(md['tmatrix']).reshape(3, 3)).all()
     md['tmatrix'] = np.random.rand(9).tolist()
     cseis = _CoreSeismogram(md, False)
-    assert np.isclose(cseis.transformation_matrix,
+    assert np.isclose(cseis.tmatrix,
                       np.array(md['tmatrix']).reshape(3, 3)).all()
 
-    # test whether the setter of transformation_matrix updates metadata correctly
+    # test whether the setter of tmatrix updates metadata correctly
     tm = np.random.rand(1, 9)
-    cseis.transformation_matrix = tm
-    assert (cseis.transformation_matrix == tm.reshape(3, 3)).all()
-    assert np.isclose(cseis.transformation_matrix, np.array(
+    cseis.tmatrix = tm
+    assert (cseis.tmatrix == tm.reshape(3, 3)).all()
+    assert np.isclose(cseis.tmatrix, np.array(
         cseis['tmatrix']).reshape(3, 3)).all()
     tm = np.random.rand(9).tolist()
-    cseis.transformation_matrix = tm
-    assert np.isclose(cseis.transformation_matrix,
+    cseis.tmatrix = tm
+    assert np.isclose(cseis.tmatrix,
                       np.array(tm).reshape(3, 3)).all()
-    assert np.isclose(cseis.transformation_matrix, np.array(
+    assert np.isclose(cseis.tmatrix, np.array(
         cseis['tmatrix']).reshape(3, 3)).all()
 
     # test exceptions
@@ -563,7 +563,7 @@ def test_Seismogram():
 
     nu = [np.sqrt(3.0)/3.0, np.sqrt(3.0)/3.0, np.sqrt(3.0)/3.0]
     seis.rotate(nu)
-    assert (np.isclose(seis.transformation_matrix,
+    assert (np.isclose(seis.tmatrix,
                        np.array([[0.70710678, -0.70710678,  0.],
                                  [0.40824829,  0.40824829, -0.81649658],
                                  [0.57735027,  0.57735027,  0.57735027]]))).all()
@@ -575,7 +575,7 @@ def test_Seismogram():
 
     nu = [np.sqrt(3.0)/3.0, np.sqrt(3.0)/3.0, np.sqrt(3.0)/3.0]
     seis.rotate(SphericalCoordinate(nu))
-    assert (np.isclose(seis.transformation_matrix,
+    assert (np.isclose(seis.tmatrix,
                        np.array([[0.70710678, -0.70710678,  0.],
                                  [0.40824829,  0.40824829, -0.81649658],
                                  [0.57735027,  0.57735027,  0.57735027]]))).all()
@@ -588,7 +588,7 @@ def test_Seismogram():
     sc.phi = np.pi/4
     sc.theta = 0.0
     seis.rotate(sc)
-    assert (np.isclose(seis.transformation_matrix,
+    assert (np.isclose(seis.tmatrix,
                        np.array([[0.70710678, -0.70710678,  0.],
                                  [0.70710678,  0.70710678,  0.],
                                  [0.,  0.,  1.]]))).all()
@@ -623,7 +623,7 @@ def test_Seismogram():
 
     seis.rotate(np.pi/4)
     seis.transform(a)
-    assert (np.isclose(seis.transformation_matrix,
+    assert (np.isclose(seis.tmatrix,
                        np.array([[1.41421,  0., 1],
                                  [0.,  1.41421, 1],
                                  [-0.707107, -0.707107, 0]]))).all()
@@ -641,13 +641,13 @@ def test_Seismogram():
     uvec.ux = 0.17085  # cos(-20deg)/5.5
     uvec.uy = -0.062185  # sin(-20deg)/5.5
     seis.free_surface_transformation(uvec, 5.0, 3.5)
-    assert (np.isclose(seis.transformation_matrix,
+    assert (np.isclose(seis.tmatrix,
                        np.array([[-0.171012, -0.469846,  0],
                                  [0.115793, -0.0421458, 0.445447],
                                  [-0.597975,  0.217647,  0.228152]]))).all()
 
-    seis.transformation_matrix = a
-    assert (seis.transformation_matrix == a).all()
+    seis.tmatrix = a
+    assert (seis.tmatrix == a).all()
 
 
 @pytest.fixture(params=[TimeSeriesEnsemble, SeismogramEnsemble])


### PR DESCRIPTION
1. fix bugs for not saving tmatrix and two boolean variables properly in metadata before actually saving to database
2. For the constructor in TimeSeires, I remove the for loop and change it for memcpy for better performance
3. convert the cursor to a list to fix bugs for getting the length of the records correctly when passing MongoDB cursor in read_ensemble_data
4. update the format of yaml files to support the new features.