### PR TITLE
Improve slowness vector

### DIFF
--- a/cxx/include/mspass/seismic/SlownessVector.h
+++ b/cxx/include/mspass/seismic/SlownessVector.h
@@ -1,6 +1,9 @@
 #ifndef _SLOWNESS_H_
 #define _SLOWNESS_H_
 #include <string>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+
 namespace mspass::seismic
 {
 /*! \brief Slowness vector object.  
@@ -74,7 +77,14 @@ slowness vector is 0.
 /* \brief Standard subraction  operator. */
         const SlownessVector operator-(const SlownessVector& other) const;
 private:
-	double azimuth0;
+    double azimuth0;
+    template<class Archive>
+       void serialize(Archive& ar,const unsigned int version)
+    {
+      ar & ux;
+      ar & uy;
+      ar & azimuth0;
+    };
 };
 
 } // End mspass::seismic namespace declaration

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -177,7 +177,12 @@ PYBIND11_MODULE(seismic, m) {
   py::class_<SlownessVector>(m,"SlownessVector","Encapsulate concept of slowness vector describing wave propagation")
     .def(py::init<>())
     .def(py::init<const SlownessVector&>())
-    .def(py::init<const double, const double, const double>())
+    /* This obscure syntax is used for setting keyword args for a constructor.
+    We want it here because we want to normally default az0.   
+    This obscure trick came from:  https://github.com/pybind/pybind11/issues/579*/
+    .def(py::init<const double, const double, const double>(),
+      py::arg("ux")=0.0,py::arg("uy")=0.0,py::arg("az0")=0.0
+    )
     .def("mag",&SlownessVector::mag,"Return the magnitude of the slowness vector")
     .def("azimuth",&SlownessVector::azimuth,"Return the azimuth of propagation defined by this slowness vector")
     .def("baz",&SlownessVector::baz,"Return the so called back azimuth defined by a slowness vector")


### PR DESCRIPTION
This is a fairly trivial repair to fix two issues I found with SlownessVector:
1.  The API has a necessary parameter for setting the azimuth the object returns if a vector has zero length.  Otherwise one would get a NaN.  The fully parameterized constructor allows changing that but the C++ include has a default of the azimuth0 value to 0.  A C++ default does not port to python directly in any way.  I added a simple, but obscure change to the pybind11 definition of that constructor to give use keyword arguments with default values.  The syntax is very weird and serves as a useful example I hadn't seen before. 
2. I added boost serializiation code for SlownessVector to the include file.  Not essential for the python code, but a necessary evil for pwmig where I need to serialize a std:;vector<SlownessVector> container.   I don't think the boost code adds any significant baggage to the code base and extends its capability in the way I'm using it in pwmig.  

I didn't put any test in for this new code as the changes are really quite trivial.  