### PR TITLE
Add taper functions

### DIFF
--- a/cxx/python/algorithms/basic_py.cc
+++ b/cxx/python/algorithms/basic_py.cc
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <mspass/algorithms/algorithms.h>
 #include <mspass/algorithms/Butterworth.h>

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -148,7 +148,25 @@ PYBIND11_MODULE(seismic, m) {
     )", scope);
 
   /* We need one of these for each std::vector container to make them function correctly*/
-  py::bind_vector<std::vector<double>>(m, "DoubleVector");
+  py::bind_vector<std::vector<double>> (m, "DoubleVector")
+    .def("__add__", [](const std::vector<double> &a, py::object b) {
+      return py::module_::import("mspasspy.ccore.seismic").attr("DoubleVector")(
+        py::array(a.size(), a.data(), py::none()).attr("__add__")(b));
+    })
+    .def("__sub__", [](const std::vector<double> &a, py::object b) {
+      return py::module_::import("mspasspy.ccore.seismic").attr("DoubleVector")(
+        py::array(a.size(), a.data(), py::none()).attr("__sub__")(b));
+    })
+    .def("__mul__", [](const std::vector<double> &a, py::object b) {
+      return py::module_::import("mspasspy.ccore.seismic").attr("DoubleVector")(
+        py::array(a.size(), a.data(), py::none()).attr("__mul__")(b));
+    })
+    .def("__truediv__", [](const std::vector<double> &a, py::object b) {
+      return py::module_::import("mspasspy.ccore.seismic").attr("DoubleVector")(
+        py::array(a.size(), a.data(), py::none()).attr("__truediv__")(b));
+    })
+  ;
+  
   /* We define the following as global such that it can be used in the algorithms.basic module.
      The usage is documented here:
      https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#binding-stl-containers

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -183,6 +183,18 @@ PYBIND11_MODULE(seismic, m) {
     .def("baz",&SlownessVector::baz,"Return the so called back azimuth defined by a slowness vector")
     .def_readwrite("ux",&SlownessVector::ux,"Slowness component in the x (Easting) direction")
     .def_readwrite("uy",&SlownessVector::uy,"Slowness component in the y (Northing) direction")
+    .def(py::pickle(
+      [](const SlownessVector &self) {
+          return py::make_tuple(self.ux, self.uy, self.azimuth());
+      },
+      [](py::tuple t) {
+        double xbuf = t[0].cast<double>();
+        double ybuf = t[1].cast<double>();
+        double abuf = t[2].cast<double>();
+        SlownessVector sv(xbuf, ybuf, abuf);
+        return sv;
+      }
+     ))
   ;
 
   py::enum_<TimeReferenceType>(m,"TimeReferenceType")

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -211,6 +211,18 @@ PYBIND11_MODULE(utility, m) {
     .def_readwrite("radius", &SphericalCoordinate::radius,"R of spherical coordinates")
     .def_readwrite("theta", &SphericalCoordinate::theta,"zonal angle of spherical coordinates")
     .def_readwrite("phi", &SphericalCoordinate::phi,"azimuthal angle of spherical coordinates")
+    .def(py::pickle(
+      [](const SphericalCoordinate &self) {
+          return py::make_tuple(self.radius, self.theta, self.phi);
+      },
+      [](py::tuple t) {
+        double rbuf = t[0].cast<double>();
+        double tbuf = t[1].cast<double>();
+        double pbuf = t[2].cast<double>();
+        SphericalCoordinate xsc = {rbuf, tbuf, pbuf};
+        return xsc;
+      }
+     ))
   ;
 
   py::class_<BasicMetadata,PyBasicMetadata>(m,"BasicMetadata")

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -1,4 +1,5 @@
 from mspasspy.util.decorators import mspass_func_wrapper
+from mspasspy.ccore.algorithms.basic import LinearTaper, CosineTaper, VectorTaper
 
 @mspass_func_wrapper
 def ator(data, tshift, *args,
@@ -175,3 +176,100 @@ def transform(data, matrix, *args,
     :param inplace_return: True to return data in mspass_func_wrapper. This is necessary to be used in mapreduce.
     """
     data.transform(matrix)
+
+@mspass_func_wrapper
+def linear_taper(data, t0head, t1head, t1tail, t0tail, *args,
+        object_history=False, alg_name=None, alg_id=None, dryrun=False,
+        inplace_return=True, function_return_key=None, **kwargs):
+    """
+    Taper front and/or end of a data object with a linear taper.
+
+    Linear tapers are defined here as a time spanning a ramp running from 0 to 1.
+    Data will be zeroed on each end of a 0 mark and a linear weight applied between
+    0 points and 1 points.  Postive ramp slope on left and negative slope ramp on
+    right. Setting t0 == t1 will disable the taper on the specified end (e.g., t0head == t1head).
+
+    :param data: data object to be processed.
+    :type data: either :class:`~mspasspy.ccore.seismic.TimeSeries` or :class:`~mspasspy.ccore.seismic.Seismogram`
+    :param t0head: t0 of the head taper
+    :type t0head: :class:`float`
+    :param t1head: t1 of the head taper
+    :type t1head: :class:`float`
+    :param t1tail: t1 of the tail taper
+    :type t1tail: :class:`float`
+    :param t0tail: t0 of the tail taper
+    :type t0tail: :class:`float`
+    :param object_history: True to preserve the processing history. For details, refer to
+     :class:`~mspasspy.util.decorators.mspass_func_wrapper`.
+    :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
+    :type alg_name: :class:`str`
+    :param alg_id: alg_id is a unique id to record the usage of func while preserving the history.
+    :type alg_id: :class:`bson.objectid.ObjectId`
+    :param dryrun: True for dry-run, which return "OK". Used in the mspass_func_wrapper.
+    :param inplace_return: True to return data in mspass_func_wrapper. This is necessary to be used in mapreduce.
+    """
+    taper = LinearTaper(t0head, t1head, t1tail, t0tail)
+    taper.apply(data)
+
+@mspass_func_wrapper
+def cosine_taper(data, t0head, t1head, t1tail, t0tail, *args,
+        object_history=False, alg_name=None, alg_id=None, dryrun=False,
+        inplace_return=True, function_return_key=None, **kwargs):
+    """
+    Taper front and/or end of a data object with a half cosine function.
+
+    A cosine taper is a common, simple approach to taper data.  When applied at the
+    front it defnes a half cycle of a cosine curve +1.0 in range -pi to 0.  On
+    the right it defines the same function for the range 0 to pi.  The period
+    of the left and right operator can be different.  Turn off left or right by
+    giving illegal start and end points and the operator will silently be
+    only one sided.
+
+    :param data: data object to be processed.
+    :type data: either :class:`~mspasspy.ccore.seismic.TimeSeries` or :class:`~mspasspy.ccore.seismic.Seismogram`
+    :param t0head: t0 of the head taper
+    :type t0head: :class:`float`
+    :param t1head: t1 of the head taper
+    :type t1head: :class:`float`
+    :param t1tail: t1 of the tail taper
+    :type t1tail: :class:`float`
+    :param t0tail: t0 of the tail taper
+    :type t0tail: :class:`float`
+    :param object_history: True to preserve the processing history. For details, refer to
+     :class:`~mspasspy.util.decorators.mspass_func_wrapper`.
+    :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
+    :type alg_name: :class:`str`
+    :param alg_id: alg_id is a unique id to record the usage of func while preserving the history.
+    :type alg_id: :class:`bson.objectid.ObjectId`
+    :param dryrun: True for dry-run, which return "OK". Used in the mspass_func_wrapper.
+    :param inplace_return: True to return data in mspass_func_wrapper. This is necessary to be used in mapreduce.
+    """
+    taper = CosineTaper(t0head, t1head, t1tail, t0tail)
+    taper.apply(data)
+    
+@mspass_func_wrapper
+def vector_taper(data, taper_array, *args,
+        object_history=False, alg_name=None, alg_id=None, dryrun=False,
+        inplace_return=True, function_return_key=None, **kwargs):
+    """
+    Apply a general taper defined by a vector to the data object.
+
+    This method provides a simple way to build a taper from a set of uniformly
+    spaced points. The apply methods will dogmatically only accept input
+    data of the same length as the taper defined in the operator. 
+
+    :param data: data object to be processed.
+    :type data: either :class:`~mspasspy.ccore.seismic.TimeSeries` or :class:`~mspasspy.ccore.seismic.Seismogram`
+    :param taper_array: the array that defines the taper
+    :type taper_array: :class:`numpy.array`
+    :param object_history: True to preserve the processing history. For details, refer to
+     :class:`~mspasspy.util.decorators.mspass_func_wrapper`.
+    :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
+    :type alg_name: :class:`str`
+    :param alg_id: alg_id is a unique id to record the usage of func while preserving the history.
+    :type alg_id: :class:`bson.objectid.ObjectId`
+    :param dryrun: True for dry-run, which return "OK". Used in the mspass_func_wrapper.
+    :param inplace_return: True to return data in mspass_func_wrapper. This is necessary to be used in mapreduce.
+    """
+    taper = VectorTaper(taper_array)
+    taper.apply(data)

--- a/python/tests/algorithms/test_basic.py
+++ b/python/tests/algorithms/test_basic.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from mspasspy.ccore.seismic import Seismogram, SlownessVector
 from mspasspy.ccore.utility import SphericalCoordinate
-from mspasspy.algorithms.basic import ator, rtoa, rotate, rotate_to_standard, free_surface_transformation, transform
+from mspasspy.algorithms.basic import ator, rtoa, rotate, rotate_to_standard, free_surface_transformation, transform, linear_taper, cosine_taper, vector_taper
 
 # module to test
 sys.path.append("python/tests")
@@ -104,3 +104,43 @@ def test_transform():
                        np.array([[-0.171012, -0.469846,  0],
                                  [0.115793, -0.0421458, 0.445447],
                                  [-0.597975,  0.217647,  0.228152]]))).all()
+
+def test_taper():
+    ts = get_live_timeseries()
+    ts.t0 = 0
+    ts.dt = 1
+    ts.npts = 200
+    ts.data += 1
+
+    ts_l = linear_taper(ts, 4, 14, 170, 180)
+    assert ts_l.data[4] == 0
+    assert ts_l.data[9] == 0.5
+    assert ts_l.data[14] == 1
+    assert ts_l.data[170] == 1
+    assert ts_l.data[175] == 0.5
+    assert ts_l.data[180] == 0
+
+    
+    ts.npts = 200
+    ts.data += 1
+    
+    ts_c = cosine_taper(ts, 4, 14, 170, 180)
+    assert ts_c.data[4] == 0
+    assert ts_c.data[9] == 0.5
+    assert ts_c.data[14] == 1
+    assert ts_c.data[170] == 1
+    assert ts_c.data[175] == 0.5
+    assert ts_c.data[180] == 0
+
+    ts.npts = 200
+    ts.data += 1
+    
+    vtaper = np.zeros(200)
+    vtaper += 0.5
+    ts_v = vector_taper(ts, vtaper)
+    assert ts_v.data[4] == 0.5
+    assert ts_v.data[9] == 0.5
+    assert ts_v.data[14] == 0.5
+    assert ts_v.data[170] == 0.5
+    assert ts_v.data[175] == 0.5
+    assert ts_v.data[180] == 0.5

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -598,6 +598,12 @@ def test_Seismogram():
     assert all(np.isclose(seis.data[:, 3], [0, 0, 1]))
     seis.rotate_to_standard()
 
+    # test for serialization of SphericalCoordinate
+    sc_copy = pickle.loads(pickle.dumps(sc))
+    assert sc_copy.radius == sc.radius
+    assert sc_copy.theta == sc.theta
+    assert sc_copy.phi == sc.phi
+
     a = np.zeros((3, 3))
     a[0][0] = 1.0
     a[0][1] = 1.0
@@ -648,6 +654,13 @@ def test_Seismogram():
 
     seis.tmatrix = a
     assert (seis.tmatrix == a).all()
+
+    
+    # test for serialization of SlownessVector
+    uvec_copy = pickle.loads(pickle.dumps(uvec))
+    assert uvec_copy.ux == uvec.ux
+    assert uvec_copy.uy == uvec.uy
+    assert uvec_copy.azimuth() == uvec.azimuth()
 
 
 @pytest.fixture(params=[TimeSeriesEnsemble, SeismogramEnsemble])


### PR DESCRIPTION
While working out the parallel workflow for the tutorial, we found that the taper functions also needs to be serializable. This branch includes the following changes:

- added wrapper function for tapers
- added basic algorithmic methods for the `DoubleVector` object and it now behaves more close to a numpy array
- made SphericalCoordinate and SlownessVector serializable as they can be used as arguments in a map call to certain algorithms