### PR TITLE
Fix graphics

### DIFF
--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -1038,7 +1038,7 @@ class SeismicPlotter:
             origin_position = "lower"
         pyplot.imshow(
             work,
-            aspect='auto',
+            aspect="auto",
             cmap=self._color_map,
             origin=origin_position,
             extent=extent,
@@ -1086,7 +1086,7 @@ class SeismicPlotter:
             vmax = scale
         pyplot.imshow(
             work,
-            aspect='auto',
+            aspect="auto",
             cmap=self._color_map,
             extent=extent,
             vmin=vmin,

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -1038,7 +1038,7 @@ class SeismicPlotter:
             origin_position = "lower"
         pyplot.imshow(
             work,
-            aspect=aspect,
+            aspect='auto',
             cmap=self._color_map,
             origin=origin_position,
             extent=extent,
@@ -1086,7 +1086,7 @@ class SeismicPlotter:
             vmax = scale
         pyplot.imshow(
             work,
-            aspect=aspect,
+            aspect='auto',
             cmap=self._color_map,
             extent=extent,
             vmin=vmin,

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -548,7 +548,7 @@ class SeismicPlotter:
     to plot data in the seismic reflection convention with time on the
     y axis and oriented backward (increasing downward).
 
-    Four times of plots are supported:  wiggle trace, wiggle trace variable
+    Four types of plots are supported:  wiggle trace, wiggle trace variable
     area (i.e. filled on positive peaks), image plots, and colored wiggle
     trace variable area (wtva overlays an image display).
     Ensembles of Seismogram objects (SeismogramEnsemble object) are plotted in
@@ -571,10 +571,10 @@ class SeismicPlotter:
         has a few common optional parameters to set at construction
         time.  Note style is intentionally not a constructor
         parameter because of parameter interdependence.  The default
-        plot style is wtvaimg.  Use change_style to use a different
-        plotting style.
+        plot style is "wtva".  Use change_style to use change plot
+        style.
 
-        :param scale:  optoinal scale factor to apply to data before plotting
+        :param scale:  optional scale factor to apply to data before plotting
           (default assumes data have been scaled to amplitude of order 1)
         :param  normalize:  Default assumes the data have been scaled with
         one of the mspass amplitude scaling functions to be of order one
@@ -594,7 +594,7 @@ class SeismicPlotter:
         # as it may duplicate the call to change_style at the end, BUT
         # if the default changes these initial values do not need to be
         # changed
-        self._style = "wtvaimg"
+        self._style = "wtva"
         self._fill_color = "k"  # black in matplotlib
         self._color_map = "seismic"
         # these are options to raw codes adapted from  fatiando a terra


### PR DESCRIPTION
Two things in this set of changes:
1.  Fixed a long standing bug that messed up scaling of plots in the "wtvaimg" mode.    Fix may not be perfect, but is an improvement over present form that produces really bad plots in that mode most of the time.   The possible residual issue is that we may need to handle the "aspect" parameter for image plotting more elegantly.   I'm not sure with these changes a user can actually change the aspect ratio manually.   I don't expect that to be a very common need though so I didn't think the effort required to test all the possibilities was worth the trouble.
2. I changed the default style to "wtva" (wiggle trace variable area) instead of "wtvaimg" (the style that previously was giving trouble).   Maybe should be the simplest "wt" but in most cases wtva plots are a better data visualization that wt - an option though.