### PR TITLE
Updated HPC doc and docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,22 @@
-version: '3'
+version: '3.7'
 
 services:
 
   mspass-dbmanager:
     image: mspass/mspass
     volumes:
-      - "${PWD}:/home"
+      - "${PWD}/:/home"
     ports:
       - 27017:27017
     depends_on:
-      mspass-shard-0:
-        condition: service_healthy
-      mspass-shard-1:
-        condition: service_healthy
+      - mspass-shard-0
+      - mspass-shard-1
     environment:
       MSPASS_ROLE: dbmanager
       MSPASS_SHARD_LIST: mspass-shard-0/mspass-shard-0:27017 mspass-shard-1/mspass-shard-1:27017
       MONGODB_PORT: 27017
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongo localhost:27017/test --quiet 
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet 
       interval: 10s
       timeout: 60s
       retries: 5
@@ -28,14 +26,14 @@ services:
     hostname: mspass-shard-0
     image: mspass/mspass
     volumes:
-      - "${PWD}:/home"
+      - "${PWD}/:/home"
     environment:
       MSPASS_ROLE: shard
       MSPASS_SHARD_ID: 0
       MONGODB_PORT: 27017
       SHARD_DB_PATH: scratch
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongo localhost:27017/test --quiet 
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet 
       interval: 10s
       timeout: 60s
       retries: 5
@@ -45,14 +43,14 @@ services:
     hostname: mspass-shard-1
     image: mspass/mspass
     volumes:
-      - "${PWD}:/home"
+      - "${PWD}/:/home"
     environment:
       MSPASS_ROLE: shard
       MSPASS_SHARD_ID: 1
       MONGODB_PORT: 27017
       SHARD_DB_PATH: scratch
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongo localhost:27017/test --quiet
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
       interval: 10s
       timeout: 60s
       retries: 5
@@ -61,7 +59,7 @@ services:
   mspass-scheduler:
     image: mspass/mspass
     volumes:
-      - "${PWD}:/home"
+      - "${PWD}/:/home"
     ports:
       - 8786:8786
     environment:
@@ -78,10 +76,9 @@ services:
   mspass-worker:
     image: mspass/mspass
     volumes:
-      - "${PWD}:/home"
+      - "${PWD}/:/home"
     depends_on:
-      mspass-scheduler:
-        condition: service_healthy
+      - mspass-scheduler
     environment:
       MSPASS_ROLE: worker
       MSPASS_SCHEDULER: dask
@@ -90,14 +87,12 @@ services:
   mspass-frontend:
     image: mspass/mspass
     volumes:
-      - "${PWD}:/home"
+      - "${PWD}/:/home"
     ports:
       - 8888:8888
     depends_on:
-      mspass-dbmanager:
-        condition: service_healthy
-      mspass-scheduler:
-        condition: service_healthy
+      - mspass-dbmanager
+      - mspass-scheduler
     environment:
       MSPASS_ROLE: frontend
       MSPASS_SCHEDULER: dask

--- a/docs/source/getting_started/deploy_mspass_on_HPC.rst
+++ b/docs/source/getting_started/deploy_mspass_on_HPC.rst
@@ -388,15 +388,17 @@ Connection to the jupyter notebook server is then simple via a web browser
 running on top of the gateway.
 
 If running on distributed nodes, when starting the DB Client, the host name
-should be specified. For example:
+should be specified, it is defined as the environment variable MSPASS_SCHEDULER_ADDRESS. 
+For example:
 
 .. code-block:: python
 
     from mspasspy.db.client import DBClient
-    dbclient=DBClient("c205-001")
+    import os
+    dbclient=DBClient(os.environ.get("MSPASS_SCHEDULER_ADDRESS"))
 
-Here the primary node is c205-001, and the frontend is running on the node, 
-so it should be specified.
+Here the primary node is MSPASS_SCHEDULER_ADDRESS, and the frontend is 
+running on the node, it should be specified explicitly.
 
 Setting Up Configuration Files on a new Cluster
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/getting_started/deploy_mspass_on_HPC.rst
+++ b/docs/source/getting_started/deploy_mspass_on_HPC.rst
@@ -387,6 +387,17 @@ which should generate an output similar to that above for the sbatch example.
 Connection to the jupyter notebook server is then simple via a web browser
 running on top of the gateway.
 
+If running on distributed nodes, when starting the DB Client, the host name
+should be specified. For example:
+
+.. code-block:: python
+
+    from mspasspy.db.client import DBClient
+    dbclient=DBClient("c205-001")
+
+Here the primary node is c205-001, and the frontend is running on the node, 
+so it should be specified.
+
 Setting Up Configuration Files on a new Cluster
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Overview


### PR DESCRIPTION
1. Add a note in the HPC document to specify the hostname when running MsPASS on distributed nodes
2. Update `docker-compose.yml` from version 3 to 3.7 and grammar changes