### PR TITLE
Update snr.py

### DIFF
--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -485,7 +485,7 @@ def FD_snr_estimator(
                         "Five snr_stats attributes were not computed",
                     )
                     my_logger.log_error(algname, newmessage, err.severity)
-            if metric == "filtered_envelope":
+            elif metric == "filtered_envelope":
                 try:
                     analytic_nfilt = hilbert(nfilt.data)
                     analytic_sfilt = hilbert(sfilt.data)
@@ -502,7 +502,7 @@ def FD_snr_estimator(
                         "Error computing filtered_envelope metrics:  snr_envelope_Linf_over_L1 not computed",
                         ErrorSeverity.Complaint,
                     )
-            if metric == "filtered_L2":
+            elif metric == "filtered_L2":
                 try:
                     namp = RMSAmplitude(nfilt)
                     samp = RMSAmplitude(sfilt)
@@ -516,7 +516,7 @@ def FD_snr_estimator(
                     )
                     my_logger.log_error(algname, newmessage, err.severity)
 
-            if metric == "filtered_MAD":
+            elif metric == "filtered_MAD":
                 try:
                     namp = MADAmplitude(nfilt)
                     samp = MADAmplitude(sfilt)
@@ -530,7 +530,7 @@ def FD_snr_estimator(
                     )
                     my_logger.log_error(algname, newmessage, err.severity)
 
-            if metric == "filtered_Linf":
+            elif metric == "filtered_Linf":
                 try:
                     # the C function expects a fraction - for users a percentage
                     # is clearer
@@ -547,7 +547,7 @@ def FD_snr_estimator(
                     )
                     my_logger.log_error(algname, newmessage, err.severity)
 
-            if metric == "filtered_perc":
+            elif metric == "filtered_perc":
                 try:
                     namp = MADAmplitude(nfilt)
                     samp = PercAmplitude(sfilt, perc / 100.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ boto3
 botocore
 moto
 requests==2.27.1
+setuptools<=65.5.1


### PR DESCRIPTION
Fix a relatively harmless logic error in section of FD_snr_estimator that posts computed snr attributes to output python dictionary.   The error was harmless as attributes where posted but the logic created a pile of error log messages that were not correct - there was no such error.   Basically a set of if statements needed to be elif.