### PR TITLE
add starttime method

### DIFF
--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -294,6 +294,8 @@ PYBIND11_MODULE(seismic, m) {
     .def("time_is_relative",&BasicTimeSeries::time_is_relative,"Return true if t0 is not UTC=some relative time standard like shot time")
     .def("npts",&BasicTimeSeries::npts,"Return the number of time samples in this object")
     .def("t0",&BasicTimeSeries::t0,"Return the time of the first sample of data in this time series")
+    /*Useful alias for t0 method*/
+    .def("starttime",[](const BasicTimeSeries &self){return self.t0();})
     .def("set_dt",&BasicTimeSeries::set_dt,"Set the data time sample interval")
     .def("set_npts",&BasicTimeSeries::set_npts,"Set the number of data samples in this object")
     .def("set_t0",&BasicTimeSeries::set_t0,"Set time of sample 0 (t0) - does not check if consistent with time standard")

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -506,6 +506,8 @@ def test_TimeSeries():
     assert ts.data[103] == 8
     assert ts.time(100) == 0.1
     assert ts.sample_number(0.0998) == 100
+    # starttime method is an alias for t0 included as a convenience
+    assert ts.t0 == ts.starttime()
     # These metadata constructor used for cracking miniseed files
     md = Metadata()
     md["delta"] = 0.01


### PR DESCRIPTION
This branch has a trivial change.  I added a one line lambda to the pybind11 code for BasicTimeSeries to add an alias "starttime" method that is effectively the same thing as the t0 method of BasicTimeSeries.   Python applications can use starttime() an alternative to using the attribute t0.  To some it might be less confusing since there is already and endtime() method.   