### PR TITLE
add schema option

### DIFF
--- a/python/mspasspy/db/client.py
+++ b/python/mspasspy/db/client.py
@@ -51,7 +51,7 @@ class DBClient(pymongo.MongoClient):
             read_preference,
             write_concern,
             read_concern,
-            schema=schema
+            schema=schema,
         )
 
     def get_database(
@@ -69,5 +69,11 @@ class DBClient(pymongo.MongoClient):
             name = self.__default_database_name
 
         return Database(
-            self, name, codec_options, read_preference, write_concern, read_concern, schema=schema
+            self,
+            name,
+            codec_options,
+            read_preference,
+            write_concern,
+            read_concern,
+            schema=schema,
         )

--- a/python/mspasspy/db/client.py
+++ b/python/mspasspy/db/client.py
@@ -33,6 +33,7 @@ class DBClient(pymongo.MongoClient):
     def get_default_database(
         self,
         default=None,
+        schema=None,
         codec_options=None,
         read_preference=None,
         write_concern=None,
@@ -50,11 +51,13 @@ class DBClient(pymongo.MongoClient):
             read_preference,
             write_concern,
             read_concern,
+            schema=schema
         )
 
     def get_database(
         self,
         name=None,
+        schema=None,
         codec_options=None,
         read_preference=None,
         write_concern=None,
@@ -66,5 +69,5 @@ class DBClient(pymongo.MongoClient):
             name = self.__default_database_name
 
         return Database(
-            self, name, codec_options, read_preference, write_concern, read_concern
+            self, name, codec_options, read_preference, write_concern, read_concern, schema=schema
         )

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -95,8 +95,8 @@ class Database(pymongo.database.Database):
     Optional parameters are:
 
     :param schema: a :class:`str` of the yaml file name that defines
-      both the database schema and the metadata schema. If this parameter 
-      is set, it will override the following two. 
+      both the database schema and the metadata schema. If this parameter
+      is set, it will override the following two.
     :param db_schema: Set the name for the database schema to use with this
       handle.  Default is the MsPASS schema. (See User's Manual for details)
     :param md_schema:  Set the name for the Metadata schema.   Default is
@@ -290,8 +290,10 @@ class Database(pymongo.database.Database):
             self.metadata_schema = MetadataSchema(schema)
         else:
             raise MsPASSError(
-                "Error: argument schema is of type {}, which is not supported".format(type(schema)),
-                "Fatal"
+                "Error: argument schema is of type {}, which is not supported".format(
+                    type(schema)
+                ),
+                "Fatal",
             )
 
     def set_database_schema(self, schema):
@@ -309,8 +311,10 @@ class Database(pymongo.database.Database):
             self.database_schema = DatabaseSchema(schema)
         else:
             raise MsPASSError(
-                "Error: argument schema is of type {}, which is not supported".format(type(schema)),
-                "Fatal"
+                "Error: argument schema is of type {}, which is not supported".format(
+                    type(schema)
+                ),
+                "Fatal",
             )
 
     def set_schema(self, schema):
@@ -318,7 +322,7 @@ class Database(pymongo.database.Database):
         Use this method to change both the database and metadata schema defined for this
         instance of a database handle.  This method sets the database
         schema (namespace for attributes saved in MongoDB) and the metadata
-        schema (interal namespace). 
+        schema (interal namespace).
 
         :param schema: a :class:`str` of the yaml file name.
         """

--- a/python/tests/db/test_client.py
+++ b/python/tests/db/test_client.py
@@ -23,10 +23,8 @@ class TestDBClient:
         ):
             self.c2.get_default_database()
         db1 = self.c1.get_default_database(schema="mspass_lite.yaml")
-        with pytest.raises(
-            KeyError, match="site"
-        ):
-            db1.database_schema._attr_dict['site']
+        with pytest.raises(KeyError, match="site"):
+            db1.database_schema._attr_dict["site"]
 
     def test_get_database(self):
         assert self.c1.get_database().name == "my_database"
@@ -36,7 +34,5 @@ class TestDBClient:
         ):
             self.c2.get_database()
         db1 = self.c1.get_database(schema="mspass_lite.yaml")
-        with pytest.raises(
-            KeyError, match="site"
-        ):
-            db1.database_schema._attr_dict['site']
+        with pytest.raises(KeyError, match="site"):
+            db1.database_schema._attr_dict["site"]

--- a/python/tests/db/test_client.py
+++ b/python/tests/db/test_client.py
@@ -22,6 +22,11 @@ class TestDBClient:
             pymongo.errors.ConfigurationError, match="No default database"
         ):
             self.c2.get_default_database()
+        db1 = self.c1.get_default_database(schema="mspass_lite.yaml")
+        with pytest.raises(
+            KeyError, match="site"
+        ):
+            db1.database_schema._attr_dict['site']
 
     def test_get_database(self):
         assert self.c1.get_database().name == "my_database"
@@ -30,3 +35,8 @@ class TestDBClient:
             pymongo.errors.ConfigurationError, match="No default database"
         ):
             self.c2.get_database()
+        db1 = self.c1.get_database(schema="mspass_lite.yaml")
+        with pytest.raises(
+            KeyError, match="site"
+        ):
+            db1.database_schema._attr_dict['site']

--- a/python/tests/db/test_db_no_spark_dask.py
+++ b/python/tests/db/test_db_no_spark_dask.py
@@ -2890,3 +2890,12 @@ with mock.patch.dict(
 
             query = {"pwfid": 3752}
             assert 1 == self.db.testtextfile.count_documents(query)
+
+        def test_set_schema(self):
+            assert self.db.database_schema._attr_dict['site']
+            self.db.set_schema("mspass_lite.yaml")
+            with pytest.raises(
+                KeyError, match="site"
+            ):
+                self.db.database_schema._attr_dict['site']
+

--- a/python/tests/db/test_db_no_spark_dask.py
+++ b/python/tests/db/test_db_no_spark_dask.py
@@ -2892,10 +2892,7 @@ with mock.patch.dict(
             assert 1 == self.db.testtextfile.count_documents(query)
 
         def test_set_schema(self):
-            assert self.db.database_schema._attr_dict['site']
+            assert self.db.database_schema._attr_dict["site"]
             self.db.set_schema("mspass_lite.yaml")
-            with pytest.raises(
-                KeyError, match="site"
-            ):
-                self.db.database_schema._attr_dict['site']
-
+            with pytest.raises(KeyError, match="site"):
+                self.db.database_schema._attr_dict["site"]


### PR DESCRIPTION
This PR fix the API for db client, in which get_database method can set the default schema. We also added a single call to change the default schema in the Database class