### PR TITLE
fix ensemble converter bug

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -2821,13 +2821,13 @@ class Database(pymongo.database.Database):
         Reads an subset of a dataset with some logical grouping into an Ensemble container.
         It has the same fucntion as read_ensemble_data(), but is more efficient in reading binary files.
         The improvement is achieved by avoiding duplicate open and close for the same file.
-        MsPASS Objects are grouped firstly by files they are in. If two objects are in the same file, 
+        MsPASS Objects are grouped firstly by files they are in. If two objects are in the same file,
         with the same directory and filename, they will be in the same file group. For each group,
-        there will be only one open and close. For objects stored in the same file, their foffs 
-        will be collected and passed to fread_from_file(). Then open the file once, and sequentially 
+        there will be only one open and close. For objects stored in the same file, their foffs
+        will be collected and passed to fread_from_file(). Then open the file once, and sequentially
         read the data according to the foffs.
 
-        This function only supports binary file format (format=None), as the optimization will not 
+        This function only supports binary file format (format=None), as the optimization will not
         work in other formats.
 
         :param objectid_list: a :class:`list` of :class:`bson.objectid.ObjectId`,
@@ -2915,7 +2915,8 @@ class Database(pymongo.database.Database):
             if "format" in object_doc:
                 if object_doc["format"] != None:
                     raise MsPASSError(
-                        "read_ensemble_data_group() only support reading from binary files, please use read_ensemble_data() for other formats", "Invalid"
+                        "read_ensemble_data_group() only support reading from binary files, please use read_ensemble_data() for other formats",
+                        "Invalid",
                     )
 
             if data_tag:

--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -755,11 +755,8 @@ def Stream2TimeSeriesEnsemble(stream):
     enskeys = _converter_get_ensemble_keys(tse)
     if len(enskeys) > 0:
         post_ensemble_metadata(tse, enskeys)
-        # By default the above leaves copies of the ensemble md in each member
-        # Treat that a ok, but we do need to clear the temporary we posted
-        for d in tse.member:
-            # Depend on the temp being set in all members - watch out in
-            # maintenance if any of the related code changes that may be wrong
+    for d in tse.member:
+        if d.is_defined("CONVERTER_ENSEMBLE_KEYS"):
             d.erase("CONVERTER_ENSEMBLE_KEYS")
 
     return tse
@@ -810,11 +807,10 @@ def Stream2SeismogramEnsemble(stream):
     enskeys = _converter_get_ensemble_keys(res)
     if len(enskeys) > 0:
         post_ensemble_metadata(res, enskeys)
-        # By default the above leaves copies of the ensemble md in each member
-        # Treat that a ok, but we do need to clear the temporary we posted
-        for d in res.member:
-            # Depend on the temp being set in all members - watch out in
-            # maintenance if any of the related code changes that may be wrong
+    # By default the above leaves copies of the ensemble md in each member
+    # Treat that a ok, but we do need to clear the temporary we posted
+    for d in res.member:
+        if d.is_defined("CONVERTER_ENSEMBLE_KEYS"):
             d.erase("CONVERTER_ENSEMBLE_KEYS")
     return res
 

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -395,8 +395,7 @@ def is_input_dead(*args, **kwargs):
 
 
 def timeseries_copy_helper(ts1, ts2):
-    """
-    """
+    """ """
     # keys in this list are ignored - for now only one but made a list
     # to simplify additions later
     metadata_to_ignore = ["CONVERTER_ENSEMBLE_KEYS"]
@@ -418,7 +417,6 @@ def timeseries_copy_helper(ts1, ts2):
 
 
 def timeseries_ensemble_copy_helper(es1, es2):
-
     for i in range(len(es1.member)):
         timeseries_copy_helper(es1.member[i], es2.member[i])
     # fixme: not sure in what algorithm the length of es1 and es2 would be different

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -395,17 +395,30 @@ def is_input_dead(*args, **kwargs):
 
 
 def timeseries_copy_helper(ts1, ts2):
+    """
+    """
+    # keys in this list are ignored - for now only one but made a list
+    # to simplify additions later
+    metadata_to_ignore = ["CONVERTER_ENSEMBLE_KEYS"]
     ts1.npts = ts2.npts
     ts1.dt = ts2.dt
     ts1.tref = ts2.tref
     ts1.live = ts2.live
     ts1.t0 = ts2.t0
     for k in ts2.keys():  # other metadata copy
-        ts1[k] = ts2[k]  # override previous metadata is ok, since they are consistent
-    ts1.data = ts2.data
+        if k not in metadata_to_ignore:
+            # because this is used only in decorator we can assure
+            # overrides are consistent
+            ts1[k] = ts2[k]
+    # We need to clear this/these too as if they were already there the
+    # above logic preserves them
+    for k in metadata_to_ignore:
+        if ts1.is_defined(k):
+            ts1.erase(k)
 
 
 def timeseries_ensemble_copy_helper(es1, es2):
+
     for i in range(len(es1.member)):
         timeseries_copy_helper(es1.member[i], es2.member[i])
     # fixme: not sure in what algorithm the length of es1 and es2 would be different
@@ -457,14 +470,24 @@ def timeseries_as_trace(func, *args, **kwargs):
 
 
 def seismogram_copy_helper(seis1, seis2):
+    # keys in this list are ignored - for now only one but made a list
+    # to simplify additions later
+    metadata_to_ignore = ["CONVERTER_ENSEMBLE_KEYS"]
     seis1.npts = seis2.npts
     seis1.dt = seis2.dt
     seis1.tref = seis2.tref
     seis1.live = seis2.live
     seis1.t0 = seis2.t0
     for k in seis2.keys():  # other metadata copy
-        # override previous metadata is ok, since they are consistent
-        seis1[k] = seis2[k]
+        if k not in metadata_to_ignore:
+            # because this is used only in decorator we can assure
+            # overrides are consistent
+            seis1[k] = seis2[k]
+    # We need to clear this/these too as if they were already there the
+    # above logic preserves them
+    for k in metadata_to_ignore:
+        if seis1.is_defined(k):
+            seis1.erase(k)
     seis1.data = seis2.data
 
 

--- a/python/tests/db/test_db_spark_dask.py
+++ b/python/tests/db/test_db_spark_dask.py
@@ -511,11 +511,13 @@ class TestDatabase:
         self.db.index_mseed_file(fname, collection="wf_miniseed")
         assert self.db["wf_miniseed"].count_documents({}) == 3
 
-        cursor=self.db.wf_miniseed.find({})
-        pattern = r'read_ensemble_data_group\(\) only support reading from binary files, please use read_ensemble_data\(\) for other formats'
+        cursor = self.db.wf_miniseed.find({})
+        pattern = r"read_ensemble_data_group\(\) only support reading from binary files, please use read_ensemble_data\(\) for other formats"
         with pytest.raises(MsPASSError, match=pattern):
-            ensemble=self.db.read_ensemble_data_group(cursor,collection='wf_miniseed')
-        
+            ensemble = self.db.read_ensemble_data_group(
+                cursor, collection="wf_miniseed"
+            )
+
         self.db.wf_miniseed.delete_many({})
 
     def mock_urlopen(*args):


### PR DESCRIPTION
This branch fixes a serious bug in handling ensemble data.  When obspy functions were applied to ensembles the previous version  obspy functions would create output that caused
the database save method to abort.   The problem was related to
a subtle mishandling of an internal set container used to handle the
conversion of ensemble Metadata.  This commit fixes the problem
but hasn't been verified with pytest.  It shouldn't fail but could.  My fix was tested on a subset of the 2012 usarray data and it solved the problem.   Look at my fixes with a bit of skepticism to see if there is a cleaner solution.  The way the decorators are interwoven made this hard to track so changes from what I suggest should be done cautiously.   