### PR TITLE
Extend snr

### DIFF
--- a/cxx/src/lib/seismic/CoreSeismogram.cc
+++ b/cxx/src/lib/seismic/CoreSeismogram.cc
@@ -166,9 +166,9 @@ CoreSeismogram::CoreSeismogram(const Metadata& md,
           components_are_orthogonal = true;
           components_are_cardinal = true;
         }
-        /* We have to handle nsamp specially in the case when load_data 
-        is false.  To be consistent with TimeSeries we use a feature that 
-        if the Metadata container does not define npts we default it.  
+        /* We have to handle nsamp specially in the case when load_data
+        is false.  To be consistent with TimeSeries we use a feature that
+        if the Metadata container does not define npts we default it.
         In this case that means the default constructor for u and set
         nsamp to 0 (via set_npts). */
         if(md.is_defined(SEISMICMD_npts))
@@ -180,8 +180,8 @@ CoreSeismogram::CoreSeismogram(const Metadata& md,
         {
           this->set_npts(0);
         }
-        /* Note previous code had an else clause to to with the 
-        following conditional.  It used to zero the u matrix.  
+        /* Note previous code had an else clause to to with the
+        following conditional.  It used to zero the u matrix.
         The call to set_npts above will always do that so that would
         have been redundant and was removed June 2022*/
         if(load_data)

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -1199,8 +1199,8 @@ def save_snr_arrival(db,
         # note update is only allowed on the parent wf collection
         filt = {"_id": upd_id}
         update_clause = {"$set": doc}
-        dbwfcol.update_one(filt, update_clause)
-        save_id = wfid
+        dbcol.update_one(filt, update_clause)
+        save_id = upd_id
     else:
         save_id =dbcol.insert_one(doc).inserted_id
         

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -446,17 +446,17 @@ def FD_snr_estimator(
         # First extract the required windows and compute the power spectra
         n = WindowData(data_object, noise_window.start, noise_window.end)
         s = WindowData(data_object, signal_window.start, signal_window.end)
-        # WARNING:  this handler depends upon an implementation details 
-        # that could be a maintenance issue.  The python code has a catch 
-        # that kills a datum where windowing fails.   The C++ code throws 
-        # an exception when that happens.  The python code posts that error 
+        # WARNING:  this handler depends upon an implementation details
+        # that could be a maintenance issue.  The python code has a catch
+        # that kills a datum where windowing fails.   The C++ code throws
+        # an exception when that happens.  The python code posts that error
         # message to the output which we extract here
         if n.dead() or s.dead():
             if n.dead():
-                if n.elog.size()>0:
+                if n.elog.size() > 0:
                     my_logger += n.elog
             if s.dead():
-                if s.elog.size()>0:
+                if s.elog.size() > 0:
                     my_logger += s.elog
         if noise_spectrum_engine:
             nengine = noise_spectrum_engine
@@ -539,12 +539,14 @@ def FD_snr_estimator(
                         for k in stats.keys():
                             snrdata[k] = stats[k]
                     else:
-                        my_logger.log_error(algname,
+                        my_logger.log_error(
+                            algname,
                             "BandwidthStatistics marked snr_stats data invalid",
-                            ErrorSeverity.Complaint)
+                            ErrorSeverity.Complaint,
+                        )
                 except MsPASSError as err:
-                    # This handler currently would never be entered but 
-                    # left in place to keep code more robust in the event 
+                    # This handler currently would never be entered but
+                    # left in place to keep code more robust in the event
                     # of a change
                     newmessage = _reformat_mspass_error(
                         err,
@@ -784,16 +786,18 @@ def arrival_snr(
     )
     if elog.size() > 0:
         data_object.elog += elog
-    # FD_snr_estimator returns an empty dictionary if the snr 
-    # calculation fails or indicates no signal is present.  This 
+    # FD_snr_estimator returns an empty dictionary if the snr
+    # calculation fails or indicates no signal is present.  This
     # block combines that with the kill_null_signals in this logic
     if len(snrdata) > 0:
         snrdata["phase"] = phase_name
         data_object[metadata_output_key] = snrdata
     elif kill_null_signals:
-        data_object.elog.log_error("arrival_snr",
+        data_object.elog.log_error(
+            "arrival_snr",
             "FD_snr_estimator flagged this datum as having no detectable signal",
-            ErrorSeverity.Invalid)
+            ErrorSeverity.Invalid,
+        )
         data_object.kill()
     return data_object
 
@@ -1040,13 +1044,15 @@ def broadband_snr_QC(
     )
     if elog.size() > 0:
         data_object.elog += elog
-    # FD_snr_estimator returns an empty dictionary if the snr 
-    # calculation fails or indicates no signal is present.  This 
+    # FD_snr_estimator returns an empty dictionary if the snr
+    # calculation fails or indicates no signal is present.  This
     # block combines that with the kill_null_signals in this logic
     if len(snrdata) == 0:
-        data_object.elog.log_error("broadband_snr_QC",
+        data_object.elog.log_error(
+            "broadband_snr_QC",
             "FD_snr_estimator flagged this datum as having no detectable signal",
-            ErrorSeverity.Invalid)
+            ErrorSeverity.Invalid,
+        )
         if kill_null_signals:
             data_object.kill()
         return data_object
@@ -1072,16 +1078,18 @@ def broadband_snr_QC(
     data_object[metadata_output_key] = snrdata
     return data_object
 
-def save_snr_arrival(db,
-                     doc_to_save,
-                     wfid,
-                     wf_collection="wf_Seismogram",
-                     save_collection="arrival",
-                     subdocument_key=None,
-                     use_update=False,
-                     update_id=None,
-                     validate_wfid=False,
-                     )->ObjectId:
+
+def save_snr_arrival(
+    db,
+    doc_to_save,
+    wfid,
+    wf_collection="wf_Seismogram",
+    save_collection="arrival",
+    subdocument_key=None,
+    use_update=False,
+    update_id=None,
+    validate_wfid=False,
+) -> ObjectId:
     """
     This function is a companion to broadband_snr_QC.   It handles the 
     situation where the workflow aims to post calculated snr metrics to 
@@ -1176,8 +1184,8 @@ def save_snr_arrival(db,
     and nothing was saved.
     """
     dbwfcol = db[wf_collection]
-    if validate_wfid:      
-        query = {"_id" : wfid}
+    if validate_wfid:
+        query = {"_id": wfid}
         ndocs = dbwfcol.count_documents(query)
         if ndocs == 0:
             return None
@@ -1190,8 +1198,8 @@ def save_snr_arrival(db,
     else:
         upd_id = update_id
     # this block sets doc for save with or without subdoc option
-    doc=dict(doc_to_save)  # this acts like a deep copy
-    doc["wfid"]=wfid
+    doc = dict(doc_to_save)  # this acts like a deep copy
+    doc["wfid"] = wfid
     if subdocument_key:
         # The constructor for a dict is necesary to assure a deepcopy here
         doc[subdocument_key] = dict(doc)
@@ -1202,9 +1210,6 @@ def save_snr_arrival(db,
         dbcol.update_one(filt, update_clause)
         save_id = upd_id
     else:
-        save_id =dbcol.insert_one(doc).inserted_id
-        
+        save_id = dbcol.insert_one(doc).inserted_id
+
     return save_id
-        
-    
-    

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -674,20 +674,20 @@ def arrival_snr(
     removes some of the options from the more generic function and
     has a frozen structure appropriate for measuring snr of a particular phase.
     In particular it always stores the results as a subdocument (python dict)
-    keyed by the name defined in the metadata_output_key argument. 
-    This function has a close sibling called "broadband_snr_QC" that 
-    has similar behavior but add some additional functionality.   The 
+    keyed by the name defined in the metadata_output_key argument.
+    This function has a close sibling called "broadband_snr_QC" that
+    has similar behavior but add some additional functionality.   The
     most significant limitation of this function relative to broadband_snr_QC
-    is that this function ONLY accepts TimeSeries data as input.  
-    
-    This function is most appropriate 
-    for QC done within a workflow where the model is to process a large 
-    data set and winnow it down to separate the wheat from the chaff, to 
-    use a cliche consistent with "winnow".   In that situation the normal 
-    use would be to run this function with a map operator on atomic data 
-    and follow it with a call to filter to remove dead data and/or filter 
-    with tests on the computed metrics.  See User's Manual for guidance on 
-    this topic.  Because that is the expected normal use of this function 
+    is that this function ONLY accepts TimeSeries data as input.
+
+    This function is most appropriate
+    for QC done within a workflow where the model is to process a large
+    data set and winnow it down to separate the wheat from the chaff, to
+    use a cliche consistent with "winnow".   In that situation the normal
+    use would be to run this function with a map operator on atomic data
+    and follow it with a call to filter to remove dead data and/or filter
+    with tests on the computed metrics.  See User's Manual for guidance on
+    this topic.  Because that is the expected normal use of this function
     the kill_null_signals boolean defaults to True.
 
     To be more robust the function tries to handle a common error.  That is,
@@ -717,14 +717,14 @@ def arrival_snr(
     :param arrival_time_key:  key (string) used to fetch an arrival time
       if the data are in UTC and the time window received does not overlap
       the data range (see above)
-      
-    :param kill_null_signals:  boolean controlling how null snr estimator 
-    returns are handled.  When True (default) if FD_snr_estimator returns a null 
-    result (no apparent signal) that input datum is killed before being 
-    returned.  In that situation no snr metrics will be in the output because 
-    null means FD_snr_estimator couldn't detect a signal and the algorithm 
-    failed.   When False the datum is returned silently but 
-    will have no snr data defined in a dict stored with the key 
+
+    :param kill_null_signals:  boolean controlling how null snr estimator
+    returns are handled.  When True (default) if FD_snr_estimator returns a null
+    result (no apparent signal) that input datum is killed before being
+    returned.  In that situation no snr metrics will be in the output because
+    null means FD_snr_estimator couldn't detect a signal and the algorithm
+    failed.   When False the datum is returned silently but
+    will have no snr data defined in a dict stored with the key
     metadata_output_key (i.e. that attribute will be undefined in output)
 
     :param metadata_output_key:  is a string used as a key under which the
@@ -838,30 +838,30 @@ def broadband_snr_QC(
     """
     Compute a series of metrics that can be used for quality control
     filtering of seismic phase data.
-    
-    This function is intended as a workhorse to be used for low-level, 
-    automated QC of broadband data when the the data set is defined 
-    by signals linked to a timeable seismic phase.   It can be 
-    thought of as a version of a related function called 
-    "arrival_snr" with some additional features.  See the docstring 
-    for that function for what those base features are.   Features this 
+
+    This function is intended as a workhorse to be used for low-level,
+    automated QC of broadband data when the the data set is defined
+    by signals linked to a timeable seismic phase.   It can be
+    thought of as a version of a related function called
+    "arrival_snr" with some additional features.  See the docstring
+    for that function for what those base features are.   Features this
     function adds not found in arrival_snr are:
-        1.   This function allows Seismogram inputs.  Only TimeSeries 
-             data are handled by arrival_snr. 
-        2.   This function provides an option to compute arrival times 
-             from source coordinates, receiver coordinates, and a handle 
-             to an obspy tau-p calculator.   
-             
-    Otherwise it behaves the same.  Note both functions may or may not 
-    choose to interact with the function save_snr_arrival.   If you want to 
-    save the computed metrics into a form more easily fetched 
-    your workflow should extract the contents of the python dictionary 
-    stored under the metadata_output_key tag and save the result to 
-    MongoDB with the save_snr_arrival function.  That option is most 
-    useful for test runs on a more limited data set to sort out 
-    values of the computed metrics that are appropriate for a secondary 
-    winnowing of the your data.   See User's Manual for more on 
-    this concept. 
+        1.   This function allows Seismogram inputs.  Only TimeSeries
+             data are handled by arrival_snr.
+        2.   This function provides an option to compute arrival times
+             from source coordinates, receiver coordinates, and a handle
+             to an obspy tau-p calculator.
+
+    Otherwise it behaves the same.  Note both functions may or may not
+    choose to interact with the function save_snr_arrival.   If you want to
+    save the computed metrics into a form more easily fetched
+    your workflow should extract the contents of the python dictionary
+    stored under the metadata_output_key tag and save the result to
+    MongoDB with the save_snr_arrival function.  That option is most
+    useful for test runs on a more limited data set to sort out
+    values of the computed metrics that are appropriate for a secondary
+    winnowing of the your data.   See User's Manual for more on
+    this concept.
 
     The input of arg 0 (data_object) can be either a TimeSeries or
     a Seismogram object.  If a Seismogram object is passed the "component"
@@ -886,11 +886,11 @@ def broadband_snr_QC(
 
     The following args are passed directly to the function FD_snr_estimator:
     noise_window, noise_spectrum_engine, signal_window, signal_spectrum_engine,
-    band_cutoff_snr, signal_detection_minimum_bandwidth, tbp, ntapers, 
+    band_cutoff_snr, signal_detection_minimum_bandwidth, tbp, ntapers,
     high_frequency_search_start, fix_high_edge, npoles, perc, optional_metrics,
-    and save_spectrum.  Below we only describe arguments added by this 
+    and save_spectrum.  Below we only describe arguments added by this
     function:
-    
+
     data_object,
     phase_name="P",
     metadata_output_key="Parrival",
@@ -900,21 +900,21 @@ def broadband_snr_QC(
     component=2,
     source_collection="source",
     receiver_collection=None,
-    
-    :param data_object:  An atomic MsPASS data object to which the 
+
+    :param data_object:  An atomic MsPASS data object to which the
     algorithms requested should be applied.   Currently that means a
-    TimeSeries or Seismogram object.   Any other input will result 
-    in a TypeError exception.  As noted above for Seismogram input the 
-    component argument defines which data component is to be used for the 
-    snr computations.  
-    
+    TimeSeries or Seismogram object.   Any other input will result
+    in a TypeError exception.  As noted above for Seismogram input the
+    component argument defines which data component is to be used for the
+    snr computations.
+
     :param component: integer (0, 1, or 2) defining which component of a
     Seismogram object to use to compute the requested snr metrics.   This
     parameter is ignored if the input is a TimeSeries.
 
-    :param metadata_output_key:  string defining the key where the results 
-    are to be posted to the returned data_object.   The results are always 
-    posted to a python dictionary and then posted to the returned 
+    :param metadata_output_key:  string defining the key where the results
+    are to be posted to the returned data_object.   The results are always
+    posted to a python dictionary and then posted to the returned
     data_object with this key.   Default is "Parrival"
 
     :param use_measured_arrival_time:  boolean defining the method used to
@@ -945,8 +945,8 @@ def broadband_snr_QC(
     :param source_collection:  normalization collection for source data.
     The default is the MsPASS name "source" which means the function will
     try to load the source hypocenter coordinates (when required) as
-    source_lat, source_lon, source_depth, and source_time from the input 
-    data_object.  The id of that document is posted to the output dictionary 
+    source_lat, source_lon, source_depth, and source_time from the input
+    data_object.  The id of that document is posted to the output dictionary
     stored under metadata_output_key.
 
     :param receiver_collection:  when set this name will override the
@@ -1094,96 +1094,96 @@ def save_snr_arrival(
     validate_wfid=False,
 ) -> ObjectId:
     """
-    This function is a companion to broadband_snr_QC.   It handles the 
-    situation where the workflow aims to post calculated snr metrics to 
+    This function is a companion to broadband_snr_QC.   It handles the
+    situation where the workflow aims to post calculated snr metrics to
     an output database (normally in the "arrival" collection but optionally
-    to a parent waveform collection.  ).   The alternative models as 
-    noted in the User's Manual is to use the kill option to broadband_snr_QC 
-    followed by a call to the filter method of bag/rdd to remove the 
-    deadwood and reduce the size of data passed downstream in large 
-    parallel workflow.   That case is better handled by using 
-    broadband_snr_QC directly.   
-    
-    How the data are saved is controlled by four parameters:   save_collection, 
-    use_update, update_id and subdocument_key.   They interact in a way 
+    to a parent waveform collection.  ).   The alternative models as
+    noted in the User's Manual is to use the kill option to broadband_snr_QC
+    followed by a call to the filter method of bag/rdd to remove the
+    deadwood and reduce the size of data passed downstream in large
+    parallel workflow.   That case is better handled by using
+    broadband_snr_QC directly.
+
+    How the data are saved is controlled by four parameters:   save_collection,
+    use_update, update_id and subdocument_key.   They interact in a way
     that is best summarized as a set of cases that procuce behavior
     you may want:
-        1.  If save_collection is not the parent waveform collection, 
+        1.  If save_collection is not the parent waveform collection,
             behavior is driven by use_update combined with subdocument_key.
             When use_update is False (default) the contents of doc_to_save
-            will be used to define a new document in save_collection 
-            with the MongoDB insert_one method.   
-        2.  When use_update is True the update_id will be assumed to be 
-            defined and point be the ObjectId of an existing document 
-            in save_collection.   Specifically that id will be used as 
-            the query clause for a call the insert_one method.   This 
-            combination is useful if a workflow is being driven by 
-            arrival data stored in save_collection created, for example, 
-            for a css3.0 a event->origin->assoc->arrival catalog of 
-            arrival picks.   A variant of this mode will occur if the 
-            argument subdocument_key is defined (default is None).  If 
-            you define subgdocument_key the contents of doc_to_save will 
-            be stored as a subdocument in save_collection accessible 
-            with the key defined by subdocument_key.  
+            will be used to define a new document in save_collection
+            with the MongoDB insert_one method.
+        2.  When use_update is True the update_id will be assumed to be
+            defined and point be the ObjectId of an existing document
+            in save_collection.   Specifically that id will be used as
+            the query clause for a call the insert_one method.   This
+            combination is useful if a workflow is being driven by
+            arrival data stored in save_collection created, for example,
+            for a css3.0 a event->origin->assoc->arrival catalog of
+            arrival picks.   A variant of this mode will occur if the
+            argument subdocument_key is defined (default is None).  If
+            you define subgdocument_key the contents of doc_to_save will
+            be stored as a subdocument in save_collection accessible
+            with the key defined by subdocument_key.
         3.  If save_collection is the same as the parent waveform collection
-            (defined via the input parameter wf_collection) the 
-            value of use_update will be ignored and only an update will 
-            be attempted.  The reason is that if one tried to save the 
-            contents of doc_to_save to a waveform collection would corrupt 
-            the database by have a bunch of documents that that could not 
+            (defined via the input parameter wf_collection) the
+            value of use_update will be ignored and only an update will
+            be attempted.  The reason is that if one tried to save the
+            contents of doc_to_save to a waveform collection would corrupt
+            the database by have a bunch of documents that that could not
             be used to construct a valid data object (the normal use for
-            one of the wf collections). 
-    
-    :param db:  MongoDB database handle to use for transactions that 
+            one of the wf collections).
+
+    :param db:  MongoDB database handle to use for transactions that
     are the focus of this algorithm.
-    
-    :param doc_to_save:  python dictionary containing data to be saved. 
-    Where and now this is saved is controlled by save_collection, 
-    use_update, and subdocument_key as described above. 
-    
-    :param wfid:   waveform document id of the parent datum.   It is 
-    assumed to be an ObjectId of linking the data in doc_to_save to 
+
+    :param doc_to_save:  python dictionary containing data to be saved.
+    Where and now this is saved is controlled by save_collection,
+    use_update, and subdocument_key as described above.
+
+    :param wfid:   waveform document id of the parent datum.   It is
+    assumed to be an ObjectId of linking the data in doc_to_save to
     the parent.   It is ALWAYS saved in the output with the key "wfid".
-    
-    :param wf_collection:  string defining the collection from which the 
-    datum from which the data stored in doc_to_save are associated.   wfid 
-    is assumed define a valid document in wf_collection.   Default is 
+
+    :param wf_collection:  string defining the collection from which the
+    datum from which the data stored in doc_to_save are associated.   wfid
+    is assumed define a valid document in wf_collection.   Default is
     "wf_Seismogram".
-    
-    :param save_collection:  string defining the collection name to which 
+
+    :param save_collection:  string defining the collection name to which
     doc_to_save should be pushed.   See above for how this name interacts
-    with other parameters. 
-    
+    with other parameters.
+
     :param subdocument_key:   Optional key for saving doc_to_save as a
-    a subdocument in the save_collection.   Default is None which means 
-    the contents of doc_to_save will be saved (or update) as is.  
-    For saves to (default) arrival collection this parameter should 
-    normally be left None, but is allowed.   If save_collection is the 
-    parent waveform collection setting this to some sensible key is 
-    recommended to avoid possible name collisions with waveform 
-    Metadata key-value pairs.    Default is None which means no 
+    a subdocument in the save_collection.   Default is None which means
+    the contents of doc_to_save will be saved (or update) as is.
+    For saves to (default) arrival collection this parameter should
+    normally be left None, but is allowed.   If save_collection is the
+    parent waveform collection setting this to some sensible key is
+    recommended to avoid possible name collisions with waveform
+    Metadata key-value pairs.    Default is None which means no
     subdocuments are created.
-    
-    :param use_update:  boolean controlling whether or not to use 
-    updates or inserts for the contents of doc_to_save.  See above for 
-    a description of how this interacts with other arguments to this 
+
+    :param use_update:  boolean controlling whether or not to use
+    updates or inserts for the contents of doc_to_save.  See above for
+    a description of how this interacts with other arguments to this
     function.  Default is False.
-    
-    :param update_id:   ObjectId of target document when running in update 
-    mode.  When save_collection is the same as wf_collection this parameter 
-    is ignored and the required id passed as wfid will be used for the 
-    update key matching.   Also ignored with the default behavior if 
-    inserting doc_to_save as a new document.  Required only if running 
-    with a different collection and updating is desired.  The type example 
-    noted above would be updates to existing arrival informations 
-    created from a css3.0 database. 
-    
-    :param validate_wfid:   When set True the id defined by the 
-    required argument wfid will be validated by querying wf_collection.   
+
+    :param update_id:   ObjectId of target document when running in update
+    mode.  When save_collection is the same as wf_collection this parameter
+    is ignored and the required id passed as wfid will be used for the
+    update key matching.   Also ignored with the default behavior if
+    inserting doc_to_save as a new document.  Required only if running
+    with a different collection and updating is desired.  The type example
+    noted above would be updates to existing arrival informations
+    created from a css3.0 database.
+
+    :param validate_wfid:   When set True the id defined by the
+    required argument wfid will be validated by querying wf_collection.
     In this mode if wfid is not found the function will silently return None.
-    Callers using this mode should handle that condition.   
-                     
-    :return:  ObjectId of saved record.  None if something went wrong 
+    Callers using this mode should handle that condition.
+
+    :return:  ObjectId of saved record.  None if something went wrong
     and nothing was saved.
     """
     dbwfcol = db[wf_collection]

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -1917,8 +1917,9 @@ class MiniseedMatcher(DictionaryCacheMatcher):
         testid = self.db_make_cache_id(doc)
         if testid is None:
             return None
-        matches = self.normcache[testid]
-        if len(matches) <= 0:
+        if testid in self.normcache:
+            matches = self.normcache[testid]
+        else:
             return None
 
         # linear search similar to that in find_one above

--- a/python/tests/algorithms/test_snr.py
+++ b/python/tests/algorithms/test_snr.py
@@ -1,12 +1,13 @@
 from mspasspy.ccore.algorithms.deconvolution import MTPowerSpectrumEngine
 from mspasspy.ccore.seismic import TimeSeries, TimeReferenceType
 from mspasspy.ccore.algorithms.basic import TimeWindow
-from mspasspy.algorithms.snr import (snr, 
-                                     FD_snr_estimator, 
-                                     arrival_snr, 
-                                     broadband_snr_QC, 
-                                     save_snr_arrival,
-                                     )
+from mspasspy.algorithms.snr import (
+    snr,
+    FD_snr_estimator,
+    arrival_snr,
+    broadband_snr_QC,
+    save_snr_arrival,
+)
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
 import numpy as np
@@ -246,28 +247,34 @@ def test_snr():
     )
     print(json_util.dumps(asnr_out3["Parrival"], indent=2))
     verify_snr_outputs_match(asnr_out["Parrival"], asnr_out3["Parrival"])
-    # Finally test the database function to save results of previous 
+    # Finally test the database function to save results of previous
     # function to an arrival collection.
     dbclient = DBClient("localhost")
     db = dbclient.get_database("test_snrQC")
     doc_to_save = asnr_out3["Parrival"]
-    # Fake the id as if these data had been read from db.  The 
+    # Fake the id as if these data had been read from db.  The
     # id is required to create a cross-reference to the wf collection
-    # when saving arrival document.  We actually save the test data 
-    # and read it back to get that id.  We need that to test the 
-    # validate_wfid option that is orthogonal to the rest of the 
+    # when saving arrival document.  We actually save the test data
+    # and read it back to get that id.  We need that to test the
+    # validate_wfid option that is orthogonal to the rest of the
     # save_snr_arrival function
-    db.save_data(ts,collection="wf_TimeSeries")
+    db.save_data(ts, collection="wf_TimeSeries")
     wfdoc = db.wf_TimeSeries.find_one()
     wfid = wfdoc["_id"]
-    idout = save_snr_arrival(db, doc_to_save, wfid,
-                             wf_collection="wf_TimeSeries",
-                             validate_wfid=True)
-    print("Saved snr data to arrival with id=",idout)
+    idout = save_snr_arrival(
+        db, doc_to_save, wfid, wf_collection="wf_TimeSeries", validate_wfid=True
+    )
+    print("Saved snr data to arrival with id=", idout)
     arrival_doc = db.arrival.find_one()
-    verify_snr_outputs_match(doc_to_save,arrival_doc)
+    verify_snr_outputs_match(doc_to_save, arrival_doc)
     # This tests update mode on arrival collection
     print("Testing update mode to arrival")
-    idout2 = save_snr_arrival(db,doc_to_save,wfid,wf_collection="wf_TimeSeries",
-                              use_update=True,update_id=idout)
-    assert idout2==idout
+    idout2 = save_snr_arrival(
+        db,
+        doc_to_save,
+        wfid,
+        wf_collection="wf_TimeSeries",
+        use_update=True,
+        update_id=idout,
+    )
+    assert idout2 == idout

--- a/python/tests/algorithms/test_snr.py
+++ b/python/tests/algorithms/test_snr.py
@@ -124,15 +124,15 @@ def test_snr():
     tval = fd_snr_output[0]["low_f_band_edge"]
     assert np.isclose(tval, 0.03332777870354941)
     tval = fd_snr_output[0]["high_f_band_edge"]
-    assert np.isclose(tval, 15.364105982336277)
+    assert np.isclose(tval, 16.563906015664056)
     tval = fd_snr_output[0]["low_f_band_edge_snr"]
-    assert np.isclose(tval, 14.452106992292247)
+    assert np.isclose(tval, 11.458212683258578)
     tval = fd_snr_output[0]["high_f_band_edge_snr"]
-    assert np.isclose(tval, 2.0387483301356752)
+    assert np.isclose(tval, 2.0289812704609314)
     tval = fd_snr_output[0]["bandwidth_fraction"]
-    assert np.isclose(tval, 0.30666666666666664)
+    assert np.isclose(tval, 0.3306666666666667)
     tval = fd_snr_output[0]["bandwidth"]
-    assert np.isclose(tval, 53.27401850779296)
+    assert np.isclose(tval, 53.927127774666644)
     # Note this is not 50 because the signal window npts is an odd number
     # In that sitaution ffts have last frequecy Nyqust - df/2
     tval = fd_snr_output[0]["spectrum_frequency_range"]
@@ -161,9 +161,9 @@ def test_snr():
     tval = fd_snr_output[0]["high_f_band_edge"]
     assert np.isclose(tval, 2.0)
     tval = fd_snr_output[0]["low_f_band_edge_snr"]
-    assert np.isclose(tval, 14.452106992292247)
+    assert np.isclose(tval, 11.458212683258578)
     tval = fd_snr_output[0]["high_f_band_edge_snr"]
-    assert np.isclose(tval, 61.37973288189221)
+    assert np.isclose(tval, 66.0799403744919)
     tval = fd_snr_output[0]["bandwidth_fraction"]
     assert np.isclose(tval, 0.03934)
     tval = fd_snr_output[0]["bandwidth"]
@@ -175,17 +175,17 @@ def test_snr():
 
     # optional metric validation
     tval = fd_snr_output[0]["mean_snr"]
-    assert np.isclose(tval, 69.53423294512893)
+    assert np.isclose(tval, 75.88331422185868)
     tval = fd_snr_output[0]["maximum_snr"]
-    assert np.isclose(tval, 108.87572942017883)
+    assert np.isclose(tval, 197.29008426129326)
     tval = fd_snr_output[0]["median_snr"]
-    assert np.isclose(tval, 69.93575550602118)
+    assert np.isclose(tval, 76.17635106932579)
     tval = fd_snr_output[0]["minimum_snr"]
-    assert np.isclose(tval, 14.452106992292247)
+    assert np.isclose(tval, 11.458212683258578)
     tval = fd_snr_output[0]["q3_4_snr"]
-    assert np.isclose(tval, 80.01427281740997)
+    assert np.isclose(tval, 86.59300028360848)
     tval = fd_snr_output[0]["q1_4_snr"]
-    assert np.isclose(tval, 60.583163703711946)
+    assert np.isclose(tval, 66.16303805496165)
     tval = fd_snr_output[0]["stats_are_valid"]
     assert tval
     tval = fd_snr_output[0]["snr_filtered_envelope_peak"]

--- a/python/tests/algorithms/test_snr.py
+++ b/python/tests/algorithms/test_snr.py
@@ -1,7 +1,12 @@
 from mspasspy.ccore.algorithms.deconvolution import MTPowerSpectrumEngine
 from mspasspy.ccore.seismic import TimeSeries, TimeReferenceType
 from mspasspy.ccore.algorithms.basic import TimeWindow
-from mspasspy.algorithms.snr import snr, FD_snr_estimator, arrival_snr, arrival_snr_QC
+from mspasspy.algorithms.snr import (snr, 
+                                     FD_snr_estimator, 
+                                     arrival_snr, 
+                                     broadband_snr_QC, 
+                                     save_snr_arrival,
+                                     )
 import numpy as np
 from scipy import signal
 from bson import json_util
@@ -234,7 +239,7 @@ def test_snr():
     verify_snr_outputs_match(asnr_out["Parrival"], asnr_out2["Parrival"])
 
     print("Testing arrival_snr_QC variant")
-    asnr_out3 = arrival_snr_QC(
+    asnr_out3 = broadband_snr_QC(
         ts2, noise_window=nwin, signal_window=swin, use_measured_arrival_time=True
     )
     print(json_util.dumps(asnr_out3["Parrival"], indent=2))
@@ -243,3 +248,4 @@ def test_snr():
     # until we finalize a design for an arrival collection initiated on
     # github 11/29/2022.  Remove this comment when that is done and that
     # test has been created and verified.
+


### PR DESCRIPTION
This should largely finish the snr module for now.   Includes a bunch of bug fixes found when applying this to thousands of real data from our large usarray test data set that is not feasible to put in github due to the size.  In the process I also reorganized the top level function to split what previously was a single function into two.   That is necessary to allow the user to run the same function either inline with a map call followed by filter to remove junk or in a database mode where the computed metrics are posted to an arrival collection.

This also now has a complete test suite for the functions in snr.py.   I'm sure coverage will show some missing but I think the tests cover the main features. 

Before this branch is merged we need to decide if we need to add a formal "arrival" collection to the default schema.   This implementation has "arrival" hard wired as the default save target for the database save function.  