### PR TITLE
Update reduce.py

### DIFF
--- a/python/mspasspy/db/collection.py
+++ b/python/mspasspy/db/collection.py
@@ -21,12 +21,12 @@ class Collection(pymongo.database.Collection):
 
     def __setstate__(self, data):
         # Same as the Database class
-        # The following is also needed for this object to be serialized correctly 
+        # The following is also needed for this object to be serialized correctly
         # with dask distributed. Otherwise, the deserialized codec_options
         # will become a different type unrecognized by pymongo. Not sure why...
         from bson.codec_options import CodecOptions, TypeRegistry
         from bson.binary import UuidRepresentation
-        
+
         data["_BaseObject__codec_options"] = eval(data["_BaseObject__codec_options"])
         self.__dict__.update(data)
 

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -245,7 +245,8 @@ class Database(pymongo.database.Database):
         # work without it.  Not sure how the symbol MongoClient is required
         # here but it is - ignore if a lint like ide says MongoClient is not used
         from pymongo import MongoClient
-        # The following is also needed for this object to be serialized correctly 
+
+        # The following is also needed for this object to be serialized correctly
         # with dask distributed. Otherwise, the deserialized codec_options
         # will become a different type unrecognized by pymongo. Not sure why...
         from bson.codec_options import CodecOptions, TypeRegistry

--- a/python/mspasspy/reduce.py
+++ b/python/mspasspy/reduce.py
@@ -45,13 +45,26 @@ def stack(data1, data2, object_history=False, alg_id=None, alg_name=None, dryrun
 
 def mspass_spark_foldby(self, key="site_id"):
     """
-    This function implements a convenient foldby method for :class:`dask.bag.Bag`.
-    The concept is to compose gathers of TimeSeries or Seismograms with a common key from a list of TimeSeries or Seismograms.
-    So, the input needs to be a Bag of :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`,
-    and the output is a Bag of :class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` or :class:`mspasspy.ccore.seismic.SeismogramEnsemble`.
+    This function implements a convenient foldby method for a spark RDD to generate ensembles from atomic data.  
+    The concept is to assemble ensembles of :class:`mspasspy.ccore.seismic.TimeSeries` or 
+    :class:`mspasspy.ccore.seismic.Seismogram` objects with a common Metadata attribute using 
+    a single key.  The output is the ensemble objects we call class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` 
+    and :class:`mspasspy.ccore.seismic.SeismogramEnsemble` respectively.  Note that "foldby" in this context
+    acts a bit like a reduce operator BUT the data volume is not reduced;  we just bundle groups of 
+    related data into ensembles.   The outputs are always larger due to the overhead of the ensemble 
+    container.   That is important as be careful with this operator as it can easily create huge
+    ensembles that could cause a memory fault in your workflow.  
+    
+    Note that because this is implemented as a method of the RDD class the usage is a different from 
+    the map and reduce methods.  arg0 is "self" which means it must be defined by the input RDD.  
+    
+    Example::
+    
+      # preceded by set of map-reduce lines to create RDD mydata
+      mydata = mspass_spark_foldby(mydata,key="source_id")
 
     :param key: The key that defines the gather. By default, it will use "site_id" to produce a common station gather.
-    :return: :class:`dask.bag.Bag` of :class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` or :class:`mspasspy.ccore.seismic.SeismogramEnsemble`.
+    :return: :class:`pyspark.RDD` of :class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` or :class:`mspasspy.ccore.seismic.SeismogramEnsemble`.
     """
     return (
         self.map(lambda x: (x[key], x))
@@ -66,13 +79,26 @@ def mspass_spark_foldby(self, key="site_id"):
 
 def mspass_dask_foldby(self, key="site_id"):
     """
-    This function implements a convenient foldby method for :class:`pyspark.RDD`.
-    The concept is to compose gathers of TimeSeries or Seismograms with a common key from a list of TimeSeries or Seismograms.
-    So, the input needs to be an RDD of :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`,
-    and the output is an RDD of :class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` or :class:`mspasspy.ccore.seismic.SeismogramEnsemble`.
+    This function implements a convenient foldby method for a dask bag to generate ensembles from atomic data.  
+    The concept is to assemble ensembles of :class:`mspasspy.ccore.seismic.TimeSeries` or 
+    :class:`mspasspy.ccore.seismic.Seismogram` objects with a common Metadata attribute using 
+    a single key.  The output is the ensemble objects we call class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` 
+    and :class:`mspasspy.ccore.seismic.SeismogramEnsemble` respectively.  Note that "foldby" in this context
+    acts a bit like a reduce operator BUT the data volume is not reduced;  we just bundle groups of 
+    related data into ensembles.   The outputs are always larger due to the overhead of the ensemble 
+    container.   That is important as be careful with this operator as it can easily create huge
+    ensembles that could cause a memory fault in your workflow.  
+    
+    Note that because this is implemented as a method of the bag class the usage is a different from 
+    the map and reduce methods.  arg0 is "self" which means it must be defined by the input bag.  
+    
+    Example::
+    
+      # preceded by set of map-reduce lines to create a bag called mydata
+      mydata = mspass_dask_foldby(mydata,key="source_id")
 
     :param key: The key that defines the gather. By default, it will use "site_id" to produce a common station gather.
-    :return: :class:`pyspark.RDD` of :class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` or :class:`mspasspy.ccore.seismic.SeismogramEnsemble`.
+    :return: :class:`dask.bag.Bag` of :class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` or :class:`mspasspy.ccore.seismic.SeismogramEnsemble`.
     """
     return self.foldby(
         lambda x: x[key],

--- a/python/mspasspy/reduce.py
+++ b/python/mspasspy/reduce.py
@@ -45,21 +45,21 @@ def stack(data1, data2, object_history=False, alg_id=None, alg_name=None, dryrun
 
 def mspass_spark_foldby(self, key="site_id"):
     """
-    This function implements a convenient foldby method for a spark RDD to generate ensembles from atomic data.  
-    The concept is to assemble ensembles of :class:`mspasspy.ccore.seismic.TimeSeries` or 
-    :class:`mspasspy.ccore.seismic.Seismogram` objects with a common Metadata attribute using 
-    a single key.  The output is the ensemble objects we call class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` 
+    This function implements a convenient foldby method for a spark RDD to generate ensembles from atomic data.
+    The concept is to assemble ensembles of :class:`mspasspy.ccore.seismic.TimeSeries` or
+    :class:`mspasspy.ccore.seismic.Seismogram` objects with a common Metadata attribute using
+    a single key.  The output is the ensemble objects we call class:`mspasspy.ccore.seismic.TimeSeriesEnsemble`
     and :class:`mspasspy.ccore.seismic.SeismogramEnsemble` respectively.  Note that "foldby" in this context
-    acts a bit like a reduce operator BUT the data volume is not reduced;  we just bundle groups of 
-    related data into ensembles.   The outputs are always larger due to the overhead of the ensemble 
+    acts a bit like a reduce operator BUT the data volume is not reduced;  we just bundle groups of
+    related data into ensembles.   The outputs are always larger due to the overhead of the ensemble
     container.   That is important as be careful with this operator as it can easily create huge
-    ensembles that could cause a memory fault in your workflow.  
-    
-    Note that because this is implemented as a method of the RDD class the usage is a different from 
-    the map and reduce methods.  arg0 is "self" which means it must be defined by the input RDD.  
-    
+    ensembles that could cause a memory fault in your workflow.
+
+    Note that because this is implemented as a method of the RDD class the usage is a different from
+    the map and reduce methods.  arg0 is "self" which means it must be defined by the input RDD.
+
     Example::
-    
+
       # preceded by set of map-reduce lines to create RDD mydata
       mydata = mspass_spark_foldby(mydata,key="source_id")
 
@@ -79,21 +79,21 @@ def mspass_spark_foldby(self, key="site_id"):
 
 def mspass_dask_foldby(self, key="site_id"):
     """
-    This function implements a convenient foldby method for a dask bag to generate ensembles from atomic data.  
-    The concept is to assemble ensembles of :class:`mspasspy.ccore.seismic.TimeSeries` or 
-    :class:`mspasspy.ccore.seismic.Seismogram` objects with a common Metadata attribute using 
-    a single key.  The output is the ensemble objects we call class:`mspasspy.ccore.seismic.TimeSeriesEnsemble` 
+    This function implements a convenient foldby method for a dask bag to generate ensembles from atomic data.
+    The concept is to assemble ensembles of :class:`mspasspy.ccore.seismic.TimeSeries` or
+    :class:`mspasspy.ccore.seismic.Seismogram` objects with a common Metadata attribute using
+    a single key.  The output is the ensemble objects we call class:`mspasspy.ccore.seismic.TimeSeriesEnsemble`
     and :class:`mspasspy.ccore.seismic.SeismogramEnsemble` respectively.  Note that "foldby" in this context
-    acts a bit like a reduce operator BUT the data volume is not reduced;  we just bundle groups of 
-    related data into ensembles.   The outputs are always larger due to the overhead of the ensemble 
+    acts a bit like a reduce operator BUT the data volume is not reduced;  we just bundle groups of
+    related data into ensembles.   The outputs are always larger due to the overhead of the ensemble
     container.   That is important as be careful with this operator as it can easily create huge
-    ensembles that could cause a memory fault in your workflow.  
-    
-    Note that because this is implemented as a method of the bag class the usage is a different from 
-    the map and reduce methods.  arg0 is "self" which means it must be defined by the input bag.  
-    
+    ensembles that could cause a memory fault in your workflow.
+
+    Note that because this is implemented as a method of the bag class the usage is a different from
+    the map and reduce methods.  arg0 is "self" which means it must be defined by the input bag.
+
     Example::
-    
+
       # preceded by set of map-reduce lines to create a bag called mydata
       mydata = mspass_dask_foldby(mydata,key="source_id")
 


### PR DESCRIPTION
Improve docstrings for dask and spark foldby operators.   The previous version had the dask and spark docstrings reversed.  I also added an example.  It took me a fair amount of trial and error to realize the usage in the example is correct.  Note I am only assuming the spark version is the same.