### PR TITLE
bigfix for decorator error handling

### DIFF
--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -100,6 +100,9 @@ def mspass_func_wrapper(func, data, *args, object_history=False, alg_id=None, al
         else:
             logging_helper.ensemble_error(
                 data, alg_name, err, ErrorSeverity.Invalid)
+        # some unexpected error happen, if inplace_return is true, we may want to return the original data
+        if inplace_return:
+            return data
     except MsPASSError as ex:
         if ex.severity == ErrorSeverity.Fatal:
             raise
@@ -108,6 +111,9 @@ def mspass_func_wrapper(func, data, *args, object_history=False, alg_id=None, al
         else:
             logging_helper.ensemble_error(
                 data, alg_name, ex.message, ex.severity)
+        # some unexpected error happen, if inplace_return is true, we may want to return the original data
+        if inplace_return:
+            return data
 
 
 @decorator

--- a/python/tests/algorithms/test_basic.py
+++ b/python/tests/algorithms/test_basic.py
@@ -105,6 +105,10 @@ def test_transform():
                                  [0.115793, -0.0421458, 0.445447],
                                  [-0.597975,  0.217647,  0.228152]]))).all()
 
+    # test with invalid uvec, but inplace return
+    seis4 = free_surface_transformation(seis2, SlownessVector(1.0, 1.0, 0.0), 5.0, 3.5)
+    assert seis4
+
 def test_taper():
     ts = get_live_timeseries()
     ts.t0 = 0

--- a/python/tests/algorithms/test_basic.py
+++ b/python/tests/algorithms/test_basic.py
@@ -51,7 +51,7 @@ def test_rotate():
     seis2 = rotate(seis, sc)
     assert all(np.isclose(seis2.data[:, 3], [0, -0.707107, 0.707107]))
     seis3 = rotate_to_standard(seis2)
-    assert all(seis3.data[:, 3] == [0, 0, 1])
+    assert all(np.isclose(seis3.data[:, 3], [0, 0, 1]))
 
 def test_transform():
     seis = Seismogram()


### PR DESCRIPTION
bugfix for decorators:
when there is an error when running the try block in the mspass_func_wrapper and inplace_return is True, we better return the original data object so that it won't block the downstream processing.