### PR TITLE
Add missing information for data_tag

### DIFF
--- a/data/yaml/mspass.yaml
+++ b/data/yaml/mspass.yaml
@@ -117,6 +117,11 @@ Database:
         elog_id:
           reference: elog
           constraint: xref_key
+        data_tag:
+           type: string
+           concept:  Used as a tag for data at a particular stage of processing. Used in save_data.
+           constraint: normal
+
 
   wf_Seismogram:
     data_type: Seismogram

--- a/data/yaml/mspass.yaml
+++ b/data/yaml/mspass.yaml
@@ -118,9 +118,9 @@ Database:
           reference: elog
           constraint: xref_key
         data_tag:
-           type: string
-           concept:  Used as a tag for data at a particular stage of processing. Used in save_data.
-           constraint: normal
+          type: string
+          concept: Used as a tag for data at a particular stage of processing. Used in save_data.
+          constraint: optional
 
 
   wf_Seismogram:

--- a/data/yaml/mspass_lite.yaml
+++ b/data/yaml/mspass_lite.yaml
@@ -101,6 +101,10 @@ Database:
         elog_id:
           reference: elog
           constraint: xref_key
+        data_tag:
+          type: string
+          concept: Used as a tag for data at a particular stage of processing. Used in save_data.
+          constraint: optional
 
   wf_Seismogram:
     data_type: Seismogram


### PR DESCRIPTION
This is a change only to mspass.yaml to fix an unambiguous mistake in mspass schema.  I found this by running clean_collection in the short course tutorial and found it cleared data_tag I had set in the save.  I wasn't sure if that attribute should be tagged "normal" or "optional".   I set it "normal", but am a bit fuzzy on the distinction