### PR TITLE
bug fix to Database._convert_mseed_index

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -5564,6 +5564,7 @@ class Database(pymongo.database.Database):
         o["foff"] = index_record.foff
         o["nbytes"] = index_record.nbytes
         o["npts"] = index_record.npts
+        o["endtime"] = index_record.endtime
         return o
 
     def index_mseed_file(


### PR DESCRIPTION
This is a bug that refuses to die.   Thought we had killed in months ago.   Adds "endtime" attribute to dict returned by this method.