### PR TITLE
Fix bug when t0shift options is used

### DIFF
--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -291,10 +291,10 @@ def WindowData(d, win_start, win_end, t0shift=None,
     try:
         # This handler duplicates an error test in the WindowData C code but
         # it will be more efficient to handle it here.
-        if win_start < d.t0 or win_end > d.endtime():
+        if tscut.start < d.t0 or twcut.end > d.endtime():
             detailline = 'Window range: {wst},{wet}  Data range:  {dst},{det}'.format(
-                wst=win_start,
-                wet=win_end,
+                wst=tscut.start,
+                wet=tscut.end,
                 dst=d.t0,
                 det=d.endtime()
             )

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -291,10 +291,10 @@ def WindowData(d, win_start, win_end, t0shift=None,
     try:
         # This handler duplicates an error test in the WindowData C code but
         # it will be more efficient to handle it here.
-        if tscut.start < d.t0 or twcut.end > d.endtime():
+        if twcut.start < d.t0 or twcut.end > d.endtime():
             detailline = 'Window range: {wst},{wet}  Data range:  {dst},{det}'.format(
-                wst=tscut.start,
-                wet=tscut.end,
+                wst=twcut.start,
+                wet=twcut.end,
                 dst=d.t0,
                 det=d.endtime()
             )


### PR DESCRIPTION
This fixes a bug in WindowData that did not handle the t0shift options correctly.  It failed every time it was called because the range test used did not apply the shift when that was enabled.  The changes are pretty trivial so I advise you simply merge this branch immediately. 

Longer term action is needed to have the tests check the t0shift option.  This bug was present because that test was missing.   I looked at the test code and decided it was not so trivial to fix because the existing test code is not set up for utc data where this feature would be used.   Advise you accept this pull request and post adding such a test to the fairly short term development agenda.