### PR TITLE
Add configurations to show the 'Edit on GitHub' button

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = 'MsPASS'
-copyright = '2020, Ian Wang'
+copyright = '2020-2021, Ian Wang'
 author = 'Ian Wang'
 
 # The full version, including alpha/beta/rc tags
@@ -74,6 +74,15 @@ html_static_path = ['_static', 'doxygen']
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 html_show_sphinx = False
+
+html_context = {
+    "display_github": True,
+    "github_user": "mspass-team",
+    "github_repo": "mspass",
+    "github_version": "master",
+    "conf_py_path": "/docs/source/",
+    "theme_vcs_pageview_mode": "blob",
+}
 
 # Breathe Configuration
 breathe_default_project = 'MsPASS C++ API'


### PR DESCRIPTION
Currently, each page on the documentation shows a "View page source" link, which links to the plain text source file:
![image](https://user-images.githubusercontent.com/3974108/124492261-36371a80-dd82-11eb-928c-2372023ca34f.png)

It's more useful to link directly to the source files in the GitHub repository, because the source files are rendered well on GitHub and are easier to read. It's also much easier for users to submit quick fixes for typos.

![image](https://user-images.githubusercontent.com/3974108/124492219-27506800-dd82-11eb-8a1a-8d7af8fd81ac.png)

The `html_context` is documented in https://github.com/readthedocs/sphinx_rtd_theme/issues/465.

It works well in my other projects, so I expect it should work well for mspass too. However, I can't test it because for me, it's difficult to build mspass from source codes locally.
