### PR TITLE
Fix data gap

### DIFF
--- a/cxx/include/mspass/seismic/DataGap.h
+++ b/cxx/include/mspass/seismic/DataGap.h
@@ -73,6 +73,16 @@ This function provides a common mechanism to define such a gap in the data.
       could be used to add that functionality.
       */
       void clear_gaps(){if(!gaps.empty())gaps.clear();};
+      /*! Return number of defined gaps. */
+      int size() const{return gaps.size();};
+      /*! Return the subset of gaps within a specified time interval. 
+       *
+       * \param tw TimeWindow defining range to be returned.  Note 
+       * overlaps with the edge will be returned with range outside the
+       * range defined by tw.  If the tw is larger than the range of 
+       * the current content returns a copy of itself. 
+       */
+      DataGap subset(const mspass::algorithms::TimeWindow tw) const;
       /*! Shift the times of all gaps by a value.
        *
        When used with a TimeSeries or Seismogram the concept of UTC 

--- a/cxx/include/mspass/seismic/DataGap.h
+++ b/cxx/include/mspass/seismic/DataGap.h
@@ -74,7 +74,7 @@ This function provides a common mechanism to define such a gap in the data.
       */
       void clear_gaps(){if(!gaps.empty())gaps.clear();};
       /*! Return number of defined gaps. */
-      int size() const{return gaps.size();};
+      int number_gaps() const{return gaps.size();};
       /*! Return the subset of gaps within a specified time interval. 
        *
        * \param tw TimeWindow defining range to be returned.  Note 

--- a/cxx/include/mspass/seismic/DataGap.h
+++ b/cxx/include/mspass/seismic/DataGap.h
@@ -28,6 +28,7 @@ public:
     DataGap(){};
     /*! Construct with an initial list of TimeWindows defining gaps. */
     DataGap(const std::list<mspass::algorithms::TimeWindow>& twlist);
+    DataGap(const DataGap& parent):gaps(parent.gaps){};
     virtual ~DataGap(){};
 /*!
 Checks if data at time ttest is a gap or valid data.
@@ -59,20 +60,33 @@ Sometimes an algorithm detects or needs to create a gap (e.g. a mute,
 or a constructor).
 This function provides a common mechanism to define such a gap in the data.
 **/
-      void add_gap(const mspass::algorithms::TimeWindow tw){gaps.insert(tw);};
+      void add_gap(const mspass::algorithms::TimeWindow tw);
 /*! Getter returns a list of TimeWindows defining a set of gaps. */
       std::list<mspass::algorithms::TimeWindow> get_gaps() const;
       /*! \brief Clear gaps.
 
-It is sometimes necessary to clear gap definitions.
-This is particularly important when a descendent of this class
-is cloned and then morphed into something else.
-*/
+      It is sometimes necessary to clear gap definitions.
+      This is particularly important when a descendent of this class
+      is cloned and then morphed into something else.
+      This method clears the entire content.  This class assumes 
+      gaps are an immutable property of recorded data.  A subclass
+      could be used to add that functionality.
+      */
       void clear_gaps(){if(!gaps.empty())gaps.clear();};
-/*! \brief virtual method for zeroing data gaps.
-
-Any object using this object needs to implement this method */
-      virtual void zero_gaps()=0;
+      /*! Shift the times of all gaps by a value.
+       *
+       When used with a TimeSeries or Seismogram the concept of UTC 
+       versus relative time requires shifting the time origin.  
+       This method should be used in that context or any other context 
+       where the data origin is shifted.   The number passed as shift 
+       is subtracted from all the window start and end times that define 
+       data gaps. 
+       */
+       void translate_origin(double time_of_new_origin);
+      /*! Standard assignment operator.*/
+      DataGap& operator=(const DataGap& parent);
+      /*! Add contents of another DataGap container to this one.  */
+      DataGap& operator+=(const DataGap& other);
 protected:
   /*! \brief Holds data gap definitions.
   We use an STL set object to define data gaps for any time series

--- a/cxx/include/mspass/seismic/TimeSeriesWGaps.h
+++ b/cxx/include/mspass/seismic/TimeSeriesWGaps.h
@@ -21,6 +21,8 @@ public:
   TimeSeriesWGaps(const TimeSeriesWGaps& parent)
       : TimeSeries(dynamic_cast<const TimeSeries&>(parent)),
               DataGap(dynamic_cast<const DataGap&>(parent)){};;
+  TimeSeriesWGaps(const TimeSeries& tsp, const DataGap& dgp) 
+	  : TimeSeries(tsp), DataGap(dgp) {};
   TimeSeriesWGaps& operator=(const TimeSeriesWGaps& parent);
   virtual ~TimeSeriesWGaps(){};
   /*!

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -136,23 +136,6 @@ public:
   }
 };
 
-/* Trampoline class for DataGap */
-class PyDataGap : public DataGap
-{
-public:
-  /* BasicTimeSeries has virtual methods that are not pure because
-  forms that contain gap handlers need additional functionality.
-  We thus use a different qualifier to PYBIND11_OVERLOAD macro here.
-  i.e. omit the PURE part of the name*/
-  void zero_gaps()
-  {
-    PYBIND11_OVERLOAD_PURE(
-      void,
-      DataGap,
-      zero_gaps);
-  }
-};
-
 PYBIND11_MODULE(seismic, m) {
   m.attr("__name__") = "mspasspy.ccore.seismic";
   m.doc() = "A submodule for seismic namespace of ccore";
@@ -935,8 +918,11 @@ PYBIND11_MODULE(seismic, m) {
       ))
     ;
 
-    py::class_<DataGap,PyDataGap>(m,"DataGap","Base class for lightweight definition of data gaps")
+    /*TODO:  This needs a pickle interface.*/
+    py::class_<DataGap>(m,"DataGap","Base class for lightweight definition of data gaps")
       .def(py::init<>())
+      .def(py::init<const DataGap&>())
+      //.def(py::init<std::list<mspass::algorithms::TimeWindow&>())
       /* Cannot get bindings with the next line for this constructor to compile.
       Disabled as the python interface only uses DataGap as a base class for TimeSeriesWGaps
       and I see now reason a python code would need this constructor*/
@@ -948,8 +934,12 @@ PYBIND11_MODULE(seismic, m) {
       .def("add_gap",&DataGap::add_gap,"Define a specified time range as a data gap")
       .def("get_gaps",&DataGap::get_gaps,"Return a list of TimeWindows marked as gaps")
       .def("clear_gaps",&DataGap::clear_gaps,"Flush the entire gaps container")
+      .def("translate_origin",&DataGap::translate_origin,
+		      "Shift time origin by a specified value")
+      .def(py::self += py::self)
     ;
 
+    /*TODO:  this needs a pickle interface.*/
     py::class_<TimeSeriesWGaps,TimeSeries,DataGap>(m,"TimeSeriesWGaps","TimeSeries object with gap handling methods")
       .def(py::init<>())
       .def(py::init<const TimeSeries&>())

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -936,6 +936,9 @@ PYBIND11_MODULE(seismic, m) {
       .def("clear_gaps",&DataGap::clear_gaps,"Flush the entire gaps container")
       .def("translate_origin",&DataGap::translate_origin,
 		      "Shift time origin by a specified value")
+      .def("size",&DataGap::size,"Return number of defined gaps")
+      .def("subset",&DataGap::subset,
+		      "Return a subset of content spanning input range")
       .def(py::self += py::self)
     ;
 

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -947,7 +947,7 @@ PYBIND11_MODULE(seismic, m) {
                  "Test if there is a gap inside a specified time range (defined with TimeWindow object)")
       .def("add_gap",&DataGap::add_gap,"Define a specified time range as a data gap")
       .def("get_gaps",&DataGap::get_gaps,"Return a list of TimeWindows marked as gaps")
-      .def("clear_gaps",&DataGap::add_gap,"Flush the entire gaps container")
+      .def("clear_gaps",&DataGap::clear_gaps,"Flush the entire gaps container")
     ;
 
     py::class_<TimeSeriesWGaps,TimeSeries,DataGap>(m,"TimeSeriesWGaps","TimeSeries object with gap handling methods")

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -936,7 +936,7 @@ PYBIND11_MODULE(seismic, m) {
       .def("clear_gaps",&DataGap::clear_gaps,"Flush the entire gaps container")
       .def("translate_origin",&DataGap::translate_origin,
 		      "Shift time origin by a specified value")
-      .def("size",&DataGap::size,"Return number of defined gaps")
+      .def("size",&DataGap::number_gaps,"Return number of defined gaps")
       .def("subset",&DataGap::subset,
 		      "Return a subset of content spanning input range")
       .def(py::self += py::self)

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -936,7 +936,7 @@ PYBIND11_MODULE(seismic, m) {
       .def("clear_gaps",&DataGap::clear_gaps,"Flush the entire gaps container")
       .def("translate_origin",&DataGap::translate_origin,
 		      "Shift time origin by a specified value")
-      .def("size",&DataGap::number_gaps,"Return number of defined gaps")
+      .def("number_gaps",&DataGap::number_gaps,"Return number of defined gaps")
       .def("subset",&DataGap::subset,
 		      "Return a subset of content spanning input range")
       .def(py::self += py::self)

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -944,6 +944,7 @@ PYBIND11_MODULE(seismic, m) {
       .def(py::init<>())
       .def(py::init<const TimeSeries&>())
       .def(py::init<const TimeSeriesWGaps&>())
+      .def(py::init<const TimeSeries&,const DataGap&>())
       .def("ator",&TimeSeriesWGaps::ator,"Convert to relative time shifting gaps to match")
       .def("rtoa",py::overload_cast<>(&TimeSeriesWGaps::rtoa),
          "Return to UTC time using time shift defined in earlier ator call")

--- a/cxx/src/lib/seismic/DataGap.cc
+++ b/cxx/src/lib/seismic/DataGap.cc
@@ -61,6 +61,23 @@ std::list<TimeWindow> DataGap::get_gaps() const
     result.push_back(*sptr);
   return result;
 }
+DataGap DataGap::subset(const TimeWindow tw) const
+{
+  /* This could be implemented with the set equal_range method 
+   * but these objects are expected to normally be very small
+   * and it is a lot clearer what this algorithm does.
+   * */
+   DataGap result;
+   std::list<TimeWindow> gaplist = this->get_gaps();
+   for(auto twptr= gaplist.begin();twptr!=gaplist.end();++twptr)
+   {
+     if( ((twptr->end)>tw.start) && ((twptr->start)<tw.end))
+     {
+       result.add_gap(*twptr);
+     }
+   }
+   return result;
+}
 /* std::set iterators are always effectively const and the const 
  * cannot be cast away.  Hence, this algorithm is much more complex
  * than I thought it would be.  Have to make a copy of the gaps 

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -1539,7 +1539,7 @@ def test_DataGap():
     # using get_gaps as above - faster but need earlier to test get_gaps
     tw = TimeWindow(15.0, 40.0)
     dg.add_gap(tw)
-    n = dg.size()
+    n = dg.number_gaps()
     assert n == 2
     # this next text depends upon the fact that the container used in
     # DataGaps is ordered by window start time.   It  could fail if
@@ -1556,7 +1556,7 @@ def test_DataGap():
 
     # clear gaps discards everything
     dg_copy.clear_gaps()
-    n = dg_copy.size()
+    n = dg_copy.number_gaps()
     assert n == 0
 
     # shift the origin by 5.0 s and verify it worked correctly
@@ -1568,7 +1568,7 @@ def test_DataGap():
     tw = TimeWindow(100.0, 150.0)
     dg.add_gap(tw)
     dg.translate_origin(5.0)
-    n = dg.size()
+    n = dg.number_gaps()
     gpl = dg.get_gaps()
     assert n == 2
     tw = gpl[0]
@@ -1591,14 +1591,14 @@ def test_DataGap():
     tw = TimeWindow(200.0, 250.0)
     dgrhs.add_gap(tw)
     dg += dgrhs
-    n = dg.size()
+    n = dg.number_gaps()
     assert n == 3
     assert dg.is_gap(225.0)
     # now to add an overlapping window
     assert not dg.is_gap(190.0)
     tw = TimeWindow(185.0, 210.0)
     dg.add_gap(tw)
-    n = dg.size()
+    n = dg.number_gaps()
     assert n == 3
     assert dg.is_gap(190.0)
     # test the subset method.
@@ -1607,24 +1607,24 @@ def test_DataGap():
     # note at this point the content of dg is [ 10, 20; 100, 150, 185,250]
     twtest = TimeWindow(30.0, 160.0)
     dgs = dg.subset(twtest)
-    assert dgs.size() == 1
+    assert dgs.number_gaps() == 1
     # test range larger than self
     twtest = TimeWindow(0.0, 500.0)
     dgs = dg.subset(twtest)
-    assert dgs.size() == 3
+    assert dgs.number_gaps() == 3
     # overlaping left side test
     twtest = TimeWindow(15.0, 500.0)
     dgs = dg.subset(twtest)
-    assert dgs.size() == 3
+    assert dgs.number_gaps() == 3
     # overlapping right side and left side
     twtest = TimeWindow(15.0, 200.0)
     dgs = dg.subset(twtest)
-    assert dgs.size() == 3
+    assert dgs.number_gaps() == 3
     # exclude left
     twtest = TimeWindow(30.0, 200.0)
     dgs = dg.subset(twtest)
-    assert dgs.size() == 2
+    assert dgs.number_gaps() == 2
     # exclude right
     twtest = TimeWindow(0.0, 170.0)
     dgs = dg.subset(twtest)
-    assert dgs.size() == 2
+    assert dgs.number_gaps() == 2


### PR DESCRIPTION
This started out as a simple bug fix for a mistake in the pybind11 code for this auxiliary class.   I realized, however, that in working with a prototype for surgical mutes that this was a very useful container that might work well as a component of a generic surgical mute algorithm.   Working on the prototype with a data set from Homestake I realized it lacked a couple important capabilities:
1.  The previous version required gaps intervals to not overlap.  An attempt to add a gap definition that overlapped an existing one would cause nothing to happen.   That happened because the original concept was recorded data gaps, which are effectively always immutable.   For a more generic use that needed to be relaxed.  I did that here by adding some minor complexity to the add_gaps method.   Tests show it that functionality now works.
2. I saw a need for the C++ operator += (need for the using += in python of course) that would cleanly merge two different DataGap containers.  Once functionality 1 was added this was trivial.   Well, not really as there was an odd property of the std::set container that complicated the code requiring a complete copy of the left hand side before merging the right hand side.  What I did works, but I'm not quite sure why it was necessary.   I considered it harmless, however, as this container should rarely be huge enough that such a copy operation is a serous performance problem. 