### PR TITLE
Fix bug in handling ensemble files with mixed storage mode

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -7261,9 +7261,9 @@ class Database(pymongo.database.Database):
         # Because this is private method that should only be used
         # interally we do no type checking for speed.
         nmembers = len(mdlist)
-        if object_type is TimeSeriesEnsemble:
+        if object_type is (TimeSeriesEnsemble or TimeSeries):
             ensemble = TimeSeriesEnsemble(nmembers)
-        elif object_type is SeismogramEnsemble:
+        elif object_type is (SeismogramEnsemble or Seismogram):
             ensemble = SeismogramEnsemble(nmembers)
         else:
             message = "Database._load_enemble_file:  Received illegal value for object_type argument\n"
@@ -7279,7 +7279,7 @@ class Database(pymongo.database.Database):
                 # buffer for the sample data and initialize it to zero.
                 # This allows sample data readers to load the buffer without
                 # having to handle memory management.
-                if object_type is TimeSeriesEnsemble:
+                if object_type is (TimeSeriesEnsemble or TimeSeries):
                     d = TimeSeries(md)
                     ensemble.member.append(d)
                 else:
@@ -7291,7 +7291,7 @@ class Database(pymongo.database.Database):
             except MsPASSError as merr:
                 # if the constructor fails mspass_object will be invalid
                 # To preserve the error we have to create a shell to hold the error
-                if object_type is TimeSeriesEnsemble:
+                if object_type is (TimeSeriesEnsemble or TimeSeries):
                     d = TimeSeries()
                 else:
                     d = Seismogram()

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -7261,9 +7261,9 @@ class Database(pymongo.database.Database):
         # Because this is private method that should only be used
         # interally we do no type checking for speed.
         nmembers = len(mdlist)
-        if object_type is (TimeSeriesEnsemble or TimeSeries):
+        if object_type is TimeSeries:
             ensemble = TimeSeriesEnsemble(nmembers)
-        elif object_type is (SeismogramEnsemble or Seismogram):
+        elif object_type is Seismogram:
             ensemble = SeismogramEnsemble(nmembers)
         else:
             message = "Database._load_enemble_file:  Received illegal value for object_type argument\n"
@@ -7279,7 +7279,7 @@ class Database(pymongo.database.Database):
                 # buffer for the sample data and initialize it to zero.
                 # This allows sample data readers to load the buffer without
                 # having to handle memory management.
-                if object_type is (TimeSeriesEnsemble or TimeSeries):
+                if object_type is TimeSeries:
                     d = TimeSeries(md)
                     ensemble.member.append(d)
                 else:
@@ -7291,7 +7291,7 @@ class Database(pymongo.database.Database):
             except MsPASSError as merr:
                 # if the constructor fails mspass_object will be invalid
                 # To preserve the error we have to create a shell to hold the error
-                if object_type is (TimeSeriesEnsemble or TimeSeries):
+                if object_type is TimeSeries:
                     d = TimeSeries()
                 else:
                     d = Seismogram()

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -7263,7 +7263,7 @@ class Database(pymongo.database.Database):
         nmembers = len(mdlist)
         if object_type is TimeSeriesEnsemble:
             ensemble = TimeSeriesEnsemble(nmembers)
-        elif object_type is SeismogramEnsmble:
+        elif object_type is SeismogramEnsemble:
             ensemble = SeismogramEnsemble(nmembers)
         else:
             message = "Database._load_enemble_file:  Received illegal value for object_type argument\n"

--- a/python/tests/test_mspass_client_spark_dask.py
+++ b/python/tests/test_mspass_client_spark_dask.py
@@ -150,7 +150,7 @@ class TestMsPASSClient:
         monkeypatch.undo()
 
     def test_spark_scheduler(self, monkeypatch):
-        monkeypatch.setattr(SparkConf, "__init__", mock_excpt)
+        monkeypatch.setattr(SparkSession.builder, "appName", mock_excpt)
         with pytest.raises(
             MsPASSError,
             match="Runntime error: cannot create a spark configuration with: spark://168.0.0.1",
@@ -161,7 +161,7 @@ class TestMsPASSClient:
         monkeypatch.setenv("MSPASS_SCHEDULER", "spark")
         monkeypatch.setenv("MSPASS_SCHEDULER_ADDRESS", "168.0.0.1")
         monkeypatch.setenv("SPARK_MASTER_PORT", "12345")
-        monkeypatch.setattr(SparkConf, "__init__", mock_excpt)
+        monkeypatch.setattr(SparkSession.builder, "appName", mock_excpt)
         with pytest.raises(
             MsPASSError,
             match="Runntime error: cannot create a spark configuration with: spark://168.0.0.1:12345",


### PR DESCRIPTION
I think this will fix the bug in reading ensembles from files.   I haven't run these through pytest yet so may require a second iteration to fix this.   This is a pretty serious bug as reading from miniseed files fails until this is fixed.  