### PR TITLE
Update normalize.py

### DIFF
--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -1917,8 +1917,9 @@ class MiniseedMatcher(DictionaryCacheMatcher):
         testid = self.db_make_cache_id(doc)
         if testid is None:
             return None
-        matches = self.normcache[testid]
-        if len(matches) <= 0:
+        if testid in self.normcache:
+            matches = self.normcache[testid]
+        else:
             return None
 
         # linear search similar to that in find_one above


### PR DESCRIPTION
I thought we fixed this bug, but it seems to still be here.  The old code failed on any datum where there was no match in the normcache.   The proposed solution works on test data and resolves the problem.