### PR TITLE
Fix readonly problem

### DIFF
--- a/cxx/src/lib/algorithms/bundle.cc
+++ b/cxx/src/lib/algorithms/bundle.cc
@@ -403,6 +403,7 @@ Ensemble<Seismogram> bundle_seed_data(Ensemble<TimeSeries>& d)
     for(i=0,dptr=d.member.begin();dptr!=d.member.end();++i,++dptr)
     {
     //DEBUG
+/*
     cout<<"i="<<i<<" values: "
       << lastnet <<":"
       << laststa <<":"
@@ -413,6 +414,7 @@ Ensemble<Seismogram> bundle_seed_data(Ensemble<TimeSeries>& d)
       << sta <<":"
       << chan <<":"
       << loc <<endl;
+*/
       if(dptr->dead())
       {
         /* If net, sta, and loc are defined we try to blunder on so we can
@@ -517,6 +519,12 @@ Ensemble<Seismogram> bundle_seed_data(Ensemble<TimeSeries>& d)
                   hvec.push_back(dynamic_cast<ProcessingHistory*>(&d.member[i0+k]));
                 }
               }
+//DEBUG
+for(size_t k=0;k<3;++k) cout << work[k].get_string(SEISMICMD_sta)
+<< " " <<work[k].get_string(SEISMICMD_chan)
+<< " " <<work[k].get_double(SEISMICMD_hang)
+<< " " <<work[k].get_double(SEISMICMD_vang)
+<<endl;
               Seismogram d3c;
               try{
                 d3c=Seismogram(CoreSeismogram(work),algname);
@@ -528,6 +536,16 @@ Ensemble<Seismogram> bundle_seed_data(Ensemble<TimeSeries>& d)
                 d3c.kill();
                 d3c.elog.log_error(err);
               }
+//DEBUG
+cout << "Transformation matrix in bundled result"<<endl;
+dmatrix tm_tmp=d3c.get_transformation_matrix();
+cout << tm_tmp <<endl;
+cout << "First 10 samples:"<<endl;
+for(size_t ii=0;ii<10;++ii)
+{
+for(size_t jj=0;jj<3;++jj) cout << d3c.u(jj,ii)<<" ";
+cout<<endl;
+}
               ens3c.member.push_back(d3c);
             }
             else

--- a/cxx/src/lib/algorithms/bundle.cc
+++ b/cxx/src/lib/algorithms/bundle.cc
@@ -402,19 +402,6 @@ Ensemble<Seismogram> bundle_seed_data(Ensemble<TimeSeries>& d)
     size_t i;
     for(i=0,dptr=d.member.begin();dptr!=d.member.end();++i,++dptr)
     {
-    //DEBUG
-/*
-    cout<<"i="<<i<<" values: "
-      << lastnet <<":"
-      << laststa <<":"
-      << lastchan <<":"
-      << lastloc <<endl
-      << "Current= "
-      << net <<":"
-      << sta <<":"
-      << chan <<":"
-      << loc <<endl;
-*/
       if(dptr->dead())
       {
         /* If net, sta, and loc are defined we try to blunder on so we can
@@ -519,12 +506,6 @@ Ensemble<Seismogram> bundle_seed_data(Ensemble<TimeSeries>& d)
                   hvec.push_back(dynamic_cast<ProcessingHistory*>(&d.member[i0+k]));
                 }
               }
-//DEBUG
-for(size_t k=0;k<3;++k) cout << work[k].get_string(SEISMICMD_sta)
-<< " " <<work[k].get_string(SEISMICMD_chan)
-<< " " <<work[k].get_double(SEISMICMD_hang)
-<< " " <<work[k].get_double(SEISMICMD_vang)
-<<endl;
               Seismogram d3c;
               try{
                 d3c=Seismogram(CoreSeismogram(work),algname);
@@ -536,16 +517,6 @@ for(size_t k=0;k<3;++k) cout << work[k].get_string(SEISMICMD_sta)
                 d3c.kill();
                 d3c.elog.log_error(err);
               }
-//DEBUG
-cout << "Transformation matrix in bundled result"<<endl;
-dmatrix tm_tmp=d3c.get_transformation_matrix();
-cout << tm_tmp <<endl;
-cout << "First 10 samples:"<<endl;
-for(size_t ii=0;ii<10;++ii)
-{
-for(size_t jj=0;jj<3;++jj) cout << d3c.u(jj,ii)<<" ";
-cout<<endl;
-}
               ens3c.member.push_back(d3c);
             }
             else

--- a/cxx/src/lib/seismic/CoreSeismogram.cc
+++ b/cxx/src/lib/seismic/CoreSeismogram.cc
@@ -251,6 +251,8 @@ CoreSeismogram::CoreSeismogram(const vector<CoreTimeSeries>& ts,
             && (fabs( (t0_component[0]-t0_component[1])/dt() )<1.0)
             && (fabs( (t0_component[1]-t0_component[2])/dt() )<1.0))
     {
+//DEBUG
+cout << "Using regular start time algorithm"<<endl;
         /* Older code had this.   No longer needed with logic above that
         calls set_npts.  that method creates and initialized the u dmatrix*/
         //this->u=dmatrix(3,nsamp);
@@ -272,6 +274,8 @@ CoreSeismogram::CoreSeismogram(const vector<CoreTimeSeries>& ts,
     }
     else
     {
+//DEBUG
+cout << "Using irregular start time algorithm"<<endl;
         /*Land here if the start time or number of samples
         is irregular.  We cut the output to latest start time to earliest end time*/
         /* WARNING - debugging may be needed for this block. SEISPP versio of this
@@ -296,6 +300,7 @@ CoreSeismogram::CoreSeismogram(const vector<CoreTimeSeries>& ts,
         double delta=this->dt();
         for(int ic=0; ic<3; ++ic)
         {
+            t=this->t0();
             for(j=0; j<ts[ic].s.size(); ++j)
             {
                 i=ts[ic].sample_number(t);
@@ -307,6 +312,14 @@ CoreSeismogram::CoreSeismogram(const vector<CoreTimeSeries>& ts,
             }
         }
     }
+//DEBUG
+cout << "First 10 samples while in constructor:"<<endl;
+for(size_t ii=0;ii<10;++ii)
+{
+for(size_t jj=0;jj<3;++jj) cout << this->u(jj,ii)<<" ";
+cout<<endl;
+}
+
     /* Finally we need to set the transformation matrix.
      This is a direct application of conversion of routines
     in spherical coordinate procedures.  They are procedural
@@ -327,6 +340,12 @@ CoreSeismogram::CoreSeismogram(const vector<CoreTimeSeries>& ts,
         scor.phi=hang[i];
         scor.theta=vang[i];
         nu=SphericalToUnitVector(scor);
+//DEBUG
+cout << "spherical:  "<<mspass::utility::deg(hang[i])<<" "
+<< mspass::utility::deg(vang[i])<<endl;
+cout <<"unit vector:";
+for(j=0;j<3;++j)cout << nu[j] <<" ";
+cout << endl;
         for(j=0; j<3; ++j)tmatrix[i][j]=nu[j];
         delete [] nu;
     }

--- a/cxx/src/lib/seismic/CoreSeismogram.cc
+++ b/cxx/src/lib/seismic/CoreSeismogram.cc
@@ -251,8 +251,6 @@ CoreSeismogram::CoreSeismogram(const vector<CoreTimeSeries>& ts,
             && (fabs( (t0_component[0]-t0_component[1])/dt() )<1.0)
             && (fabs( (t0_component[1]-t0_component[2])/dt() )<1.0))
     {
-//DEBUG
-cout << "Using regular start time algorithm"<<endl;
         /* Older code had this.   No longer needed with logic above that
         calls set_npts.  that method creates and initialized the u dmatrix*/
         //this->u=dmatrix(3,nsamp);
@@ -274,8 +272,6 @@ cout << "Using regular start time algorithm"<<endl;
     }
     else
     {
-//DEBUG
-cout << "Using irregular start time algorithm"<<endl;
         /*Land here if the start time or number of samples
         is irregular.  We cut the output to latest start time to earliest end time*/
         /* WARNING - debugging may be needed for this block. SEISPP versio of this
@@ -312,14 +308,6 @@ cout << "Using irregular start time algorithm"<<endl;
             }
         }
     }
-//DEBUG
-cout << "First 10 samples while in constructor:"<<endl;
-for(size_t ii=0;ii<10;++ii)
-{
-for(size_t jj=0;jj<3;++jj) cout << this->u(jj,ii)<<" ";
-cout<<endl;
-}
-
     /* Finally we need to set the transformation matrix.
      This is a direct application of conversion of routines
     in spherical coordinate procedures.  They are procedural
@@ -340,12 +328,6 @@ cout<<endl;
         scor.phi=hang[i];
         scor.theta=vang[i];
         nu=SphericalToUnitVector(scor);
-//DEBUG
-cout << "spherical:  "<<mspass::utility::deg(hang[i])<<" "
-<< mspass::utility::deg(vang[i])<<endl;
-cout <<"unit vector:";
-for(j=0;j<3;++j)cout << nu[j] <<" ";
-cout << endl;
         for(j=0; j<3; ++j)tmatrix[i][j]=nu[j];
         delete [] nu;
     }

--- a/data/yaml/mspass.yaml
+++ b/data/yaml/mspass.yaml
@@ -447,6 +447,9 @@ Metadata:
       source_id:
         collection: wf_TimeSeries
         readonly: false
+      utc_convertible:
+        collection: wf_TimeSeries
+        readonly: false
       net:
         collection: site
         readonly: true
@@ -544,6 +547,9 @@ Metadata:
         collection: wf_Seismogram
         readonly: false
       tmatrix:
+        collection: wf_Seismogram
+        readonly: false
+      utc_convertible:
         collection: wf_Seismogram
         readonly: false
       net:

--- a/data/yaml/mspass.yaml
+++ b/data/yaml/mspass.yaml
@@ -435,6 +435,9 @@ Metadata:
       time_standard:
         collection: wf_TimeSeries
         readonly: false
+      utc_convertible:
+        collection: wf_TimeSeries
+        readonly: false
       calib:
         collection: wf_TimeSeries
         readonly: false
@@ -445,9 +448,6 @@ Metadata:
         collection: wf_TimeSeries
         readonly: false
       source_id:
-        collection: wf_TimeSeries
-        readonly: false
-      utc_convertible:
         collection: wf_TimeSeries
         readonly: false
       net:
@@ -537,6 +537,9 @@ Metadata:
       time_standard:
         collection: wf_Seismogram
         readonly: false
+      utc_convertible:
+        collection: wf_Seismogram
+        readonly: false
       calib:
         collection: wf_Seismogram
         readonly: false
@@ -547,9 +550,6 @@ Metadata:
         collection: wf_Seismogram
         readonly: false
       tmatrix:
-        collection: wf_Seismogram
-        readonly: false
-      utc_convertible:
         collection: wf_Seismogram
         readonly: false
       net:

--- a/data/yaml/mspass_lite.yaml
+++ b/data/yaml/mspass_lite.yaml
@@ -223,6 +223,9 @@ Metadata:
       time_standard:
         collection: wf_TimeSeries
         readonly: false
+      utc_convertible:
+        collection: wf_TimeSeries
+        readonly: false
       calib:
         collection: wf_TimeSeries
         readonly: false
@@ -257,6 +260,9 @@ Metadata:
         collection: wf_Seismogram
         readonly: false
       time_standard:
+        collection: wf_Seismogram
+        readonly: false
+      utc_convertible:
         collection: wf_Seismogram
         readonly: false
       calib:

--- a/python/mspasspy/algorithms/bundle.py
+++ b/python/mspasspy/algorithms/bundle.py
@@ -56,6 +56,13 @@ def bundle_seed_data(ensemble):
     bundle are subject to the same truncation or discard rules described
     in the related function Bundle3C.
 
+    Note there is not guarantee the Seismogram objects returned 
+    will be in standard coordinates.  In fact, they will never be 
+    with standard channel names because of the internal sorting. 
+    It would normally be highly recommended the user call the 
+    rotate_to_standard method on each Seismogram before any use. 
+
+
     :param ensemble: is the input ensemble of TimeSeries to be processed.
     :return:   ensemble of Seismogram objects made by bundling input data
     :rtype:  SeismogramEnsemble

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -733,6 +733,11 @@ class Database(pymongo.database.Database):
             # finally ready to insert the wf doc - keep the id as we'll need
             # it for tagging any elog entries
             wfid = wf_collection.insert_one(insertion_dict).inserted_id
+            # Put wfid into the object's meta as the new definition of 
+            # the parent of this waveform
+            # TODO - I think we need to reset the history container here 
+            # and mark this new save as an ORIGIN leaving till later
+            mspass_object['_id']=wfid
 
             # Empty error logs are skipped.  When nonzero tag them with tid
             # just returned

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3055,7 +3055,12 @@ class Database(pymongo.database.Database):
                     # del chanrec['serialized_inventory']
                     for chan in chans:
                         chanrec['chan'] = chan.code
-                        chanrec['vang'] = chan.dip
+			# the Dip attribute in a stationxml file 
+			# is like strike-dip and relative to horizontal
+			# line with positive down.  vang is the 
+			# css30 attribute that is spherical coordinate 
+			# theta angle
+                        chanrec['vang'] = chan.dip + 90.0
                         chanrec['hang'] = chan.azimuth
                         chanrec['edepth'] = chan.depth
                         st = chan.start_date

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -759,7 +759,8 @@ class Database(pymongo.database.Database):
                 #TODO will support url mode later
                 #elif storage_mode == "url":
                 #    pass
-                
+            
+            # save history if not empty
             history_obj_id_name = self.database_schema.default_name('history_object') + '_id'
             if mspass_object.is_empty():
                 history_object_id = None
@@ -771,11 +772,8 @@ class Database(pymongo.database.Database):
                 # optional history save - only done if history container is not empty
                 history_object_id = self._save_history(mspass_object, alg_name, alg_id)
                 insertion_dict[history_obj_id_name] = history_object_id
-
-            # we still need to save the elog here because there might be Complaint elog above
-            # and we want to associate the elog_id with wf document
-
-
+            
+            # add tag
             if data_tag:
                 insertion_dict['data_tag']=data_tag
             else:

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -844,9 +844,11 @@ class TestDatabase():
         ts2['starttime'] = '123'
 
         save_res_code = self.db.save_data(ts1, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         save_res_code = self.db.save_data(ts2, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         
         fixed_cnt = self.db.clean_collection('wf_TimeSeries')
         assert fixed_cnt == {'npts':1, 'delta':1}
@@ -871,7 +873,8 @@ class TestDatabase():
         ts.erase('npts')
         ts['starttime_shift'] = 1.0
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         assert ts.live
         
         # test nonexist document
@@ -897,7 +900,8 @@ class TestDatabase():
         ts['starttime_shift'] = 1.0
         ts.erase('site_id')
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         fixes_cnt = self.db.clean(ts['_id'], verbose=True, required_xref_list=['site_id'], delete_missing_xref=True)
         assert len(fixes_cnt) == 0
         assert not self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
@@ -913,7 +917,8 @@ class TestDatabase():
         ts['npts'] = "123"
         ts['starttime_shift'] = 1.0
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         fixes_cnt = self.db.clean(ts['_id'], verbose=True)
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert res
@@ -961,7 +966,8 @@ class TestDatabase():
         logging_helper.info(ts, '1', 'deepcopy')
         ts['starttime_shift'] = 1.0
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert res
         assert 'extra1' in res
@@ -978,7 +984,8 @@ class TestDatabase():
         logging_helper.info(ts, '1', 'deepcopy')
         ts['starttime_shift'] = 1.0
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert res
         assert 'extra1' in res
@@ -1016,7 +1023,8 @@ class TestDatabase():
         # mismatch type
         ts['delta'] = '123'
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert not 'npts' in res
         assert res['delta'] == '123'
@@ -1041,9 +1049,11 @@ class TestDatabase():
         logging_helper.info(bad_wf_ts, '1', 'deepcopy')
 
         save_res_code = self.db.save_data(bad_xref_key_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         save_res_code = self.db.save_data(bad_wf_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2','site_id'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
 
         bad_xref_key_doc = self.db['wf_TimeSeries'].find_one({'_id': bad_xref_key_ts['_id']})
         bad_wf_doc = self.db['wf_TimeSeries'].find_one({'_id': bad_wf_ts['_id']})
@@ -1077,7 +1087,8 @@ class TestDatabase():
         ts.erase('npts')
 
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2', 'starttime'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         self.db['wf_TimeSeries'].update_one({'_id': ts['_id']}, {'$set': {'t0':1.0}})
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert 'starttime' not in res
@@ -1095,7 +1106,8 @@ class TestDatabase():
         ts['npts'] = 'xyz'
 
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2', 'starttime'])
-        assert save_res_code == 0
+        $assert save_res_code == 0
+        assert save_res_code[0]
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
 
         assert self.db._check_mismatch_key(res, 'wf_TimeSeries', 'npts')
@@ -1110,7 +1122,8 @@ class TestDatabase():
         logging_helper.info(ts, '1', 'deepcopy')
         ts['starttime_shift'] = 1.0
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert 'delta' in res and 'sampling_rate' in res and 'starttime' in res
         counts = self.db._delete_attributes('wf_TimeSeries', ['delta', 'sampling_rate', 'starttime'])
@@ -1125,7 +1138,8 @@ class TestDatabase():
         logging_helper.info(ts, '1', 'deepcopy')
         ts['starttime_shift'] = 1.0
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert 'delta' in res and 'sampling_rate' in res and 'starttime' in res
         delta_val = res['delta']
@@ -1147,7 +1161,8 @@ class TestDatabase():
         ts['delta'] = '123'
         ts['sampling_rate'] = '123'
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert res['npts'] == 'xyz' and res['delta'] == '123' and res['sampling_rate'] == '123'
         counts = self.db._fix_attribute_types('wf_TimeSeries')
@@ -1175,13 +1190,17 @@ class TestDatabase():
         bad_channel_id_ts['channel_id'] = ObjectId()
 
         save_res_code = self.db.save_data(missing_site_id_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         save_res_code = self.db.save_data(bad_site_id_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         save_res_code = self.db.save_data(bad_source_id_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         save_res_code = self.db.save_data(bad_channel_id_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
 
         # undefined collection name
         with pytest.raises(MsPASSError, match='check_links:  collection xxx is not defined in database schema'):
@@ -1227,9 +1246,11 @@ class TestDatabase():
         bad_type_docs_ts['npts'] = 'xyz'
 
         save_res_code = self.db.save_data(bad_type_docs_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         save_res_code = self.db.save_data(undefined_key_docs_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
 
         # test empty matched documents
         query_dict = {'_id': ObjectId()}
@@ -1253,9 +1274,11 @@ class TestDatabase():
         wrong_types_ts['npts'] = 'xyz'
 
         save_res_code = self.db.save_data(wrong_types_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
         save_res_code = self.db.save_data(undef_ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2'])
-        assert save_res_code == 0
+        #assert save_res_code == 0
+        assert save_res_code[0]
 
         # test empty matched documents
         query_dict = {'_id': ObjectId()}

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -1106,7 +1106,7 @@ class TestDatabase():
         ts['npts'] = 'xyz'
 
         save_res_code = self.db.save_data(ts, mode='promiscuous', storage_mode='gridfs', exclude_keys=['extra2', 'starttime'])
-        $assert save_res_code == 0
+        #assert save_res_code == 0
         assert save_res_code[0]
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
 

--- a/python/tests/global_history/test_manager.py
+++ b/python/tests/global_history/test_manager.py
@@ -373,9 +373,9 @@ class TestManager():
             assert ts.current_nodedata().algid == str(alg_id)
             assert ts.is_volatile()
 
-        save_res_code = manager_db.save_data(spark_res[0], alg_name='filter', alg_id=str(alg_id))
+        save_res = manager_db.save_data(spark_res[0], alg_name='filter', alg_id=str(alg_id))
         # hardcode net, sta, net, loc to avoid serialization problem here, they are readonly metadata keys -> non fatal keys = 4
-        assert save_res_code == 4
+        assert save_res.live
         assert manager_db['history_object'].count_documents({'alg_name': 'filter'}) == 1
         doc = manager_db['history_object'].find_one({'alg_name': 'filter'})
         assert doc


### PR DESCRIPTION
This branch has a complete rewrite of the save_data method and update_metadata method.  It removes the private _update_metadata method completely.   save_data now is the union of the old _update_metadata and the old save data.   The new update_metadata method behaves very differently from the old one.   See doctrings for details. 

This first push is known to be broken.   I am getting weird results locally with pytest that i am pretty sure are related to the fact my development ubuntu machine has an incomplete test environment.   This push should not be taken seriously until I can view the test run results and try to fix what I can.   @haruming  I will need your help resolving some of the test conflicts and revising the test script to mesh with the changes to save_data and update_metadata.