### PR TITLE
Bug fix handling data_tag

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -6516,7 +6516,7 @@ class Database(pymongo.database.Database):
             # We need to clear data tag if was previously defined in
             # this case or a the old tag will be saved with this datum
             if "data_tag" in insertion_dict:
-                insertion_dict.erase("data_tag")
+                insertion_dict.pop("data_tag")
         if storage_mode:
             insertion_dict["storage_mode"] = storage_mode
         else:


### PR DESCRIPTION
This fixes a bug created by an api mismatch between Metadata and dict.  Code used erase on a dict which throws an error when it is executed.