### PR TITLE
Change the structure of the RFdeconProcessor to make it serializable

### DIFF
--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -292,14 +292,7 @@ PYBIND11_MODULE(seismic, m) {
     .def_property("tmatrix",
       [](const CoreSeismogram &self){
         dmatrix tm = self.get_transformation_matrix();
-        auto v = static_cast<Publicdmatrix&>(tm).ary;
-        std::vector<double>* c = new std::vector<double>(std::move(v));
-        auto capsule = py::capsule(c, [](void *x) { delete reinterpret_cast<std::vector<double>*>(x); });
-        std::vector<ssize_t> size(2,3);
-        std::vector<ssize_t> stride(2);
-        stride[0] = sizeof(double);
-        stride[1] = sizeof(double) * 3;
-        return py::array(py::dtype(py::format_descriptor<double>::format()), size, stride, c->data(), capsule);
+        return pybind11::module::import("numpy").attr("array")(tm);
       },
       [](CoreSeismogram &self, py::object tm) {
         self.set_transformation_matrix(tm);

--- a/cxx/src/lib/utility/AntelopePf.cc
+++ b/cxx/src/lib/utility/AntelopePf.cc
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <sstream>
 #include "mspass/utility/MsPASSError.h"
+#include "mspass/utility/utility.h"
 #include "mspass/utility/AntelopePf.h"
 namespace mspass::utility {
 using namespace std;
@@ -344,6 +345,15 @@ AntelopePf::AntelopePf(string pfbase)
         else
         {
             pffiles=split_pfpath(pfbase,s);
+        }
+        const std::string mspass_home_envname("MSPASS_HOME");
+        char *base;
+        /* Note man page for getenv says explicitly the return of getenv should not
+                be touched - i.e. don't free it*/
+        base=getenv(mspass_home_envname.c_str());
+        if(base!=NULL)
+        {
+            pffiles.push_back(data_directory()+"/pf/"+pfbase);
         }
         list<string>::iterator pfptr;
         int nread;

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+import pickle
+import numpy as np
+import pytest
+
+sys.path.append("python/tests")
+from helper import (get_live_seismogram,
+                    get_live_timeseries,
+                    get_sin_timeseries,
+                    get_live_timeseries_ensemble,
+                    get_live_seismogram_ensemble)
+
+from mspasspy.algorithms.RFdeconProcessor import RFdeconProcessor
+
+def test_RFdeconProcessor():
+    decon_processor = RFdeconProcessor(alg="MultiTaperXcor")
+
+    seis_data = get_live_seismogram()
+    seis_wavelet = get_live_seismogram()
+    seis_noise = get_live_seismogram()
+
+    decon_processor.loaddata(seis_data)
+    decon_processor.loadwavelet(seis_wavelet)
+    decon_processor.loadnoise(seis_noise)
+
+    # decon_processor_copy = pickle.loads(pickle.dumps(decon_processor))
+    data = pickle.dumps(decon_processor)
+    decon_processor_copy = pickle.loads(data)
+
+    assert (decon_processor.dvector == decon_processor_copy.dvector).all()
+    assert (decon_processor.wvector == decon_processor_copy.wvector).all()
+    assert (decon_processor.nvector == decon_processor_copy.nvector).all()


### PR DESCRIPTION
We run into the error that RFdeconProcessor was not able to be serialized by pickle automatically when using it in a map call. This is because a lot of the member variables of this python object are C++ bonded objects. Therefore, we are will not be able to use the object at all unless we serialize all the related C++ objects with pybind11. This includes the different decon operators as well as other underlying objects such as `ComplexArray` and `ShapingWavelet`. 

Therefore, instead of implementing the pickle method of all those objects, I decided to change the `RFdeconProcessor` python object such that it does not store copies of the actual decon processor. Instead, it creates one on the fly with all the necessary parameters stored in it that are native to Python. The overhead of this approach shouldn't be too much, and I think this change may actually be faster than serializing the decon operators in a parallel workflow.

 The other issue I revealed when testing it is that the decon operator depends on the `PFPATH` env that is not defined in either our test workflow or the docker container. I am not sure how you were able to use it in the container previously. Maybe we should change the default `PFPATH` to be a relative path to the already defined `MSPASS_HOME`.