### PR TITLE
Improve fileio

### DIFF
--- a/cxx/include/mspass/io/fileio.h
+++ b/cxx/include/mspass/io/fileio.h
@@ -1,0 +1,138 @@
+#ifndef _MSEED_INDEX_H_
+#define _MSEED_INDEX_H_
+#include <string>
+#include "mspass/seismic/TimeSeries.h"
+#include "mspass/seismic/Seismogram.h"
+namespace mspass::io
+{
+/*! \brief Fast file writer for native TimeSeries save to a file.
+
+When saving data to a file system there is no standard way to do so we
+know of that is faster than the low level C fwrite function.  This function
+uses fwrite to write ONLY the sample data in the input TimeSeries object to
+a file specified by a directory (dir) and leaf file name (dfile).  It can
+do so because the std::vector container is required by the standard to define
+a contiguous block of memory. This function is expected to be used in MsPASS
+only under the hood of the python database writer for native saves.
+
+The function constructs a unix path file name as dir+"/"+dfile.  If that
+file does not exist it will be created.  If it does exist the write will
+append to the existing file.   The attributes dir, dfile, and foff are
+always saved in the data's Metadata container so they can be saved to
+the MonogoDB database in MsPASS AFTER calling this writer.  For that reason
+d is not const because it simply isn't.
+
+\param d data to be saved (altered on return as noted above)
+\param dir directory name (assumed to not contain a trailing /)
+\param dfile leaf file name for save
+
+\return file position in output file of the first byte written.
+the same number is saved in the "foff" metadata attribute.
+
+\expection This function will throw a MsPASS error for one of several
+common io related issues. Caller should always include the call to this
+function in a try block.
+
+*/
+long int fwrite_to_file(mspass::seismic::TimeSeries& d,
+  const std::string dir,const std::string dfile);
+/*! \brief Fast file writer for native Seismogram save to a file.
+
+When saving data to a file system there is no standard way to do so we
+know of that is faster than the low level C fwrite function.  This function
+uses fwrite to write ONLY the sample data in the input Seismogram object to
+a file specified by a directory (dir) and leaf file name (dfile).  It can
+do so because the std::vector container is required by the standard to define
+a contiguous block of memory. This function is expected to be used in MsPASS
+only under the hood of the python database writer for native saves.  This
+function works for Seismogram objects it this form only because the dmatrix
+container puts all the sample data for the 3xnpts matrix in a contiguous
+block of memory fetched interally with the get_address method.
+
+The function constructs a unix path file name as dir+"/"+dfile.  If that
+file does not exist it will be created.  If it does exist the write will
+append to the existing file.   The attributes dir, dfile, and foff are
+always saved in the data's Metadata container so they can be saved to
+the MonogoDB database in MsPASS AFTER calling this writer.  For that reason
+d is not const because it simply isn't.
+
+\param d data to be saved (altered on return as noted above)
+\param dir directory name (assumed to not contain a trailing /)
+\param dfile leaf file name for save
+
+\return file position in output file of the first byte written.
+the same number is saved in the "foff" metadata attribute.
+
+\expection This function will throw a MsPASS error for one of several
+common io related issues. Caller should always include the call to this
+function in a try block.
+
+*/
+long int fwrite_to_file(mspass::seismic::Seismogram& d,
+  const std::string dir,const std::string dfile);
+/*! \brief Use C fread to read sample data from a file.
+
+This low level function is used in the file based reader of mspass to
+speed up python readers.  It is intrinsically dangerous because it assumes
+the data object has a preconstructed size sufficient to hold the data
+loaded with the low-level C fread function.
+That buffer in this function is the the dmatrix container, u, used to hold
+the sample data of a Seismogram object.  The reader assumes the input
+has been initialized on construction or with set_npts to the size
+matching the data file contents.  If there is a mismatch the results
+are unpredictable.
+
+\param Seismogram object to hold the sample data to be read from the file.
+  Note that this function acts like a subroutine with entire purpose being
+  to fill the data array of this object.
+\param dir is the directory name to use for file name (no trailing slash)
+\param dfile is the leaf file name to be openned.
+\param foff is a the number of bytes to seek for first byte of data.
+
+\return number of samples read.  Note caller should test this
+value as a short read will not cause an error to be thrown.  The value
+return should be 3 * d.npts().
+
+\exception This function may throw a MsPASSError exception if anything
+goes wrong in the read process (open failure, seek fails, fread fails completely).
+If that happens the data result should be killed as the sample contents are
+guaranteed to be invalid.
+*/
+
+size_t fread_from_file(mspass::seismic::Seismogram& d,const std::string dir, const std::string dfile,
+     const long int foff);
+
+/*! \brief Use C fread to read sample data from a file.
+
+This low level function is used in the file based reader of mspass to
+speed up python readers.  It is intrinsically dangerous because it assumes
+the data object has a preconstructed size sufficient to hold the data
+loaded with the low-level C fread function.
+That buffer in this function is the std::vector container, s, used to hold
+the sample data of a Seismogram object.  The reader assumes the input
+has been initialized on construction or with set_npts to the size
+matching the data file contents.  If there is a mismatch the results
+are unpredictable.
+
+\param TimeSeries object to hold the sample data to be read from the file
+  Note that this function acts like a subroutine with entire purpose being
+  to fill the data array of this object.
+\param dir is the directory name to use for file name (no trailing slash)
+\param dfile is the leaf file name to be openned.
+\param foff is a the number of bytes to seek for first byte of data.
+
+\return number of samples read.  Note caller should test this
+value as a short read will not cause an error to be thrown.  The value
+return should be d.npts().
+
+\exception This function may throw a MsPASSError exception if anything
+goes wrong in the read process (open failure, seek fails, fread fails completely).
+If that happens the data result should be killed as the sample contents are
+guaranteed to be invalid.
+*/
+
+size_t fread_from_file(mspass::seismic::TimeSeries& d,const std::string dir, const std::string dfile,
+     const long int foff);
+
+}
+#endif

--- a/cxx/include/mspass/seismic/CoreTimeSeries.h
+++ b/cxx/include/mspass/seismic/CoreTimeSeries.h
@@ -13,7 +13,8 @@ that aren't essential to define the data object, but which are necessary
 for some algorithms.
 \author Gary L. Pavlis
 **/
-class CoreTimeSeries: public mspass::seismic::BasicTimeSeries , public mspass::utility::Metadata
+class CoreTimeSeries: virtual public mspass::seismic::BasicTimeSeries ,
+             virtual public mspass::utility::Metadata
 {
 public:
 /*!

--- a/cxx/include/mspass/seismic/CoreTimeSeries.h
+++ b/cxx/include/mspass/seismic/CoreTimeSeries.h
@@ -13,8 +13,8 @@ that aren't essential to define the data object, but which are necessary
 for some algorithms.
 \author Gary L. Pavlis
 **/
-class CoreTimeSeries: virtual public mspass::seismic::BasicTimeSeries ,
-             virtual public mspass::utility::Metadata
+class CoreTimeSeries: public mspass::seismic::BasicTimeSeries ,
+             public mspass::utility::Metadata
 {
 public:
 /*!

--- a/cxx/include/mspass/seismic/Seismogram.h
+++ b/cxx/include/mspass/seismic/Seismogram.h
@@ -128,6 +128,45 @@ with serialization.
     const std::string jobid=std::string("UNDEFINED"),
       const std::string readername=std::string("load3C"),
         const std::string algid=std::string("0"));
+
+/*! \brief Construct from Metadata definition that includes data path.
+ *
+ A Metadata object is sufficiently general that it can contain enough
+ information to contruct an object from attributes contained in it.
+ This constuctor uses that approach, with the actual loading of data
+ being an option (on by default).   In mspass this is constructor is
+ used to load data with Metadata constructed from MongoDB and then
+ using the path created from two parameters (dir and dfile used as
+ in css3.0 wfdisc) to read data.   The API is general but the
+ implementation in mspass is very rigid.   It blindly assumes the
+ data being read are binary doubles in the right byte order and
+ ordered in the native order for dmatrix (Fortran order).  i.e.
+ the constuctor does a raw fread of ns*3 doubles into the internal
+ array used in the dmatrix implementation.
+
+ A second element of the Metadata that is special for MsPASS is the
+ handling of the transformation matrix by this constructor.   In MsPASS
+ the transformation matrix is stored as a python object in MongoDB.
+ This constructor aims to fetch that entity with the key 'tmatrix'.
+ To be more robust and simpler to use with data not loaded from mongodb
+ we default tmatrix to assume the data are in standard coordinates.  That is,
+ if the key tmatrix is not defined in Metadata passed as arg0, the
+ constructor assumes it should set the transformation matrix to an identity.
+ Use set_transformation_matrix if that assumption is wrong for your data.
+
+ \param md is the Metadata used for the construction.
+
+ \param load_data if true (default) a file name is constructed from
+ dir+"/"+dfile, the file is openned, fseek is called to foff,
+ data are read with fread, and the file is closed.  If false a dmatrix
+ for u is still created of size 3xns, but the matrix is only initialized
+ to all zeros.
+
+ \exception  Will throw a MsPASSError if required metadata are missing.
+ */
+   Seismogram(const Metadata& md, bool load_data)
+     : mspass::seismic::CoreSeismogram(md,load_data), mspass::utility::ProcessingHistory()
+   {};
   /*! Standard copy constructor. */
   Seismogram(const Seismogram& parent)
     : mspass::seismic::CoreSeismogram(parent), mspass::utility::ProcessingHistory(parent)

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -54,6 +54,29 @@ public:
       : mspass::seismic::CoreTimeSeries(bts,md),
          mspass::utility::ProcessingHistory()
   {};
+  /*! Partially construct from Metadata alone.
+
+  This constructor is useful for interaction with MongoDB where the
+  Metadata container is constructed directly from MongoDB documents the
+  database uses for storage.  A key restrition of this constructor is that
+  BasicTimeSeries attributes and the size of the internal array buffer, which
+  is set by npts, are extracted from Metadata with keys fixed in the C++ code.
+  The following keys are required or this contructor will throw a MwPASSWrror:
+
+    dt - sample sample_interval
+    t0 - data startttime
+    npts - number of samples (s array will be initialized to this many zeros)
+    time_standard - UTC or Relative (anything but UTC is taken as relative)
+
+  It will also handle but not require the two attributes used in the mspass
+  schema to handle shifting from absolute to relative time.  These keys
+  are
+    t0_shift - sets amount t0 has been shiftee when originally utc but set
+      to relative with the shift method.  Ignored if time is UTC or it is
+      not defined.  
+
+  */
+  TimeSeries(const Metadata& md);
 
   /*!  \brief Construct from lower level CoreTimeSeries.
 

--- a/cxx/include/mspass/seismic/keywords.h
+++ b/cxx/include/mspass/seismic/keywords.h
@@ -1,5 +1,6 @@
 #ifndef _KEYWORDS_H_
 #define _KEYWORDS_H_
+#include <string>
 /*! \brief Define metadata keys.
 
 This include file defines a set ofconst std::string values that serve as
@@ -78,5 +79,11 @@ const std::string SEISMICMD_sta("sta");
 const std::string SEISMICMD_chan("chan");
 /*! location code assigned to an instrument (loc component of SEED net:sta:chan)*/
 const std::string SEISMICMD_loc("loc");
+/*! Define time reference (normally UTC or Relative)*/
+const std::string SEISMICMD_time_standard("time_standard");
+/*! Define the t0_shift attribute of BasicTimeSeries. */
+const std::string SEISMICMD_t0_shift("starttime_shift");
+/*! Defines boolean used in BasicTimeSeries for properly handling Relative/UTC time standards*/
+const std::string SEISMICMD_utc_convertible("utc_convertible");
 }
 #endif

--- a/cxx/python/io/io_py.cc
+++ b/cxx/python/io/io_py.cc
@@ -6,6 +6,21 @@
 #include <pybind11/embed.h>
 
 #include "mspass/io/mseed_index.h"
+#include "mspass/io/fileio.h"
+#include "mspass/seismic/TimeSeries.h"
+#include "mspass/seismic/Seismogram.h"
+/*  these are supposed to be included from fileio.h - temporary for testing only*/
+namespace mspass::io {
+
+long int fwrite_to_file(mspass::seismic::TimeSeries& d,
+  const std::string dir,const std::string dfile);
+long int fwrite_to_file(mspass::seismic::Seismogram& d,
+    const std::string dir,const std::string dfile);
+size_t fread_from_file(mspass::seismic::Seismogram& d,const std::string dir, const std::string dfile,
+    const long int foff);
+size_t fread_from_file(mspass::seismic::TimeSeries& d,const std::string dir, const std::string dfile,
+    const long int foff);
+}
 
 PYBIND11_MAKE_OPAQUE(std::vector<mspass::io::mseed_index>);
 namespace mspass {
@@ -51,6 +66,40 @@ PYBIND11_MODULE(io,m){
     py::arg("verbose") = false
     )
   ;
+ m.def("_fwrite_to_file",py::overload_cast<mspass::seismic::Seismogram&,
+    const std::string,const std::string>(&fwrite_to_file),
+    "Open and read sample data for native format std::vector<double> container",
+    py::return_value_policy::copy,
+    py::arg("d"),
+    py::arg("dir"),
+    py::arg("dfile")
+  );
+  m.def("_fwrite_to_file",py::overload_cast<mspass::seismic::TimeSeries&,
+     const std::string,const std::string>(&fwrite_to_file),
+     "Open and read sample data for native format dmatrix container",
+     py::return_value_policy::copy,
+     py::arg("d"),
+     py::arg("dir"),
+     py::arg("dfile")
+   );
+   m.def("_fread_from_file",
+      py::overload_cast<mspass::seismic::TimeSeries&,
+         const std::string,const std::string,const long int>(&fread_from_file),
+      "Read the sample data for a TimeSeries object from a file as native doubles",
+     py::arg("d"),
+     py::arg("dir"),
+     py::arg("dfile"),
+     py::arg("foff")
+   );
+   m.def("_fread_from_file",
+      py::overload_cast<mspass::seismic::Seismogram&,
+         const std::string,const std::string,const long int>(&fread_from_file),
+      "Read the sample data for a Seismogram object from a file as native doubles",
+     py::arg("d"),
+     py::arg("dir"),
+     py::arg("dfile"),
+     py::arg("foff")
+   );
 }
 }   // namespace mspasspy
 }  // namespace mspas

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -178,7 +178,7 @@ PYBIND11_MODULE(seismic, m) {
     .def(py::init<>())
     .def(py::init<const SlownessVector&>())
     /* This obscure syntax is used for setting keyword args for a constructor.
-    We want it here because we want to normally default az0.   
+    We want it here because we want to normally default az0.
     This obscure trick came from:  https://github.com/pybind/pybind11/issues/579*/
     .def(py::init<const double, const double, const double>(),
       py::arg("ux")=0.0,py::arg("uy")=0.0,py::arg("az0")=0.0
@@ -348,6 +348,7 @@ PYBIND11_MODULE(seismic, m) {
     .def(py::init<const CoreSeismogram&>())
     .def(py::init<const size_t>())
     .def(py::init<const BasicTimeSeries&,const Metadata&>())
+    .def(py::init<const Metadata&,bool>())
     .def(py::init<const CoreSeismogram&,const std::string>())
     /* Don't think we really want to expose this to python if we don't need to
     .def(py::init<const BasicTimeSeries&,const Metadata&, const CoreSeismogram,
@@ -429,6 +430,7 @@ PYBIND11_MODULE(seismic, m) {
       .def(py::init<const size_t>())
       .def(py::init<const CoreTimeSeries&>())
       .def(py::init<const BasicTimeSeries&,const Metadata&>())
+      .def(py::init<const Metadata&>())
       .def(py::init<const CoreTimeSeries&,const std::string>())
       /* Not certain we should have this in the python api.  It is used in pickle interface but doesn't seem
 	helpful for python.  Uncomment if this proves false.

--- a/cxx/src/lib/io/CMakeLists.txt
+++ b/cxx/src/lib/io/CMakeLists.txt
@@ -1,6 +1,8 @@
 FILE(GLOB sources_io *.cc)
 include_directories(
   ${MSEED_INCLUDE_DIR}
+  ${pybind11_INCLUDE_DIR}
+  ${PYTHON_INCLUDE_DIRS}
   ${PROJECT_BINARY_DIR}/include
   ${PROJECT_SOURCE_DIR}/include
 )

--- a/cxx/src/lib/io/fileio.cc
+++ b/cxx/src/lib/io/fileio.cc
@@ -1,0 +1,132 @@
+#include <memory>
+#include <vector>
+#include <stdio.h>
+#include <string>
+#include "mspass/utility/MsPASSError.h"
+#include "mspass/seismic/keywords.h"
+#include "mspass/seismic/TimeSeries.h"
+#include "mspass/seismic/Seismogram.h"
+#include "mspass/io/fileio.h"
+namespace mspass::io
+{
+//using namespace mspass::io;
+using namespace mspass::seismic;
+using mspass::utility::MsPASSError;
+using mspass::utility::ErrorSeverity;
+using namespace std;
+/* This is a file scope function to allow the overlaoded fwrite_to_file
+functions to share this common code to write a contiguous buffer of data.
+to a file.
+
+Note I considered adding an old school call to flock to assure this
+function would be thread safe.   However, the man page for the posix
+function flockfile says that is no longer necessary and stdio is
+now tread safe - fopen creates an intrinsic lock that is not released
+until fclose is called.  That is important for mspass as multiple threads
+writing to the same file can be expected to be common. */
+long int fwrite_sample_data(const string dir, const string dfile, double *dptr, const size_t nd)
+{
+	try{
+		FILE *fp;
+		long int foff;
+		string fname;
+		if(dir.length()>0)
+		  /* for expected context for use in python we will assume dir does not
+			have a trailing path separator so we always insert / */
+			fname = dir + "/" + dfile;
+		else
+		  /* Null as always in unix means use current directory*/
+			fname=dfile;
+		if((fp=fopen(fname.c_str(),"a")) == NULL)
+		  /* use the name of the overloaded parent instead of the actual function - intentional*/
+			throw MsPASSError("fwrite_to_file:  Open failed on file "+fname,ErrorSeverity::Invalid);
+	  /* Both fseek and ftell can fail in weird circumstances, but I intentionally
+		do not trap that condition as if either have issues I am quite sure
+		the fwrite will fail */
+		fseek(fp,0L,2);
+		foff = ftell(fp);
+		if( fwrite((void*)dptr,sizeof(double),nd,fp) != nd)
+		{
+			fclose(fp);
+			throw MsPASSError("fwrite_to_file:  fwrite error to file "+fname,ErrorSeverity::Invalid);
+		}
+		fclose(fp);
+		return foff;
+	}catch(...){throw;};
+}
+long int fwrite_to_file(TimeSeries& d,const string dir,const string dfile)
+{
+	/* Using this function avoids repetitious code with Seismogram version. */
+	long int foff;
+	try{
+	  foff = fwrite_sample_data(dir,dfile,d.s.data(),d.npts());
+	}catch(...){throw;};
+	/* We always set these 3 attributes in Metadata so they can be properly
+	saved to the database after a successful write.  Repetitious with Seismogram
+	but a function to do this would be more confusing that helpful */
+	d.put_string(SEISMICMD_dir,dir);
+	d.put_string(SEISMICMD_dfile,dfile);
+	d.put_long(SEISMICMD_foff,foff);
+	return(foff);
+}
+long int fwrite_to_file(Seismogram& d, const string dir,const string dfile)
+{
+	/* Using this function avoids repetitious code with TimeSeries version.
+	Note use of 3*npts as the buffer size*/
+	long int foff;
+	try{
+		foff = fwrite_sample_data(dir,dfile,d.u.get_address(0,0),3*d.npts());
+	}catch(...){throw;};
+	d.put_string(SEISMICMD_dir,dir);
+	d.put_string(SEISMICMD_dfile,dfile);
+	d.put_long(SEISMICMD_foff,foff);
+
+	return(foff);
+}
+
+size_t fread_sample_data(double *buffer,const string dir, const string dfile,
+     const long int foff,const int nsamples)
+{
+	FILE *fp;
+	string fname;
+	if(dir.length()>0)
+	  /* for expected context for use in python we will assume dir does not
+		have a trailing path separator so we always insert / */
+		fname = dir + "/" + dfile;
+	else
+	  /* Null as always in unix means use current directory*/
+		fname=dfile;
+	if((fp=fopen(fname.c_str(),"r")) == NULL)
+		throw MsPASSError("fread_data_from_file:  Open failed on file "+fname,ErrorSeverity::Invalid);
+	if(foff>0)
+	{
+		if(fseek(fp,foff,SEEK_SET))
+		{
+			fclose(fp);
+		  throw MsPASSError("fread_data_from_file:  fseek failure on file="+fname,ErrorSeverity::Invalid);
+		}
+	}
+	size_t retcount;
+	retcount = fread((void*)buffer,sizeof(double),nsamples,fp);
+	fclose(fp);
+	return retcount;
+}
+size_t fread_from_file(Seismogram& d,const string dir, const string dfile,
+     const long int foff)
+{
+	size_t ns_read;
+	try{
+		ns_read = fread_sample_data(d.u.get_address(0,0),dir,dfile,foff,3*d.npts());
+		return ns_read;
+	}catch(...){throw;};
+}
+size_t fread_from_file(TimeSeries& d,const string dir, const string dfile,
+     const long int foff)
+{
+	size_t ns_read;
+	try{
+		ns_read = fread_sample_data(&(d.s[0]),dir,dfile,foff,d.npts());
+		return ns_read;
+	}catch(...){throw;};
+}
+} // Termination of namespace definitions

--- a/cxx/src/lib/seismic/TimeSeries.cc
+++ b/cxx/src/lib/seismic/TimeSeries.cc
@@ -57,7 +57,17 @@ TimeSeries::TimeSeries(const Metadata& md) : Metadata(md),ProcessingHistory()
             this->force_t0_shift(t0shift);
           }
         }
+        /* Maintenance issue:   The first version of this code had this
+        construct to set npts:
         long ns = this->get_long(SEISMICMD_npts);
+        For reasons I (glp) could not figure out ns was always returned as 0
+        when extracted from this.   The Metadata(md) call in the first line of
+        this constructor should have set npts but it did not do so for some
+        reason.  The following is a workaround that is totally equivalent but
+        why it is necessary is not at all clear.  I am putting this here as this
+        could come back to bite us.
+        */
+        long int ns = md.get_long(SEISMICMD_npts);
         /* this CoreTimeSeries method sets the npts attribute and
         initializes the s buffer to all zeros */
         this->set_npts(ns);

--- a/cxx/src/lib/seismic/TimeSeries.cc
+++ b/cxx/src/lib/seismic/TimeSeries.cc
@@ -1,8 +1,10 @@
+#include "mspass/seismic/keywords.h"
 #include "mspass/seismic/TimeSeries.h"
 namespace mspass::seismic
 {
 using namespace std;
 using namespace mspass::utility;
+using namespace mspass::seismic;
 
 TimeSeries::TimeSeries(const CoreTimeSeries& d, const std::string alg)
     : CoreTimeSeries(d),ProcessingHistory()
@@ -22,6 +24,44 @@ TimeSeries::TimeSeries(const BasicTimeSeries& b, const Metadata& m,
     : CoreTimeSeries(b,m),ProcessingHistory(his)
 {
   this->s=d;
+}
+TimeSeries::TimeSeries(const Metadata& md) : Metadata(md),ProcessingHistory()
+{
+    mlive=false;
+    try {
+        /* Names used are from mspass defintions as of Jan 2020.
+        We don't need to call the set methods for these attributes as they
+        would add the overhead of setting delta, startime, and npts to the
+        same value passed. */
+        this->mdt = this->get_double(SEISMICMD_dt);
+        this->mt0 = this->get_double(SEISMICMD_t0);
+        if(this->is_defined(SEISMICMD_time_standard))
+        {
+          if(this->get_string(SEISMICMD_time_standard) == "UTC")
+            this->set_tref(TimeReferenceType::UTC);
+          else
+          {
+            this->set_tref(TimeReferenceType::Relative);
+            this->elog.log_error("CoreSeismogram Metadata constructor",
+              SEISMICMD_time_standard+" attribute is not defined - set to Relative",
+              ErrorSeverity::Complaint);
+          }
+        }
+        if(this->time_is_relative())
+        {
+          /* It is not an error if a t0 shift is not defined and we are
+          in relative time. That is the norm for active source data. */
+          if(this->is_defined(SEISMICMD_t0_shift))
+          {
+            double t0shift=this->get_double(SEISMICMD_t0_shift);
+            this->force_t0_shift(t0shift);
+          }
+        }
+        long ns = this->get_long(SEISMICMD_npts);
+        /* this CoreTimeSeries method sets the npts attribute and
+        initializes the s buffer to all zeros */
+        this->set_npts(ns);
+    }catch(...) {throw;};
 }
 TimeSeries& TimeSeries::operator=(const TimeSeries& parent)
 {

--- a/cxx/src/lib/seismic/TimeSeries.cc
+++ b/cxx/src/lib/seismic/TimeSeries.cc
@@ -25,10 +25,11 @@ TimeSeries::TimeSeries(const BasicTimeSeries& b, const Metadata& m,
 {
   this->s=d;
 }
-TimeSeries::TimeSeries(const Metadata& md) : Metadata(md),ProcessingHistory()
+TimeSeries::TimeSeries(const Metadata& md) : ProcessingHistory()
 {
     mlive=false;
     try {
+        this->Metadata::operator=(md);
         /* Names used are from mspass defintions as of Jan 2020.
         We don't need to call the set methods for these attributes as they
         would add the overhead of setting delta, startime, and npts to the
@@ -57,16 +58,6 @@ TimeSeries::TimeSeries(const Metadata& md) : Metadata(md),ProcessingHistory()
             this->force_t0_shift(t0shift);
           }
         }
-        /* Maintenance issue:   The first version of this code had this
-        construct to set npts:
-        long ns = this->get_long(SEISMICMD_npts);
-        For reasons I (glp) could not figure out ns was always returned as 0
-        when extracted from this.   The Metadata(md) call in the first line of
-        this constructor should have set npts but it did not do so for some
-        reason.  The following is a workaround that is totally equivalent but
-        why it is necessary is not at all clear.  I am putting this here as this
-        could come back to bite us.
-        */
         long int ns = md.get_long(SEISMICMD_npts);
         /* this CoreTimeSeries method sets the npts attribute and
         initializes the s buffer to all zeros */

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3472,10 +3472,10 @@ class Database(pymongo.database.Database):
                     # method is an unnecessary confusion and I don't think 
                     # settign npts or data are necessary given the code of 
                     # Stream2Seismogram - st.toSeismogram is an alias for that
-                    #sm = st.toSeismogram(cardinal=True)
-                    #mspass_object.npts = sm.data.columns()
-                    #mspass_object.data = sm.data
-                    mspass_object = Stream2Seismogram(st,cardinal=True)
+                    sm = st.toSeismogram(cardinal=True)
+                    mspass_object.npts = sm.data.columns()
+                    mspass_object.data = sm.data
+                    #mspass_object = Stream2Seismogram(st,cardinal=True)
 
     @staticmethod
     def _save_data_to_dfile(mspass_object, dir, dfile, format=None,kill_on_failure=False):

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3466,6 +3466,8 @@ class Database(pymongo.database.Database):
                             interpolation_samples=merge_interpolation_samples,
                         )
                     tr = st[0]
+                    # These two lines are needed to properly initialize 
+                    # the DoubleVector before calling Trace2TimeSeries
                     mspass_object.npts = len(tr.data)
                     mspass_object.data = DoubleVector(tr.data)
                     mspass_object = Trace2TimeSeries(tr)
@@ -3474,10 +3476,13 @@ class Database(pymongo.database.Database):
                     # method is an unnecessary confusion and I don't think 
                     # settign npts or data are necessary given the code of 
                     # Stream2Seismogram - st.toSeismogram is an alias for that
+                    # This is almost but not quite equivalent to this:
+                    # mspass_object = Stream2Seismogram(st,cardinal=True)
+                    # Seems Stream2Seismogram does not properly handle 
+                    # the data pointer
                     sm = st.toSeismogram(cardinal=True)
                     mspass_object.npts = sm.data.columns()
                     mspass_object.data = sm.data
-                    #mspass_object = Stream2Seismogram(st,cardinal=True)
 
     @staticmethod
     def _save_data_to_dfile(mspass_object, dir, dfile, format=None,kill_on_failure=False):

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -19,7 +19,8 @@ import obspy
 from obspy import Inventory
 from obspy import UTCDateTime
 
-from mspasspy.ccore.io import _mseed_file_indexer
+from mspasspy.ccore.io import _mseed_file_indexer,_fwrite_to_file,_fread_from_file
+from mspasspy.util.converter import Trace2TimeSeries,Stream2Seismogram
 
 from mspasspy.ccore.seismic import (
     TimeSeries,
@@ -502,17 +503,29 @@ class Database(pymongo.database.Database):
                 md[k] = b"\x00"
             else:
                 md[k] = None
-        if object_type is TimeSeries:
-            # FIXME: This is awkward. Need to revisit when we have proper constructors.
-            mspass_object = TimeSeries(
-                {k: md[k] for k in md}, np.ndarray([0], dtype=np.float64)
-            )
-            # FIXME: if npts is in the exclude list or not in the schema, the following won't work.
-            # May need to consider adding a "required" key to the metadata schema to avoid invalid combination.
-            if "npts" in object_doc:
-                mspass_object.npts = object_doc["npts"]
-        else:
-            mspass_object = Seismogram(_CoreSeismogram(md, False))
+        try:
+            # Note a CRITICAL feature of the Metadata constructors
+            # for both of these objects is that they allocate the 
+            # buffer for the sample data and initialize it to zero.
+            # This allows sample data readers to load the buffer without 
+            # having to handle memory management.
+            if object_type is TimeSeries:
+                mspass_object = TimeSeries(md)
+            else:
+                # api mismatch here.  This ccore Seismogram constructor 
+                # had an ancestor that had an option to read data here. 
+                # we never do that here
+                mspass_object = Seismogram(md,False)
+        except MsPASSError as merr:
+            # if the constructor fails mspass_object will be invalid
+            # To preserve the error we have to create a shell to hold the error
+            if object_type is TimeSeries:
+                mspass_object=TimeSeries()  
+            else:
+                mspass_object=Seismogram()
+            # Default constructors leaves result marked dead so below should work
+            mspass_object.elog.log_error(merr)
+            return mspass_object
 
         # not continue step 2 & 3 if the mspass object is dead
         if is_dead:
@@ -3403,27 +3416,38 @@ class Database(pymongo.database.Database):
         """
         if not isinstance(mspass_object, (TimeSeries, Seismogram)):
             raise TypeError("only TimeSeries and Seismogram are supported")
-        fname = os.path.join(dir, dfile)
-        with open(fname, mode="rb") as fh:
-            fh.seek(foff)
-            if not format:
-                float_array = array("d")
-                if isinstance(mspass_object, TimeSeries):
-                    if not mspass_object.is_defined("npts"):
-                        raise KeyError("npts is not defined")
-                    float_array.frombytes(fh.read(mspass_object.get("npts") * 8))
-                    mspass_object.data = DoubleVector(float_array)
-                elif isinstance(mspass_object, Seismogram):
-                    if not mspass_object.is_defined("npts"):
-                        raise KeyError("npts is not defined")
-                    float_array.frombytes(fh.read(mspass_object.get("npts") * 8 * 3))
-                    mspass_object.data = dmatrix(3, mspass_object.get("npts"))
-                    for i in range(3):
-                        for j in range(mspass_object.get("npts")):
-                            mspass_object.data[i, j] = float_array[
-                                i * mspass_object.get("npts") + j
-                            ]
-            else:
+            
+        if not format:
+            if isinstance(mspass_object,TimeSeries):
+                try:
+                    count = _fread_from_file(mspass_object,
+                                dir,dfile,foff)
+                    if count != mspass_object.npts:
+                        message ="fread count mismatch.  Expected to read {npts} but fread returned a count of {count}".format(npts=mspass_object.npts,count=count)
+                        mspass_object.elog.log_error("_read_data_from_dfile",message,ErrorSeverity.Complaint)
+                except MsPASSError as merr:
+                    # Errors thrown must always cause a kill
+                    mspass_object.kill()
+                    mspass_object.elog.log_error(merr)
+            else: 
+                # We can only get here if this is a Seismogram
+                try:
+                    nsamples = 3*mspass_object.npts
+                    count = _fread_from_file(mspass_object,
+                                        dir,dfile,foff)
+                    if count != nsamples:
+                       message ="fread count mismatch.  Expected to read {nsamples} doubles but fread returned a count of {count}".format(nsamples=nsamples,count=count)
+                       mspass_object.elog.log_error("_read_data_from_dfile",message,ErrorSeverity.Complaint)
+                except MsPASSError as merr:
+                    # Errors thrown must always cause a kill
+                    mspass_object.kill()
+                    mspass_object.elog.log_error(merr) 
+        
+        else:
+            fname = os.path.join(dir, dfile)
+            with open(fname, mode="rb") as fh:
+                if foff > 0:
+                    fh.seek(foff)
                 flh = io.BytesIO(fh.read(nbytes))
                 st = obspy.read(flh, format=format)
                 if isinstance(mspass_object, TimeSeries):
@@ -3442,27 +3466,44 @@ class Database(pymongo.database.Database):
                             interpolation_samples=merge_interpolation_samples,
                         )
                     tr = st[0]
-                    # Now we convert this to a TimeSeries and load other Metadata
-                    # Note the exclusion copy and the test verifying net,sta,chan,
-                    # loc, and startime all match
-                    mspass_object.npts = len(tr.data)
-                    mspass_object.data = DoubleVector(tr.data)
+                    mspass_object = Trace2TimeSeries(tr)
                 elif isinstance(mspass_object, Seismogram):
-                    sm = st.toSeismogram(cardinal=True)
-                    mspass_object.npts = sm.data.columns()
-                    mspass_object.data = sm.data
+                    # This was previous form.   The toSeismogram run as a 
+                    # method is an unnecessary confusion and I don't think 
+                    # settign npts or data are necessary given the code of 
+                    # Stream2Seismogram - st.toSeismogram is an alias for that
+                    #sm = st.toSeismogram(cardinal=True)
+                    #mspass_object.npts = sm.data.columns()
+                    #mspass_object.data = sm.data
+                    mspass_object = Stream2Seismogram(st,cardinal=True)
 
     @staticmethod
-    def _save_data_to_dfile(mspass_object, dir, dfile, format=None):
+    def _save_data_to_dfile(mspass_object, dir, dfile, format=None,kill_on_failure=False):
         """
-        Saves sample data as a binary dump of the sample data. Save a mspasspy object as a pure binary dump of
-        the sample data in native (Fortran) order. Opens the file and ALWAYS appends data to the end of the file.
-
-        This method is subject to several issues to beware of before using them:
-        (1) they are subject to damage by other processes/program, (2) updates are nearly impossible without
-        stranding (potentially large quantities) of data in the middle of files or
-        corrupting a file with a careless insert, and (3) when the number of files
-        gets large managing them becomes difficult.
+        This is a private method used under the hood to save the sample data
+        of atomic MsPASS data objects.  How the save happens is highly 
+        dependent upon the format argument.  When None, which is the 
+        default, the data are written to the file specified by dir and dfile 
+        using low-level C fwrite calls.  The function used always appends 
+        data to eof if the file already exists to allow accumation of data 
+        in "gather" files to reduce file name overhead in hpc systems. 
+        If format is anything else the function attempts to use one of 
+        the obspy formatted writers.  That means the format string must be 
+        one of the `supported formats <https://docs.obspy.org/packages/autogen/obspy.core.stream.Stream.write.html#supported-formats>`__ of ObsPy reader.
+        
+        
+        Writing to a file can fail for any number of reasons.   write errors 
+        are trapped internally in this function any errors posted to elog of
+        mspass_object.   If the kill_on_failure boolean is set true the 
+        function will call the kill method of the data function and the 
+        that datum will be marked dead.   That is not normally a good idea 
+        if there is any additional work to do on the data so the default
+        for that parameter is false.  
+        
+        Because we use a stream model for file storage be aware 
+        that insertion and deletion in a file are not possible.  If you 
+        need lots of editing functionality with files you should use the 
+        one file to one object model or (better yet) use gridfs storage.
 
         :param mspass_object: the target object.
         :type mspass_object: either :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`
@@ -3472,21 +3513,38 @@ class Database(pymongo.database.Database):
         :type dfile: :class:`str`
         :param format: the format of the file. This can be one of the `supported formats <https://docs.obspy.org/packages/autogen/obspy.core.stream.Stream.write.html#supported-formats>`__ of ObsPy reader. By default (``None``), the format will be the binary waveform.
         :type format: :class:`str`
+        :param kill_on_failure:  When true if an io error occurs the data object's 
+          kill method will be invoked.  When false (the default) io errors are 
+          logged and left set live.  (Note data already marked dead are return 
+          are ignored by this function. )
+        :type kill_on_failure: boolean
         :return: Position of first data sample (foff) and the size of the saved chunk.
+           If the input is flagged as dead return (-1,0)
         """
         if not isinstance(mspass_object, (TimeSeries, Seismogram)):
             raise TypeError("only TimeSeries and Seismogram are supported")
-        fname = os.path.join(dir, dfile)
-        os.makedirs(os.path.dirname(fname), exist_ok=True)
-        with open(fname, mode="a+b") as fh:
-            foff = fh.seek(0, 2)
-            if not format:
-                if isinstance(mspass_object, TimeSeries):
-                    # fixme DoubleVector
-                    ub = bytes(np.array(mspass_object.data))
-                elif isinstance(mspass_object, Seismogram):
-                    ub = bytes(mspass_object.data)
+        if mspass_object.dead():
+            return -1,0
+        
+        if not format:
+            try:
+                # This function has overloading.  this might not work
+                foff = _fwrite_to_file(mspass_object,dir,dfile)
+            except MsPASSError as merr:
+                mspass_object.elog.log_error(merr)
+                if kill_on_failure:
+                    mspass_object.kill()
+            # we can compute the number of bytes written for this case
+            if isinstance(mspass_object, TimeSeries):
+                nbytes_written = 8*mspass_object.npts
             else:
+                # This can only be a Seismogram currently so this is not elif
+                nbytes_written = 24*mspass_object.npts
+        else:
+            fname = os.path.join(dir, dfile)
+            os.makedirs(os.path.dirname(fname), exist_ok=True)
+            with open(fname, mode="a+b") as fh:
+                foff = fh.seek(0, 2)
                 f_byte = io.BytesIO()
                 if isinstance(mspass_object, TimeSeries):
                     mspass_object.toTrace().write(f_byte, format=format)
@@ -3494,8 +3552,9 @@ class Database(pymongo.database.Database):
                     mspass_object.toStream().write(f_byte, format=format)
                 f_byte.seek(0)
                 ub = f_byte.read()
-            fh.write(ub)
-        return foff, len(ub)
+                fh.write(ub)
+                nbytes_written = len(ub)
+        return foff, nbytes_written
 
     def _save_data_to_gridfs(self, mspass_object, gridfs_id=None):
         """

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3466,6 +3466,8 @@ class Database(pymongo.database.Database):
                             interpolation_samples=merge_interpolation_samples,
                         )
                     tr = st[0]
+                    mspass_object.npts = len(tr.data)
+                    mspass_object.data = DoubleVector(tr.data)
                     mspass_object = Trace2TimeSeries(tr)
                 elif isinstance(mspass_object, Seismogram):
                     # This was previous form.   The toSeismogram run as a 


### PR DESCRIPTION
This branch implements several important changes that should dramatically improve file-based io performance.  The fundamental strategy was to isolate all io to C++ code on so the readers and writers never had to deal with the "DoubleVector" python construct created on the python side by pybind11.  The new C++ code is in the  fileio.h and fileio.cc in the "io" sections of include and lib respectively.   The readers all use raw fread to the data array buffers and the writers all use fwrite from the same buffers.   I've tested the code with a local python script I wrote, but I think the existing tests should certify the changes work correctly.  The changes I made to Database to use the new C++ functions should not effect the tests.  If not, we'll need to deal with that when we find out if my claim is true. 

There are a couple of issues that came up in this development mspass-team members may want to look at before we merge these changes.  
1.  I first started to implement old-school file locking for the writers since there was a strong possibility in a parallel setting two threads/process could try to write to the same file simultaneously.  However, when I read the unix man pages for functions related to file locking they pretty much said they were archaic.   What I read says the posix standard now requires an intrinsic lock on any file when it is opened in write or append mode.   If my reading of this is wrong, we could have an issue here.  
2. I fixed a piece of Database written by @haruming that I didn't test, but which I think our test suite will verify.   The issue is that I think the original had an unnecessary inefficiency.  If no an inefficiency the change here is a least clearer as to what it does.  Here is the block of code where I left the original commented out in case this breaks:
```
                elif isinstance(mspass_object, Seismogram):
                    # This was previous form.   The toSeismogram run as a
                    # method is an unnecessary confusion and I don't think
                    # settign npts or data are necessary given the code of
                    # Stream2Seismogram - st.toSeismogram is an alias for that
                    #sm = st.toSeismogram(cardinal=True)
                    #mspass_object.npts = sm.data.columns()
                    #mspass_object.data = sm.data
                    mspass_object = Stream2Seismogram(st,cardinal=True)
```
If the tests show this works we should strip those commented out lines before we merge this with master.