### PR TITLE
Extend 3c transforms

### DIFF
--- a/cxx/src/lib/seismic/CoreSeismogram.cc
+++ b/cxx/src/lib/seismic/CoreSeismogram.cc
@@ -621,7 +621,11 @@ void CoreSeismogram::rotate(const double nu[3])
 /* simplified procedure to rotate only zonal angle by phi radians.
  Similar to above but using only azimuth angle AND doing a simple
  rotation in the horizontal plane.  Efficient algorithm only
- alters 0 and 1 components. */
+ alters 0 and 1 components. 
+
+Note sign is spherical coordinate form with phi positive anticlockwise.
+Sign in rotate with spherical coordinate is different because phi is 
+converted to azimuth.  Note that is just the sign of b in the code.*/
 void CoreSeismogram::rotate(double phi)
 {
     if( (u.size()[1]<=0) || dead()) return; // do nothing in these situations
@@ -631,9 +635,9 @@ void CoreSeismogram::rotate(double phi)
     b=sin(phi);
     double tmnew[3][3];
     tmnew[0][0] = a;
-    tmnew[1][0] = b;
+    tmnew[1][0] = -b;
     tmnew[2][0] = 0.0;
-    tmnew[0][1] = -b;
+    tmnew[0][1] = b;
     tmnew[1][1] = a;
     tmnew[2][1] = 0.0;
     tmnew[0][2] = 0.0;
@@ -641,7 +645,7 @@ void CoreSeismogram::rotate(double phi)
     tmnew[2][2] = 1.0;
 
     /* Now multiply the data by this transformation matrix.
-     Not trick in this i only goes to 2 because 3 component
+     Note trick in this i only goes to 2 because 3 component
      is an identity.*/
     double *work[2];
     for(i=0; i<2; ++i)work[i] = new double[nsamp];

--- a/cxx/test/tcs/test_tcs.cc
+++ b/cxx/test/tcs/test_tcs.cc
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
   vt3[0]=0.0; vt3[1]=0.0;  vt3[2]=1.0;
   assert(is_close(s3.u,3,vt3));
 	cout << "Testing multiple, accumulated transformations" << endl;
-	s3.rotate(M_PI_4);
+	s3.rotate(-M_PI_4);
 	s3.transform(a);
         cout << "Accumulated transformation matrix from double transformation"
             <<endl;

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -8,8 +8,10 @@ from mspasspy.ccore.seismic import (
     TimeSeriesEnsemble,
     Seismogram,
     SeismogramEnsemble,
+    SlownessVector,
 )
-
+from mspasspy.ccore.utility import SphericalCoordinate
+import numpy as np
 
 @mspass_func_wrapper
 def ExtractComponent(
@@ -225,6 +227,10 @@ def rotate_to_standard(
     it is set true.  Otherwise, it applies the inverse transformation and then sets this variable true.
     Note even if the current transformation matrix is not orthogonal it will be put back into
     cardinal coordinates.
+    
+    If inversion of the transformation matrix is not possible (e.g. two components are colinear)
+    an error thrown by the C++ function is caught, posted to elog, and the 
+    datum return will be marked dead.
 
     :param data: data object to be rotated.
     :type data: :class:`~mspasspy.ccore.seismic.Seismogram`
@@ -243,15 +249,24 @@ def rotate_to_standard(
         transformation matrix is required and that matrix is singular.  This can happen if the
         transformation matrix is incorrectly defined or the actual data are coplanar.
     """
-    data.rotate_to_standard()
+    try:
+        data.rotate_to_standard()
+    except MsPASSError as merr:
+        data.elog.log_error(merr)
+        data.kill()
+        
 
 
 @mspass_func_wrapper
 def free_surface_transformation(
     data,
-    uvec,
-    vp0,
-    vs0,
+    uvec=None,
+    vp0=None,
+    vs0=None,
+    ux_key="ux",
+    uy_key="uy",
+    vp0_key="vp0",
+    vs0_key="vs0",
     *args,
     object_history=False,
     alg_name=None,
@@ -265,17 +280,85 @@ def free_surface_transformation(
     Computes and applies the Kennett [1991] free surface transformation matrix.
 
     Kennett [1991] gives the form for a free surface transformation operator
-    that reduces to a nonorthogonal transformation matrix when the wavefield is
-    not evanescent.  On output x1 will be transverse, x2 will be SV (radial),
-    and x3 will be longitudinal.
+    that defines a transformation matrix that provides optimal separation 
+    of P, SV, and SH for a receiver at the free surface of an isotropic medium 
+    with constant P and S velocity.   The transformation is only valid if the 
+    incident wavefield is not evanescent (i.e. at or past the SV critical angle).
+    It is important to realize the tranformation matrix does not define 
+    an orthogonal transformation.  It is also, of course, only an approximation 
+    since it is strictly correct only for a constant velocity medium. 
+    The tranformation operator requires: (1) a slowness vector, (2) an 
+    estimate of surface P wave velocity, and (3) an estimate of surface 
+    shear wave velocity.   In all cases the input for the slowness 
+    vector uses a local cartesian system with the vector specified as 
+    component ux and uy.  ux is the component of the slowness of 
+    an incident wavefield in the geographic x direction, which means 
+    positive at local east.  uy is the complementary component for the 
+    y direction defined by local north.  The components of the slowness
+    vector are assumed to be in units of s/km.   (Warning:  obspy's and
+    other implementations of the commonly used tau-p calculator return 
+    slowness (ray parameter) in spherical units of s/radian - r sin(theta)/v)
+    
+    The required parameters (slowness vector and velocities) can be 
+    passed to the function one of two ways.   Because it is much simpler 
+    to implement in a map operator the default expect those parameters to 
+    be set in the data object's Metadata container.  The default keys for 
+    fetching each attribute are defined by the four arguments 
+    "ux_key", "uy_key", "vp0_key", and "vs0_key".   All four have 
+    standard defaults defined in the function signature and below.  
+    The Metadata fetching algorithm can be overridden by defining 
+    the same data through the three optional arguments with the key 
+    names "uvec", "vp0", and "vs0".   (see below for detailed descriptions)
+    
+    The switching between Metadata fetching and a constant arguments 
+    is not all or none.   If a slowness vector is defined through uvec
+    it will always override metadata.  Handing of vp0 and vs0 is independent. 
+    i.e. you can define uvec and not define vp0 and vs0 or conversely 
+    you can (more commonly) define vp0 and vs0 but not define uvec.  
+    In all cases not defining an arg is a signal to fetch it from 
+    Metadata.  
+    
+    When this function is applied to ensembles and the Metadata fetch 
+    approach is used (default) the function assumes all ensemble members 
+    have the required metadata keys defined.  Any that do not are killed. 
+    The same happens for atomic data passed to this function if any of 
+    the required keys are missing.  In fact, you should realize the 
+    ensemble algorithm simply applies this function in a recursion over all 
+    the members. 
+    
+    The output components are in the order defined in Kennett's original
+    paper.  The order is 0=SH, 1=SV, 2=L.   
 
-    :param data: data object to be transformed.
-    :type data: :class:`~mspasspy.ccore.seismic.Seismogram`
-    :param uvec: slowness vector of the incident wavefield
+    :param data: data object to be transformed.  For ensembles the transformation 
+    is applied to all members.  Note the Metadata fetch mechanism is the only 
+    recommended way to handle ensembles.  An elog message will be posted 
+    to the ensemble's elog container if you try to use a constant slowness 
+    vector passed via uvec. It will not warn about constant vp0 and vs0 
+    as that case is common.
+    :type data: :class:`~mspasspy.ccore.seismic.Seismogram` or 
+    :class:`~mspasspy.ccore.seismic.SeismogramEnsemble`
+    :param ux_key:  key to use to fetch EW component of slowness vector 
+    from Metadata container.  Default is "ux".
+    :type ux_key:  string
+    :param uy_key:  key to use to fetch NS component of slowness vector 
+    from Metadata container.  Default is "uy".
+    :type uy_key:  string
+    :param vp0_key:  key to use to fetch free surface P wave velocity 
+    from Metadata container.  Default is "vp0".
+    :type vp0_key:  string
+    :param vs0_key: key to use to fetch free surface S wave velocity
+    from Metadata container.  Default is "vs0".
+    :type vs0_key:  string
+    :param uvec: slowness vector of the incident wavefield defined via 
+    custom C++ class :class:`~mspasspy.ccore.seismic.SlownessVector`.  
+    Default is None which is taken as a signal to fetch the slowness vector 
+    components from Metadata using ux_key and uy_key.
     :type uvec: :class:`~mspasspy.ccore.seismic.SlownessVector`
-    :param vp0: Surface P wave velocity
+    :param vp0: Surface P wave velocity.  Default is None which is taken 
+    as a signal to fetch this quantity from Metadata using the vp0_key.
     :type vp0: :class:`float`
-    :param vs0: Surface S wave velocity.
+    :param vs0: Surface S wave velocity.  Default is None which is taken 
+    as a signal to fetch this quantity from Metadata using the vs0_key.
     :type vs0: :class:`float`
     :param object_history: True to preserve the processing history. For details, refer to
      :class:`~mspasspy.util.decorators.mspass_func_wrapper`.
@@ -289,7 +372,69 @@ def free_surface_transformation(
      return something that is appropriate to save as Metadata.  If so, use this argument to
      define the key used to set that field in the data that is returned.
     """
-    data.free_surface_transformation(uvec, vp0, vs0)
+
+    if isinstance(data,Seismogram):
+        if uvec:
+            slowness_vector = uvec
+        else:
+            if data.is_defined(ux_key) and data.is_defined(uy_key):
+                ux = data[ux_key]
+                uy = data[uy_key]
+                slowness_vector=SlownessVector(ux,uy)
+            else:
+                message = "required Metadata with keys ="+ux_key+" and "+uy_key
+                message += " are not defined - datum killed"
+                data.elog.log_error("free_surface_transformation",message,ErrorSeverity.Invalid)
+                data.kill()
+        if vp0:
+            P_fs = vp0
+        else:
+            if data.is_defined(vp0_key):
+                P_fs = data[vp0_key]
+            else:
+                message = "required Metadata attribute "+vp0_key+" is not defined - datum killed"
+                data.elog.log_error("free_surface_transformation",message,ErrorSeverity.Invalid)
+                data.kill()
+        if vs0:
+            S_fs = vs0
+        else:
+            if data.is_defined(vs0_key):
+                S_fs = data[vs0_key]
+            else:
+                message = "required Metadata attribute "+vs0_key+" is not defined - datum killed"
+                data.elog.log_error("free_surface_transformation",message,ErrorSeverity.Invalid)
+                data.kill()
+        if data.live:
+            data.free_surface_transformation(slowness_vector,P_fs,S_fs)
+                
+    elif isinstance(data,SeismogramEnsemble):
+        if uvec:
+            message="Using a constant slowness vector and surface velocities for all ensemble members\n"
+            message="That is ill advised unless this is an event gather for a small aperture array"
+            data.elog.log_error("free_surface_transformation",message,ErrorSeverity.Complaint)
+        for i in range(len(data.member)):
+            # this is a recursion so be aware
+            data.member[i] = free_surface_transformation(
+                                                data.member[i],
+                                                ux_key=ux_key,
+                                                uy_key=uy_key,
+                                                vp0_key=vp0_key,
+                                                vs0_key=vs0_key,
+                                                uvec=uvec,
+                                                vp0=vp0,
+                                                vs0=vs0,
+                                                object_history=object_history,
+                                                alg_name=alg_name,
+                                                alg_id=alg_id,
+                                                dryrun=dryrun,
+                                                inplace_return=inplace_return,
+                                                function_return_key=function_return_key,
+                                            )
+    else:
+        message="free_surface_transform received invalid type for arg0 of {}\n".format(type(data))
+        message += "Must be either a Seismogram or SeismogramEnsemble"
+        raise ValueError(message)
+    return data
 
 
 @mspass_func_wrapper
@@ -329,6 +474,287 @@ def transform(
      define the key used to set that field in the data that is returned.
     """
     data.transform(matrix)
+    
+@mspass_func_wrapper
+def transform_to_RTZ(data,
+                     key='seaz',
+                     phi=None,
+                     angle_units='degrees',
+                     key_is_backazimuth=True,
+                     object_history=False,
+                     alg_name=None,
+                     alg_id=None,
+                     dryrun=False,
+                     inplace_return=False,
+                     function_return_key=None,
+                 ):
+    """
+    Applies coordinate transform to RTZ version of ray coordinates.
+    
+    RTZ is the simplest transformation for three component data to 
+    what is commonly called ray coordinates.  R-radial (SV), T-transverse
+    (SH). and Z=vertical (bad measure of longitudinal).  The function 
+    first forces the data to cardinal direction using rotate_to_standard 
+    and then rotates the coordinates around the vertical axis.   The 
+    rotation can be defined in one of two ways.  The default behavior 
+    is to attempt to extract the back azimuth from the station to the 
+    source with the key defined by the "key" argument (defaults to 'seaz').
+    That behavior will be overriden if the "phi" kwarg value is set.  
+    Phi is assumed to be the angle to rotate the coordinates using the 
+    math convention for the phi angle with positive anticlockwise.  
+    The units of the value retrieved with the key argument or the value 
+    passed via the phi argument are by default assumed to be in degrees. 
+    If using the phi argument you specify the angle in radians if you 
+    also set the "angle_units" argument to "radians".
+    
+    :param data:   data object to be transformed
+    :type data:  :class:`~mspasspy.ccore.seismic.Seismogram` or 
+     :class:`~mspass.ccore.seismic.SeismogramEnsemble`.
+    :param key:  key to use to fetch back azimuth value (assumed degrees always)
+    :type key:  string
+    :param phi:   angle to rotate around vertical to define the transformation 
+    (positive anticlockwise convention NOT azimuth convention)  Default is None 
+    which means ignore this parameter and use key.  Setting this value to 
+    something other than None causes the key method to be overridden.
+    :type phi:  float
+    :param angle_units:  should be either 'degrees' (default) or 'radians'.
+    An invalid value will be treated as an attempt to switch to radians 
+    but will generate an elog warning message.  This argument is ignored unless
+    phi is not null (None type)
+    :type angle_units: string
+    :param key_is_backazimuth: boolean that when True (default) assumes the 
+    angle extrated with the key argument value is a backazimuth in degrees. 
+    If set False, the angle will be assumed to be a rotation angle in 
+    with the anticlockwise positive convention.  
+    :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
+    :type alg_name: :class:`str`
+    :param alg_id: alg_id is a unique id to record the usage of func while preserving the history.
+    :type alg_id: :class:`bson.objectid.ObjectId`
+    :param dryrun: True for dry-run, which return "OK". Used in the mspass_func_wrapper.
+    :param inplace_return: True to return data in mspass_func_wrapper. This is necessary to be used in mapreduce.
+    :param function_return_key:  Some functions one might want to wrap with this decorator
+     return something that is appropriate to save as Metadata.  If so, use this argument to
+     define the key used to set that field in the data that is returned.
+     
+    :return:  transformed version of input.  For ensembles the entire ensemble 
+    is transformed.
+    """
+    if phi:
+        if angle_units=="degrees":
+            phi_rad = np.radians(phi)
+        else:
+            if angle_units != "radians":
+                message = "Illegal value for angle_units argument="+angle_units
+                message += " assuming radians"
+                data.elog.log_error("transform_to_RTZ",message,ErrorSeverity.Complaint)
+            phi_rad = phi
+        use_metadata = False
+    else:
+        use_metadata=True
+    if isinstance(data,Seismogram):
+        if use_metadata:
+            if data.is_defined(key):
+                phi_deg = data[key]
+                if key_is_backazimuth:
+                    az = phi_deg + 180.0  
+                    phi_deg = 90.0 - az
+                phi_rad = np.radians(phi_deg)
+            else:
+                message = "required Metadata key="+key+" not defined for this datum - killed"
+                data.elog.log_error("transform_to_RTZ",message,ErrorSeverity.Invalid)
+                data.kill()
+                return data 
+        try:
+            data.rotate_to_standard()
+            data.rotate(phi_rad)
+        except MsPASSError as merr:
+            data.log_error(merr)
+            data.kill()
+    elif isinstance(data,SeismogramEnsemble):
+        for i in range(len(data.member)):
+            # this is a recursion so be aware
+            data.member[i] = transform_to_RTZ(
+                                    data.member[i],
+                                    key=key,
+                                    phi=phi,
+                                    angle_units=angle_units,
+                                    object_history=object_history,
+                                    alg_name=alg_name,
+                                    alg_id=alg_id,
+                                    dryrun=dryrun,
+                                    inplace_return=inplace_return,
+                                    function_return_key=function_return_key,
+                                )
+    else:
+        message="transform_to_RTZ received invalid type for arg0 of {}\n".format(type(data))
+        message += "Must be either a Seismogram or SeismogramEnsemble"
+        raise ValueError(message)
+    return data
+
+@mspass_func_wrapper
+def transform_to_LQT(data,
+                     seaz_key='seaz',
+                     ema_key='ema',
+                     phi=None,
+                     theta=None,
+                     angle_units='degrees',
+                     object_history=False,
+                     alg_name=None,
+                     alg_id=None,
+                     dryrun=False,
+                     inplace_return=False,
+                     function_return_key=None,
+                 ):
+    """
+    Applies coordinate transform to LQT version of ray coordinates.
+    
+    LQT is an orthogonal coordinate transformation for Seismogram 
+    objects that cause the output data to have x1-Longitudinal (positive up
+    normally set to the predicted emergence angle of P particle motion),
+    x2 - Q a rotated radial direction (in propagation direction but tilted by theta).
+    and x3 - transverse (T) in direction to define a right handed coordinate 
+    system.  The function produces this transformation 
+    by the product f three transformation:
+        1.  Uses rotate_to_standard to assure we start from cardinal directions.
+        2.  Transformation to what might be called TQL using the Seismogram 
+            C++ method rotate using a SphericalCoordinate definition.
+        3.  Transformation to LQT to rearrange the order of the Seismogram 
+            data matrix (also requires a sign change on T to keep the output 
+            right handed)
+        
+    The form of the transformation can be specified in one of two 
+    completely different ways.   By default the function attempts to 
+    extract the back azimuth from station to event with using the 
+    metadata key defined by 'seaz_key' (default 'seaz') and the P 
+    emergence angle with the metadata key defined by the 'ema_key' 
+    argument (default 'ema').   If the arguments 'phi' and 'theta' are 
+    defined they are assumed angles to be used to defined the 
+    transformation and no attempt will be made to fetch the value from 
+    Metaata (Rarely a good idea with ensemble but can be useful for atomic data.
+    Using Metadata is strongly preferred because it also preserves what 
+    the angles used where.  They are not if the argument approach is used.)
+    Metadata values are required to be in degree units.  If the argument 
+    approach is used radian values can to used if you also set 
+    the argument "angle_units" to "radians".
+    
+    Note the operation handles the singular case of theta==0.0 where it 
+    simply uses the phi value and rotates the coordinates in a variant of 
+    RTZ (variant because order is different).      
+    :param seaz_key:  key to use to fetch back azimuth value (assumed degrees always)
+    :type key:  string (default "seaz")
+    :param ema_key:  key to use to fetch emergence angle defining L direction 
+    relative to local vertical.  
+    :type ema_key:  string (defautl "ema")
+    :param phi:   angle to rotate around vertical to define the transformation 
+    (positive anticlockwise convention NOT azimuth convention)  Default is None 
+    which means ignore this parameter and use key.  Setting this value to 
+    something other than None causes the Metadata fetch method to be overridden.
+    WARNING:  this is not backazimuth but angle relative to E direction.
+    Note that is not at all what is expected when using a Metadata key
+    :type phi:  float
+    :param theta:   angle relative to local vertical for defining the L 
+    coordinate direction.  It is the same as theta in spherical coordinates 
+    with emergence angle pointing upward.  Default is None which causes the 
+    algorithm to automatically assume the Metadata key method should be used.
+    :type theta:  float
+    :param angle_units:  should be either 'degrees' (default) or 'radians'.
+    An invalid value will be treated as an attempt to switch to radians 
+    but will generate an elog warning message.  This argument is ignored unless
+    phi is not null (None type)
+    :type angle_units: string
+    :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
+    :type alg_name: :class:`str`
+    :param alg_id: alg_id is a unique id to record the usage of func while preserving the history.
+    :type alg_id: :class:`bson.objectid.ObjectId`
+    :param dryrun: True for dry-run, which return "OK". Used in the mspass_func_wrapper.
+    :param inplace_return: True to return data in mspass_func_wrapper. This is necessary to be used in mapreduce.
+    :param function_return_key:  Some functions one might want to wrap with this decorator
+     return something that is appropriate to save as Metadata.  If so, use this argument to
+     define the key used to set that field in the data that is returned.
+     
+     :return:  transformed version of input.  For ensembles the entire ensemble 
+     is transformed.
+    """
+    if phi and theta:
+        if angle_units=="degrees":
+            phi_rad = np.radians(phi)
+            theta_rad = np.radians(theta)
+        else:
+            if angle_units != "radians":
+                message = "Illegal value for angle_units argument="+angle_units
+                message += " assuming radians"
+                data.elog.log_error("transform_to_LQT",message,ErrorSeverity.Complaint)
+            phi_rad = phi
+            theta_rad = theta
+        use_metadata = False
+    else:
+        use_metadata=True
+    if isinstance(data,Seismogram):
+        if use_metadata:
+            if data.is_defined(seaz_key) and data.is_defined(ema_key):
+                seaz = data[seaz_key]
+                # need azimuth not back azimuth
+                az = seaz-180.0
+                phi_deg = 90.0 - az
+                # trig funtions work the same if angle wraps so no neeed to test
+                # for fixed range
+                phi_rad = np.radians(phi_deg)
+                ema_deg = data[ema_key]
+                theta_rad = np.radians(ema_deg)
+            else:
+                message = "At least one of required metadata keys="
+                message += seaz_key + " and " + ema_key
+                message += " are not defined in this datume - killed"
+                data.elog.log_error("transform_to_LQT",message,ErrorSeverity.Invalid)
+                data.kill()
+                return data
+        try:
+            data.rotate_to_standard()
+            sc = SphericalCoordinate()
+            sc.phi = phi_rad
+            sc.theta = theta_rad
+            sc.radius=1.0  # not strictly necessary but prudent
+            # rotate method is overloaded allowing this type of input
+            data.rotate(sc)
+            # The rotate method returns the data in TQL order.  
+            # Standard convention is LQT so we reorder the data
+            # This could be done more efficiently with vector operators 
+            # but we need to use the transform method to assure the 
+            # internal tranformation matrix is properly updated
+            a=np.zeros([3,3])
+            a[0,2]=1.0
+            a[1,1]=1.0
+            a[2,0]=-1.0
+            data.transform(a)
+            #x = np.array(data.data[0,:])
+            #data.data[0,:] = data.data[2,:]  
+            # change the sign of T to keep coordinates right handed == LQT
+            #data.data[2,:] = -x  
+        except MsPASSError as merr:
+            data.log_error(merr)
+            data.kill()
+    elif isinstance(data,SeismogramEnsemble):
+        for i in range(len(data.member)):
+            # this is a recursion so be aware
+            data.member[i] = transform_to_LQT(
+                                    data.member[i],
+                                    seaz_key=seaz_key,
+                                    ema_key=ema_key,
+                                    phi=phi,
+                                    theta=theta,
+                                    angle_units=angle_units,
+                                    object_history=object_history,
+                                    alg_name=alg_name,
+                                    alg_id=alg_id,
+                                    dryrun=dryrun,
+                                    inplace_return=inplace_return,
+                                    function_return_key=function_return_key,
+                                )
+    else:
+        message="transform_to_LQT received invalid type for arg0 of {}\n".format(type(data))
+        message += "Must be either a Seismogram or SeismogramEnsemble"
+        raise ValueError(message)
+    return data
 
 
 @mspass_func_wrapper

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -13,6 +13,7 @@ from mspasspy.ccore.seismic import (
 from mspasspy.ccore.utility import SphericalCoordinate
 import numpy as np
 
+
 @mspass_func_wrapper
 def ExtractComponent(
     data,
@@ -227,9 +228,9 @@ def rotate_to_standard(
     it is set true.  Otherwise, it applies the inverse transformation and then sets this variable true.
     Note even if the current transformation matrix is not orthogonal it will be put back into
     cardinal coordinates.
-    
+
     If inversion of the transformation matrix is not possible (e.g. two components are colinear)
-    an error thrown by the C++ function is caught, posted to elog, and the 
+    an error thrown by the C++ function is caught, posted to elog, and the
     datum return will be marked dead.
 
     :param data: data object to be rotated.
@@ -254,7 +255,6 @@ def rotate_to_standard(
     except MsPASSError as merr:
         data.elog.log_error(merr)
         data.kill()
-        
 
 
 @mspass_func_wrapper
@@ -280,84 +280,84 @@ def free_surface_transformation(
     Computes and applies the Kennett [1991] free surface transformation matrix.
 
     Kennett [1991] gives the form for a free surface transformation operator
-    that defines a transformation matrix that provides optimal separation 
-    of P, SV, and SH for a receiver at the free surface of an isotropic medium 
-    with constant P and S velocity.   The transformation is only valid if the 
+    that defines a transformation matrix that provides optimal separation
+    of P, SV, and SH for a receiver at the free surface of an isotropic medium
+    with constant P and S velocity.   The transformation is only valid if the
     incident wavefield is not evanescent (i.e. at or past the SV critical angle).
-    It is important to realize the tranformation matrix does not define 
-    an orthogonal transformation.  It is also, of course, only an approximation 
-    since it is strictly correct only for a constant velocity medium. 
-    The tranformation operator requires: (1) a slowness vector, (2) an 
-    estimate of surface P wave velocity, and (3) an estimate of surface 
-    shear wave velocity.   In all cases the input for the slowness 
-    vector uses a local cartesian system with the vector specified as 
-    component ux and uy.  ux is the component of the slowness of 
-    an incident wavefield in the geographic x direction, which means 
-    positive at local east.  uy is the complementary component for the 
+    It is important to realize the tranformation matrix does not define
+    an orthogonal transformation.  It is also, of course, only an approximation
+    since it is strictly correct only for a constant velocity medium.
+    The tranformation operator requires: (1) a slowness vector, (2) an
+    estimate of surface P wave velocity, and (3) an estimate of surface
+    shear wave velocity.   In all cases the input for the slowness
+    vector uses a local cartesian system with the vector specified as
+    component ux and uy.  ux is the component of the slowness of
+    an incident wavefield in the geographic x direction, which means
+    positive at local east.  uy is the complementary component for the
     y direction defined by local north.  The components of the slowness
     vector are assumed to be in units of s/km.   (Warning:  obspy's and
-    other implementations of the commonly used tau-p calculator return 
+    other implementations of the commonly used tau-p calculator return
     slowness (ray parameter) in spherical units of s/radian - r sin(theta)/v)
-    
-    The required parameters (slowness vector and velocities) can be 
-    passed to the function one of two ways.   Because it is much simpler 
-    to implement in a map operator the default expect those parameters to 
-    be set in the data object's Metadata container.  The default keys for 
-    fetching each attribute are defined by the four arguments 
-    "ux_key", "uy_key", "vp0_key", and "vs0_key".   All four have 
-    standard defaults defined in the function signature and below.  
-    The Metadata fetching algorithm can be overridden by defining 
-    the same data through the three optional arguments with the key 
-    names "uvec", "vp0", and "vs0".   (see below for detailed descriptions)
-    
-    The switching between Metadata fetching and a constant arguments 
-    is not all or none.   If a slowness vector is defined through uvec
-    it will always override metadata.  Handing of vp0 and vs0 is independent. 
-    i.e. you can define uvec and not define vp0 and vs0 or conversely 
-    you can (more commonly) define vp0 and vs0 but not define uvec.  
-    In all cases not defining an arg is a signal to fetch it from 
-    Metadata.  
-    
-    When this function is applied to ensembles and the Metadata fetch 
-    approach is used (default) the function assumes all ensemble members 
-    have the required metadata keys defined.  Any that do not are killed. 
-    The same happens for atomic data passed to this function if any of 
-    the required keys are missing.  In fact, you should realize the 
-    ensemble algorithm simply applies this function in a recursion over all 
-    the members. 
-    
-    The output components are in the order defined in Kennett's original
-    paper.  The order is 0=SH, 1=SV, 2=L.   
 
-    :param data: data object to be transformed.  For ensembles the transformation 
-    is applied to all members.  Note the Metadata fetch mechanism is the only 
-    recommended way to handle ensembles.  An elog message will be posted 
-    to the ensemble's elog container if you try to use a constant slowness 
-    vector passed via uvec. It will not warn about constant vp0 and vs0 
+    The required parameters (slowness vector and velocities) can be
+    passed to the function one of two ways.   Because it is much simpler
+    to implement in a map operator the default expect those parameters to
+    be set in the data object's Metadata container.  The default keys for
+    fetching each attribute are defined by the four arguments
+    "ux_key", "uy_key", "vp0_key", and "vs0_key".   All four have
+    standard defaults defined in the function signature and below.
+    The Metadata fetching algorithm can be overridden by defining
+    the same data through the three optional arguments with the key
+    names "uvec", "vp0", and "vs0".   (see below for detailed descriptions)
+
+    The switching between Metadata fetching and a constant arguments
+    is not all or none.   If a slowness vector is defined through uvec
+    it will always override metadata.  Handing of vp0 and vs0 is independent.
+    i.e. you can define uvec and not define vp0 and vs0 or conversely
+    you can (more commonly) define vp0 and vs0 but not define uvec.
+    In all cases not defining an arg is a signal to fetch it from
+    Metadata.
+
+    When this function is applied to ensembles and the Metadata fetch
+    approach is used (default) the function assumes all ensemble members
+    have the required metadata keys defined.  Any that do not are killed.
+    The same happens for atomic data passed to this function if any of
+    the required keys are missing.  In fact, you should realize the
+    ensemble algorithm simply applies this function in a recursion over all
+    the members.
+
+    The output components are in the order defined in Kennett's original
+    paper.  The order is 0=SH, 1=SV, 2=L.
+
+    :param data: data object to be transformed.  For ensembles the transformation
+    is applied to all members.  Note the Metadata fetch mechanism is the only
+    recommended way to handle ensembles.  An elog message will be posted
+    to the ensemble's elog container if you try to use a constant slowness
+    vector passed via uvec. It will not warn about constant vp0 and vs0
     as that case is common.
-    :type data: :class:`~mspasspy.ccore.seismic.Seismogram` or 
+    :type data: :class:`~mspasspy.ccore.seismic.Seismogram` or
     :class:`~mspasspy.ccore.seismic.SeismogramEnsemble`
-    :param ux_key:  key to use to fetch EW component of slowness vector 
+    :param ux_key:  key to use to fetch EW component of slowness vector
     from Metadata container.  Default is "ux".
     :type ux_key:  string
-    :param uy_key:  key to use to fetch NS component of slowness vector 
+    :param uy_key:  key to use to fetch NS component of slowness vector
     from Metadata container.  Default is "uy".
     :type uy_key:  string
-    :param vp0_key:  key to use to fetch free surface P wave velocity 
+    :param vp0_key:  key to use to fetch free surface P wave velocity
     from Metadata container.  Default is "vp0".
     :type vp0_key:  string
     :param vs0_key: key to use to fetch free surface S wave velocity
     from Metadata container.  Default is "vs0".
     :type vs0_key:  string
-    :param uvec: slowness vector of the incident wavefield defined via 
-    custom C++ class :class:`~mspasspy.ccore.seismic.SlownessVector`.  
-    Default is None which is taken as a signal to fetch the slowness vector 
+    :param uvec: slowness vector of the incident wavefield defined via
+    custom C++ class :class:`~mspasspy.ccore.seismic.SlownessVector`.
+    Default is None which is taken as a signal to fetch the slowness vector
     components from Metadata using ux_key and uy_key.
     :type uvec: :class:`~mspasspy.ccore.seismic.SlownessVector`
-    :param vp0: Surface P wave velocity.  Default is None which is taken 
+    :param vp0: Surface P wave velocity.  Default is None which is taken
     as a signal to fetch this quantity from Metadata using the vp0_key.
     :type vp0: :class:`float`
-    :param vs0: Surface S wave velocity.  Default is None which is taken 
+    :param vs0: Surface S wave velocity.  Default is None which is taken
     as a signal to fetch this quantity from Metadata using the vs0_key.
     :type vs0: :class:`float`
     :param object_history: True to preserve the processing history. For details, refer to
@@ -373,18 +373,20 @@ def free_surface_transformation(
      define the key used to set that field in the data that is returned.
     """
 
-    if isinstance(data,Seismogram):
+    if isinstance(data, Seismogram):
         if uvec:
             slowness_vector = uvec
         else:
             if data.is_defined(ux_key) and data.is_defined(uy_key):
                 ux = data[ux_key]
                 uy = data[uy_key]
-                slowness_vector=SlownessVector(ux,uy)
+                slowness_vector = SlownessVector(ux, uy)
             else:
-                message = "required Metadata with keys ="+ux_key+" and "+uy_key
+                message = "required Metadata with keys =" + ux_key + " and " + uy_key
                 message += " are not defined - datum killed"
-                data.elog.log_error("free_surface_transformation",message,ErrorSeverity.Invalid)
+                data.elog.log_error(
+                    "free_surface_transformation", message, ErrorSeverity.Invalid
+                )
                 data.kill()
         if vp0:
             P_fs = vp0
@@ -392,8 +394,14 @@ def free_surface_transformation(
             if data.is_defined(vp0_key):
                 P_fs = data[vp0_key]
             else:
-                message = "required Metadata attribute "+vp0_key+" is not defined - datum killed"
-                data.elog.log_error("free_surface_transformation",message,ErrorSeverity.Invalid)
+                message = (
+                    "required Metadata attribute "
+                    + vp0_key
+                    + " is not defined - datum killed"
+                )
+                data.elog.log_error(
+                    "free_surface_transformation", message, ErrorSeverity.Invalid
+                )
                 data.kill()
         if vs0:
             S_fs = vs0
@@ -401,37 +409,49 @@ def free_surface_transformation(
             if data.is_defined(vs0_key):
                 S_fs = data[vs0_key]
             else:
-                message = "required Metadata attribute "+vs0_key+" is not defined - datum killed"
-                data.elog.log_error("free_surface_transformation",message,ErrorSeverity.Invalid)
+                message = (
+                    "required Metadata attribute "
+                    + vs0_key
+                    + " is not defined - datum killed"
+                )
+                data.elog.log_error(
+                    "free_surface_transformation", message, ErrorSeverity.Invalid
+                )
                 data.kill()
         if data.live:
-            data.free_surface_transformation(slowness_vector,P_fs,S_fs)
-                
-    elif isinstance(data,SeismogramEnsemble):
+            data.free_surface_transformation(slowness_vector, P_fs, S_fs)
+
+    elif isinstance(data, SeismogramEnsemble):
         if uvec:
-            message="Using a constant slowness vector and surface velocities for all ensemble members\n"
-            message="That is ill advised unless this is an event gather for a small aperture array"
-            data.elog.log_error("free_surface_transformation",message,ErrorSeverity.Complaint)
+            message = "Using a constant slowness vector and surface velocities for all ensemble members\n"
+            message = "That is ill advised unless this is an event gather for a small aperture array"
+            data.elog.log_error(
+                "free_surface_transformation", message, ErrorSeverity.Complaint
+            )
         for i in range(len(data.member)):
             # this is a recursion so be aware
             data.member[i] = free_surface_transformation(
-                                                data.member[i],
-                                                ux_key=ux_key,
-                                                uy_key=uy_key,
-                                                vp0_key=vp0_key,
-                                                vs0_key=vs0_key,
-                                                uvec=uvec,
-                                                vp0=vp0,
-                                                vs0=vs0,
-                                                object_history=object_history,
-                                                alg_name=alg_name,
-                                                alg_id=alg_id,
-                                                dryrun=dryrun,
-                                                inplace_return=inplace_return,
-                                                function_return_key=function_return_key,
-                                            )
+                data.member[i],
+                ux_key=ux_key,
+                uy_key=uy_key,
+                vp0_key=vp0_key,
+                vs0_key=vs0_key,
+                uvec=uvec,
+                vp0=vp0,
+                vs0=vs0,
+                object_history=object_history,
+                alg_name=alg_name,
+                alg_id=alg_id,
+                dryrun=dryrun,
+                inplace_return=inplace_return,
+                function_return_key=function_return_key,
+            )
     else:
-        message="free_surface_transform received invalid type for arg0 of {}\n".format(type(data))
+        message = (
+            "free_surface_transform received invalid type for arg0 of {}\n".format(
+                type(data)
+            )
+        )
         message += "Must be either a Seismogram or SeismogramEnsemble"
         raise ValueError(message)
     return data
@@ -474,58 +494,60 @@ def transform(
      define the key used to set that field in the data that is returned.
     """
     data.transform(matrix)
-    
+
+
 @mspass_func_wrapper
-def transform_to_RTZ(data,
-                     key='seaz',
-                     phi=None,
-                     angle_units='degrees',
-                     key_is_backazimuth=True,
-                     object_history=False,
-                     alg_name=None,
-                     alg_id=None,
-                     dryrun=False,
-                     inplace_return=False,
-                     function_return_key=None,
-                 ):
+def transform_to_RTZ(
+    data,
+    key="seaz",
+    phi=None,
+    angle_units="degrees",
+    key_is_backazimuth=True,
+    object_history=False,
+    alg_name=None,
+    alg_id=None,
+    dryrun=False,
+    inplace_return=False,
+    function_return_key=None,
+):
     """
     Applies coordinate transform to RTZ version of ray coordinates.
-    
-    RTZ is the simplest transformation for three component data to 
+
+    RTZ is the simplest transformation for three component data to
     what is commonly called ray coordinates.  R-radial (SV), T-transverse
-    (SH). and Z=vertical (bad measure of longitudinal).  The function 
-    first forces the data to cardinal direction using rotate_to_standard 
-    and then rotates the coordinates around the vertical axis.   The 
-    rotation can be defined in one of two ways.  The default behavior 
-    is to attempt to extract the back azimuth from the station to the 
+    (SH). and Z=vertical (bad measure of longitudinal).  The function
+    first forces the data to cardinal direction using rotate_to_standard
+    and then rotates the coordinates around the vertical axis.   The
+    rotation can be defined in one of two ways.  The default behavior
+    is to attempt to extract the back azimuth from the station to the
     source with the key defined by the "key" argument (defaults to 'seaz').
-    That behavior will be overriden if the "phi" kwarg value is set.  
-    Phi is assumed to be the angle to rotate the coordinates using the 
-    math convention for the phi angle with positive anticlockwise.  
-    The units of the value retrieved with the key argument or the value 
-    passed via the phi argument are by default assumed to be in degrees. 
-    If using the phi argument you specify the angle in radians if you 
+    That behavior will be overriden if the "phi" kwarg value is set.
+    Phi is assumed to be the angle to rotate the coordinates using the
+    math convention for the phi angle with positive anticlockwise.
+    The units of the value retrieved with the key argument or the value
+    passed via the phi argument are by default assumed to be in degrees.
+    If using the phi argument you specify the angle in radians if you
     also set the "angle_units" argument to "radians".
-    
+
     :param data:   data object to be transformed
-    :type data:  :class:`~mspasspy.ccore.seismic.Seismogram` or 
+    :type data:  :class:`~mspasspy.ccore.seismic.Seismogram` or
      :class:`~mspass.ccore.seismic.SeismogramEnsemble`.
     :param key:  key to use to fetch back azimuth value (assumed degrees always)
     :type key:  string
-    :param phi:   angle to rotate around vertical to define the transformation 
-    (positive anticlockwise convention NOT azimuth convention)  Default is None 
-    which means ignore this parameter and use key.  Setting this value to 
+    :param phi:   angle to rotate around vertical to define the transformation
+    (positive anticlockwise convention NOT azimuth convention)  Default is None
+    which means ignore this parameter and use key.  Setting this value to
     something other than None causes the key method to be overridden.
     :type phi:  float
     :param angle_units:  should be either 'degrees' (default) or 'radians'.
-    An invalid value will be treated as an attempt to switch to radians 
+    An invalid value will be treated as an attempt to switch to radians
     but will generate an elog warning message.  This argument is ignored unless
     phi is not null (None type)
     :type angle_units: string
-    :param key_is_backazimuth: boolean that when True (default) assumes the 
-    angle extrated with the key argument value is a backazimuth in degrees. 
-    If set False, the angle will be assumed to be a rotation angle in 
-    with the anticlockwise positive convention.  
+    :param key_is_backazimuth: boolean that when True (default) assumes the
+    angle extrated with the key argument value is a backazimuth in degrees.
+    If set False, the angle will be assumed to be a rotation angle in
+    with the anticlockwise positive convention.
     :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
     :type alg_name: :class:`str`
     :param alg_id: alg_id is a unique id to record the usage of func while preserving the history.
@@ -535,130 +557,140 @@ def transform_to_RTZ(data,
     :param function_return_key:  Some functions one might want to wrap with this decorator
      return something that is appropriate to save as Metadata.  If so, use this argument to
      define the key used to set that field in the data that is returned.
-     
-    :return:  transformed version of input.  For ensembles the entire ensemble 
+
+    :return:  transformed version of input.  For ensembles the entire ensemble
     is transformed.
     """
     if phi:
-        if angle_units=="degrees":
+        if angle_units == "degrees":
             phi_rad = np.radians(phi)
         else:
             if angle_units != "radians":
-                message = "Illegal value for angle_units argument="+angle_units
+                message = "Illegal value for angle_units argument=" + angle_units
                 message += " assuming radians"
-                data.elog.log_error("transform_to_RTZ",message,ErrorSeverity.Complaint)
+                data.elog.log_error(
+                    "transform_to_RTZ", message, ErrorSeverity.Complaint
+                )
             phi_rad = phi
         use_metadata = False
     else:
-        use_metadata=True
-    if isinstance(data,Seismogram):
+        use_metadata = True
+    if isinstance(data, Seismogram):
         if use_metadata:
             if data.is_defined(key):
                 phi_deg = data[key]
                 if key_is_backazimuth:
-                    az = phi_deg + 180.0  
+                    az = phi_deg + 180.0
                     phi_deg = 90.0 - az
                 phi_rad = np.radians(phi_deg)
             else:
-                message = "required Metadata key="+key+" not defined for this datum - killed"
-                data.elog.log_error("transform_to_RTZ",message,ErrorSeverity.Invalid)
+                message = (
+                    "required Metadata key="
+                    + key
+                    + " not defined for this datum - killed"
+                )
+                data.elog.log_error("transform_to_RTZ", message, ErrorSeverity.Invalid)
                 data.kill()
-                return data 
+                return data
         try:
             data.rotate_to_standard()
             data.rotate(phi_rad)
         except MsPASSError as merr:
             data.log_error(merr)
             data.kill()
-    elif isinstance(data,SeismogramEnsemble):
+    elif isinstance(data, SeismogramEnsemble):
         for i in range(len(data.member)):
             # this is a recursion so be aware
             data.member[i] = transform_to_RTZ(
-                                    data.member[i],
-                                    key=key,
-                                    phi=phi,
-                                    angle_units=angle_units,
-                                    object_history=object_history,
-                                    alg_name=alg_name,
-                                    alg_id=alg_id,
-                                    dryrun=dryrun,
-                                    inplace_return=inplace_return,
-                                    function_return_key=function_return_key,
-                                )
+                data.member[i],
+                key=key,
+                phi=phi,
+                angle_units=angle_units,
+                object_history=object_history,
+                alg_name=alg_name,
+                alg_id=alg_id,
+                dryrun=dryrun,
+                inplace_return=inplace_return,
+                function_return_key=function_return_key,
+            )
     else:
-        message="transform_to_RTZ received invalid type for arg0 of {}\n".format(type(data))
+        message = "transform_to_RTZ received invalid type for arg0 of {}\n".format(
+            type(data)
+        )
         message += "Must be either a Seismogram or SeismogramEnsemble"
         raise ValueError(message)
     return data
 
+
 @mspass_func_wrapper
-def transform_to_LQT(data,
-                     seaz_key='seaz',
-                     ema_key='ema',
-                     phi=None,
-                     theta=None,
-                     angle_units='degrees',
-                     object_history=False,
-                     alg_name=None,
-                     alg_id=None,
-                     dryrun=False,
-                     inplace_return=False,
-                     function_return_key=None,
-                 ):
+def transform_to_LQT(
+    data,
+    seaz_key="seaz",
+    ema_key="ema",
+    phi=None,
+    theta=None,
+    angle_units="degrees",
+    object_history=False,
+    alg_name=None,
+    alg_id=None,
+    dryrun=False,
+    inplace_return=False,
+    function_return_key=None,
+):
     """
     Applies coordinate transform to LQT version of ray coordinates.
-    
-    LQT is an orthogonal coordinate transformation for Seismogram 
+
+    LQT is an orthogonal coordinate transformation for Seismogram
     objects that cause the output data to have x1-Longitudinal (positive up
     normally set to the predicted emergence angle of P particle motion),
     x2 - Q a rotated radial direction (in propagation direction but tilted by theta).
-    and x3 - transverse (T) in direction to define a right handed coordinate 
-    system.  The function produces this transformation 
+    and x3 - transverse (T) in direction to define a right handed coordinate
+    system.  The function produces this transformation
     by the product f three transformation:
         1.  Uses rotate_to_standard to assure we start from cardinal directions.
-        2.  Transformation to what might be called TQL using the Seismogram 
+        2.  Transformation to what might be called TQL using the Seismogram
             C++ method rotate using a SphericalCoordinate definition.
-        3.  Transformation to LQT to rearrange the order of the Seismogram 
-            data matrix (also requires a sign change on T to keep the output 
+        3.  Transformation to LQT to rearrange the order of the Seismogram
+            data matrix (also requires a sign change on T to keep the output
             right handed)
-        
-    The form of the transformation can be specified in one of two 
-    completely different ways.   By default the function attempts to 
-    extract the back azimuth from station to event with using the 
-    metadata key defined by 'seaz_key' (default 'seaz') and the P 
-    emergence angle with the metadata key defined by the 'ema_key' 
-    argument (default 'ema').   If the arguments 'phi' and 'theta' are 
-    defined they are assumed angles to be used to defined the 
-    transformation and no attempt will be made to fetch the value from 
+
+    The form of the transformation can be specified in one of two
+    completely different ways.   By default the function attempts to
+    extract the back azimuth from station to event with using the
+    metadata key defined by 'seaz_key' (default 'seaz') and the P
+    emergence angle with the metadata key defined by the 'ema_key'
+    argument (default 'ema').   If the arguments 'phi' and 'theta' are
+    defined they are assumed angles to be used to defined the
+    transformation and no attempt will be made to fetch the value from
     Metaata (Rarely a good idea with ensemble but can be useful for atomic data.
-    Using Metadata is strongly preferred because it also preserves what 
+    Using Metadata is strongly preferred because it also preserves what
     the angles used where.  They are not if the argument approach is used.)
-    Metadata values are required to be in degree units.  If the argument 
-    approach is used radian values can to used if you also set 
+    Metadata values are required to be in degree units.  If the argument
+    approach is used radian values can to used if you also set
     the argument "angle_units" to "radians".
-    
-    Note the operation handles the singular case of theta==0.0 where it 
-    simply uses the phi value and rotates the coordinates in a variant of 
-    RTZ (variant because order is different).      
+
+    Note the operation handles the singular case of theta==0.0 where it
+    simply uses the phi value and rotates the coordinates in a variant of
+    RTZ (variant because order is different).
     :param seaz_key:  key to use to fetch back azimuth value (assumed degrees always)
     :type key:  string (default "seaz")
-    :param ema_key:  key to use to fetch emergence angle defining L direction 
-    relative to local vertical.  
+    :param ema_key:  key to use to fetch emergence angle defining L direction
+    relative to local vertical.
     :type ema_key:  string (defautl "ema")
-    :param phi:   angle to rotate around vertical to define the transformation 
-    (positive anticlockwise convention NOT azimuth convention)  Default is None 
-    which means ignore this parameter and use key.  Setting this value to 
+    :param phi:   angle to rotate around vertical to define the transformation
+    (positive anticlockwise convention NOT azimuth convention)  Default is None
+    which means ignore this parameter and use key.  Setting this value to
     something other than None causes the Metadata fetch method to be overridden.
     WARNING:  this is not backazimuth but angle relative to E direction.
     Note that is not at all what is expected when using a Metadata key
     :type phi:  float
-    :param theta:   angle relative to local vertical for defining the L 
-    coordinate direction.  It is the same as theta in spherical coordinates 
-    with emergence angle pointing upward.  Default is None which causes the 
+    :param theta:   angle relative to local vertical for defining the L
+    coordinate direction.  It is the same as theta in spherical coordinates
+    with emergence angle pointing upward.  Default is None which causes the
     algorithm to automatically assume the Metadata key method should be used.
     :type theta:  float
     :param angle_units:  should be either 'degrees' (default) or 'radians'.
-    An invalid value will be treated as an attempt to switch to radians 
+    An invalid value will be treated as an attempt to switch to radians
     but will generate an elog warning message.  This argument is ignored unless
     phi is not null (None type)
     :type angle_units: string
@@ -671,30 +703,32 @@ def transform_to_LQT(data,
     :param function_return_key:  Some functions one might want to wrap with this decorator
      return something that is appropriate to save as Metadata.  If so, use this argument to
      define the key used to set that field in the data that is returned.
-     
-     :return:  transformed version of input.  For ensembles the entire ensemble 
+
+     :return:  transformed version of input.  For ensembles the entire ensemble
      is transformed.
     """
     if phi and theta:
-        if angle_units=="degrees":
+        if angle_units == "degrees":
             phi_rad = np.radians(phi)
             theta_rad = np.radians(theta)
         else:
             if angle_units != "radians":
-                message = "Illegal value for angle_units argument="+angle_units
+                message = "Illegal value for angle_units argument=" + angle_units
                 message += " assuming radians"
-                data.elog.log_error("transform_to_LQT",message,ErrorSeverity.Complaint)
+                data.elog.log_error(
+                    "transform_to_LQT", message, ErrorSeverity.Complaint
+                )
             phi_rad = phi
             theta_rad = theta
         use_metadata = False
     else:
-        use_metadata=True
-    if isinstance(data,Seismogram):
+        use_metadata = True
+    if isinstance(data, Seismogram):
         if use_metadata:
             if data.is_defined(seaz_key) and data.is_defined(ema_key):
                 seaz = data[seaz_key]
                 # need azimuth not back azimuth
-                az = seaz-180.0
+                az = seaz - 180.0
                 phi_deg = 90.0 - az
                 # trig funtions work the same if angle wraps so no neeed to test
                 # for fixed range
@@ -705,7 +739,7 @@ def transform_to_LQT(data,
                 message = "At least one of required metadata keys="
                 message += seaz_key + " and " + ema_key
                 message += " are not defined in this datume - killed"
-                data.elog.log_error("transform_to_LQT",message,ErrorSeverity.Invalid)
+                data.elog.log_error("transform_to_LQT", message, ErrorSeverity.Invalid)
                 data.kill()
                 return data
         try:
@@ -713,45 +747,47 @@ def transform_to_LQT(data,
             sc = SphericalCoordinate()
             sc.phi = phi_rad
             sc.theta = theta_rad
-            sc.radius=1.0  # not strictly necessary but prudent
+            sc.radius = 1.0  # not strictly necessary but prudent
             # rotate method is overloaded allowing this type of input
             data.rotate(sc)
-            # The rotate method returns the data in TQL order.  
+            # The rotate method returns the data in TQL order.
             # Standard convention is LQT so we reorder the data
-            # This could be done more efficiently with vector operators 
-            # but we need to use the transform method to assure the 
+            # This could be done more efficiently with vector operators
+            # but we need to use the transform method to assure the
             # internal tranformation matrix is properly updated
-            a=np.zeros([3,3])
-            a[0,2]=1.0
-            a[1,1]=1.0
-            a[2,0]=-1.0
+            a = np.zeros([3, 3])
+            a[0, 2] = 1.0
+            a[1, 1] = 1.0
+            a[2, 0] = -1.0
             data.transform(a)
-            #x = np.array(data.data[0,:])
-            #data.data[0,:] = data.data[2,:]  
+            # x = np.array(data.data[0,:])
+            # data.data[0,:] = data.data[2,:]
             # change the sign of T to keep coordinates right handed == LQT
-            #data.data[2,:] = -x  
+            # data.data[2,:] = -x
         except MsPASSError as merr:
             data.log_error(merr)
             data.kill()
-    elif isinstance(data,SeismogramEnsemble):
+    elif isinstance(data, SeismogramEnsemble):
         for i in range(len(data.member)):
             # this is a recursion so be aware
             data.member[i] = transform_to_LQT(
-                                    data.member[i],
-                                    seaz_key=seaz_key,
-                                    ema_key=ema_key,
-                                    phi=phi,
-                                    theta=theta,
-                                    angle_units=angle_units,
-                                    object_history=object_history,
-                                    alg_name=alg_name,
-                                    alg_id=alg_id,
-                                    dryrun=dryrun,
-                                    inplace_return=inplace_return,
-                                    function_return_key=function_return_key,
-                                )
+                data.member[i],
+                seaz_key=seaz_key,
+                ema_key=ema_key,
+                phi=phi,
+                theta=theta,
+                angle_units=angle_units,
+                object_history=object_history,
+                alg_name=alg_name,
+                alg_id=alg_id,
+                dryrun=dryrun,
+                inplace_return=inplace_return,
+                function_return_key=function_return_key,
+            )
     else:
-        message="transform_to_LQT received invalid type for arg0 of {}\n".format(type(data))
+        message = "transform_to_LQT received invalid type for arg0 of {}\n".format(
+            type(data)
+        )
         message += "Must be either a Seismogram or SeismogramEnsemble"
         raise ValueError(message)
     return data

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -453,7 +453,7 @@ def free_surface_transformation(
             )
         )
         message += "Must be either a Seismogram or SeismogramEnsemble"
-        raise ValueError(message)
+        raise TypeError(message)
     return data
 
 
@@ -618,7 +618,7 @@ def transform_to_RTZ(
             type(data)
         )
         message += "Must be either a Seismogram or SeismogramEnsemble"
-        raise ValueError(message)
+        raise TypeError(message)
     return data
 
 
@@ -789,7 +789,7 @@ def transform_to_LQT(
             type(data)
         )
         message += "Must be either a Seismogram or SeismogramEnsemble"
-        raise ValueError(message)
+        raise TypeError(message)
     return data
 
 

--- a/python/tests/algorithms/test_basic.py
+++ b/python/tests/algorithms/test_basic.py
@@ -26,15 +26,17 @@ sys.path.append("python/tests")
 
 from helper import get_live_seismogram, get_live_timeseries, get_sin_timeseries
 
+
 def is_identity(tm):
     """
-    File-scope function used to standardize test that output of 
-    a 3x3 matrix is an identity.   
+    File-scope function used to standardize test that output of
+    a 3x3 matrix is an identity.
     """
-    assert all(np.isclose(tm[:,0],[1.0,0.0,0.0]))
-    assert all(np.isclose(tm[:,1],[0.0,1.0,0.0]))
-    assert all(np.isclose(tm[:,2],[0.0,0.0,1.0]))
+    assert all(np.isclose(tm[:, 0], [1.0, 0.0, 0.0]))
+    assert all(np.isclose(tm[:, 1], [0.0, 1.0, 0.0]))
+    assert all(np.isclose(tm[:, 2], [0.0, 0.0, 1.0]))
     return True
+
 
 def test_ExtractComponent():
     seis = Seismogram(10)
@@ -83,9 +85,9 @@ def test_ExtractComponent():
 
 def test_ator_rtoa():
     """
-    This tests the function forms of the rtoa and ator methods common 
-    to Seismogram and TimeSeries objects.   This test only verifies 
-    TimeSeries objects work correctly.  
+    This tests the function forms of the rtoa and ator methods common
+    to Seismogram and TimeSeries objects.   This test only verifies
+    TimeSeries objects work correctly.
     """
     ts = get_live_timeseries()
     original_t0 = ts.t0
@@ -100,10 +102,10 @@ def test_ator_rtoa():
 
 def test_rotate():
     """
-    Tests the 3D rotate method of Seismogram.    rotate is overloaded 
-    and has a different algorithm with the same name that only rotates 
-    the coordinates around the z axis.  Not tested independently here 
-    as it is tested indirectly in the higher level function 
+    Tests the 3D rotate method of Seismogram.    rotate is overloaded
+    and has a different algorithm with the same name that only rotates
+    the coordinates around the z axis.  Not tested independently here
+    as it is tested indirectly in the higher level function
     test_transform_to_RTZ below.
 
     """
@@ -182,17 +184,18 @@ def test_transform():
     assert all(np.isclose(seis2.data[:, 1], [1, 1, 1]))
     assert all(np.isclose(seis2.data[:, 2], [1, 1, 0]))
     assert all(np.isclose(seis2.data[:, 3], [0, 0, 1]))
-    
+
+
 def test_free_surface_transform():
     """
-    Tests the free_surface_transform method and wrapper in basic.py. 
-    The wrapper adds flexibility in the api not in the C++ method. 
-    Those are tested here along with error handlers in the python 
+    Tests the free_surface_transform method and wrapper in basic.py.
+    The wrapper adds flexibility in the api not in the C++ method.
+    Those are tested here along with error handlers in the python
     wrappers.
     """
-    
+
     # This is the same data matrix used in transform_to_LQT
-    # probably should be made a fixture since I'm reusing it but 
+    # probably should be made a fixture since I'm reusing it but
     # if it still is here it means I didn't do that.
     seis = Seismogram(3)
     seis.set_npts(3)
@@ -204,164 +207,168 @@ def test_free_surface_transform():
     theta = 10.0
     theta_rad = np.radians(theta)
     # define a set of vectors that resolve a set of consistent LQT directions. \
-    # anchor is L that is azimuth 30 degrees and with ema of 10 degrees 
-    sc_L=SphericalCoordinate()
-    sc_L.phi=phi_rad
-    sc_L.theta=theta_rad
-    sc_L.radius=1.0
-    
-    sc_Q=SphericalCoordinate()
-    sc_Q.phi=phi_rad
-    sc_Q.theta=theta_rad + np.pi/2.0
-    sc_Q.radius=1.0
-  
-    sc_T=SphericalCoordinate()
-    sc_T.phi = phi_rad + np.pi/2.0
-    sc_T.theta = np.pi/2.0
-    sc_T.radius=1.0
-    
+    # anchor is L that is azimuth 30 degrees and with ema of 10 degrees
+    sc_L = SphericalCoordinate()
+    sc_L.phi = phi_rad
+    sc_L.theta = theta_rad
+    sc_L.radius = 1.0
+
+    sc_Q = SphericalCoordinate()
+    sc_Q.phi = phi_rad
+    sc_Q.theta = theta_rad + np.pi / 2.0
+    sc_Q.radius = 1.0
+
+    sc_T = SphericalCoordinate()
+    sc_T.phi = phi_rad + np.pi / 2.0
+    sc_T.theta = np.pi / 2.0
+    sc_T.radius = 1.0
+
     # now load those three vectors into seis
     for i in range(3):
-        x=sc_L.unit_vector
-        seis.data[i,0] = x[i]
+        x = sc_L.unit_vector
+        seis.data[i, 0] = x[i]
     for i in range(3):
-        x=sc_Q.unit_vector
-        seis.data[i,1] = x[i]
+        x = sc_Q.unit_vector
+        seis.data[i, 1] = x[i]
     for i in range(3):
-        x=sc_T.unit_vector
-        seis.data[i,2] = x[i]
-        
+        x = sc_T.unit_vector
+        seis.data[i, 2] = x[i]
+
     # copy so we can reuse original
     seis0 = Seismogram(seis)
+
     # we use this to test output - column 0 is L, column 1 is Q, and 2 is T
     # hence the tests used in this function
     def fstout_ok(s):
-        assert np.isclose(s.data[0,0],0.0) # L should have zero T
-        assert np.isclose(s.data[0,1],0.0) # Q should have zero T
-        assert all(np.isclose(s.data[:,2],[-0.5,0.0,0.0]))  # fst has factor of 2 corection on T
-        return True          
+        assert np.isclose(s.data[0, 0], 0.0)  # L should have zero T
+        assert np.isclose(s.data[0, 1], 0.0)  # Q should have zero T
+        assert all(
+            np.isclose(s.data[:, 2], [-0.5, 0.0, 0.0])
+        )  # fst has factor of 2 corection on T
+        return True
 
-    umag = 1.0/10.0  # slowness of 10 km/s apparent velocity
+    umag = 1.0 / 10.0  # slowness of 10 km/s apparent velocity
     u_phi = phi_rad  # set so radial of data matrix will be in u direction
-    ux = umag*np.cos(u_phi)
-    uy = umag*np.sin(u_phi)
-    uvec = SlownessVector(ux,uy)
+    ux = umag * np.cos(u_phi)
+    uy = umag * np.sin(u_phi)
+    uvec = SlownessVector(ux, uy)
     sout = free_surface_transformation(seis, uvec, 5.0, 3.5)
     ok = fstout_ok(sout)
     assert ok
-    # verify fst properly sets the transformation matrix so 
+    # verify fst properly sets the transformation matrix so
     # rotate_to_standard can restore
     sout.rotate_to_standard()
     ok = is_identity(sout.tmatrix)
     assert ok
     # verify the data are restored properly as well - only doing this test once
     for i in range(3):
-        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
+        assert all(np.isclose(sout.data[:, i], seis0.data[:, i]))
 
     # now test loading slowness vector through metadata
-    seis=Seismogram(seis0)
-    seis['ux'] = uvec.ux
-    seis['uy'] = uvec.uy
-    seis['vp0'] = 5.0
-    seis['vs0'] = 3.5
+    seis = Seismogram(seis0)
+    seis["ux"] = uvec.ux
+    seis["uy"] = uvec.uy
+    seis["vp0"] = 5.0
+    seis["vs0"] = 3.5
     sout = free_surface_transformation(seis)
     ok = fstout_ok(sout)
     assert ok
-    
+
     # test variants with ux,uy in Metadata but vp0 and vs0 in args
-    seis=Seismogram(seis0)
-    seis['ux'] = uvec.ux
-    seis['uy'] = uvec.uy
-    seis['vs0'] = 3.5
-    sout = free_surface_transformation(seis,vp0=5.0)
+    seis = Seismogram(seis0)
+    seis["ux"] = uvec.ux
+    seis["uy"] = uvec.uy
+    seis["vs0"] = 3.5
+    sout = free_surface_transformation(seis, vp0=5.0)
     ok = fstout_ok(sout)
     assert ok
-    
-    seis=Seismogram(seis0)
-    seis['ux'] = uvec.ux
-    seis['uy'] = uvec.uy
-    seis['vp0'] = 5.0
-    sout = free_surface_transformation(seis,vs0=3.5)
+
+    seis = Seismogram(seis0)
+    seis["ux"] = uvec.ux
+    seis["uy"] = uvec.uy
+    seis["vp0"] = 5.0
+    sout = free_surface_transformation(seis, vs0=3.5)
     ok = fstout_ok(sout)
     assert ok
-    
+
     # the uvec but metadata vp0 and vs0
-    seis=Seismogram(seis0)
-    seis['vp0'] = 5.0
-    seis['vs0'] = 3.5
-    sout = free_surface_transformation(seis,uvec)
+    seis = Seismogram(seis0)
+    seis["vp0"] = 5.0
+    seis["vs0"] = 3.5
+    sout = free_surface_transformation(seis, uvec)
     ok = fstout_ok(sout)
     assert ok
-    
+
     # verify alternate key usage - testing all at once sufficient for current implementation
-    seis=Seismogram(seis0)
-    seis['slow_x'] = uvec.ux
-    seis['slow_y'] = uvec.uy
-    seis['P0'] = 5.0
-    seis['S0'] = 3.5
-    sout = free_surface_transformation(seis,
-                                       ux_key='slow_x',
-                                       uy_key='slow_y',
-                                       vp0_key='P0',
-                                       vs0_key='S0',
-                                       )
+    seis = Seismogram(seis0)
+    seis["slow_x"] = uvec.ux
+    seis["slow_y"] = uvec.uy
+    seis["P0"] = 5.0
+    seis["S0"] = 3.5
+    sout = free_surface_transformation(
+        seis,
+        ux_key="slow_x",
+        uy_key="slow_y",
+        vp0_key="P0",
+        vs0_key="S0",
+    )
     ok = fstout_ok(sout)
     assert ok
-    
+
     # now test ensemble - test just with using Metadata fetch
     ens = SeismogramEnsemble(3)
-    seis=Seismogram(seis0)
-    seis['ux'] = uvec.ux
-    seis['uy'] = uvec.uy
-    seis['vp0'] = 5.0
-    seis['vs0'] = 3.5
+    seis = Seismogram(seis0)
+    seis["ux"] = uvec.ux
+    seis["uy"] = uvec.uy
+    seis["vp0"] = 5.0
+    seis["vs0"] = 3.5
     for i in range(3):
         ens.member.append(Seismogram(seis))
     ens.set_live()
     ensout = free_surface_transformation(ens)
     assert ensout.live
-    assert len(ensout.member)==3
+    assert len(ensout.member) == 3
     for i in range(len(ensout.member)):
         ok = fstout_ok(ensout.member[i])
         assert ok
-        
-        
+
     # finally test error handlers
     # first test slowness data missing from Metadata when required
-    seis=Seismogram(seis0)
-    seis['vp0'] = 5.0
-    seis['vs0'] = 3.5
-    sout=free_surface_transformation(seis)
+    seis = Seismogram(seis0)
+    seis["vp0"] = 5.0
+    seis["vs0"] = 3.5
+    sout = free_surface_transformation(seis)
     assert sout.dead()
-    assert sout.elog.size()==1
+    assert sout.elog.size() == 1
     # repeat for vp0 an vs0
-    seis=Seismogram(seis0)
-    seis['ux'] = uvec.ux
-    seis['uy'] = uvec.uy
-    seis['vs0'] = 3.5
-    sout=free_surface_transformation(seis)
+    seis = Seismogram(seis0)
+    seis["ux"] = uvec.ux
+    seis["uy"] = uvec.uy
+    seis["vs0"] = 3.5
+    sout = free_surface_transformation(seis)
     assert sout.dead()
-    assert sout.elog.size()==1
-    seis=Seismogram(seis0)
-    seis['ux'] = uvec.ux
-    seis['uy'] = uvec.uy
-    seis['vp0'] = 5.0
-    sout=free_surface_transformation(seis)
+    assert sout.elog.size() == 1
+    seis = Seismogram(seis0)
+    seis["ux"] = uvec.ux
+    seis["uy"] = uvec.uy
+    seis["vp0"] = 5.0
+    sout = free_surface_transformation(seis)
     assert sout.dead()
-    assert sout.elog.size()==1
+    assert sout.elog.size() == 1
     # invalid arg0 should throw an exception
-    x='foobar'
-    with pytest.raises(ValueError,match="received invalid type"):
+    x = "foobar"
+    with pytest.raises(ValueError, match="received invalid type"):
         sout = free_surface_transformation(x)
+
 
 def test_transform_to_RTZ():
     """
     This function tests the higher level function called transform_to_RTZ.
-    That function supports both atomic an ensemble Seismogram input so 
-    we test both.  Error handlers are tested at the end. 
+    That function supports both atomic an ensemble Seismogram input so
+    we test both.  Error handlers are tested at the end.
     """
-    # create a Seismogram that should resolve to [1,0,0] after RTZ 
-    # transform.  Multiple duplicate samples are probably not essential 
+    # create a Seismogram that should resolve to [1,0,0] after RTZ
+    # transform.  Multiple duplicate samples are probably not essential
     # but more like real data where npts of 1 would be never occur.
     seis = Seismogram(10)
     seis.npts = 10
@@ -370,91 +377,92 @@ def test_transform_to_RTZ():
     seis.set_live()
     phi = 30.0
     phi_rad = np.radians(phi)
-    seis.data[0,:] = np.cos(phi_rad)
-    seis.data[1,:] = np.sin(phi_rad)
-    seis.data[2,:] = 10.0
-    
-    # need this more than once so make a deep copy 
+    seis.data[0, :] = np.cos(phi_rad)
+    seis.data[1, :] = np.sin(phi_rad)
+    seis.data[2, :] = 10.0
+
+    # need this more than once so make a deep copy
     seis0 = Seismogram(seis)
-    
-    # test atomic version for input via args 
-    sout = transform_to_RTZ(seis,phi=phi,angle_units="degrees")
-    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+
+    # test atomic version for input via args
+    sout = transform_to_RTZ(seis, phi=phi, angle_units="degrees")
+    assert all(np.isclose(sout.data[:, 0], [1.0, 0.0, 10.0]))
     sout.rotate_to_standard()
-    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
-    
+    assert all(np.isclose(sout.data[:, 0], seis0.data[:, 0]))
+
     # test with radians
-    seis=Seismogram(seis0)
-    sout = transform_to_RTZ(seis,phi=phi_rad,angle_units="radians")
-    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    seis = Seismogram(seis0)
+    sout = transform_to_RTZ(seis, phi=phi_rad, angle_units="radians")
+    assert all(np.isclose(sout.data[:, 0], [1.0, 0.0, 10.0]))
     sout.rotate_to_standard()
-    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
-    
+    assert all(np.isclose(sout.data[:, 0], seis0.data[:, 0]))
+
     # test with metadata input
-    seis=Seismogram(seis0)
+    seis = Seismogram(seis0)
     az = 90.0 - phi
-    seis['seaz']=az+180.0
+    seis["seaz"] = az + 180.0
     sout = transform_to_RTZ(seis)
-    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    assert all(np.isclose(sout.data[:, 0], [1.0, 0.0, 10.0]))
     sout.rotate_to_standard()
-    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
-    
-    # repeat with alternate key 
-    seis=Seismogram(seis0)
+    assert all(np.isclose(sout.data[:, 0], seis0.data[:, 0]))
+
+    # repeat with alternate key
+    seis = Seismogram(seis0)
     az = 90.0 - phi
-    seis['backaz']=az+180.0
-    sout = transform_to_RTZ(seis,key='backaz')
-    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    seis["backaz"] = az + 180.0
+    sout = transform_to_RTZ(seis, key="backaz")
+    assert all(np.isclose(sout.data[:, 0], [1.0, 0.0, 10.0]))
     sout.rotate_to_standard()
-    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
-    
-    # test of ensembles will only use Metadata method.   
-    # atomic version tests what is needed for arg method and 
+    assert all(np.isclose(sout.data[:, 0], seis0.data[:, 0]))
+
+    # test of ensembles will only use Metadata method.
+    # atomic version tests what is needed for arg method and
     # is not recommended for ensembles anyway
-    nmembers=3
+    nmembers = 3
     e = SeismogramEnsemble(3)
     az = 90.0 - phi
-    seaz = az+180.0
+    seaz = az + 180.0
     seis = Seismogram(seis0)
-    seis['seaz'] = seaz
-    for i in range (3):
+    seis["seaz"] = seaz
+    for i in range(3):
         e.member.append(Seismogram(seis))
     # ensemble is 3 copies of the same data this test used above
     # has seaz set
     eout = transform_to_RTZ(e)
     for d in eout.member:
         assert d.live
-        assert all(np.isclose(d.data[:,0],[1.0,0.0,10.0]))
-        
+        assert all(np.isclose(d.data[:, 0], [1.0, 0.0, 10.0]))
+
     # test error handlers
     # illegal units argument error - logs but doesn't kill
-    seis=Seismogram(seis0)
-    sout=transform_to_RTZ(seis,phi=phi_rad,angle_units="invalid")
+    seis = Seismogram(seis0)
+    sout = transform_to_RTZ(seis, phi=phi_rad, angle_units="invalid")
     assert sout.elog.size() == 1
     assert sout.live
     # should default back to radians so the tests as above should pass
-    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    assert all(np.isclose(sout.data[:, 0], [1.0, 0.0, 10.0]))
     sout.rotate_to_standard()
-    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
-    
+    assert all(np.isclose(sout.data[:, 0], seis0.data[:, 0]))
+
     # required metadata not defined will cause a kill
-    seis=Seismogram(seis0)
-    sout=transform_to_RTZ(seis)
+    seis = Seismogram(seis0)
+    sout = transform_to_RTZ(seis)
     assert sout.elog.size() == 1
     assert sout.dead()
-    
+
     # invalid data throws an exception
-    x='foobar'
-    with pytest.raises(ValueError,match="received invalid type"):
+    x = "foobar"
+    with pytest.raises(ValueError, match="received invalid type"):
         sout = transform_to_RTZ(x)
+
 
 def test_transform_to_LQT():
     """
     This function tests the higher level function called transform_to_LQT.
-    That function supports both atomic an ensemble Seismogram input so 
-    we test both.  Error handlers are tested at the end. 
+    That function supports both atomic an ensemble Seismogram input so
+    we test both.  Error handlers are tested at the end.
     """
-    # create a Seismogram that should resolve to an identity in the first 
+    # create a Seismogram that should resolve to an identity in the first
     # three columns of the data matrix.  We do that by making
     # x1-L, x2-Q, and x3-T as defined by LQT using L as the anchor
     seis = Seismogram(3)
@@ -467,99 +475,98 @@ def test_transform_to_LQT():
     theta = 10.0
     theta_rad = np.radians(theta)
     # define a set of vectors that resolve a set of consistent LQT directions. \
-    # anchor is L that is azimuth 30 degrees and with ema of 10 degrees 
-    sc_L=SphericalCoordinate()
-    sc_L.phi=phi_rad
-    sc_L.theta=theta_rad
-    sc_L.radius=1.0
-    
-    sc_Q=SphericalCoordinate()
-    sc_Q.phi=phi_rad
-    sc_Q.theta=theta_rad + np.pi/2.0
-    sc_Q.radius=1.0
-  
-    sc_T=SphericalCoordinate()
-    sc_T.phi = phi_rad + np.pi/2.0
-    sc_T.theta = np.pi/2.0
-    sc_T.radius=1.0
-    
+    # anchor is L that is azimuth 30 degrees and with ema of 10 degrees
+    sc_L = SphericalCoordinate()
+    sc_L.phi = phi_rad
+    sc_L.theta = theta_rad
+    sc_L.radius = 1.0
+
+    sc_Q = SphericalCoordinate()
+    sc_Q.phi = phi_rad
+    sc_Q.theta = theta_rad + np.pi / 2.0
+    sc_Q.radius = 1.0
+
+    sc_T = SphericalCoordinate()
+    sc_T.phi = phi_rad + np.pi / 2.0
+    sc_T.theta = np.pi / 2.0
+    sc_T.radius = 1.0
+
     # now load those three vectors into seis
     for i in range(3):
-        x=sc_L.unit_vector
-        seis.data[i,0] = x[i]
+        x = sc_L.unit_vector
+        seis.data[i, 0] = x[i]
     for i in range(3):
-        x=sc_Q.unit_vector
-        seis.data[i,1] = x[i]
+        x = sc_Q.unit_vector
+        seis.data[i, 1] = x[i]
     for i in range(3):
-        x=sc_T.unit_vector
-        seis.data[i,2] = x[i]
-        
+        x = sc_T.unit_vector
+        seis.data[i, 2] = x[i]
+
     def is_identity(s):
         """
-        Inline function used to standardize test that output of 
+        Inline function used to standardize test that output of
         transform_to_LQT make data vector in this test an identity
-        matrix. 
+        matrix.
         """
-        assert all(np.isclose(s.data[:,0],[1.0,0.0,0.0]))
-        assert all(np.isclose(s.data[:,1],[0.0,1.0,0.0]))
-        assert all(np.isclose(s.data[:,2],[0.0,0.0,1.0]))
+        assert all(np.isclose(s.data[:, 0], [1.0, 0.0, 0.0]))
+        assert all(np.isclose(s.data[:, 1], [0.0, 1.0, 0.0]))
+        assert all(np.isclose(s.data[:, 2], [0.0, 0.0, 1.0]))
         return True
-    
-    
-    # need this more than once so make a deep copy 
+
+    # need this more than once so make a deep copy
     seis0 = Seismogram(seis)
-    
-    # test atomic version for input via args 
-    sout = transform_to_LQT(seis,phi=phi,theta=theta,angle_units="degrees")
+
+    # test atomic version for input via args
+    sout = transform_to_LQT(seis, phi=phi, theta=theta, angle_units="degrees")
     ok = is_identity(sout)
     assert ok
     sout.rotate_to_standard()
     for i in range(3):
-        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
-    
+        assert all(np.isclose(sout.data[:, i], seis0.data[:, i]))
+
     # test with radians
-    sout = transform_to_LQT(seis,phi=phi_rad,theta=theta_rad,angle_units="radians")
+    sout = transform_to_LQT(seis, phi=phi_rad, theta=theta_rad, angle_units="radians")
     ok = is_identity(sout)
     assert ok
     sout.rotate_to_standard()
     for i in range(3):
-        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
-    
+        assert all(np.isclose(sout.data[:, i], seis0.data[:, i]))
+
     # test with metadata input
-    seis=Seismogram(seis0)
+    seis = Seismogram(seis0)
     az = 90.0 - phi
-    seis['seaz']=az+180.0
-    seis['ema']=theta
+    seis["seaz"] = az + 180.0
+    seis["ema"] = theta
     sout = transform_to_LQT(seis)
     ok = is_identity(sout)
     assert ok
     sout.rotate_to_standard()
     for i in range(3):
-        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
-        
+        assert all(np.isclose(sout.data[:, i], seis0.data[:, i]))
+
     # repeat with alternate keys
-    seis=Seismogram(seis0)
+    seis = Seismogram(seis0)
     az = 90.0 - phi
-    seis['backaz']=az+180.0
-    seis['theta']=theta
-    sout = transform_to_LQT(seis,seaz_key='backaz',ema_key='theta')
+    seis["backaz"] = az + 180.0
+    seis["theta"] = theta
+    sout = transform_to_LQT(seis, seaz_key="backaz", ema_key="theta")
     ok = is_identity(sout)
     assert ok
     sout.rotate_to_standard()
     for i in range(3):
-        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
-    
-    # test of ensembles will only use Metadata method.   
-    # atomic version tests what is needed for arg method and 
+        assert all(np.isclose(sout.data[:, i], seis0.data[:, i]))
+
+    # test of ensembles will only use Metadata method.
+    # atomic version tests what is needed for arg method and
     # is not recommended for ensembles anyway
-    nmembers=3
+    nmembers = 3
     e = SeismogramEnsemble(3)
     az = 90.0 - phi
-    seaz = az+180.0
+    seaz = az + 180.0
     seis = Seismogram(seis0)
-    seis['seaz'] = seaz
-    seis['ema'] = theta
-    for i in range (3):
+    seis["seaz"] = seaz
+    seis["ema"] = theta
+    for i in range(3):
         e.member.append(Seismogram(seis))
     # ensemble is 3 copies of the same data this test used above
     # has seaz set
@@ -568,11 +575,11 @@ def test_transform_to_LQT():
         assert d.live
         ok = is_identity(d)
         assert ok
-        
+
     # test error handlers
     # illegal units argument error - logs but doesn't kill
-    seis=Seismogram(seis0)
-    sout=transform_to_LQT(seis,phi=phi_rad,theta=theta_rad,angle_units="invalid")
+    seis = Seismogram(seis0)
+    sout = transform_to_LQT(seis, phi=phi_rad, theta=theta_rad, angle_units="invalid")
     assert sout.elog.size() == 1
     assert sout.live
     # should default back to radians so the tests as above should pass
@@ -580,16 +587,15 @@ def test_transform_to_LQT():
     assert ok
     sout.rotate_to_standard()
     for i in range(3):
-        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
-    
+        assert all(np.isclose(sout.data[:, i], seis0.data[:, i]))
+
     # required metadata not defined will cause a kill
-    seis=Seismogram(seis0)
-    sout=transform_to_LQT(seis)
+    seis = Seismogram(seis0)
+    sout = transform_to_LQT(seis)
     assert sout.elog.size() == 1
     assert sout.dead()
-    
-    # invalid data throws an exception
-    x='foobar'
-    with pytest.raises(ValueError,match="received invalid type"):
-        sout = transform_to_RTZ(x)
 
+    # invalid data throws an exception
+    x = "foobar"
+    with pytest.raises(ValueError, match="received invalid type"):
+        sout = transform_to_RTZ(x)

--- a/python/tests/algorithms/test_basic.py
+++ b/python/tests/algorithms/test_basic.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 
 from mspasspy.ccore.seismic import (
+    TimeSeries,
     Seismogram,
     SlownessVector,
     SeismogramEnsemble,
@@ -356,8 +357,9 @@ def test_free_surface_transform():
     assert sout.dead()
     assert sout.elog.size() == 1
     # invalid arg0 should throw an exception
-    x = "foobar"
-    with pytest.raises(ValueError, match="received invalid type"):
+    x = TimeSeries()
+    x.set_live()
+    with pytest.raises(TypeError, match="received invalid type"):
         sout = free_surface_transformation(x)
 
 
@@ -419,12 +421,12 @@ def test_transform_to_RTZ():
     # atomic version tests what is needed for arg method and
     # is not recommended for ensembles anyway
     nmembers = 3
-    e = SeismogramEnsemble(3)
+    e = SeismogramEnsemble(nmembers)
     az = 90.0 - phi
     seaz = az + 180.0
     seis = Seismogram(seis0)
     seis["seaz"] = seaz
-    for i in range(3):
+    for i in range(nmembers):
         e.member.append(Seismogram(seis))
     # ensemble is 3 copies of the same data this test used above
     # has seaz set
@@ -451,8 +453,9 @@ def test_transform_to_RTZ():
     assert sout.dead()
 
     # invalid data throws an exception
-    x = "foobar"
-    with pytest.raises(ValueError, match="received invalid type"):
+    x = TimeSeries()
+    x.set_live()
+    with pytest.raises(TypeError, match="received invalid type"):
         sout = transform_to_RTZ(x)
 
 
@@ -596,6 +599,7 @@ def test_transform_to_LQT():
     assert sout.dead()
 
     # invalid data throws an exception
-    x = "foobar"
-    with pytest.raises(ValueError, match="received invalid type"):
-        sout = transform_to_RTZ(x)
+    x = TimeSeries()
+    x.set_live()
+    with pytest.raises(TypeError, match="received invalid type"):
+        sout = transform_to_LQT(x)

--- a/python/tests/algorithms/test_basic.py
+++ b/python/tests/algorithms/test_basic.py
@@ -1,4 +1,5 @@
 import sys
+import pytest
 import numpy as np
 
 from mspasspy.ccore.seismic import (
@@ -16,6 +17,8 @@ from mspasspy.algorithms.basic import (
     rotate_to_standard,
     free_surface_transformation,
     transform,
+    transform_to_RTZ,
+    transform_to_LQT,
 )
 
 # module to test
@@ -23,6 +26,15 @@ sys.path.append("python/tests")
 
 from helper import get_live_seismogram, get_live_timeseries, get_sin_timeseries
 
+def is_identity(tm):
+    """
+    File-scope function used to standardize test that output of 
+    a 3x3 matrix is an identity.   
+    """
+    assert all(np.isclose(tm[:,0],[1.0,0.0,0.0]))
+    assert all(np.isclose(tm[:,1],[0.0,1.0,0.0]))
+    assert all(np.isclose(tm[:,2],[0.0,0.0,1.0]))
+    return True
 
 def test_ExtractComponent():
     seis = Seismogram(10)
@@ -70,6 +82,11 @@ def test_ExtractComponent():
 
 
 def test_ator_rtoa():
+    """
+    This tests the function forms of the rtoa and ator methods common 
+    to Seismogram and TimeSeries objects.   This test only verifies 
+    TimeSeries objects work correctly.  
+    """
     ts = get_live_timeseries()
     original_t0 = ts.t0
     ts_new = ator(ts, 1)
@@ -82,11 +99,19 @@ def test_ator_rtoa():
 
 
 def test_rotate():
+    """
+    Tests the 3D rotate method of Seismogram.    rotate is overloaded 
+    and has a different algorithm with the same name that only rotates 
+    the coordinates around the z axis.  Not tested independently here 
+    as it is tested indirectly in the higher level function 
+    test_transform_to_RTZ below.
+
+    """
     seis = Seismogram()
     seis.npts = 100
     seis.t0 = 0.0
     seis.dt = 0.001
-    seis.live = 1
+    seis.set_live()
     for i in range(3):
         for j in range(100):
             if i == 0:
@@ -113,11 +138,14 @@ def test_rotate():
 
 
 def test_transform():
+    """
+    Tests the general matrix transformation operator of Seismogram.
+    """
     seis = Seismogram()
     seis.npts = 100
     seis.t0 = 0.0
     seis.dt = 0.001
-    seis.live = 1
+    seis.set_live()
     for i in range(3):
         for j in range(100):
             if i == 0:
@@ -154,24 +182,414 @@ def test_transform():
     assert all(np.isclose(seis2.data[:, 1], [1, 1, 1]))
     assert all(np.isclose(seis2.data[:, 2], [1, 1, 0]))
     assert all(np.isclose(seis2.data[:, 3], [0, 0, 1]))
+    
+def test_free_surface_transform():
+    """
+    Tests the free_surface_transform method and wrapper in basic.py. 
+    The wrapper adds flexibility in the api not in the C++ method. 
+    Those are tested here along with error handlers in the python 
+    wrappers.
+    """
+    
+    # This is the same data matrix used in transform_to_LQT
+    # probably should be made a fixture since I'm reusing it but 
+    # if it still is here it means I didn't do that.
+    seis = Seismogram(3)
+    seis.set_npts(3)
+    seis.t0 = 0.0
+    seis.dt = 0.001
+    seis.set_live()
+    phi = 60.0
+    phi_rad = np.radians(phi)
+    theta = 10.0
+    theta_rad = np.radians(theta)
+    # define a set of vectors that resolve a set of consistent LQT directions. \
+    # anchor is L that is azimuth 30 degrees and with ema of 10 degrees 
+    sc_L=SphericalCoordinate()
+    sc_L.phi=phi_rad
+    sc_L.theta=theta_rad
+    sc_L.radius=1.0
+    
+    sc_Q=SphericalCoordinate()
+    sc_Q.phi=phi_rad
+    sc_Q.theta=theta_rad + np.pi/2.0
+    sc_Q.radius=1.0
+  
+    sc_T=SphericalCoordinate()
+    sc_T.phi = phi_rad + np.pi/2.0
+    sc_T.theta = np.pi/2.0
+    sc_T.radius=1.0
+    
+    # now load those three vectors into seis
+    for i in range(3):
+        x=sc_L.unit_vector
+        seis.data[i,0] = x[i]
+    for i in range(3):
+        x=sc_Q.unit_vector
+        seis.data[i,1] = x[i]
+    for i in range(3):
+        x=sc_T.unit_vector
+        seis.data[i,2] = x[i]
+        
+    # copy so we can reuse original
+    seis0 = Seismogram(seis)
+    # we use this to test output - column 0 is L, column 1 is Q, and 2 is T
+    # hence the tests used in this function
+    def fstout_ok(s):
+        assert np.isclose(s.data[0,0],0.0) # L should have zero T
+        assert np.isclose(s.data[0,1],0.0) # Q should have zero T
+        assert all(np.isclose(s.data[:,2],[-0.5,0.0,0.0]))  # fst has factor of 2 corection on T
+        return True          
 
-    uvec = SlownessVector()
-    uvec.ux = 0.17085  # cos(-20deg)/5.5
-    uvec.uy = -0.062185  # sin(-20deg)/5.5
-    seis3 = free_surface_transformation(seis2, uvec, 5.0, 3.5)
-    assert (
-        np.isclose(
-            seis3.tmatrix,
-            np.array(
-                [
-                    [-0.171012, -0.469846, 0],
-                    [0.115793, -0.0421458, 0.445447],
-                    [-0.597975, 0.217647, 0.228152],
-                ]
-            ),
-        )
-    ).all()
+    umag = 1.0/10.0  # slowness of 10 km/s apparent velocity
+    u_phi = phi_rad  # set so radial of data matrix will be in u direction
+    ux = umag*np.cos(u_phi)
+    uy = umag*np.sin(u_phi)
+    uvec = SlownessVector(ux,uy)
+    sout = free_surface_transformation(seis, uvec, 5.0, 3.5)
+    ok = fstout_ok(sout)
+    assert ok
+    # verify fst properly sets the transformation matrix so 
+    # rotate_to_standard can restore
+    sout.rotate_to_standard()
+    ok = is_identity(sout.tmatrix)
+    assert ok
+    # verify the data are restored properly as well - only doing this test once
+    for i in range(3):
+        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
 
-    # test with invalid uvec, but inplace return
-    seis4 = free_surface_transformation(seis2, SlownessVector(1.0, 1.0, 0.0), 5.0, 3.5)
-    assert seis4
+    # now test loading slowness vector through metadata
+    seis=Seismogram(seis0)
+    seis['ux'] = uvec.ux
+    seis['uy'] = uvec.uy
+    seis['vp0'] = 5.0
+    seis['vs0'] = 3.5
+    sout = free_surface_transformation(seis)
+    ok = fstout_ok(sout)
+    assert ok
+    
+    # test variants with ux,uy in Metadata but vp0 and vs0 in args
+    seis=Seismogram(seis0)
+    seis['ux'] = uvec.ux
+    seis['uy'] = uvec.uy
+    seis['vs0'] = 3.5
+    sout = free_surface_transformation(seis,vp0=5.0)
+    ok = fstout_ok(sout)
+    assert ok
+    
+    seis=Seismogram(seis0)
+    seis['ux'] = uvec.ux
+    seis['uy'] = uvec.uy
+    seis['vp0'] = 5.0
+    sout = free_surface_transformation(seis,vs0=3.5)
+    ok = fstout_ok(sout)
+    assert ok
+    
+    # the uvec but metadata vp0 and vs0
+    seis=Seismogram(seis0)
+    seis['vp0'] = 5.0
+    seis['vs0'] = 3.5
+    sout = free_surface_transformation(seis,uvec)
+    ok = fstout_ok(sout)
+    assert ok
+    
+    # verify alternate key usage - testing all at once sufficient for current implementation
+    seis=Seismogram(seis0)
+    seis['slow_x'] = uvec.ux
+    seis['slow_y'] = uvec.uy
+    seis['P0'] = 5.0
+    seis['S0'] = 3.5
+    sout = free_surface_transformation(seis,
+                                       ux_key='slow_x',
+                                       uy_key='slow_y',
+                                       vp0_key='P0',
+                                       vs0_key='S0',
+                                       )
+    ok = fstout_ok(sout)
+    assert ok
+    
+    # now test ensemble - test just with using Metadata fetch
+    ens = SeismogramEnsemble(3)
+    seis=Seismogram(seis0)
+    seis['ux'] = uvec.ux
+    seis['uy'] = uvec.uy
+    seis['vp0'] = 5.0
+    seis['vs0'] = 3.5
+    for i in range(3):
+        ens.member.append(Seismogram(seis))
+    ens.set_live()
+    ensout = free_surface_transformation(ens)
+    assert ensout.live
+    assert len(ensout.member)==3
+    for i in range(len(ensout.member)):
+        ok = fstout_ok(ensout.member[i])
+        assert ok
+        
+        
+    # finally test error handlers
+    # first test slowness data missing from Metadata when required
+    seis=Seismogram(seis0)
+    seis['vp0'] = 5.0
+    seis['vs0'] = 3.5
+    sout=free_surface_transformation(seis)
+    assert sout.dead()
+    assert sout.elog.size()==1
+    # repeat for vp0 an vs0
+    seis=Seismogram(seis0)
+    seis['ux'] = uvec.ux
+    seis['uy'] = uvec.uy
+    seis['vs0'] = 3.5
+    sout=free_surface_transformation(seis)
+    assert sout.dead()
+    assert sout.elog.size()==1
+    seis=Seismogram(seis0)
+    seis['ux'] = uvec.ux
+    seis['uy'] = uvec.uy
+    seis['vp0'] = 5.0
+    sout=free_surface_transformation(seis)
+    assert sout.dead()
+    assert sout.elog.size()==1
+    # invalid arg0 should throw an exception
+    x='foobar'
+    with pytest.raises(ValueError,match="received invalid type"):
+        sout = free_surface_transformation(x)
+
+def test_transform_to_RTZ():
+    """
+    This function tests the higher level function called transform_to_RTZ.
+    That function supports both atomic an ensemble Seismogram input so 
+    we test both.  Error handlers are tested at the end. 
+    """
+    # create a Seismogram that should resolve to [1,0,0] after RTZ 
+    # transform.  Multiple duplicate samples are probably not essential 
+    # but more like real data where npts of 1 would be never occur.
+    seis = Seismogram(10)
+    seis.npts = 10
+    seis.t0 = 0.0
+    seis.dt = 0.001
+    seis.set_live()
+    phi = 30.0
+    phi_rad = np.radians(phi)
+    seis.data[0,:] = np.cos(phi_rad)
+    seis.data[1,:] = np.sin(phi_rad)
+    seis.data[2,:] = 10.0
+    
+    # need this more than once so make a deep copy 
+    seis0 = Seismogram(seis)
+    
+    # test atomic version for input via args 
+    sout = transform_to_RTZ(seis,phi=phi,angle_units="degrees")
+    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    sout.rotate_to_standard()
+    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
+    
+    # test with radians
+    seis=Seismogram(seis0)
+    sout = transform_to_RTZ(seis,phi=phi_rad,angle_units="radians")
+    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    sout.rotate_to_standard()
+    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
+    
+    # test with metadata input
+    seis=Seismogram(seis0)
+    az = 90.0 - phi
+    seis['seaz']=az+180.0
+    sout = transform_to_RTZ(seis)
+    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    sout.rotate_to_standard()
+    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
+    
+    # repeat with alternate key 
+    seis=Seismogram(seis0)
+    az = 90.0 - phi
+    seis['backaz']=az+180.0
+    sout = transform_to_RTZ(seis,key='backaz')
+    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    sout.rotate_to_standard()
+    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
+    
+    # test of ensembles will only use Metadata method.   
+    # atomic version tests what is needed for arg method and 
+    # is not recommended for ensembles anyway
+    nmembers=3
+    e = SeismogramEnsemble(3)
+    az = 90.0 - phi
+    seaz = az+180.0
+    seis = Seismogram(seis0)
+    seis['seaz'] = seaz
+    for i in range (3):
+        e.member.append(Seismogram(seis))
+    # ensemble is 3 copies of the same data this test used above
+    # has seaz set
+    eout = transform_to_RTZ(e)
+    for d in eout.member:
+        assert d.live
+        assert all(np.isclose(d.data[:,0],[1.0,0.0,10.0]))
+        
+    # test error handlers
+    # illegal units argument error - logs but doesn't kill
+    seis=Seismogram(seis0)
+    sout=transform_to_RTZ(seis,phi=phi_rad,angle_units="invalid")
+    assert sout.elog.size() == 1
+    assert sout.live
+    # should default back to radians so the tests as above should pass
+    assert all(np.isclose(sout.data[:,0],[1.0,0.0,10.0]))
+    sout.rotate_to_standard()
+    assert all(np.isclose(sout.data[:,0],seis0.data[:,0]))
+    
+    # required metadata not defined will cause a kill
+    seis=Seismogram(seis0)
+    sout=transform_to_RTZ(seis)
+    assert sout.elog.size() == 1
+    assert sout.dead()
+    
+    # invalid data throws an exception
+    x='foobar'
+    with pytest.raises(ValueError,match="received invalid type"):
+        sout = transform_to_RTZ(x)
+
+def test_transform_to_LQT():
+    """
+    This function tests the higher level function called transform_to_LQT.
+    That function supports both atomic an ensemble Seismogram input so 
+    we test both.  Error handlers are tested at the end. 
+    """
+    # create a Seismogram that should resolve to an identity in the first 
+    # three columns of the data matrix.  We do that by making
+    # x1-L, x2-Q, and x3-T as defined by LQT using L as the anchor
+    seis = Seismogram(3)
+    seis.set_npts(3)
+    seis.t0 = 0.0
+    seis.dt = 0.001
+    seis.set_live()
+    phi = 60.0
+    phi_rad = np.radians(phi)
+    theta = 10.0
+    theta_rad = np.radians(theta)
+    # define a set of vectors that resolve a set of consistent LQT directions. \
+    # anchor is L that is azimuth 30 degrees and with ema of 10 degrees 
+    sc_L=SphericalCoordinate()
+    sc_L.phi=phi_rad
+    sc_L.theta=theta_rad
+    sc_L.radius=1.0
+    
+    sc_Q=SphericalCoordinate()
+    sc_Q.phi=phi_rad
+    sc_Q.theta=theta_rad + np.pi/2.0
+    sc_Q.radius=1.0
+  
+    sc_T=SphericalCoordinate()
+    sc_T.phi = phi_rad + np.pi/2.0
+    sc_T.theta = np.pi/2.0
+    sc_T.radius=1.0
+    
+    # now load those three vectors into seis
+    for i in range(3):
+        x=sc_L.unit_vector
+        seis.data[i,0] = x[i]
+    for i in range(3):
+        x=sc_Q.unit_vector
+        seis.data[i,1] = x[i]
+    for i in range(3):
+        x=sc_T.unit_vector
+        seis.data[i,2] = x[i]
+        
+    def is_identity(s):
+        """
+        Inline function used to standardize test that output of 
+        transform_to_LQT make data vector in this test an identity
+        matrix. 
+        """
+        assert all(np.isclose(s.data[:,0],[1.0,0.0,0.0]))
+        assert all(np.isclose(s.data[:,1],[0.0,1.0,0.0]))
+        assert all(np.isclose(s.data[:,2],[0.0,0.0,1.0]))
+        return True
+    
+    
+    # need this more than once so make a deep copy 
+    seis0 = Seismogram(seis)
+    
+    # test atomic version for input via args 
+    sout = transform_to_LQT(seis,phi=phi,theta=theta,angle_units="degrees")
+    ok = is_identity(sout)
+    assert ok
+    sout.rotate_to_standard()
+    for i in range(3):
+        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
+    
+    # test with radians
+    sout = transform_to_LQT(seis,phi=phi_rad,theta=theta_rad,angle_units="radians")
+    ok = is_identity(sout)
+    assert ok
+    sout.rotate_to_standard()
+    for i in range(3):
+        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
+    
+    # test with metadata input
+    seis=Seismogram(seis0)
+    az = 90.0 - phi
+    seis['seaz']=az+180.0
+    seis['ema']=theta
+    sout = transform_to_LQT(seis)
+    ok = is_identity(sout)
+    assert ok
+    sout.rotate_to_standard()
+    for i in range(3):
+        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
+        
+    # repeat with alternate keys
+    seis=Seismogram(seis0)
+    az = 90.0 - phi
+    seis['backaz']=az+180.0
+    seis['theta']=theta
+    sout = transform_to_LQT(seis,seaz_key='backaz',ema_key='theta')
+    ok = is_identity(sout)
+    assert ok
+    sout.rotate_to_standard()
+    for i in range(3):
+        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
+    
+    # test of ensembles will only use Metadata method.   
+    # atomic version tests what is needed for arg method and 
+    # is not recommended for ensembles anyway
+    nmembers=3
+    e = SeismogramEnsemble(3)
+    az = 90.0 - phi
+    seaz = az+180.0
+    seis = Seismogram(seis0)
+    seis['seaz'] = seaz
+    seis['ema'] = theta
+    for i in range (3):
+        e.member.append(Seismogram(seis))
+    # ensemble is 3 copies of the same data this test used above
+    # has seaz set
+    eout = transform_to_LQT(e)
+    for d in eout.member:
+        assert d.live
+        ok = is_identity(d)
+        assert ok
+        
+    # test error handlers
+    # illegal units argument error - logs but doesn't kill
+    seis=Seismogram(seis0)
+    sout=transform_to_LQT(seis,phi=phi_rad,theta=theta_rad,angle_units="invalid")
+    assert sout.elog.size() == 1
+    assert sout.live
+    # should default back to radians so the tests as above should pass
+    ok = is_identity(sout)
+    assert ok
+    sout.rotate_to_standard()
+    for i in range(3):
+        assert all(np.isclose(sout.data[:,i],seis0.data[:,i]))
+    
+    # required metadata not defined will cause a kill
+    seis=Seismogram(seis0)
+    sout=transform_to_LQT(seis)
+    assert sout.elog.size() == 1
+    assert sout.dead()
+    
+    # invalid data throws an exception
+    x='foobar'
+    with pytest.raises(ValueError,match="received invalid type"):
+        sout = transform_to_RTZ(x)
+

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -775,7 +775,7 @@ def test_Seismogram():
     assert all(np.isclose(seis_copy.data[:, 3], [0, 0, 1]))
     seis.rotate_to_standard()
 
-    seis.rotate(np.pi / 4)
+    seis.rotate(-np.pi / 4)
     seis.transform(a)
     assert (
         np.isclose(


### PR DESCRIPTION
Fixes and extensions to address Issue #511.   Five major changes/additions:
1.  Adds new transform_to_RTZ function
2. Adds new transform_to_LQT function
3. Changes the api for free_surface_transformation to add more flexible input.  Default now assumes fetching required data from Metadata to make the function easier to use in a map operator. 
4. Complete pytest functions for the above. 
5. Cleaned up a confusion on the sign of the angle of rotation for the overloaded C++ function.  That is now largely hidden behind the higher level functions anyway but the most important fix is making the sign convention unambiguous in the doxygen comments.

Note I'm pushing this to verify all the changes match my local test runs.    I want to do a final sanity check against data before suggesting this really be merged.