### PR TITLE
fix array bug in fileio

### DIFF
--- a/cxx/src/lib/io/fileio.cc
+++ b/cxx/src/lib/io/fileio.cc
@@ -105,7 +105,11 @@ std::vector<long int> fwrite_to_file(mspass::seismic::LoggingEnsemble<mspass::se
 			throw MsPASSError("fwrite_to_file:  Open failed on file "+fname,ErrorSeverity::Invalid);
 		for (int i = 0; i < d.member.size(); ++i) {
 			/* Silenetly skip dead data */
-			if(d.member[i].dead()) continue;
+			if(d.member[i].dead()) {
+				foffs.push_back(0);
+				// place holder
+				continue;
+			}
 			long int foff = ftell(fp);
 			foffs.push_back(foff);
 			TimeSeries& t = d.member[i];

--- a/python/tests/db/test_db_spark_dask.py
+++ b/python/tests/db/test_db_spark_dask.py
@@ -293,7 +293,7 @@ class TestDatabase:
         )
         assert np.isclose(ts_ensemble.member[0].data, res.data).all()
         res = self.db.read_data(
-            ts_ensemble.member[1]["_id"],
+            ts_ensemble.member[2]["_id"],
             mode="promiscuous",
             normalize=["site", "source", "channel"],
         )

--- a/python/tests/db/test_db_spark_dask.py
+++ b/python/tests/db/test_db_spark_dask.py
@@ -270,6 +270,42 @@ class TestDatabase:
         assert not gfsh.exists(gridfs_id)
 
     def test_save_ensemble_data_binary_file(self):
+        # testing live data
+        ts1 = copy.deepcopy(self.test_ts)
+        ts2 = copy.deepcopy(self.test_ts)
+        ts3 = copy.deepcopy(self.test_ts)
+        logging_helper.info(ts1, "1", "deepcopy")
+        logging_helper.info(ts2, "1", "deepcopy")
+        logging_helper.info(ts3, "1", "deepcopy")
+        ts_ensemble = TimeSeriesEnsemble()
+        ts_ensemble.member.append(ts1)
+        ts_ensemble.member.append(ts2)
+        ts_ensemble.member.append(ts3)
+        ts_ensemble.set_live()
+        dfile = "test_db_output_n"
+        dir = "python/tests/datan/"
+        self.db.save_ensemble_data_binary_file(ts_ensemble, dfile=dfile, dir=dir)
+        self.db.database_schema.set_default("wf_TimeSeries", "wf")
+        res = self.db.read_data(
+            ts_ensemble.member[0]["_id"],
+            mode="promiscuous",
+            normalize=["site", "source", "channel"],
+        )
+        assert np.isclose(ts_ensemble.member[0].data, res.data).all()
+        res = self.db.read_data(
+            ts_ensemble.member[1]["_id"],
+            mode="promiscuous",
+            normalize=["site", "source", "channel"],
+        )
+        assert np.isclose(ts_ensemble.member[1].data, res.data).all()
+        res = self.db.read_data(
+            ts_ensemble.member[2]["_id"],
+            mode="promiscuous",
+            normalize=["site", "source", "channel"],
+        )
+        assert np.isclose(ts_ensemble.member[2].data, res.data).all()
+
+        # testing dead data
         ts1 = copy.deepcopy(self.test_ts)
         ts2 = copy.deepcopy(self.test_ts)
         ts3 = copy.deepcopy(self.test_ts)

--- a/python/tests/db/test_db_spark_dask.py
+++ b/python/tests/db/test_db_spark_dask.py
@@ -273,6 +273,7 @@ class TestDatabase:
         ts1 = copy.deepcopy(self.test_ts)
         ts2 = copy.deepcopy(self.test_ts)
         ts3 = copy.deepcopy(self.test_ts)
+        ts2.kill()
         logging_helper.info(ts1, "1", "deepcopy")
         logging_helper.info(ts2, "1", "deepcopy")
         logging_helper.info(ts3, "1", "deepcopy")
@@ -293,12 +294,6 @@ class TestDatabase:
         assert np.isclose(ts_ensemble.member[0].data, res.data).all()
         res = self.db.read_data(
             ts_ensemble.member[1]["_id"],
-            mode="promiscuous",
-            normalize=["site", "source", "channel"],
-        )
-        assert np.isclose(ts_ensemble.member[1].data, res.data).all()
-        res = self.db.read_data(
-            ts_ensemble.member[2]["_id"],
             mode="promiscuous",
             normalize=["site", "source", "channel"],
         )


### PR DESCRIPTION
I found when running the code below, `index out of range` error occurs.
```python
db.save_ensemble_data_binary_file(e,dir=dir,dfile=dfile)
```

Reason:
In `fwrite_to_file` function, dead data is skipped and its foff is not added to the foffs array, so the array is shorter than the length of the ensemble. However, the `save_ensemble_data_binary_file` function thinks the foffs array has the same length of the ensemble, so the index is out of range.

My fix is also adding a foff(0) for the dead object, it will not be used but can prevent the index error.