### PR TITLE
fix cflags, sse2 and avx2 when building numcodecs in arm

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ github.event_name != 'schedule' }}
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,12 +79,12 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image (amd64 only)
+      - name: Build and push Docker image (arm64 only)
         uses: docker/build-push-action@v4
         if: ${{ github.event_name != 'schedule' }}
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,12 +79,12 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image (arm64 only)
+      - name: Build and push Docker image (amd64 only)
         uses: docker/build-push-action@v4
         if: ${{ github.event_name != 'schedule' }}
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ github.event_name != 'schedule' }}
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,7 @@ RUN unzip /usr/local/spark/python/lib/pyspark.zip \
 ADD requirements.txt requirements.txt
 RUN pip3 --no-cache-dir install --upgrade pip \
 	&& docker-clean
-RUN if [ "$TARGETARCH" == "arm64" ]; then export CFLAGS="-g" \
+RUN if [ "$TARGETARCH" == "arm64" ]; then export CFLAGS="-O3" \
 	&& export DISABLE_NUMCODECS_SSE2=true && export DISABLE_NUMCODECS_AVX2=true; fi\
 	&& pip3 --no-cache-dir install numpy \
     && pip3 --no-cache-dir install -r requirements.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,8 @@ RUN unzip /usr/local/spark/python/lib/pyspark.zip \
 ADD requirements.txt requirements.txt
 RUN pip3 --no-cache-dir install --upgrade pip \
 	&& docker-clean
-RUN export CFLAGS="-g" && export DISABLE_NUMCODECS_SSE2=true && export DISABLE_NUMCODECS_AVX2=true\
+RUN if [ "$TARGETARCH" == "arm64" ]; then export CFLAGS="-g" \
+	&& export DISABLE_NUMCODECS_SSE2=true && export DISABLE_NUMCODECS_AVX2=true; fi\
 	&& pip3 --no-cache-dir install numpy \
     && pip3 --no-cache-dir install -r requirements.txt \
     && rm -f requirements.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,13 +149,11 @@ RUN unzip /usr/local/spark/python/lib/pyspark.zip \
 	&& docker-clean
 
 # Install Python dependencies through pip
-ENV DISABLE_NUMCODECS_SSE2 true
-ENV DISABLE_NUMCODECS_AVX2 true
-ENV CFLAGS -g
 ADD requirements.txt requirements.txt
 RUN pip3 --no-cache-dir install --upgrade pip \
 	&& docker-clean
-RUN pip3 --no-cache-dir install numpy \
+RUN export CFLAGS="-g" && export DISABLE_NUMCODECS_SSE2=true && export DISABLE_NUMCODECS_AVX2=true\
+	&& pip3 --no-cache-dir install numpy \
     && pip3 --no-cache-dir install -r requirements.txt \
     && rm -f requirements.txt \
 	&& docker-clean
@@ -174,7 +172,7 @@ RUN pip3 --no-cache-dir install --upgrade setuptools \
 
 # Add cxx library
 ADD cxx /mspass/cxx
-RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp && unset CFLAGS && cd /mspass/cxx \
+RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp && cd /mspass/cxx \
     && mkdir build && cd build \
     && cmake .. \
     && make \
@@ -189,7 +187,7 @@ ENV MSPASS_HOME /mspass
 # Add setup.py to install python components
 ADD setup.py /mspass/setup.py
 ADD python /mspass/python
-RUN unset CFLAGS && pip3 install /mspass -v \
+RUN pip3 install /mspass -v \
 	&& docker-clean
 
 # Install jedi

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -149,13 +149,11 @@ RUN unzip /usr/local/spark/python/lib/pyspark.zip \
 	&& docker-clean
 
 # Install Python dependencies through pip
-ENV DISABLE_NUMCODECS_SSE2 true
-ENV DISABLE_NUMCODECS_AVX2 true
-ENV CFLAGS -g
 ADD requirements.txt requirements.txt
 RUN pip3 --no-cache-dir install --upgrade pip \
 	&& docker-clean
-RUN pip3 --no-cache-dir install numpy \
+RUN export CFLAGS="-g" && export DISABLE_NUMCODECS_SSE2=true && export DISABLE_NUMCODECS_AVX2=true\
+	&& pip3 --no-cache-dir install numpy \
     && pip3 --no-cache-dir install -r requirements.txt \
     && rm -f requirements.txt \
 	&& docker-clean
@@ -174,7 +172,7 @@ RUN pip3 --no-cache-dir install --upgrade setuptools \
 
 # Add cxx library
 ADD cxx /mspass/cxx
-RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp && unset CFLAGS && cd /mspass/cxx \
+RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp && cd /mspass/cxx \
     && mkdir build && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Debug .. \
     && make \
@@ -189,7 +187,7 @@ ENV MSPASS_HOME /mspass
 # Add setup.py to install python components
 ADD setup.py /mspass/setup.py
 ADD python /mspass/python
-RUN unset CFLAGS && pip3 install --global-option build --global-option --debug /mspass -v \
+RUN pip3 install --global-option build --global-option --debug /mspass -v \
 	&& docker-clean
 
 # Install jedi

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -152,7 +152,7 @@ RUN unzip /usr/local/spark/python/lib/pyspark.zip \
 ADD requirements.txt requirements.txt
 RUN pip3 --no-cache-dir install --upgrade pip \
 	&& docker-clean
-RUN if [ "$TARGETARCH" == "arm64" ]; then export CFLAGS="-g" \
+RUN if [ "$TARGETARCH" == "arm64" ]; then export CFLAGS="-O3" \
 	&& export DISABLE_NUMCODECS_SSE2=true && export DISABLE_NUMCODECS_AVX2=true; fi\
 	&& pip3 --no-cache-dir install numpy \
     && pip3 --no-cache-dir install -r requirements.txt \

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -152,7 +152,8 @@ RUN unzip /usr/local/spark/python/lib/pyspark.zip \
 ADD requirements.txt requirements.txt
 RUN pip3 --no-cache-dir install --upgrade pip \
 	&& docker-clean
-RUN export CFLAGS="-g" && export DISABLE_NUMCODECS_SSE2=true && export DISABLE_NUMCODECS_AVX2=true\
+RUN if [ "$TARGETARCH" == "arm64" ]; then export CFLAGS="-g" \
+	&& export DISABLE_NUMCODECS_SSE2=true && export DISABLE_NUMCODECS_AVX2=true; fi\
 	&& pip3 --no-cache-dir install numpy \
     && pip3 --no-cache-dir install -r requirements.txt \
     && rm -f requirements.txt \


### PR DESCRIPTION
When running MongoDB on arm, there were flags to disable sse2 and avx2, because of ENV variables defined in dockerfile. 
Removed the ENV variables and only set it inside a RUN command. They should not be present in the resulting Docker image.