### PR TITLE
add customized collection class

### DIFF
--- a/python/mspasspy/db/collection.py
+++ b/python/mspasspy/db/collection.py
@@ -1,7 +1,5 @@
 import pymongo
 
-_UJOIN = u"%s.%s"
-
 
 class Collection(pymongo.database.Collection):
     """
@@ -26,7 +24,7 @@ class Collection(pymongo.database.Collection):
     def __getitem__(self, name):
         return Collection(
             self.__database,
-            _UJOIN % (self.__name, name),
+            "%s.%s" % (self.__name, name),
             False,
             self.codec_options,
             self.read_preference,

--- a/python/mspasspy/db/collection.py
+++ b/python/mspasspy/db/collection.py
@@ -1,5 +1,6 @@
 import pymongo
 
+
 class Collection(pymongo.database.Collection):
     """
     A modified Mongo collection class.
@@ -21,20 +22,29 @@ class Collection(pymongo.database.Collection):
         self.__dict__.update(data)
 
     def __getitem__(self, name):
-        return Collection(self.__database,
-                          _UJOIN % (self.__name, name),
-                          False,
-                          self.codec_options,
-                          self.read_preference,
-                          self.write_concern,
-                          self.read_concern)
+        return Collection(
+            self.__database,
+            _UJOIN % (self.__name, name),
+            False,
+            self.codec_options,
+            self.read_preference,
+            self.write_concern,
+            self.read_concern,
+        )
 
-    def with_options(self, codec_options=None, read_preference=None,
-                     write_concern=None, read_concern=None):
-        return Collection(self.__database,
-                          self.__name,
-                          False,
-                          codec_options or self.codec_options,
-                          read_preference or self.read_preference,
-                          write_concern or self.write_concern,
-                          read_concern or self.read_concern)
+    def with_options(
+        self,
+        codec_options=None,
+        read_preference=None,
+        write_concern=None,
+        read_concern=None,
+    ):
+        return Collection(
+            self.__database,
+            self.__name,
+            False,
+            codec_options or self.codec_options,
+            read_preference or self.read_preference,
+            write_concern or self.write_concern,
+            read_concern or self.read_concern,
+        )

--- a/python/mspasspy/db/collection.py
+++ b/python/mspasspy/db/collection.py
@@ -1,0 +1,40 @@
+import pymongo
+
+class Collection(pymongo.database.Collection):
+    """
+    A modified Mongo collection class.
+
+    The native collection class of Mongo does not have __setstate__ and
+    __getstate__ defined, which prevents it from being serialized. We add
+    the two methods here as an addition so that the collection can be passed
+    around by the scheduler and worker.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Collection, self).__init__(*args, **kwargs)
+
+    def __getstate__(self):
+        ret = self.__dict__.copy()
+        return ret
+
+    def __setstate__(self, data):
+        self.__dict__.update(data)
+
+    def __getitem__(self, name):
+        return Collection(self.__database,
+                          _UJOIN % (self.__name, name),
+                          False,
+                          self.codec_options,
+                          self.read_preference,
+                          self.write_concern,
+                          self.read_concern)
+
+    def with_options(self, codec_options=None, read_preference=None,
+                     write_concern=None, read_concern=None):
+        return Collection(self.__database,
+                          self.__name,
+                          False,
+                          codec_options or self.codec_options,
+                          read_preference or self.read_preference,
+                          write_concern or self.write_concern,
+                          read_concern or self.read_concern)

--- a/python/mspasspy/db/collection.py
+++ b/python/mspasspy/db/collection.py
@@ -1,5 +1,7 @@
 import pymongo
 
+_UJOIN = u"%s.%s"
+
 
 class Collection(pymongo.database.Collection):
     """

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -257,8 +257,14 @@ class Database(pymongo.database.Database):
         """
         return Collection(self, name)
 
-    def get_collection(self, name, codec_options=None, read_preference=None,
-                    write_concern=None, read_concern=None):
+    def get_collection(
+        self,
+        name,
+        codec_options=None,
+        read_preference=None,
+        write_concern=None,
+        read_concern=None,
+    ):
         """
         Get a :class:`mspasspy.db.collection.Collection` with the given name
         and options.
@@ -285,12 +291,25 @@ class Database(pymongo.database.Database):
             used.
         """
         return Collection(
-            self, name, False, codec_options, read_preference,
-            write_concern, read_concern)
+            self,
+            name,
+            False,
+            codec_options,
+            read_preference,
+            write_concern,
+            read_concern,
+        )
 
-    def create_collection(self, name, codec_options=None,
-                          read_preference=None, write_concern=None,
-                          read_concern=None, session=None, **kwargs):
+    def create_collection(
+        self,
+        name,
+        codec_options=None,
+        read_preference=None,
+        write_concern=None,
+        read_concern=None,
+        session=None,
+        **kwargs
+    ):
         """
         Create a new :class:`mspasspy.db.collection.Collection` in this
         database.
@@ -337,14 +356,24 @@ class Database(pymongo.database.Database):
         with self.__client._tmp_session(session) as s:
             # Skip this check in a transaction where listCollections is not
             # supported.
-            if ((not s or not s.in_transaction) and
-                    name in self.list_collection_names(
-                        filter={"name": name}, session=s)):
-                raise pymongo.errors.CollectionInvalid("collection %s already exists" % name)
+            if (not s or not s.in_transaction) and name in self.list_collection_names(
+                filter={"name": name}, session=s
+            ):
+                raise pymongo.errors.CollectionInvalid(
+                    "collection %s already exists" % name
+                )
 
-            return Collection(self, name, True, codec_options,
-                              read_preference, write_concern,
-                              read_concern, session=s, **kwargs)
+            return Collection(
+                self,
+                name,
+                True,
+                codec_options,
+                read_preference,
+                write_concern,
+                read_concern,
+                session=s,
+                **kwargs
+            )
 
     def set_metadata_schema(self, schema):
         """

--- a/python/tests/db/test_collection.py
+++ b/python/tests/db/test_collection.py
@@ -1,0 +1,73 @@
+import pickle
+from datetime import datetime
+from bson.objectid import ObjectId
+
+from mspasspy.db.schema import MetadataSchema
+
+from mspasspy.db.client import DBClient
+from mspasspy.db.database import Database
+#from mspasspy.db.collection import Collection
+
+
+class TestDatabase:
+    def setup_class(self):
+        client = DBClient("localhost")
+        self.db = Database(client, "dbtest")
+        self.db2 = Database(client, "dbtest")
+        self.metadata_def = MetadataSchema()
+        # clean up the database locally
+        for col_name in self.db.list_collection_names():
+            self.db[col_name].delete_many({})
+
+        site_id = ObjectId()
+        channel_id = ObjectId()
+        source_id = ObjectId()
+        self.db["site"].insert_one(
+            {
+                "_id": site_id,
+                "net": "net1",
+                "sta": "sta1",
+                "loc": "loc",
+                "lat": 1.0,
+                "lon": 1.0,
+                "elev": 2.0,
+                "starttime": datetime.utcnow().timestamp(),
+                "endtime": datetime.utcnow().timestamp(),
+            }
+        )
+        self.db["channel"].insert_one(
+            {
+                "_id": channel_id,
+                "net": "net1",
+                "sta": "sta1",
+                "loc": "loc1",
+                "chan": "chan",
+                "lat": 1.1,
+                "lon": 1.1,
+                "elev": 2.1,
+                "starttime": datetime.utcnow().timestamp(),
+                "endtime": datetime.utcnow().timestamp(),
+                "edepth": 3.0,
+                "vang": 1.0,
+                "hang": 1.0,
+            }
+        )
+        self.db["source"].insert_one(
+            {
+                "_id": source_id,
+                "lat": 1.2,
+                "lon": 1.2,
+                "time": datetime.utcnow().timestamp(),
+                "depth": 3.1,
+                "magnitude": 1.0,
+            }
+        )
+    
+    def test_collection(self):
+        col1 = self.db.source
+        col2 = self.db["source"]
+        assert col1 == col2
+
+        col11 = pickle.loads(pickle.dumps(col1))
+        col21 = pickle.loads(pickle.dumps(col2))
+        assert col11 == col21

--- a/python/tests/db/test_collection.py
+++ b/python/tests/db/test_collection.py
@@ -6,7 +6,8 @@ from mspasspy.db.schema import MetadataSchema
 
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
-#from mspasspy.db.collection import Collection
+
+# from mspasspy.db.collection import Collection
 
 
 class TestDatabase:
@@ -62,7 +63,7 @@ class TestDatabase:
                 "magnitude": 1.0,
             }
         )
-    
+
     def test_collection(self):
         col1 = self.db.source
         col2 = self.db["source"]

--- a/python/tests/db/test_collection.py
+++ b/python/tests/db/test_collection.py
@@ -53,7 +53,8 @@ class TestDatabase:
                 "hang": 1.0,
             }
         )
-        self.db["source"].insert_one(
+        col_source = self.db.create_collection("source")
+        col_source.insert_one(
             {
                 "_id": source_id,
                 "lat": 1.2,
@@ -76,3 +77,12 @@ class TestDatabase:
         col11 = pickle.loads(pickle.dumps(col1))
         col21 = pickle.loads(pickle.dumps(col2))
         assert col11 == col21
+
+        col11.test2.insert_one(
+            {
+                "lat": 1.9,
+                "lon": 1.2,
+                "time": datetime.utcnow().timestamp(),
+            }
+        )
+        assert col11["test2"].find_one()["lat"] == 1.9

--- a/python/tests/db/test_collection.py
+++ b/python/tests/db/test_collection.py
@@ -64,6 +64,10 @@ class TestDatabase:
             }
         )
 
+    def teardown_class(self):
+        client = DBClient("localhost")
+        client.drop_database("dbtest")
+
     def test_collection(self):
         col1 = self.db.source
         col2 = self.db["source"]


### PR DESCRIPTION
@pavlis has discovered a potential bug where calling any function that uses the Database class may run into the error saying:
```
TypeError: codec_options must be an instance of bson.codec_options.CodecOptions
```

The full error log from the run looks like this:
```
TypeError Traceback (most recent call last)
<ipython-input-24-dc62b940ab12> in <module>
 43 cursor=db.wf_miniseed.find(query)
 44 seisbag = read_distributed_data(db,cursor)
---> 45 seisbag.compute()
 46 #seisbag = seisbag.map(detrend,type='constant')
 47 #seisbag = seisbag.map(lambda d : ator(d,d[\"Ptime\"]))

/usr/local/lib/python3.6/dist-packages/dask/base.py in compute(self, **kwargs)
 281 dask.base.compute
 282 \"\"\"
--> 283 (result,) = compute(self, traverse=False, **kwargs)
 284 return result
 285 

/usr/local/lib/python3.6/dist-packages/dask/base.py in compute(*args, **kwargs)
 563 postcomputes.append(x.__dask_postcompute__())
 564 
--> 565 results = schedule(dsk, keys, **kwargs)
 566 return repack([f(r, *a) for r, (f, a) in zip(results, postcomputes)])
 567 

/usr/local/lib/python3.6/dist-packages/distributed/client.py in get(self, dsk, keys, workers, allow_other_workers, resources, sync, asynchronous, direct, retries, priority, fifo_timeout, actors, **kwargs)
 2652 should_rejoin = False
 2653 try:
-> 2654 results = self.gather(packed, asynchronous=asynchronous, direct=direct)
 2655 finally:
 2656 for f in futures.values():

/usr/local/lib/python3.6/dist-packages/distributed/client.py in gather(self, futures, errors, direct, asynchronous)
 1967 direct=direct,
 1968 local_worker=local_worker,
-> 1969 asynchronous=asynchronous,
 1970 )
 1971 

/usr/local/lib/python3.6/dist-packages/distributed/client.py in sync(self, func, asynchronous, callback_timeout, *args, **kwargs)
 836 else:
 837 return sync(
--> 838 self.loop, func, *args, callback_timeout=callback_timeout, **kwargs
 839 )
 840 

/usr/local/lib/python3.6/dist-packages/distributed/utils.py in sync(loop, func, callback_timeout, *args, **kwargs)
 349 if error[0]:
 350 typ, exc, tb = error[0]
--> 351 raise exc.with_traceback(tb)
 352 else:
 353 return result[0]

/usr/local/lib/python3.6/dist-packages/distributed/utils.py in f()
 332 if callback_timeout is not None:
 333 future = asyncio.wait_for(future, callback_timeout)
--> 334 result[0] = yield future
 335 except Exception as exc:
 336 error[0] = sys.exc_info()

/usr/local/lib/python3.6/dist-packages/tornado/gen.py in run(self)
 760 
 761 try:
--> 762 value = future.result()
 763 except Exception:
 764 exc_info = sys.exc_info()

/usr/local/lib/python3.6/dist-packages/distributed/client.py in _gather(self, futures, errors, direct, local_worker)
 1826 exc = CancelledError(key)
 1827 else:
-> 1828 raise exception.with_traceback(traceback)
 1829 raise exc
 1830 if errors == \"skip\":

/usr/local/lib/python3.6/dist-packages/dask/bag/core.py in reify()
 1814 def reify(seq):
 1815 if isinstance(seq, Iterator):
-> 1816 seq = list(seq)
 1817 if len(seq) and isinstance(seq[0], Iterator):
 1818 seq = list(map(list, seq))

/usr/local/lib/python3.6/dist-packages/dask/bag/core.py in __next__()
 2001 kwargs = dict(zip(self.kwarg_keys, vals[-self.nkws :]))
 2002 return self.f(*args, **kwargs)
-> 2003 return self.f(*vals)
 2004 
 2005 def check_all_iterators_consumed(self):

/usr/local/lib/python3.6/dist-packages/mspasspy/db/database.py in <lambda>()
 174 data_tag=data_tag,
 175 aws_access_key_id=aws_access_key_id,
--> 176 aws_secret_access_key=aws_secret_access_key,
 177 )
 178 )

/usr/local/lib/python3.6/dist-packages/mspasspy/db/database.py in read_data()
 421 
 422 # find the corresponding document according to object id
--> 423 col = self[wf_collection]
 424 try:
 425 oid = object_id[\"_id\"]

/usr/local/lib/python3.6/dist-packages/pymongo/database.py in __getitem__()
 302 - `name`: the name of the collection to get
 303 \"\"\"
--> 304 return Collection(self, name)
 305 
 306 def get_collection(self, name, codec_options=None, read_preference=None,

/usr/local/lib/python3.6/dist-packages/pymongo/collection.py in __init__()
 161 read_preference or database.read_preference,
 162 write_concern or database.write_concern,
--> 163 read_concern or database.read_concern)
 164 
 165 if not isinstance(name, string_type):

/usr/local/lib/python3.6/dist-packages/pymongo/common.py in __init__()
 831 
 832 if not isinstance(codec_options, CodecOptions):
--> 833 raise TypeError(\"codec_options must be an instance of \"
 834 \"bson.codec_options.CodecOptions\")
 835 self.__codec_options = codec_options

TypeError: codec_options must be an instance of bson.codec_options.CodecOptions
```

It is obvious that the error is related to serialization at the stage of re-constructing the objects. It is unclear to me how exactly this error occurs as I was not able to reproduce the behavior with a simple test based on our test code for the read_distributed_data function. However, I suspect that it is due to the native Collection class of pymongo that doesn't support serialization (which is standard practice for any objects that has its state rely on a remote session). However, in our case, it is not necessarily a problem to re-connect to the database when de-serializing. 

I started by adding a simple test that pickles a collection object, and it does run into an error of 
```
RecursionError: maximum recursion depth exceeded while calling a Python object
```
This is due to a mix of the behavior of pickle when `__setstate__` and `__getstate__` are not defined as well as how the collection class' `__getattr__` method is defined. I am not gonna go into that detail here, but it is just showing that the original class does not support serialization. 

In this PR, I added our own Collection class derived from the pymongo one, and it supports pickle without any issues (I hope at least). @pavlis Please test the notebook with this branch and see if the problem goes away. Thank you!