### PR TITLE
Add data editing functionality

### DIFF
--- a/docs/source/user_manual/DataEditing.rst
+++ b/docs/source/user_manual/DataEditing.rst
@@ -1,0 +1,349 @@
+Data Editing
+=======================
+Concepts
+------------
+MsPASS uses an idea that has been a part of seismic reflection from the
+earliest days of digital processing of seismic signals commonly called
+trace editing.   Trace editing means removing "bad" data from subsequent
+processing where the meaning of "bad" is based on some computed metric or
+human editing using a graphical user interface.   In all cases, the decision
+of "good" or "bad" is not grey but a black and white (boolean) decision.
+We implement this concept in MsPASS through a boolean `live` attribute
+that is a component of all MsPASS data objects (i.e. both atomic data
+TimeSeries and Seismogram as well as ensembles of same).   Any MsPASS
+data object can be "killed" by callig it's `kill` method.   Algorithms
+can and always should test the attribute `live` to verify the data object
+has data that can be viewed as valid.  No algorithm should ever assume
+data marked dead (live set False) can be used for any further processing.
+
+In MsPASS we abstract the process of defining "trace editing" through
+a standardized API.  In this section of the manual we describe how to
+use the generic metrics that are part of MsPASS.   We also show how
+users can add custom metrics by either computing custom Metadata or
+running an inline computation on the sample data.
+
+MsPASS Trace Editing Algorithms
+----------------------------------
+Binary Comparison operators - example for starters
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+All the algorithms currently implemented in MsPASS use another model
+borrowed from seismic reflection processing.  That is, the editing is
+driven by tests of the values of one or more "header" (As noted
+elsewhere MsPASS data defined a generalized "header" we call Metadata)
+attributes.   That means all standard numeric comparison operators
+(in python the >, <, <=, >=, ==, and != operators).
+
+Before defining the abstraction and the common API it is, perhaps, more
+instructive to give an example.   Suppose we wanted to exclude
+all data from processing that have an estimated bandwidth less than 12 dB
+(2 octaves).   This is an example serial job looping over an entire
+dataset defined by Seismogram objects::
+
+  ... Preceding code: import commands and creating database handle db ...
+
+  editor = MetadataLT("bandwidth",12.0)
+  query = {}   # Change to a MongoDB query too process data subset
+  cursor = db.wf_Seismogram.find(query)
+  for doc in cursor:
+    d = db.read_data(doc)
+    d = arrival_snr_QC(d)
+    d = editor.kill_if_true(d)
+
+
+We made this example as simple as possible by using all defaults for the
+function arrival_snr_QC.   That function has many options and depends upon
+a detail that the example assumes was prevous computed;  the Metadata attribute
+"Parrival" is assumed to have been set to a time within the time interval
+spanned by each datum.  A key step is the creation of the python class
+`MetadataLT` in the first line.  The name is mean to be mnemonic for
+using a Metadata test with the "Less Than (LT or python <)" operation
+using the value stored in Metadata with the key "bandwidth".   We use the
+`kill_if_true` method of `MetadataLT` to implement the test.  That method
+will return a version of `d` marked dead if the value of "bandwidth" is
+less than 12.0.
+
+For completeness here is a parallel version of
+that same script using dask::
+
+  editor = MetadataLT("bandwidth",12.0)
+  query = {}
+  seisbag = db.read_distributed_data(db,query)
+  seisbag = seisbag.map(arrival_snr_QC)
+  seisbag = seisbag.map(editor.kill_if_true)
+
+
+where we also removed the comments and omit the (required to do anything)
+call to `seisbag.compute()` because this example would always be
+most appropriate as a section inside a workflow.   A call to compute at the
+end of that segment would likely produce a memory fault for anything but a
+small data set.  For more on that issue sections in parallel processing.
+
+All Binary Comparisons
++++++++++++++++++++++++++++
+All the binary comparison operators using tests against a Metadata attribute
+Have the same, common API with the following elements:
+
+#. All are implemented as a subclass of an (abstract) base class called
+   Executioner.
+#. All have and one and only one constructor.
+#. All the constructors have have two required, positional argument.  The
+   first is the Metadata key whose value is to compared to the value set
+   as arg1 (pyhon numbering starting at 0).  In the example above the key
+   is "bandwidth" and the test value is 12.0.
+#. All have an optional `verbose` boolean argument.  When set True all kills
+   will generate an informational error log entry with a detailed message
+   on why the datum was killed.   The default, in all cases, is False because
+   trace editing of data of large data sets can produce bloated error logs
+   when done in verbose mode.
+#. All have names of the form `MetadataXX` with `Metadata` a fixed string and
+   XX the Fortranish name for the corresponding binary comparison.  For
+   instance, in the example above we used `MetadataLT` which means the
+   comparison used is the python < operator.
+#. All implement the (required) method kill_if_true.   As the name implies
+   that method kills the datum if the conditional defined in construction of
+   the object resolves true.   For our example above that means if `x` is the value
+   extracted from Metadata and `a` is the bound set as arg1 in the constructor,
+   the datum is killed if `x<a`.  This method always returns a copy of the
+   data passed to it marked dead or alive depending on the outcome of the
+   test.  That is essential for use of the function in a map operator like
+   our parallel example above. All will throw a MsPASSError exception
+   if the data received is not one of the data objects known to MsPASS.
+   All implementations also silently do nothing if the input is already marked
+   dead.
+
+The following is a table of the names of all the binary comparison functions
+showing the common API.   In each cell `x` is the value extracted from
+Metadata and `a` is the bound for the binary test.  Both the key and `a`
+are defined on construction of the class.  The `kill_if_true` method
+kills the datum if the test shown resolves as True.
+
+.. list-table:: Binary Metadata-based Edit Classes
+   :width: 50,50
+   :header-rows: 1
+
+   * - Class name
+     - Kill Test
+   * - MetadataGT
+     - x >  a
+   * - MetadataGE
+     - x >= a
+   * - MetadataEQ
+     - x == a
+   * - MetadataNE
+     - x != a
+   * - MetadataLT
+     - x < a
+   * - MetadataLE
+     - x <= a
+
+The constructors for all binary comparison testers have this the following,
+common signature:
+
+```
+def __init__(self,key,value,verbose=False):
+```
+
+where `key` is the Metadata key used to fetch the data for `x` in the
+table above and `value` is the value assigned to `a`.
+
+The verbose flag is a common argument for all the MsPASS metadata-based
+testers.   Normally (default verbose=False) kills are done silently.
+When set true all kills will generate an `Informational` elog entry with
+a detailed message giving the details of why the datum was killed.  In
+all cases verbose defaults false because often editors can kill a significant
+fraction of raw data and generate bloated elog collections when result of
+the workflow is saved.
+
+Existence Tests
+++++++++++++++++++++++
+Unlike classical header implementations that have fixed slots that
+always have data in them, Metadata is open-ended and data for a particular
+key may or may not exist.   We thus supply two existence classes.
+The class names are `MetadataDefined` and `MetadataUndefined`.   The
+kill_if_true methods for these each kill a datum if a key loaded in
+on construction exists or does not exist respectively.   Both
+have constructors with this signature:
+
+```
+def __init__(self,key,verbose=False):
+```
+
+where `key` is the Metadata key that is to be tested by the kill_if_true
+method.  verbose is as noted above for the binary comparison testers.
+
+`MetadataUndefined` is a particularly important editor to prefilter data
+prior to running one or more processing functions.   If a function requires
+one or more metadata attributes `MetadataUndefined` can be used to
+filter out all data that would cause that algorithm to fail anyway.
+
+Interval Comparison
+++++++++++++++++++++++++
+
+Another common test for editing data is filtering data defined by
+a range of values.   A type example is P wave receiver functions that
+commonly only use data with epicentral distances between about 30 and 100 degrees.
+Another would be the size of some amplitude metric defined by a range of postive values.
+A way to accomplish that within a workflow is to apply an interval filter that
+kills data outside the specified range.
+
+There are two complications in defining a range test.  First, there are two
+mirror-image tests:   is the value to be tested inside an interval or
+outside the interval (like the receiver function distance example above).
+The second is should the test be inclusive of the edges?  i.e. should the
+tests be <= or just < (similarly >= or >)?   That could have been done with
+nine different classes for all the possible combinations of the three boolean
+variables it takes to define all the possibilities.  Instead we implemented
+a single class called `MetadataInterval` with three boolean values defined
+in the constructor.  The constructor has this signature:
+
+```
+def __init__(self,key,lower_endpoint,upper_endpoint,
+   use_lower_edge=True, use_upper_edge=True, kill_if_outside=True,verbose=False):
+```
+
+The three booleans (`use_upper_edge`, `use_lower_edge`, and `kill_if_outside`)
+determine how equality with the edges is handled and if the test is "inside" or
+"outside" the specified range.  These are defined in the table below noting
+that in the table `a=lower_endpoint` and `b=upper_endpoint`.  In all cases
+True means if the test is true the datum will be marked dead.
+
+.. list-table:: MetadataInterval operators
+   :width: 30,30,30,30
+   :header-rows: 1
+
+   * - use_lower_edge
+     - use_upper_edge
+     - inside_test
+     - Kill test
+   * - True
+     - True
+     - True
+     - a <= x <= b
+   * - False
+     - True
+     - True
+     - a < x <= b
+   * - True
+     - False
+     - True
+     - a <= x < b
+   * - False
+     - False
+     - True
+     - a < x < b
+   * - True
+     - True
+     - False
+     - x <= a and x >= b
+   * - False
+     - True
+     - False
+     - x < a and x >= b
+   * - True
+     - False
+     - False
+     - x <= a and x > b
+   * - False
+     - False
+     - False
+     - x < a and x > b
+
+
+
+Defining Multiple Editors
+++++++++++++++++++++++++++++++
+
+The final Metadata-based editor in MsPASS was given the name `FiringSquad`.
+Although the name is admittedly a bit tongue-in-cheek, the imagery the name
+provokes describes the function well:  a datum facing a firing squad
+is facing multiple executioner who may or may not kill you.   This class
+has a signature similar to the other Metadata-based editors:
+
+```
+   class FiringSquad(Executioner):
+```
+
+Meaning it inherits the base class `Executioner` and requires a custom
+implementation of the `kill_if_true` method. It can be used alone in
+a workflow exactly like the single test functions described above.
+A `FiringSquad` is simply a way to apply multiple Metadata tests
+in a single function call to the `kill_if_true` method.
+
+As with MetadataInterval
+the constructor is different and has this signature::
+
+  def __init__(self,executioner_list,verbose=False):
+
+where `executioner_list` is expected to be any iterable container made up
+only of python classes that are subclasses of Executioner. (All the classes
+covered in this document are subclasses of Executioner.)  Verbose has the
+same meaning as described above with an important exception.  It is no
+global but refers only to errors internal to `FiringSquad`.  Any testers
+having a verbose option will have have an independent verbose flag applied.
+
+When the `kill_if_true` method is called for this class the list of
+executioners are called in order defined by the list.  The victim cannot
+be hit by more than one bullet.  Once a datum is killed the `kill_if_true`
+method returns the body and drops further tests.
+
+A feature of a `FiringSquad` not enabled in any of the other classes described
+in this document is it implements operator +=.  Its use is to append an
+additional test to an existing `FiringSquad`.   e.g. suppose we had a workflow
+that creates a `FiringSquad` associated with the symbol `squad`.  The
+example below creates a <= test against the Metadata key "mad_snr" and
+adds it to the list of test in `squad`::
+
+ maddog = MetadataLE("mad_snr",4.0)
+ squad += maddog
+
+Finally, note it is possible to have recursive `FiringSquad` tests.  That is, a
+`FiringSquad` can itself contain another `FiringSquad` as one of the
+tests set in the `executioner_list` passed on construction.
+
+How to Implement an Extension
+--------------------------------
+Before considering developing an extension editor consider seriously if
+what you need can be accomplished with one of two alternatives:
+
+#.  Can the test be cast into a composite `FiringSquad` with the right components.
+#.  If you need to compute some nonstandard quantity from the sample data ask
+    yourself if the result can be reduced to a small set of numbers that can
+    be saved as Metadata?   If so, you can focus on the unique calculations and
+    have the code post the results to Metadata.
+    There is a high probability you can then
+    use one or more of the classes described above to apply the needed
+    test.
+
+Anyone familiar with a basic understanding of
+inheritance in an object-oriented language in general and python in particular
+will recognize our implementation of all the classes described above as
+textbook applications of inheritance.  A custom extension that can plug into
+this same class structure must do two things:
+
+#.   The class declaration must declare it to be a subclass of `Executioner`.
+#.   The class MUST implement a custom `kill_if_true` method.
+
+In addition, almost any implementation will require a base constructor
+(i.e. the line `def __init__(self,...args..):`)
+defining internal parameters that define the boundaries of the kill test.
+The kill_if_true method would normally use "self" parameters set by the
+constructor.
+
+Some key points about extensions:
+
+*  Our examples all use attributes fetched from Metadata.  That is NOT a
+   requirement.  Many algorithms are possible that would compute a test
+   directly from sample data.  Be warned, however, that different MsPASS data objects all have
+   fundamentally different sample data organizations.  Hence, a class that
+   handles sample data would require a test for the unique data to which
+   it could be applied.
+*  Our examples are dogmatic in requiring the data be MsPASS data objects.
+   That is required because the implementation uses the kill method that
+   the caller can be assured is part of the data object received.  Extensions
+   that can plug in cleanly (e.g. as a member of a `FiringSquad`) should do
+   the same test for MsPASS data objects.  That test is standardized in the
+   base class method `input_is_valid`.   Use of that method in
+   extensions is strongly advised to avoid unexpected aborts.
+*  Consider implementing the verbose option as described here for consistency.
+*  As with many things like this the best way to see how to build is an
+   extension is to use the class implementations described above as examples.

--- a/python/mspasspy/algorithms/edit.py
+++ b/python/mspasspy/algorithms/edit.py
@@ -1,0 +1,655 @@
+from abc import ABC, abstractmethod
+from mspasspy.ccore.seismic import (TimeSeries,
+                                    Seismogram,
+                                    TimeSeriesEnsemble,
+                                    SeismogramEnsemble)
+from mspasspy.ccore.utility import (MsPASSError,
+                                    ErrorSeverity)
+# Use of abstract base class based on:
+# https://python-course.eu/oop/the-abc-of-abstract-base-classes.php
+class Executioner(ABC):
+    """
+    Abstract base class for family of python classes used for killing
+    mspass data objects failing to pass a particular metric.
+    It is made abstract to define required methods a particular instance
+    must create.  As in any good OOP that also means subclasses can
+    add additional methods.   This class should be used only as base 
+    class as it has no functionality by itself.
+    """
+
+    @abstractmethod
+    def kill_if_true(self,d):
+        """
+        This method should run a test on d that will call the kill method 
+        on MsPASS atomic object d if the test defined by the implementation 
+        fails.  This is the main working method of this class of function 
+        objects.
+        """
+        pass
+
+    def input_is_valid(self,d):
+        """
+        This is a common method all instances of this class needed for
+        mspass.  It uses isinstance tests of d to standardize the test that
+        the input is valid data.  It returns True if d is one a valid data
+        object known to mspass.  Returns false it not.  Caller must decide
+        what to do if the function returns false.
+        """
+        if isinstance(d,(TimeSeries,Seismogram,TimeSeriesEnsemble,SeismogramEnsemble)):
+            return True
+        else:
+            return False
+    def log_kill(self,d,testname,message,severity=ErrorSeverity.Informational):
+        """
+        This base class method is used to standardize the error logging 
+        functionality of all Executioners.   It writes a standardized 
+        message to simplify writing of subclasses - they need only 
+        define the testname (normally the name of the subclass) and 
+        format a specific message to be posted.  
+        
+        Note most subclasses will may want to include a verbose option 
+        (or the reciprocal silent) and only write log messages when 
+        verbose is set true.  
+        
+        :param d:  MsPASS data object to which elog message is to be 
+          written.
+        :param testname: is the string assigned to the "algorithm" field 
+        of the message posted to d.elog.
+        :param message:  specialized message to post - this string is added 
+        to an internal generic message.
+        :param severity:  ErrorSeverity to assign to elog message 
+        (See ErrorLogger docstring).  Default is Informational
+        """
+        if self.input_is_valid(d):
+            kill_message = "Killed by kill_if_true method.  Reason:\n"
+            kill_message += message
+            d.elog.log_error(testname,kill_message,severity)
+        else:
+            raise MsPASSError("Execution.log_kill method received invalid data;  must be a MsPASS data object",
+                              ErrorSeverity.Fatal)
+
+
+class MetadataGT(Executioner):
+    """
+    Implementation of Executioner using a greater than test of a 
+    Metadata attribute.  Both the metadata key and the threshold 
+    for the kill test are set on creation.  This implementation should 
+    work on any value pairs for which the > operator in python works. 
+    That is true for pairs of numeric types, for example, but will fail 
+    if one of the pair is a string (an error anyway for any rational use of this).
+    It should also work for any pair of pyobjects for which operator > is defined, 
+    although anything nonstandard should be tested carefully before using 
+    this class for editing data with such nonstandard types.  This was 
+    mostly intended for simple numeric attributes.
+    """
+    def __init__(self,key,value,verbose=False):
+        """
+        One and only constructor.  Sets the parameters that define this 
+        tester.
+        
+        :param key:  key used for extracting a Metadata component for test
+        :param value:  is the threshold value for the test.
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.value = value
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if the d[self.key] > value stored with the class.
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if self.key in d:
+                testval = d[self.key]
+                if testval > self.value:
+                    d.kill()
+                    if self.verbose:
+                        message = "Value associated with key={key} of {dval} is greater than test value={value}".format(
+                            key=self.key,dval=d[self.key],value=self.value)
+                        self.log_kill(d,"MetadataGT",message)
+        else:
+            raise MsPASSError("MetadataGT received invalid input data",ErrorSeverity.Fatal)
+        return d
+
+class MetadataGE(Executioner):
+    """
+    Implementation of Executioner using a greater than or equal test of a 
+    Metadata attribute.  Both the metadata key and the threshold 
+    for the kill test are set on creation.  This implementation should 
+    work on any value pairs for which the >= operator in python works. 
+    That is true for pairs of numeric types, for example, but will fail 
+    if one of the pair is a string (an error anyway for any rational use of this).
+    It should also work for any pair of pyobjects for which operator >= is defined, 
+    although anything nonstandard should be tested carefully before using 
+    this class for editing data with such nonstandard types.  This was 
+    mostly intended for simple numeric attributes.
+    """
+    def __init__(self,key,value,verbose=False):
+        """
+        One and only constructor.  Sets the parameters that define this 
+        tester.
+        
+        :param key:  key used for extracting a Metadata component for test
+        :param value:  is the threshold value for the test.
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.value = value
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if the d[self.key] >= value stored with the class.
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if self.key in d:
+                testval = d[self.key]
+                if testval >= self.value:
+                    d.kill()
+                    if self.verbose:
+                        message = "Value associated with key={key} of {dval} is >= test value={value}".format(
+                            key=self.key,dval=d[self.key],value=self.value)
+                        self.log_kill(d,"MetadataGE",message)
+        else:
+            raise MsPASSError("MetadataGE received invalid input data",ErrorSeverity.Fatal)
+        return d
+
+class MetadataLT(Executioner):
+    """
+    Implementation of Executioner using a lessthan test of a 
+    Metadata attribute.  Both the metadata key and the threshold 
+    for the kill test are set on creation.  This implementation should 
+    work on any value pairs for which the < operator in python works. 
+    That is true for pairs of numeric types, for example, but will fail 
+    if one of the pair is a string (an error anyway for any rational use of this).
+    It should also work for any pair of pyobjects for which operator < is defined, 
+    although anything nonstandard should be tested carefully before using 
+    this class for editing data with such nonstandard types.  This was 
+    mostly intended for simple numeric attributes.
+    """
+    def __init__(self,key,value,verbose=False):
+        """
+        One and only constructor.  Sets the parameters that define this 
+        tester.
+        
+        :param key:  key used for extracting a Metadata component for test
+        :param value:  is the threshold value for the test.
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.value = value
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if the d[self.key] > value stored with the class.
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if self.key in d:
+                testval = d[self.key]
+                if testval < self.value:
+                    d.kill()
+                    if self.verbose:
+                        message = "Value associated with key={key} of {dval} is < than test value={value}".format(
+                            key=self.key,dval=d[self.key],value=self.value)
+                        self.log_kill(d,"MetadataLT",message)
+        else:
+            raise MsPASSError("MetadataLT received invalid input data",ErrorSeverity.Fatal)
+        return d
+
+class MetadataLE(Executioner):
+    """
+    Implementation of Executioner using a less than or equal test of a 
+    Metadata attribute.  Both the metadata key and the threshold 
+    for the kill test are set on creation.  This implementation should 
+    work on any value pairs for which the <= operator in python works. 
+    That is true for pairs of numeric types, for example, but will fail 
+    if one of the pair is a string (an error anyway for any rational use of this).
+    It should also work for any pair of pyobjects for which operator >= is defined, 
+    although anything nonstandard should be tested carefully before using 
+    this class for editing data with such nonstandard types.  This was 
+    mostly intended for simple numeric attributes.
+    """
+    def __init__(self,key,value,verbose=False):
+        """
+        One and only constructor.  Sets the parameters that define this 
+        tester.
+        
+        :param key:  key used for extracting a Metadata component for test
+        :param value:  is the threshold value for the test.
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.value = value
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if the d[self.key] <= value stored with the class.
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if self.key in d:
+                testval = d[self.key]
+                if testval <= self.value:
+                    d.kill()
+                    if self.verbose:
+                        message = "Value associated with key={key} of {dval} is <= to test value={value}".format(
+                            key=self.key,dval=d[self.key],value=self.value)
+                        self.log_kill(d,"MetadataLT",message)
+        else:
+            raise MsPASSError("MetadataLE received invalid input data",ErrorSeverity.Fatal)
+        return d
+
+
+
+class MetadataEQ(Executioner):
+    """
+    Implementation of Executioner using an equality test of a 
+    Metadata attribute.  Both the metadata key and the threshold 
+    for the kill test are set on creation.  This implementation should 
+    work on any value pairs for which the == operator in python works. 
+    That is true for pairs of numeric types, for example, but will fail 
+    if one of the pair is a string (an error anyway for any rational use of this).
+    It should also work for any pair of pyobjects for which operator >= is defined, 
+    although anything nonstandard should be tested carefully before using 
+    this class for editing data with such nonstandard types.  This was 
+    mostly intended for simple numeric attributes.  It can be used for 
+    booleans even though few would write an if statement testing if two 
+    booleans were equal.
+    """
+    def __init__(self,key,value,verbose=False):
+        """
+        One and only constructor.  Sets the parameters that define this 
+        tester.
+        
+        :param key:  key used for extracting a Metadata component for test
+        :param value:  is the threshold value for the test.
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.value = value
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if the d[self.key] == value stored with the class.
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if self.key in d:
+                testval = d[self.key]
+                if testval == self.value:
+                    d.kill()
+                    if self.verbose:
+                        message = "Value associated with key={key} of {dval} is equal to test value={value}".format(
+                            key=self.key,dval=d[self.key],value=self.value)
+                        self.log_kill(d,"MetadataEQ",message)
+        else:
+            raise MsPASSError("MetadataEQ received invalid input data",ErrorSeverity.Fatal)
+        return d
+    
+class MetadataNE(Executioner):
+    """
+    Implementation of Executioner using an not equal (NE) test of a 
+    Metadata attribute.  Both the metadata key and the threshold 
+    for the kill test are set on creation.  This implementation should 
+    work on any value pairs for which the != operator in python works. 
+    That is true for pairs of numeric types, for example, but will fail 
+    if one of the pair is a string (an error anyway for any rational use of this).
+    It should also work for any pair of pyobjects for which operator >= is defined, 
+    although anything nonstandard should be tested carefully before using 
+    this class for editing data with such nonstandard types.  This was 
+    mostly intended for simple numeric attributes.  It can be used for 
+    booleans even though few would write an if statement testing if two 
+    booleans were equal.
+    """
+    def __init__(self,key,value,verbose=False):
+        """
+        One and only constructor.  Sets the parameters that define this 
+        tester.
+        
+        :param key:  key used for extracting a Metadata component for test
+        :param value:  is the threshold value for the test.
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.value = value
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if the d[self.key] != value stored with the class.
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if self.key in d:
+                testval = d[self.key]
+                if testval == self.value:
+                    d.kill()
+                    if self.verbose:
+                        message = "Value associated with key={key} of {dval} is != to test value={value}".format(
+                            key=self.key,dval=d[self.key],value=self.value)
+                        self.log_kill(d,"MetadataNE",message)
+        else:
+            raise MsPASSError("MetadataNE received invalid input data",ErrorSeverity.Fatal)
+        return d
+    
+class MetadataDefined(Executioner):
+    """
+    Implementation of Executioner using an existence test.  The 
+    constructor loads only a key string.   The test for the kill_if_true 
+    method is then simply for the existence of a value associated with 
+    the loaded key.   Data will be killed if the defined key exists 
+    in the Metadata (header).   
+    """
+    def __init__(self,key,verbose=False):
+        """
+        One and only constructor.  Sets the key used for the existence test.
+        
+        :param key:  key used for existence test.
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if self.key is defined for this datum
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if d.is_defined(self.key):
+                d.kill()
+                if self.verbose:
+                    message = "Metadata key={key} is defined".format(key=self.key)
+                    self.log_kill(d,"MetadataDefined",message)
+        else:
+            raise MsPASSError("MetadataDefined received invalid input data",ErrorSeverity.Fatal)
+        return d
+    
+class MetadataUndefined(Executioner):
+    """
+    Implementation of Executioner using an nonexistence test.  The 
+    constructor loads only a key string.   The test for the kill_if_true 
+    method is then simply for the existence of a value associated with 
+    the loaded key.   Data will be killed if the defined key does not exists 
+    (Undefined) in the Metadata (header).   
+    
+    This class is a useful prefilter to apply to any algorithm that 
+    requires a particular metadata attribute.  Use FiringSquad to define 
+    a chain of required metadata to prefilter data input to such an algorithm.
+    """
+    def __init__(self,key,verbose=False):
+        """
+        One and only constructor.  Sets the key used for the existence test.
+        
+        :param key:  key used for existence test.
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if self.key is not defined for this datum
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if not d.is_defined(self.key):
+                d.kill()
+                if self.verbose:
+                    message = "Metadata key={key} is not defined".format(key=self.key)
+                    self.log_kill(d,"MetadataUndefined",message)
+        else:
+            raise MsPASSError("MetadataUndefined received invalid input data",ErrorSeverity.Fatal)
+        return d
+
+class MetadataInterval(Executioner):
+    """
+    Implementation of Executioner based on a numeric range of values. 
+    i.e. it tests if a metadata value is in a range defined by 
+    an upper and lower value.   Ranges have a minor complication in 
+    handling the edge condition: should or should the test not include 
+    the edge?   Rather than write different functions for the four possible 
+    combinations of <=, <, >=, and > that define a range we use 
+    constructor arguments (use_lower_edge and use_upper_edge) to 
+    turn inclusion of the boundary on and off.  
+    
+    In this context an interval test also has two logical alternatives. 
+    One may want to keep data inside an interval (most common and default)
+    or delete data within a specified interval.   That logic is controlled by 
+    the kill_if_outside boolean
+    
+    Intervals mostly make sense only for numeric types (int and float), but 
+    can be used with strings.  In reality this function should work with any 
+    object for which the operators >, <, >=, and >= are defined but that is
+    adventure land if you try.  
+    """
+    def __init__(self, key, lower_endpoint, upper_endpoint, 
+                 use_lower_edge=True, use_upper_edge=True, 
+                 kill_if_outside=True, verbose=False):
+        """
+        One and only constructor.  Sets the parameters that define this 
+        tester.
+        
+        :param key:  key used for extracting a Metadata component for test
+        :param lower_endpoint:  value defining the lower bound of the range test
+        :param upper_endpoint:  value defining the upper_bound of the range test
+        :parame use_lower_edge: if true (default) the lower range test uses 
+          >= lower_endpoint.  When false uses >.
+        :param use_upper_edge: if true (default) the upper range test uses 
+          <= uper_endpoint.  When false uses <. 
+        :param kill_if_outside:  boolean controlling logic of how test test 
+          is applied.  When true (default) data are killed when data are outside the 
+          specified range.  When false data are killed that are inside the 
+          specified range.  The default is True because that type of 
+          test is much more common than the opposite.  (e.g. retain source-receiver 
+          distances within specified range)
+        :param verbose:  if true informational messages will be posted to 
+        the elog area of d.  When false (default) kills are silent.  That 
+        default is intentioanl to reduce the size of elog data in large data 
+        sets that often require extensive editing.  Set true if you need 
+        details on why data were killed or for debugging. 
+        """
+        self.key = key
+        self.lower_endpoint = lower_endpoint
+        self.upper_endpoint = upper_endpoint
+        self.use_lower_edge = use_lower_edge
+        self.use_upper_edge = use_upper_edge
+        self.kill_if_outside = kill_if_outside
+        self.verbose = verbose
+    def kill_if_true(self,d):
+        """
+        Implementation of this abstract method for this tester.  
+        Kills d if the d[self.key] <= value stored with the class.
+        
+        Returns a (potentially edited) copy of the input to allow use in 
+        a parallel map operation.
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            if self.key in d:
+                testval = d[self.key]
+                # These two are used to defined boolean result of lower 
+                # and upper tests. Truth of result is and of the two
+                # inverting the test (inside_test false) inverts the logic (not)
+                upper_range_test=False
+                lower_range_test=False
+                if self.use_lower_edge:
+                    if testval >= self.lower_endpoint:
+                        lower_range_test = True
+                    else:
+                        lower_range_test = False
+                else:
+                    if testval > self.lower_endpoint:
+                        lower_range_test = True
+                    else:
+                        lower_range_test = False
+                if self.use_upper_edge:
+                    if testval <= self.upper_endpoint:
+                        upper_range_test = True
+                    else:
+                        upper_range_test = False
+                else:
+                    if testval < self.upper_endpoint:
+                        upper_range_test = True
+                    else:
+                        upper_range_test = False
+                
+                death_sentence = lower_range_test and upper_range_test
+                # double negatives are a bit weird here but the logic 
+                # requires the logic be inverted if testing outside the 
+                # defined interval
+                if self.kill_if_outside:
+                    death_sentence = not death_sentence
+                        
+                if death_sentence:
+                    d.kill()
+                    if self.verbose:
+                        message1 = "Value associated with key={key} of {dval} failed range test\n".format(key=self.key,dval=testval)
+                        message2 ="Interval range is {lower} to {upper}.  ".format(lower=self.lower_endpoint,upper=self.upper_endpoint)
+                        message3 = "Test booleans:  lowerEQ={lower}, upperEQ={upper}, kill_inside={inside}".format(lower=self.use_lower_edge,
+                                            upper=self.use_upper_edge, inside=self.kill_if_outside) 
+                        self.log_kill(d,"MetadataInterval",message1+message2+message3)
+        else:
+            raise MsPASSError("MetadataInterval received invalid input data",ErrorSeverity.Fatal)
+        return d
+
+class FiringSquad(Executioner):
+    """
+    Used to apply multiple Executioners in a single pass - hence the name 
+    FiringSquare image; facing more than one thing that could kill you. 
+    The implementation in kill_if_true iterates through a list of 
+    Executioners.  Once the datum is killed it is immediately returned.  
+    If the Executions are running in verbose mode that means some tests 
+    can shadow others.   It is like a firing squad where the guns are fired
+    in sequence and the body is removed as soon as there is a hit.  The 
+    victim walks away only if all the guns miss.  
+    
+    Note the class has a += operator to allow appending additional 
+    tests to the chain.
+    """
+    def __init__(self,executioner_list):
+        """
+        One and only constructor.  executioner_list does not literally 
+        have to be a list container.  It can be any container that is iterable so
+        a list, tuple, or array can be used.   Internally the contents 
+        are copied to a python list container so this the contents of 
+        executioner_list are treated as immutable.
+        
+        The constructor will throw a MsPASSError exception if any of the 
+        contents of executioner_list is not a child of the 
+        Executioner class. 
+        """
+        for ex in executioner_list:
+            if not isinstance(ex,Executioner):
+                raise MsPASSError("FiringSquad constructor:  invalid input.  Expected array of Executioners", ErrorSeverity.Fatal)
+
+        # to allow flexibility of the structure used for input we should 
+        # copy the executioner_list.  Further, this assure the 
+        # result will iterate correctly and allow for append
+        self.executioners = list()
+        for ex in executioner_list:
+            self.executioners.append(ex)
+
+    def kill_if_true(self,d):
+        """
+        Implementation of base class method.  In this case failure is 
+        defined as not passing one of the set of tests loaded  when 
+        the object was created.  As noted earlier the tests are performed 
+        in the same order they were passed to the constructor of added on 
+        with the += operator.
+        :param d: is a mspass data object to be checked 
+        """
+        if self.input_is_valid(d):
+            if d.dead():
+                return d
+            for killer in self.executioners:
+                killer.kill_if_true(d)
+                if d.dead():
+                    break
+            return d
+        else:
+            raise MsPASSError("FiringSquad received invalid input data",ErrorSeverity.Fatal)
+    def __iadd__(self,other):
+        """
+        Defines the += operator for the class. In that case it means a new 
+        test is appended.   Raises a MsPASSError set Fatal other is not a 
+        subclass of Executioner.
+        """
+        if isinstance(other,Executioner):
+            self.executioners.append(other)
+        else:
+            raise MsPASSError("FiringSquare operator +=  rhs is not an Executioner",
+                              ErrorSeverity.Fatal)
+        return self

--- a/python/tests/algorithms/test_edit.py
+++ b/python/tests/algorithms/test_edit.py
@@ -1,0 +1,135 @@
+from mspasspy.ccore.seismic import TimeSeries
+from mspasspy.algorithms.edit import (MetadataGT,
+            MetadataGE,
+            MetadataLT,
+            MetadataLE,
+            MetadataEQ,
+            MetadataNE,
+            MetadataDefined,
+            MetadataUndefined,
+            MetadataInterval,
+            FiringSquad)
+
+
+d=TimeSeries(100)
+d.set_live()
+d['test_int'] = 2
+d['test_float'] =4.0
+
+int_tester = MetadataGT('test_int',1,verbose=True)
+x=int_tester.kill_if_true(d)
+assert not x.live
+d.set_live()
+int_tester = MetadataGT('test_int',3,verbose=True)
+x=int_tester.kill_if_true(d)
+assert x.live
+
+real_tester = MetadataGT('test_float',1.0,verbose=True)
+x=real_tester.kill_if_true(d)
+assert x.dead()
+d.set_live()
+real_tester = MetadataGT('test_float',10.0,verbose=True)
+x=real_tester.kill_if_true(d)
+assert x.live
+
+# Same for GE
+real_tester = MetadataGE('test_float',1.0,verbose=True)
+x=real_tester.kill_if_true(d)
+assert x.dead()
+d.set_live()
+real_tester = MetadataGE('test_float',10.0,verbose=True)
+x=real_tester.kill_if_true(d)
+
+d.set_live()
+int_testerGE = MetadataGE('test_int',2)
+x = int_testerGE.kill_if_true(d)
+assert d.dead()
+
+#equality tester
+d.set_live()
+eqtest = MetadataEQ('test_int',2,verbose=True)
+x=eqtest.kill_if_true(d)
+assert x.dead()
+
+d.set_live()
+eqtest = MetadataEQ('test_int',9,verbose=True)
+x=eqtest.kill_if_true(d)
+assert x.live
+
+# LT versions
+d.set_live()
+lttest = MetadataLT('test_int',3,verbose=True)
+x=lttest.kill_if_true(d)
+assert x.dead()
+d.set_live()
+lttest = MetadataLT('test_int',1,verbose=True)
+x=lttest.kill_if_true(d)
+assert x.live
+
+#LE version
+d.set_live()
+letest = MetadataLE('test_int',3,verbose=True)
+x=letest.kill_if_true(d)
+assert x.dead()
+d.set_live()
+letest = MetadataLE('test_int',1,verbose=True)
+x=letest.kill_if_true(d)
+assert x.live
+d.set_live()
+letest = MetadataLE('test_int',2,verbose=True)
+x=letest.kill_if_true(d)
+assert x.dead()
+
+
+# test MetadataInterval - first a value inside
+tester = MetadataInterval('test_int',1,3,verbose=True)
+d.set_live()
+x = tester.kill_if_true(d)
+assert x.live
+d.set_live()
+tester.kill_if_outside = False
+x = tester.kill_if_true(d)
+assert x.dead()
+# now test a value at an edge
+tester = MetadataInterval('test_float',4.0,8.0,verbose=True)
+d.set_live()
+x = tester.kill_if_true(d)
+assert x.live  # not killed because of equality with 4.0 so not "inside"
+tester.kill_if_outside = False
+x = tester.kill_if_true(d)
+assert x.dead()
+
+# now test switch to remove equality as true 
+tester.use_lower_edge=False
+tester.kill_if_outside= False
+d.set_live()
+x = tester.kill_if_true(d)
+assert x.live
+d.set_live()
+tester.kill_if_outside = True
+x = tester.kill_if_true(d)
+assert x.dead()
+
+# Existence testers
+d.set_live()
+tester = MetadataDefined("test_float",verbose=True)
+tester.kill_if_true(d)
+assert d.dead()
+
+d.set_live()
+tester = MetadataUndefined("foo",verbose=True)
+tester.kill_if_true(d)
+assert d.dead()
+
+mob = [int_tester,real_tester]
+fstest = FiringSquad(mob)
+d.set_live()
+x=fstest.kill_if_true(d)
+assert x.live
+addon_tester = MetadataGT('test_float',1.0,verbose=True)
+fstest += addon_tester
+d.set_live()
+x=fstest.kill_if_true(d)
+assert not x.live
+
+


### PR DESCRIPTION
This is a complete package of (pure python) code to perform the important, generic capability of data editing (commonly called trace editing in seismic reflection processing).  This branch implements all python comparison operators that can be used to kill data (using the kill method) based on a comparison of the data's metadata value and one or more boundary values.   i.e. there are kill operators for >,>=,<,>=,==,and != as well as a "defined" or "undefined" test. There is also a generic interval tester that can handle and combination of a op x op b where a and b are bounds (the interval), x is the value being tested for a kill, and op is any of the binary python comparison operators (<,>, >=, etc.)   There is also a `FiringSquad` operator that implements a list of executioners that can be run on data in a single pass. 

I wrote a manual page because the way these are implemented is novel and based on a the object oriented concept of inheritance and functional programming that would be confusing to most seismologists. The manual page is essential for that reason.  

I didn't create and index entry for the new documentation page.   I think what we need is a hierarchy of sections we need to expand on "algorithms" with subsection pages on distinct functionality of MsPASS specific algorithms.  We probably should also move the obspy section to a subsection of algorithms.   