### PR TITLE
Add resampling

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -12,8 +12,4 @@ jobs:
         id: action_black
         with:
           black_args: "."
-      - name: Annotate diff changes using reviewdog
-        if: steps.action_black.outputs.is_formatted == 'true'
-        uses: reviewdog/action-suggester@v1
-        with:
-          tool_name: blackfmt
+

--- a/cxx/include/mspass/seismic/Ensemble.h
+++ b/cxx/include/mspass/seismic/Ensemble.h
@@ -203,6 +203,14 @@ public:
   bool live() const {return ensemble_is_live;};
   /*! Complement to live method - returns true if there are no valid data members. */
   bool dead() const {return !ensemble_is_live;};
+  /*! Check to see if ensemble has any live data.
+
+  In processing one can occasionally (not rare but not common either)
+  end up with enemble full of data marked dead.  This is a convenience
+  method to check all members.  If it finds any live member it will immediately
+  return true (ok).  If after a search of the entire ensemble no live members
+  are found it will return false AND then mark the entire ensemble bad. */
+  bool validate();
   /*! Force, with care, the ensemble to be marked live.
 
   This extension of CoreEnsemble adds a boolean that is used to test if
@@ -219,14 +227,7 @@ public:
     else
       return false;
   };
-  /*! Check to see if ensemble has any live data.
 
-  In processing once can occasionally (not rare but not common either)
-  end up with enemble full of data marked dead.  This is a convenience
-  method to check all members.  If it finds any live member it will immediately
-  return true (ok).  If after a search of the entire ensemble no live members
-  are found it will return false AND then mark the entire ensemble bad. */
-  bool validate();
   /*! Standard assignment operator. */
   LoggingEnsemble<T>& operator=(const LoggingEnsemble<T>& parent)
   {
@@ -241,6 +242,7 @@ public:
     return *this;
   };
 private:
+
   bool ensemble_is_live;
 };
 

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -30,18 +30,18 @@ class BasicResampler(ABC):
     sample rate (alternatively the sample interval, dt).
 
     ALL implementations must recognize a couple fundamental concepts:
-        1.  This is intended to ONLY be used on waveform segments.   
-            The problem of resampling continuous data requires different 
-            algorithms.  The reason is boundary effects.  All 
-            implementations are subject to edge transients.  How the 
-            implementation does or does not handle that issue is 
-            viewed as an implementation detail, 
-        2.  Downsampling ALWAYS requires some method to avoid aliasing of 
-            the output.  How that is done is considered an implementation 
-            detail. 
-            
-    This is a sketch of an algorithm is pseudopython code showing how 
-    a typical instance of this class (in the example ScipyResampler) 
+        1.  This is intended to ONLY be used on waveform segments.
+            The problem of resampling continuous data requires different
+            algorithms.  The reason is boundary effects.  All
+            implementations are subject to edge transients.  How the
+            implementation does or does not handle that issue is
+            viewed as an implementation detail,
+        2.  Downsampling ALWAYS requires some method to avoid aliasing of
+            the output.  How that is done is considered an implementation
+            detail.
+
+    This is a sketch of an algorithm is pseudopython code showing how
+    a typical instance of this class (in the example ScipyResampler)
     would be used in  parallel workflow sketch:
         
     .. rubric:: Example

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -289,8 +289,10 @@ class ScipyDecimator(BasicResampler):
                 ddt=data_dt, sdt=self.dt
             )
         else:
-            message = "Data sample interval={ddt} is not an integer multiple of {sdt}".format(
-                ddt=data_dt, sdt=self.dt
+            message = (
+                "Data sample interval={ddt} is not an integer multiple of {sdt}".format(
+                    ddt=data_dt, sdt=self.dt
+                )
             )
         return message
 

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -1,0 +1,344 @@
+from abc import ABC, abstractmethod
+from mspasspy.ccore.utility import MsPASSError,ErrorSeverity
+from mspasspy.ccore.seismic import (
+    TimeSeries,
+    Seismogram,
+    TimeSeriesEnsemble,
+    SeismogramEnsemble)
+from mspaspy.util.converter import (
+    Trace2TimeSeries,
+    TimeSeries2Trace,
+    Seismogram2Stream,
+    Stream2Seismogram,
+    SeismogramEnsemble2Stream,
+    Stream2SeismogramEnsemble,
+    )
+
+import numpy as np
+
+class BasicResampler(ABC):
+    """
+    Base class for family of resampling operators.   All it really does is 
+    define the interface and standardize the target of the operator.  
+    A key concept of this family of operator is they are intended to 
+    be used in a map operator to regularize the sample rate to a 
+    constant.   Hence, the base class defines that constant output 
+    sample rate (alternatively the sample interval, dt).  
+    
+    ALL implementations must recognize a couple fundamental concepts:
+        1.  This is intended to ONLY be used on waveform segments.   
+            The problem of resampling continuous data requires different 
+            algorithms.  The reason is boundary effects.  All 
+            implementations are subject to edge transients.  How the 
+            implementation does or does not handle that issue is 
+            viewed as an implementation detail, 
+        2.  Downsampling ALWAYS requires some method to avoid aliasing of 
+            the output.  How that is done is considered an implementation 
+            detail. 
+            
+    This is a sketch of an algorithm is pseudopython code showing how 
+    a typical instance of this class (in the sample ObspyResampler) 
+    would be used in  parallel workflow:
+        
+    .. rubric:: Example
+    
+    ro = ObspyResampler(10.0)   # target sample rate of 10 sps
+    cursor = db.TimeSeries.find({})
+    bag = read_distributed_data(cursor,collection="wf_TimeSeries")
+    bag = bag.map(ro.resample)
+    bag.map(db.save_data())
+    bag.compute()
+    
+    
+    """
+    def __init__(self,dt=None,sampling_rate=None):
+        if dt and sampling_rate:
+            raise MsPASSError(
+                  "BasicResample:  usage error.  Specify either dt or sampling_rate.  You defined both",
+                  ErrorSeverity.Fatal
+                )
+        if dt:
+            self.dt = dt
+            self.samprate = sampling_rate
+        elif sampling_rate:
+            self.dt = 1.0/sampling_rate
+            self.samprate = sampling_rate
+    @abstractmethod
+    def resample(self,mspass_object):
+        """
+        Main operator a concrete class must implement.  It should accept 
+        any mspass data object and return a clone that has been resampled 
+        to the sample interface defined by this base class. 
+        
+        """
+        pass
+    
+class ObspyResampler(BasicResampler):
+    """
+    This class is a wrapper for obspy's resample algorithm they implement 
+    as a method of their Trace and Stream objects.  Note the obpsy methods are 
+    themselves only a wrapper for ascipy function with the same name. 
+    The algorithm and its limitations are described in the obpsy and scipy 
+    documentation you can easily find with a web search.   A key point 
+    about this algorithm is that unlike decimate it allows resampling to 
+    something not an integer multiple or division from the input.  
+    A type example where that is essential is some old OBS data from 
+    Scripps instruments that had a sample rate that was a multiple of 
+    one of the more standard rates like 20 or 100.   Anti-aiasing is handled 
+    automatically by default, but can be imposed externally and overriden 
+    using the no_filter option.  
+    
+    I (glp) have no practical experience with this implementation in obspy.
+    There are hints that it is subject to a somewhat universal tradeoff 
+    between flexibility and reliability.  From all I've read I would 
+    suggest you use this algorithm only for upsampling and to resample 
+    oddball data like that from Scripps OBS instruments.  Most data 
+    are probably best downsampled to a common sample rate with a 
+    decimate algorithm whenever possible.   We have implemented a 
+    compable wrapper to this one for decimate called ObspyDecimator. 
+    
+    
+    All the arguments to the constructor are identical (in name an concept)
+    to the resample methods of Trace/Stream.  See the obspy documentation 
+    for detailed description and limitations.  
+    
+    The primary method of this class is a concrete implementation of the 
+    resample method.  
+    
+    """
+    def __init__(self,sampling_rate, window="hann",no_filter=True, strict_length=False):
+        """
+        """
+        super().__init__(sampling_rate=sampling_rate)
+        self.window=window,
+        self.no_filter=no_filter
+        self.strict_length=strict_length
+        
+    def resample(self,mspass_object):
+        if isinstance(mspass_object,TimeSeries):
+            tr = TimeSeries2Trace(mspass_object)
+            tr.resample(self.samprate,
+                        window=self.window,
+                        no_filter=self.no_filter,
+                        strict_length=self.strict_length,
+                        )
+            return Trace2TimeSeries(tr)
+        elif isinstance(mspass_object,Seismogram):
+            strm = Seismogram2Stream(mspass_object)
+            strm.resample(self.samprate,
+                        window=self.window,
+                        no_filter=self.no_filter,
+                        strict_length=self.strict_length,
+                        )
+            return Stream2Seismogram(strm)
+        elif isinstance(mspass_object,TimeSeriesEnsemble):
+            for i in len(mspass_object.member):
+                d = mspass_object.member[i]
+                decfac = self.dec_factor(d)
+                if decfac<=0:
+                    message = self.make_illegal_decimator_message(d.dt)
+                    mspass_object.member[i].elog.log_error(
+                        "ObspyDecimator.resample",
+                        message,
+                        ErrorSeverity.Invalid
+                        )
+                    mspass_object.member[i].kill()
+                else:
+                    tr = TimeSeries2Trace(d)
+                    tr.decimate(decfac,
+                                    no_filter=self.no_filter,
+                                    strict_length=self.strict_length,
+                                )
+                    mspass_object.member[i] = Trace2TimeSeries(tr)
+        elif isinstance(mspass_object,SeismogramEnsemble):
+            strm = SeismogramEnsemble2Stream(mspass_object)
+            strm.resample(self.samprate,
+                        window=self.window,
+                        no_filter=self.no_filter,
+                        strict_length=self.strict_length,
+                        )
+            return Stream2SeismogramEnsemble(strm)
+        else:
+            message = "ObspyResampler.resample: received unsupported data type="+str(type(mspass_object))
+            raise TypeError(message)
+            
+class ObspyDecimator(BasicResampler):
+    """
+    Wrapper to utilize obspy's decimate operator (actually scipy's decimate)
+    to automatically resample a set set through a map operator following 
+    the api concepts of BasicResampler.  The algorithm works only on 
+    a data set with sample intervals that work by the decimation concept.  
+    That means the data are only downsampled (or left alone) and the 
+    target sample interval is an integer multiple of the input data's 
+    sample interval.
+    
+    Most seismology data today are defined by a finite set of common sample 
+    rates that differ by integer division.   The fundamental reason is that 
+    all modern digitizers use internal downsampling with DSP chips from a
+    base sample rate orders of magnitude larger than the output. The intrinsic
+    smoothing in the FIR filters used for antialiasing reduces amplitude 
+    errors by roughly the square root of the number of samples averaged.  
+    The result is that the most common digitizers for the past 30 years 
+    have had these, most common selectable sample rates:  1 sps, 5 sps, 
+    10 sps, 20 sps, 40 sps, 50 sps, 100 sps, and 250 sps.   These all have 
+    integer relationships.   e.g. 20 sps is 100 sps divided by 5 and 
+    50 sps is 100 divided by 2.  The algorithm for this implementation
+    will ONLY WORK if the target sample rate is ALWAYS constructable from 
+    a simple integer division = integer multiple of sample interval.  
+    e.g. to decimate 100 sps data (dt=0.01) we divide the sample rate by 
+    5 or multiple the sample interval by 5 (0.05 s in this case).  
+    If any datum cannot be resampled that way it will be killed.   
+    For example, it is not possible to construct 20 sps data from 50 sps
+    data with this algorithm.  
+    
+    Be aware decimators also have intrinsic edge effects.   The anitialias
+    filter that has to be applied (you can get garbage otherwise) will always
+    produce an edge transient.  A key to success with any downsampling 
+    operator is to always have a pad zone if possible.  That is, you start 
+    with a longer time window than you will need for final processing and 
+    discard the pad zone when you enter the final stage.   Note that is 
+    true of ALL filtering actually.   
+    
+    The constructor has exactly the same argument signature as obspy's 
+    decimate function described in the docstring currently found here:
+        https://docs.obspy.org/packages/autogen/obspy.core.stream.Stream.decimate.html
+    for Stream.  The docstring for Trace is nearly identical.
+    """
+    def __init__(self,sampling_rate,no_filter=True, strict_length=False):
+        """
+        """
+        super().__init__(sampling_rate=sampling_rate)
+        self.no_filter=no_filter
+        self.strict_length=strict_length
+    def _dec_factor(self,d):
+        """
+        Returns decimation factor to use for atomic data d.  
+        d can be a mspass atomic type or an obspy Trace. 
+        Uses np.isclose to establish if the sample interval is feasible.
+        If so it returns the decimation factor as an integer that should be 
+        used on d.   Returns -1 if the sample rate is irregular and 
+        is not close enough to be an integer multiple.  Return 0 if 
+        the data dt would require upsampling
+        """
+        # internal use guarantees this can only be TimeSeries or Seismogram
+        # so this resolves
+        d_dt = d.dt
+        float_dfac=d_dt/self.dt
+        int_dfac=int(float_dfac)
+        # This perhaps should use a softer constraint than default
+        if np.isclose(float_dfac,float(int_dfac)):
+            return int_dfac
+        elif int_dfac==0:
+            return 0
+        else:
+            return -1
+    def _make_illegal_decimator_message(self,error_code,data_dt):
+        """
+        Private method to format a common message if the data's sample
+        interval, data_dt, is not feasible to produce by decimation. 
+        The error message is the return
+        """
+        if error_code == 0:
+            message = "Data sample interval={ddt} is smaller than target dt={sdt}.  This operator can only downsample".format(ddt=data_dt,sdt=self.dt)
+        else:
+            message = "Data sample interval={ddt} is not an integer multiple of {sdt}".format(ddt=data_dt,sdt=self.dt)
+        return message
+    def resample(self,mspass_object):
+        """
+        Implementation of required abstract method for this operator.   
+        The only argument is mspass_object.   The operator will downsample 
+        the contents of the sample data container for any valid input.  
+        If the input is not a mspass data object (i.e. atomic TimeSeries 
+        or Seismogram) or one of the enemble objects it will throw a 
+        TypeError exception.   
+        """
+        # We do this test at the top to avoid having returns testing for 
+        # a dead datum in each of the if conditional blocks below
+        if isinstance(mspass_object,(TimeSeries,Seismogram,TimeSeriesEnsemble,SeismogramEnsemble)):
+            if mspass_object.dead():
+                return mspass_object
+            else:
+                message = "ObspyDecimator.resample: received unsupported data type="+str(type(mspass_object))
+                raise TypeError(message)
+        if isinstance(mspass_object,TimeSeries):
+            decfac=self.dec_factor(mspass_object)
+            if decfac<=0:
+                mspass_object.kill()
+                message = self.make_illegal_decimator_message(decfac,mspass_object.dt)
+                mspass_object.elog.log_error(
+                        "ObspyDecimator.resample",
+                        message,
+                        ErrorSeverity.Invalid
+                        )
+            else:    
+                tr = TimeSeries2Trace(mspass_object)
+                tr.decimate(decfac,
+                        no_filter=self.no_filter,
+                        strict_length=self.strict_length,
+                        )
+                mspass_object = Trace2TimeSeries(tr)
+        elif isinstance(mspass_object,Seismogram):
+            decfac=self.dec_factor(mspass_object)
+            if decfac<=0:
+                mspass_object.kill()
+                message = self.make_illegal_decimator_message(decfac,mspass_object.dt)
+                mspass_object.elog.log_error(
+                        "ObspyDecimator.resample",
+                        message,
+                        ErrorSeverity.Invalid
+                        )
+            else:
+                strm = Seismogram2Stream(mspass_object)
+                for tr in strm:
+                    tr.decimate(decfac,
+                        no_filter=self.no_filter,
+                        strict_length=self.strict_length,
+                     )
+                mspass_object = Stream2Seismogram(strm)
+        elif isinstance(mspass_object,TimeSeriesEnsemble):
+            for i in len(mspass_object.member):
+                d = mspass_object.member[i]
+                decfac = self.dec_factor(d)
+                if decfac<=0:
+                    message = self.make_illegal_decimator_message(decfac,d.dt)
+                    mspass_object.member[i].elog.log_error(
+                        "ObspyDecimator.resample",
+                        message,
+                        ErrorSeverity.Invalid
+                        )
+                    mspass_object.member[i].kill()
+                else:
+                    tr = TimeSeries2Trace(mspass_object)
+                    tr.decimate(decfac,
+                                    no_filter=self.no_filter,
+                                    strict_length=self.strict_length,
+                                )
+                    mspass_object.member[i] = Trace2TimeSeries(tr)
+        else:
+        # This block is assumed equivalent to 
+        # elif isinstance(mspass_object,SeismogramEnsemble):
+        # because of isinstance test at the top.  Careful if the supported 
+        # list of data types changes
+            for i in len(mspass_object.member):
+                d = mspass_object.member[i]
+                decfac = self.dec_factor(d)
+                if decfac<=0:
+                    message = self.make_illegal_decimator_message(decfac,d.dt)
+                    mspass_object.member[i].elog.log_error(
+                        "ObspyDecimator.resample",
+                        message,
+                        ErrorSeverity.Invalid
+                        )
+                    mspass_object.member[i].kill()
+                else:
+                    strm = Seismogram2Stream(mspass_object)
+                    for tr in strm:
+                        decfac = self.dec_factor(tr)
+                        tr.decimate(decfac,
+                                    no_filter=self.no_filter,
+                                    strict_length=self.strict_length,
+                                )
+                    d = Stream2Seismogram(strm)
+                    mspass_object.member[i] = d
+
+        return mspass_object

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -22,13 +22,13 @@ from scipy import signal
 
 class BasicResampler(ABC):
     """
-    Base class for family of resampling operators.   All this class really does is 
-    define the interface and standardize the target of the operator.  
-    A key concept of this family of operator is they are intended to 
-    be used in a map operator to regularize the sample rate to a 
-    constant.   Hence, the base class defines that constant output 
-    sample rate (alternatively the sample interval, dt).  
-    
+    Base class for family of resampling operators.   All this class really does is
+    define the interface and standardize the target of the operator.
+    A key concept of this family of operator is they are intended to
+    be used in a map operator to regularize the sample rate to a
+    constant.   Hence, the base class defines that constant output
+    sample rate (alternatively the sample interval, dt).
+
     ALL implementations must recognize a couple fundamental concepts:
         1.  This is intended to ONLY be used on waveform segments.   
             The problem of resampling continuous data requires different 

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -44,7 +44,6 @@ class BasicResampler(ABC):
     a typical instance of this class (in the example ScipyResampler)
     would be used in  parallel workflow sketch:
     .. rubric:: Example
-    
     resamp_op = ScipyResampler(10.0)   # target sample rate of 10 sps
     cursor = db.TimeSeries.find({})
     bag = read_distributed_data(cursor,collection="wf_TimeSeries")

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -58,7 +58,7 @@ class BasicResampler(ABC):
     with a uniform sample rate.   All implementations should also
     follow the MsPASS rule for parallel algorithms to kill data that
     cannot be handled and not throw exceptions unless the whole usage is
-    wrong.  
+    wrong.
     """
 
     def __init__(self, dt=None, sampling_rate=None):

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -260,9 +260,9 @@ class ScipyDecimator(BasicResampler):
         Returns decimation factor to use for atomic data d.  
         d can be a mspass atomic type or an obspy Trace. 
         Uses np.isclose to establish if the sample interval is feasible.
-        If so it returns the decimation factor as an integer that should be 
-        used on d.   Returns -1 if the sample rate is irregular and 
-        is not close enough to be an integer multiple.  Return 0 if 
+        If so it returns the decimation factor as an integer that should be
+        used on d.   Returns -1 if the sample rate is irregular and
+        is not close enough to be an integer multiple.  Return 0 if
         the data dt would require upsampling
         """
         # internal use guarantees this can only be TimeSeries or Seismogram

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -298,15 +298,15 @@ class ScipyDecimator(BasicResampler):
 
     def resample(self, mspass_object):
         """
-        Implementation of required abstract method for this operator.   
-        The only argument is mspass_object.   The operator will downsample 
-        the contents of the sample data container for any valid input.  
-        If the input is not a mspass data object (i.e. atomic TimeSeries 
-        or Seismogram) or one of the enemble objects it will throw a 
-        TypeError exception.   
-        
-        Returns an edited clone of the input with revised sample data but 
-        no changes to any Metadata.  
+        Implementation of required abstract method for this operator.
+        The only argument is mspass_object.   The operator will downsample
+        the contents of the sample data container for any valid input.
+        If the input is not a mspass data object (i.e. atomic TimeSeries
+        or Seismogram) or one of the enemble objects it will throw a
+        TypeError exception.
+
+        Returns an edited clone of the input with revised sample data but
+        no changes to any Metadata.
         """
         # We do this test at the top to avoid having returns testing for
         # a dead datum in each of the if conditional blocks below

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -281,7 +281,7 @@ class ScipyDecimator(BasicResampler):
     def _make_illegal_decimator_message(self, error_code, data_dt):
         """
         Private method to format a common message if the data's sample
-        interval, data_dt, is not feasible to produce by decimation. 
+        interval, data_dt, is not feasible to produce by decimation.
         The error message is the return
         """
         if error_code == 0:

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -43,7 +43,6 @@ class BasicResampler(ABC):
     This is a sketch of an algorithm is pseudopython code showing how
     a typical instance of this class (in the example ScipyResampler)
     would be used in  parallel workflow sketch:
-        
     .. rubric:: Example
     
     resamp_op = ScipyResampler(10.0)   # target sample rate of 10 sps

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -44,7 +44,7 @@ class BasicResampler(ABC):
         
     .. rubric:: Example
     
-    ro = ObspyResampler(10.0)   # target sample rate of 10 sps
+    ro = ScipyResampler(10.0)   # target sample rate of 10 sps
     cursor = db.TimeSeries.find({})
     bag = read_distributed_data(cursor,collection="wf_TimeSeries")
     bag = bag.map(ro.resample)
@@ -75,7 +75,7 @@ class BasicResampler(ABC):
         """
         pass
     
-class ObspyResampler(BasicResampler):
+class ScipyResampler(BasicResampler):
     """
     This class is a wrapper for obspy's resample algorithm they implement 
     as a method of their Trace and Stream objects.  Note the obpsy methods are 
@@ -97,7 +97,7 @@ class ObspyResampler(BasicResampler):
     oddball data like that from Scripps OBS instruments.  Most data 
     are probably best downsampled to a common sample rate with a 
     decimate algorithm whenever possible.   We have implemented a 
-    compable wrapper to this one for decimate called ObspyDecimator. 
+    compable wrapper to this one for decimate called ScipyDecimator. 
     
     
     All the arguments to the constructor are identical (in name an concept)
@@ -132,7 +132,7 @@ class ObspyResampler(BasicResampler):
             if mspass_object.dead():
                 return mspass_object
         else:
-            message = "ObspyResampler.resample: received unsupported data type="+str(type(mspass_object))
+            message = "ScipyResampler.resample: received unsupported data type="+str(type(mspass_object))
             raise TypeError(message)
             
         if isinstance(mspass_object,TimeSeries):
@@ -166,7 +166,7 @@ class ObspyResampler(BasicResampler):
 
         return mspass_object
             
-class ObspyDecimator(BasicResampler):
+class ScipyDecimator(BasicResampler):
     """
     Wrapper to utilize obspy's decimate operator (actually scipy's decimate)
     to automatically resample a set set through a map operator following 
@@ -262,7 +262,7 @@ class ObspyDecimator(BasicResampler):
             if mspass_object.dead():
                 return mspass_object
         else:
-            message = "ObspyDecimator.resample: received unsupported data type="+str(type(mspass_object))
+            message = "ScipyDecimator.resample: received unsupported data type="+str(type(mspass_object))
             raise TypeError(message)
             
             
@@ -272,7 +272,7 @@ class ObspyDecimator(BasicResampler):
                 mspass_object.kill()
                 message = self._make_illegal_decimator_message(decfac,mspass_object.dt)
                 mspass_object.elog.log_error(
-                        "ObspyDecimator.resample",
+                        "ScipyDecimator.resample",
                         message,
                         ErrorSeverity.Invalid
                         )
@@ -296,7 +296,7 @@ class ObspyDecimator(BasicResampler):
                 mspass_object.kill()
                 message = self._make_illegal_decimator_message(decfac,mspass_object.dt)
                 mspass_object.elog.log_error(
-                        "ObspyDecimator.resample",
+                        "ScipyDecimator.resample",
                         message,
                         ErrorSeverity.Invalid
                         )

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -50,13 +50,13 @@ class BasicResampler(ABC):
     bag = bag.map(resamp_op.resample)
     bag.map(db.save_data())
     bag.compute()
-    
-    A point to emphasize is the model is to generate the operator 
-    through a constructor (ScipResampler in the example) that defines 
-    the target sample rate.  All data passed through that operator 
-    through the map operator call will be returned to create a bag/rdd 
-    with a uniform sample rate.   All implementations should also 
-    follow the MsPASS rule for parallel algorithms to kill data that 
+
+    A point to emphasize is the model is to generate the operator
+    through a constructor (ScipResampler in the example) that defines
+    the target sample rate.  All data passed through that operator
+    through the map operator call will be returned to create a bag/rdd
+    with a uniform sample rate.   All implementations should also
+    follow the MsPASS rule for parallel algorithms to kill data that
     cannot be handled and not throw exceptions unless the whole usage is
     wrong.  
     """

--- a/python/tests/algorithms/test_resample.py
+++ b/python/tests/algorithms/test_resample.py
@@ -1,0 +1,114 @@
+import numpy as np
+from helper import (
+    get_live_seismogram,
+    get_live_timeseries,
+    get_sin_timeseries,
+    get_live_timeseries_ensemble,
+    get_live_seismogram_ensemble,
+)
+from mspasspy.ccore.seismic import (
+    TimeSeries,
+    Seismogram,
+    TimeSeriesEnsemble,
+    SeismogramEnsemble)
+import matplotlib.pyplot as plt
+
+from mspasspy.algorithms.resample import ObspyDecimator,ObspyResampler
+
+def test_resample():
+    ts = get_sin_timeseries(sampling_rate=100.0)
+    # have to save this because ts is overwritten by resample method
+    ts0 = TimeSeries(ts)
+    ts_npts = ts.npts
+    # upsample test for resampler
+    upsampler=ObspyResampler(250.0)
+    tsup = upsampler.resample(ts)
+    assert np.isclose(tsup.dt,0.004)
+    # This computed npts is more robust.  Otherwise changes in helper 
+    # would break it
+    npup = int(ts_npts*250.0/100.0)
+    assert tsup.npts==npup   # weird number = int(255*250/100)
+    # now repeat for downsampling with resample algorithm
+    ts=TimeSeries(ts0)
+    ds_resampler = ObspyResampler(5.0)
+    tsds = ds_resampler.resample(ts)
+    # Note plots of this output show the auto antialiasing works as 
+    # advertised in scipy
+    assert np.isclose(tsds.dt,0.2)
+    assert tsds.npts == int(ts_npts*5.0/100.0)
+    # Repeat same downsampling with decimate
+    ts=TimeSeries(ts0)
+    decimator = ObspyDecimator(5.0)
+    tsds = decimator.resample(ts)
+    assert np.isclose(tsds.dt,0.2)
+    # the documentation doesn't tell me why by the scipy decimate 
+    # function seems to round npts up rather than use int
+    assert tsds.npts == int(ts_npts*5.0/100.0)+1
+    seis = get_live_seismogram()
+    seis0=Seismogram(seis)
+    seis = upsampler.resample(seis)
+    assert np.isclose(seis.dt,0.004)
+    npup = int(seis0.npts*250.0/20.0)
+    assert seis.npts == npup
+    seis=Seismogram(seis0)
+    seis = ds_resampler.resample(seis)
+    assert np.isclose(seis.dt,0.2)
+    assert seis.npts == int(ts_npts*5.0/20.0)
+    seis=Seismogram(seis0)
+    seis = decimator.resample(seis)
+    # again the round issue noted above
+    dec_npts = int(seis0.npts*5.0/20.0) + 1 
+    assert np.isclose(seis.dt,0.2)
+    assert seis.npts == dec_npts
+    
+    tse = get_live_timeseries_ensemble(5)
+    tse.set_live()
+    tse0 = TimeSeriesEnsemble(tse)
+    tse = upsampler.resample(tse)
+    npup = int(tse0.member[0].npts*250.0/20.0)
+    for d in tse.member:
+        assert d.live
+        assert np.isclose(d.dt,0.004)
+        assert d.npts == npup
+        
+    tse = TimeSeriesEnsemble(tse0)
+    tse = ds_resampler.resample(tse)
+    npup = int(tse0.member[0].npts*5.0/20.0)
+    for d in tse.member:
+        assert d.live
+        assert np.isclose(d.dt,0.2)
+        assert d.npts == npup
+    
+    tse = TimeSeriesEnsemble(tse0)
+    tse = decimator.resample(tse)
+    npup = int(tse0.member[0].npts*5.0/20.0)+1
+    for d in tse.member:
+        assert d.live
+        assert np.isclose(d.dt,0.2)
+        assert d.npts == npup
+    
+    seis_e = get_live_seismogram_ensemble(3)
+    seis_e0 = SeismogramEnsemble(seis_e)
+    seis_e = upsampler.resample(seis_e)
+    npup = int(seis_e0.member[0].npts*250.0/20.0)
+    for d in seis_e.member:
+        assert d.live
+        assert np.isclose(d.dt,0.004)
+        assert d.npts == npup
+        
+    seis_e = SeismogramEnsemble(seis_e0)
+    seis_e = ds_resampler.resample(seis_e)
+    npup = int(seis_e0.member[0].npts*5.0/20.0)
+    for d in seis_e.member:
+        assert d.live
+        assert np.isclose(d.dt,0.2)
+        assert d.npts == npup
+    
+    seis_e = SeismogramEnsemble(seis_e0)
+    seis_e = decimator.resample(seis_e)
+    npup = int(seis_e0.member[0].npts*5.0/20.0)+1
+    for d in seis_e.member:
+        assert d.live
+        assert np.isclose(d.dt,0.2)
+        assert d.npts == npup
+  

--- a/python/tests/algorithms/test_resample.py
+++ b/python/tests/algorithms/test_resample.py
@@ -10,10 +10,12 @@ from mspasspy.ccore.seismic import (
     TimeSeries,
     Seismogram,
     TimeSeriesEnsemble,
-    SeismogramEnsemble)
+    SeismogramEnsemble,
+)
 import matplotlib.pyplot as plt
 
-from mspasspy.algorithms.resample import ObspyDecimator,ObspyResampler
+from mspasspy.algorithms.resample import ObspyDecimator, ObspyResampler
+
 
 def test_resample():
     ts = get_sin_timeseries(sampling_rate=100.0)
@@ -21,94 +23,93 @@ def test_resample():
     ts0 = TimeSeries(ts)
     ts_npts = ts.npts
     # upsample test for resampler
-    upsampler=ObspyResampler(250.0)
+    upsampler = ObspyResampler(250.0)
     tsup = upsampler.resample(ts)
-    assert np.isclose(tsup.dt,0.004)
-    # This computed npts is more robust.  Otherwise changes in helper 
+    assert np.isclose(tsup.dt, 0.004)
+    # This computed npts is more robust.  Otherwise changes in helper
     # would break it
-    npup = int(ts_npts*250.0/100.0)
-    assert tsup.npts==npup   # weird number = int(255*250/100)
+    npup = int(ts_npts * 250.0 / 100.0)
+    assert tsup.npts == npup  # weird number = int(255*250/100)
     # now repeat for downsampling with resample algorithm
-    ts=TimeSeries(ts0)
+    ts = TimeSeries(ts0)
     ds_resampler = ObspyResampler(5.0)
     tsds = ds_resampler.resample(ts)
-    # Note plots of this output show the auto antialiasing works as 
+    # Note plots of this output show the auto antialiasing works as
     # advertised in scipy
-    assert np.isclose(tsds.dt,0.2)
-    assert tsds.npts == int(ts_npts*5.0/100.0)
+    assert np.isclose(tsds.dt, 0.2)
+    assert tsds.npts == int(ts_npts * 5.0 / 100.0)
     # Repeat same downsampling with decimate
-    ts=TimeSeries(ts0)
+    ts = TimeSeries(ts0)
     decimator = ObspyDecimator(5.0)
     tsds = decimator.resample(ts)
-    assert np.isclose(tsds.dt,0.2)
-    # the documentation doesn't tell me why by the scipy decimate 
+    assert np.isclose(tsds.dt, 0.2)
+    # the documentation doesn't tell me why by the scipy decimate
     # function seems to round npts up rather than use int
-    assert tsds.npts == int(ts_npts*5.0/100.0)+1
+    assert tsds.npts == int(ts_npts * 5.0 / 100.0) + 1
     seis = get_live_seismogram()
-    seis0=Seismogram(seis)
+    seis0 = Seismogram(seis)
     seis = upsampler.resample(seis)
-    assert np.isclose(seis.dt,0.004)
-    npup = int(seis0.npts*250.0/20.0)
+    assert np.isclose(seis.dt, 0.004)
+    npup = int(seis0.npts * 250.0 / 20.0)
     assert seis.npts == npup
-    seis=Seismogram(seis0)
+    seis = Seismogram(seis0)
     seis = ds_resampler.resample(seis)
-    assert np.isclose(seis.dt,0.2)
-    assert seis.npts == int(ts_npts*5.0/20.0)
-    seis=Seismogram(seis0)
+    assert np.isclose(seis.dt, 0.2)
+    assert seis.npts == int(ts_npts * 5.0 / 20.0)
+    seis = Seismogram(seis0)
     seis = decimator.resample(seis)
     # again the round issue noted above
-    dec_npts = int(seis0.npts*5.0/20.0) + 1 
-    assert np.isclose(seis.dt,0.2)
+    dec_npts = int(seis0.npts * 5.0 / 20.0) + 1
+    assert np.isclose(seis.dt, 0.2)
     assert seis.npts == dec_npts
-    
+
     tse = get_live_timeseries_ensemble(5)
     tse.set_live()
     tse0 = TimeSeriesEnsemble(tse)
     tse = upsampler.resample(tse)
-    npup = int(tse0.member[0].npts*250.0/20.0)
+    npup = int(tse0.member[0].npts * 250.0 / 20.0)
     for d in tse.member:
         assert d.live
-        assert np.isclose(d.dt,0.004)
+        assert np.isclose(d.dt, 0.004)
         assert d.npts == npup
-        
+
     tse = TimeSeriesEnsemble(tse0)
     tse = ds_resampler.resample(tse)
-    npup = int(tse0.member[0].npts*5.0/20.0)
+    npup = int(tse0.member[0].npts * 5.0 / 20.0)
     for d in tse.member:
         assert d.live
-        assert np.isclose(d.dt,0.2)
+        assert np.isclose(d.dt, 0.2)
         assert d.npts == npup
-    
+
     tse = TimeSeriesEnsemble(tse0)
     tse = decimator.resample(tse)
-    npup = int(tse0.member[0].npts*5.0/20.0)+1
+    npup = int(tse0.member[0].npts * 5.0 / 20.0) + 1
     for d in tse.member:
         assert d.live
-        assert np.isclose(d.dt,0.2)
+        assert np.isclose(d.dt, 0.2)
         assert d.npts == npup
-    
+
     seis_e = get_live_seismogram_ensemble(3)
     seis_e0 = SeismogramEnsemble(seis_e)
     seis_e = upsampler.resample(seis_e)
-    npup = int(seis_e0.member[0].npts*250.0/20.0)
+    npup = int(seis_e0.member[0].npts * 250.0 / 20.0)
     for d in seis_e.member:
         assert d.live
-        assert np.isclose(d.dt,0.004)
+        assert np.isclose(d.dt, 0.004)
         assert d.npts == npup
-        
+
     seis_e = SeismogramEnsemble(seis_e0)
     seis_e = ds_resampler.resample(seis_e)
-    npup = int(seis_e0.member[0].npts*5.0/20.0)
+    npup = int(seis_e0.member[0].npts * 5.0 / 20.0)
     for d in seis_e.member:
         assert d.live
-        assert np.isclose(d.dt,0.2)
+        assert np.isclose(d.dt, 0.2)
         assert d.npts == npup
-    
+
     seis_e = SeismogramEnsemble(seis_e0)
     seis_e = decimator.resample(seis_e)
-    npup = int(seis_e0.member[0].npts*5.0/20.0)+1
+    npup = int(seis_e0.member[0].npts * 5.0 / 20.0) + 1
     for d in seis_e.member:
         assert d.live
-        assert np.isclose(d.dt,0.2)
+        assert np.isclose(d.dt, 0.2)
         assert d.npts == npup
-  

--- a/python/tests/algorithms/test_resample.py
+++ b/python/tests/algorithms/test_resample.py
@@ -14,7 +14,7 @@ from mspasspy.ccore.seismic import (
 )
 import matplotlib.pyplot as plt
 
-from mspasspy.algorithms.resample import ObspyDecimator, ObspyResampler
+from mspasspy.algorithms.resample import ScipyDecimator, ScipyResampler
 
 
 def test_resample():
@@ -23,7 +23,7 @@ def test_resample():
     ts0 = TimeSeries(ts)
     ts_npts = ts.npts
     # upsample test for resampler
-    upsampler = ObspyResampler(250.0)
+    upsampler = ScipyResampler(250.0)
     tsup = upsampler.resample(ts)
     assert np.isclose(tsup.dt, 0.004)
     # This computed npts is more robust.  Otherwise changes in helper
@@ -32,7 +32,7 @@ def test_resample():
     assert tsup.npts == npup  # weird number = int(255*250/100)
     # now repeat for downsampling with resample algorithm
     ts = TimeSeries(ts0)
-    ds_resampler = ObspyResampler(5.0)
+    ds_resampler = ScipyResampler(5.0)
     tsds = ds_resampler.resample(ts)
     # Note plots of this output show the auto antialiasing works as
     # advertised in scipy
@@ -40,7 +40,7 @@ def test_resample():
     assert tsds.npts == int(ts_npts * 5.0 / 100.0)
     # Repeat same downsampling with decimate
     ts = TimeSeries(ts0)
-    decimator = ObspyDecimator(5.0)
+    decimator = ScipyDecimator(5.0)
     tsds = decimator.resample(ts)
     assert np.isclose(tsds.dt, 0.2)
     # the documentation doesn't tell me why by the scipy decimate

--- a/python/tests/helper.py
+++ b/python/tests/helper.py
@@ -82,10 +82,11 @@ def get_sin_timeseries(ts_size=255, sampling_rate=20.0):
 
 
 def get_live_seismogram_ensemble(n):
-    seis_e = SeismogramEnsemble()
+    seis_e = SeismogramEnsemble() 
     for i in range(n):
         seis = get_live_seismogram()
         seis_e.member.append(seis)
+    seis_e.set_live()
     return seis_e
 
 
@@ -94,6 +95,7 @@ def get_live_timeseries_ensemble(n):
     for i in range(n):
         ts = get_live_timeseries()
         tse.member.append(ts)
+    tse.set_live()
     return tse
 
 

--- a/python/tests/helper.py
+++ b/python/tests/helper.py
@@ -82,7 +82,7 @@ def get_sin_timeseries(ts_size=255, sampling_rate=20.0):
 
 
 def get_live_seismogram_ensemble(n):
-    seis_e = SeismogramEnsemble() 
+    seis_e = SeismogramEnsemble()
     for i in range(n):
         seis = get_live_seismogram()
         seis_e.member.append(seis)


### PR DESCRIPTION
This branch adds a new processing function we missed in our conversion some time ago of obspy functions.   What is here can be thought of as functionally similar to the obspy Trace and Stream methods called "resample" and "decimate".   I found, however, that their implementation was only a light wrapper around two scipy functions with the same names.  Rather than wrap their wrappers I elected to exploit the pybind11 capability of making our sample data look like numpy arrays.   This implementation should be as fast as the scipy functions because the implementation pass array pointers to the scipy functions.  This is a good prototype for actually doing anything that is based on numpy arrays.  Note is works as well for Seismogram objects because the functions have a "axis" argument that allowed me to apply the resamples by row of the internal sample matrix of Seismogram. 

The test programs are pretty extensive.  I think there is a hole in that they don't test exception handling completely.