### PR TITLE
For residual problem with graphics module #343 

### DIFF
--- a/cxx/python/algorithms/basic_py.cc
+++ b/cxx/python/algorithms/basic_py.cc
@@ -122,14 +122,14 @@ PYBIND11_MODULE(basic, m) {
 
   /* overload_cast would not work on this name because of a strange limitation with templated functions
    * used for the Ensemble definition.   */
-  m.def("ExtractComponentSeismogram",static_cast<TimeSeries(*)(const Seismogram&,const unsigned int)>(&ExtractComponent),
+  m.def("_ExtractComponent",static_cast<TimeSeries(*)(const Seismogram&,const unsigned int)>(&ExtractComponent),
   	"Extract component as a TimeSeries object",
       py::return_value_policy::copy,
       py::arg("tcs"),
       py::arg("component")
   );
 
-  m.def("ExtractComponentEnsemble",static_cast<Ensemble<TimeSeries>(*)(const Ensemble<Seismogram>&,const unsigned int)>(&ExtractComponent),
+  m.def("_ExtractComponent",static_cast<Ensemble<TimeSeries>(*)(const Ensemble<Seismogram>&,const unsigned int)>(&ExtractComponent),
   	"Extract one component from a 3C ensemble",
       py::return_value_policy::copy,
       py::arg("d"),

--- a/cxx/python/algorithms/basic_py.cc
+++ b/cxx/python/algorithms/basic_py.cc
@@ -122,14 +122,14 @@ PYBIND11_MODULE(basic, m) {
 
   /* overload_cast would not work on this name because of a strange limitation with templated functions
    * used for the Ensemble definition.   */
-  m.def("ExtractComponent",static_cast<TimeSeries(*)(const Seismogram&,const unsigned int)>(&ExtractComponent),
+  m.def("ExtractComponentSeismogram",static_cast<TimeSeries(*)(const Seismogram&,const unsigned int)>(&ExtractComponent),
   	"Extract component as a TimeSeries object",
       py::return_value_policy::copy,
       py::arg("tcs"),
       py::arg("component")
   );
 
-  m.def("EnsembleComponent",static_cast<Ensemble<TimeSeries>(*)(const Ensemble<Seismogram>&,const unsigned int)>(&ExtractComponent),
+  m.def("ExtractComponentEnsemble",static_cast<Ensemble<TimeSeries>(*)(const Ensemble<Seismogram>&,const unsigned int)>(&ExtractComponent),
   	"Extract one component from a 3C ensemble",
       py::return_value_policy::copy,
       py::arg("d"),

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -16,7 +16,7 @@ from mspasspy.ccore.seismic import DoubleVector
 from mspasspy.ccore.utility import AntelopePf, Metadata, MsPASSError, ErrorSeverity
 from mspasspy.util.converter import Metadata2dict
 from mspasspy.algorithms.window import WindowData
-from mspasspy.ccore.algorithms.basic import TimeWindow, ExtractComponent
+from mspasspy.ccore.algorithms.basic import TimeWindow, ExtractComponentSeismogram
 from mspasspy.ccore.algorithms.deconvolution import (
     LeastSquareDecon,
     WaterLevelDecon,
@@ -123,7 +123,7 @@ class RFdeconProcessor:
         dvector = []
         if window:
             if dtype == "Seismogram":
-                ts = ExtractComponent(d, component)
+                ts = ExtractComponentSeismogram(d, component)
                 ts = WindowData(ts, self.dwin.start, self.dwin.end)
                 dvector = ts.data
             elif dtype == "TimeSeries":
@@ -133,7 +133,7 @@ class RFdeconProcessor:
                 dvector = d
         else:
             if dtype == "Seismogram":
-                ts = ExtractComponent(d, component)
+                ts = ExtractComponentSeismogram(d, component)
                 dvector = ts.data
             elif dtype == "TimeSeries":
                 dvector = ts.data
@@ -159,7 +159,7 @@ class RFdeconProcessor:
         wvector = []
         if window:
             if dtype == "Seismogram":
-                ts = ExtractComponent(w, component)
+                ts = ExtractComponentSeismogram(w, component)
                 ts = WindowData(ts, self.dwin.start, self.dwin.end)
                 wvector = ts.data
             elif dtype == "TimeSeries":
@@ -169,7 +169,7 @@ class RFdeconProcessor:
                 wvector = w
         else:
             if dtype == "Seismogram":
-                ts = ExtractComponent(w, component)
+                ts = ExtractComponentSeismogram(w, component)
                 wvector = ts.data
             elif dtype == "TimeSeries":
                 wvector = ts.data
@@ -205,7 +205,7 @@ class RFdeconProcessor:
             tws = self.md.get_double("noise_window_start")
             twe = self.md.get_double("noise_window_end")
             if dtype == "Seismogram":
-                ts = ExtractComponent(n, component)
+                ts = ExtractComponentSeismogram(n, component)
                 ts = WindowData(ts, tws, twe)
                 nvector = ts.data
             elif dtype == "TimeSeries":
@@ -215,7 +215,7 @@ class RFdeconProcessor:
                 nvector = n
         else:
             if dtype == "Seismogram":
-                ts = ExtractComponent(n, component)
+                ts = ExtractComponentSeismogram(n, component)
                 nvector = ts.data
             elif dtype == "TimeSeries":
                 nvector = ts.data

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -16,7 +16,7 @@ from mspasspy.ccore.seismic import DoubleVector
 from mspasspy.ccore.utility import AntelopePf, Metadata, MsPASSError, ErrorSeverity
 from mspasspy.util.converter import Metadata2dict
 from mspasspy.algorithms.window import WindowData
-from mspasspy.ccore.algorithms.basic import TimeWindow, ExtractComponentSeismogram
+from mspasspy.ccore.algorithms.basic import TimeWindow, _ExtractComponent
 from mspasspy.ccore.algorithms.deconvolution import (
     LeastSquareDecon,
     WaterLevelDecon,
@@ -123,7 +123,7 @@ class RFdeconProcessor:
         dvector = []
         if window:
             if dtype == "Seismogram":
-                ts = ExtractComponentSeismogram(d, component)
+                ts = _ExtractComponent(d, component)
                 ts = WindowData(ts, self.dwin.start, self.dwin.end)
                 dvector = ts.data
             elif dtype == "TimeSeries":
@@ -133,7 +133,7 @@ class RFdeconProcessor:
                 dvector = d
         else:
             if dtype == "Seismogram":
-                ts = ExtractComponentSeismogram(d, component)
+                ts = _ExtractComponent(d, component)
                 dvector = ts.data
             elif dtype == "TimeSeries":
                 dvector = ts.data
@@ -159,7 +159,7 @@ class RFdeconProcessor:
         wvector = []
         if window:
             if dtype == "Seismogram":
-                ts = ExtractComponentSeismogram(w, component)
+                ts = _ExtractComponent(w, component)
                 ts = WindowData(ts, self.dwin.start, self.dwin.end)
                 wvector = ts.data
             elif dtype == "TimeSeries":
@@ -169,7 +169,7 @@ class RFdeconProcessor:
                 wvector = w
         else:
             if dtype == "Seismogram":
-                ts = ExtractComponentSeismogram(w, component)
+                ts = _ExtractComponent(w, component)
                 wvector = ts.data
             elif dtype == "TimeSeries":
                 wvector = ts.data
@@ -205,7 +205,7 @@ class RFdeconProcessor:
             tws = self.md.get_double("noise_window_start")
             twe = self.md.get_double("noise_window_end")
             if dtype == "Seismogram":
-                ts = ExtractComponentSeismogram(n, component)
+                ts = _ExtractComponent(n, component)
                 ts = WindowData(ts, tws, twe)
                 nvector = ts.data
             elif dtype == "TimeSeries":
@@ -215,7 +215,7 @@ class RFdeconProcessor:
                 nvector = n
         else:
             if dtype == "Seismogram":
-                ts = ExtractComponentSeismogram(n, component)
+                ts = _ExtractComponent(n, component)
                 nvector = ts.data
             elif dtype == "TimeSeries":
                 nvector = ts.data

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -50,7 +50,7 @@ def ExtractComponent(
     """
     if isinstance(data, Seismogram):
         try:
-            d = bsc.ExtractComponentSeismogram(data, component)
+            d = bsc._ExtractComponent(data, component)
             return d
         except Exception as err:
             data.elog.log_error("ExtractComponent", str(err), ErrorSeverity.Invalid)
@@ -65,7 +65,7 @@ def ExtractComponent(
             empty.kill()
             return empty
         try:
-            d = TimeSeriesEnsemble(bsc.ExtractComponentEnsemble(data, component))
+            d = TimeSeriesEnsemble(bsc._ExtractComponent(data, component))
             # second copy to convert type from CoreTimeSeriesEnsemble to TimeSeriesEnsemble
             return d
         except Exception as err:

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -50,7 +50,7 @@ def ExtractComponent(
     """
     if isinstance(data, Seismogram):
         try:
-            d = bsc.ExtractComponent(data, component)
+            d = bsc.ExtractComponentSeismogram(data, component)
             return d
         except Exception as err:
             data.elog.log_error("ExtractComponent", str(err), ErrorSeverity.Invalid)
@@ -65,7 +65,7 @@ def ExtractComponent(
             empty.kill()
             return empty
         try:
-            d = TimeSeriesEnsemble(bsc.EnsembleComponent(data, component))
+            d = TimeSeriesEnsemble(bsc.ExtractComponentEnsemble(data, component))
             # second copy to convert type from CoreTimeSeriesEnsemble to TimeSeriesEnsemble
             return d
         except Exception as err:

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -66,6 +66,7 @@ def ExtractComponent(
             return empty
         try:
             d = TimeSeriesEnsemble(bsc.EnsembleComponent(data, component))
+            # second copy to convert type from CoreTimeSeriesEnsemble to TimeSeriesEnsemble
             return d
         except Exception as err:
             logging_helper.ensemble_error(

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -13,7 +13,7 @@ from mspasspy.ccore.algorithms.amplitudes import (
     EstimateBandwidth,
     BandwidthStatistics,
 )
-from mspasspy.ccore.algorithms.basic import TimeWindow, Butterworth, ExtractComponent
+from mspasspy.ccore.algorithms.basic import TimeWindow, Butterworth, ExtractComponentSeismogram
 from mspasspy.algorithms.window import WindowData
 
 
@@ -826,7 +826,7 @@ def arrival_snr_QC(
                 + "Must be 0, 1, or 2",
                 ErrorSeverity.Fatal,
             )
-        data_to_process = ExtractComponent(data_object, component)
+        data_to_process = ExtractComponentSeismogram(data_object, component)
         if receiver_collection:
             rcol = receiver_collection
         else:

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -13,7 +13,7 @@ from mspasspy.ccore.algorithms.amplitudes import (
     EstimateBandwidth,
     BandwidthStatistics,
 )
-from mspasspy.ccore.algorithms.basic import TimeWindow, Butterworth, ExtractComponentSeismogram
+from mspasspy.ccore.algorithms.basic import TimeWindow, Butterworth, _ExtractComponent
 from mspasspy.algorithms.window import WindowData
 
 
@@ -826,7 +826,7 @@ def arrival_snr_QC(
                 + "Must be 0, 1, or 2",
                 ErrorSeverity.Fatal,
             )
-        data_to_process = ExtractComponentSeismogram(data_object, component)
+        data_to_process = _ExtractComponent(data_object, component)
         if receiver_collection:
             rcol = receiver_collection
         else:

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -7,7 +7,7 @@ from mspasspy.ccore.seismic import (
     TimeSeriesEnsemble,
     SeismogramEnsemble,
 )
-from mspasspy.ccore.algorithms.basic import ExtractComponent, EnsembleComponent
+from mspasspy.algorithms.basic import ExtractComponent
 from mspasspy.algorithms.window import scale as alg_scale
 
 
@@ -241,7 +241,7 @@ def wtvaplot(
         title3c = title
         for i in range(3):
             pyplot.figure(i)
-            dcomp = EnsembleComponent(d, i)
+            dcomp = ExtractComponent(d, i)
             if title != None:
                 title3c = "%s:%d" % (title, i)
             try:
@@ -302,7 +302,7 @@ def imageplot(
         title3c = title
         for i in range(3):
             pyplot.figure(i)
-            dcomp = EnsembleComponent(d, i)
+            dcomp = ExtractComponent(d, i)
             if title != None:
                 title3c = "%s:%d" % (title, i)
             try:
@@ -960,11 +960,11 @@ class SeismicPlotter:
         return pyplot.gcf()
 
     def _wtva_SeismogramEnsemble(self, d, fill):
-        # implement by call to EnsembleComponent and calling TimeSeriesEnsemble method 3 times
+        # implement by call to ExtractComponent and calling TimeSeriesEnsemble method 3 times
         # should return a list of 3 gcf handles
         figure_handles = []
         for k in range(3):
-            dcomp = EnsembleComponent(d, k)
+            dcomp = ExtractComponent(d, k)
             # figure_title='Component %d' % k
             # pyplot.figure(figure_title)
             pyplot.figure(k)
@@ -1048,11 +1048,11 @@ class SeismicPlotter:
         )
 
     def _imageplot_SeismogramEnsemble(self, d):
-        # implement by call to EnsembleComponent and calling TimeSeriesEnsemble method 3 times
+        # implement by call to ExtractComponent and calling TimeSeriesEnsemble method 3 times
         # should return a list of 3 gcf handles
         figure_handles = []
         for k in range(3):
-            dcomp = EnsembleComponent(d, k)
+            dcomp = ExtractComponent(d, k)
             pyplot.figure(k)
             figure = self._imageplot(dcomp)
             figure_handles.append(figure)

--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -17,7 +17,7 @@ from mspasspy.ccore.seismic import (
     SeismogramEnsemble,
     Keywords,
 )
-from mspasspy.ccore.algorithms.basic import ExtractComponent
+from mspasspy.ccore.algorithms.basic import ExtractComponentSeismogram
 
 
 def dict2Metadata(dic):
@@ -229,7 +229,7 @@ def Seismogram2Stream(
         uuids = sg.id()
         logstuff = sg.elog
         for i in range(3):
-            ts = ExtractComponent(sg, i)
+            ts = ExtractComponentSeismogram(sg, i)
             ts.put_string(Keywords.chan, chanmap[i])
             ts.put_double(Keywords.channel_hang, hang[i])
             ts.put_double(Keywords.channel_vang, vang[i])

--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -17,7 +17,7 @@ from mspasspy.ccore.seismic import (
     SeismogramEnsemble,
     Keywords,
 )
-from mspasspy.ccore.algorithms.basic import ExtractComponentSeismogram
+from mspasspy.ccore.algorithms.basic import _ExtractComponent
 
 
 def dict2Metadata(dic):
@@ -229,7 +229,7 @@ def Seismogram2Stream(
         uuids = sg.id()
         logstuff = sg.elog
         for i in range(3):
-            ts = ExtractComponentSeismogram(sg, i)
+            ts = _ExtractComponent(sg, i)
             ts.put_string(Keywords.chan, chanmap[i])
             ts.put_double(Keywords.channel_hang, hang[i])
             ts.put_double(Keywords.channel_vang, vang[i])

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -30,7 +30,7 @@ from mspasspy.ccore.utility import (
 )
 
 from mspasspy.util.error_logger import PyErrorLogger
-from mspasspy.ccore.algorithms.basic import ExtractComponent
+from mspasspy.ccore.algorithms.basic import ExtractComponentSeismogram
 from mspasspy.ccore.algorithms.deconvolution import MTPowerSpectrumEngine
 
 
@@ -1309,7 +1309,7 @@ def test_ExtractComponent():
     seis.npts = 6
     ts = []
     for i in range(3):
-        ts.append(ExtractComponent(seis, i))
+        ts.append(ExtractComponentSeismogram(seis, i))
     for i in range(3):
         assert (ts[i].data == seis.data[i]).all()
 

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -30,7 +30,7 @@ from mspasspy.ccore.utility import (
 )
 
 from mspasspy.util.error_logger import PyErrorLogger
-from mspasspy.ccore.algorithms.basic import ExtractComponentSeismogram
+from mspasspy.ccore.algorithms.basic import _ExtractComponent
 from mspasspy.ccore.algorithms.deconvolution import MTPowerSpectrumEngine
 
 
@@ -1309,7 +1309,7 @@ def test_ExtractComponent():
     seis.npts = 6
     ts = []
     for i in range(3):
-        ts.append(ExtractComponentSeismogram(seis, i))
+        ts.append(_ExtractComponent(seis, i))
     for i in range(3):
         assert (ts[i].data == seis.data[i]).all()
 


### PR DESCRIPTION
For residual problem with graphics module #343 , I changed all EnsembleComponent to ExtractComponent. But the graphics tutorial still cannot work.
Because in `ExtractComponent()`, I added a conditional statement `if data.dead():`, to ensure the input data is live. If the data is dead, `ExtractComponent()` will return an empty object. In the graphics tutorial, `makeseisens()` function in graphicstutorial.py (line 114) generates a TimeSeries ensemble that is dead. So the graphics tutorial does not work.
```
def makeseisens(d,n=20,moveout=True,moveout_dt=0.05):
    """
    Makes a TimeSeries ensemble as copies of d.  If moveout is true
    applies a linear moveout to members using moveout_dt times
    count of member in ensemble.
    """
    result=SeismogramEnsemble()
    for i in range(n):
        y=Seismogram(d)  # this makes a required deep copy
        if(moveout):
            y.t0+=float(i)*moveout_dt
        result.member.append(y)
    result.set_live() # set results live before return
    return result
```
It can be fixed by adding `result.set_live()` before return in graphicstutorial.py, then the graphics tutorial can run form beginning to end with no errors. Or I can remove the `if data.dead():` statements in `ExtractComponent()` function to ignore the live or dead status of the input data. 

****

For the secondary copy below, it is to convert the return type from `mspasspy.ccore.seismic.CoreTimeSeriesEnsemble` to `TimeSeriesEnsemble`. If there is no conversion, `_wtva()` function in graphics.py (line 826) will raise `RuntimeError` because the type is not correct. `_wtva()` function does not support `CoreTimeSeriesEnsemble` type, it only supports `TimeSeriesEnsemble` type. So I made this conversion. I added a comment here.
```
d = TimeSeriesEnsemble(bsc.EnsembleComponent(data, component))
# second copy to convert type from CoreTimeSeriesEnsemble to TimeSeriesEnsemble
```
