### PR TITLE
Update window.py

### DIFF
--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -382,6 +382,9 @@ def WindowData_with_duration(
     alg_id=None,
     dryrun=False,
 ):
+    """
+    THIS FUNCTION NEEDS A DOCSTRING.   I DON'T WANT TO WRITE IT AS I DON'T SEE WHY IT EVEN EXIST.  THERE IS A BUG IN THE CODE BELOW.
+    """
     if duration < 0:
         detailline = "Window duration: {dur}  Data range:  {dst},{det}".format(
             dur=duration, dst=d.t0, det=d.endtime()
@@ -393,7 +396,7 @@ def WindowData_with_duration(
         )
         d.kill()
         return d
-    win_start = d.t0 + 1
+    win_start = d.t0
     win_end = win_start + duration
     if d.dead():
         return d


### PR DESCRIPTION
I ran across this code when I was trying to remember now to use the mspass_func_wrapper and noticed:
1. I does not have docstring
2. It is not correct as previous version of this had a bug in how it set the start of time window.   You can see the one line change I made.  It may break the tests.

I actually think this function is not needed.   To my mind it would be harder to remember a function with a similar but different name than to just remember what a TimeWindow object is or use a start and end time explicitly set as two parameters.