### PR TITLE
Add osc-arm64 build of conda using the new osx-14 runner

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '21 21 * * 5'
   push:
-    branches: [ master ]
+    branches: [ master, build-conda-fix-2 ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   release:
@@ -67,4 +67,32 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             ANACONDA_API_TOKEN=${{ secrets.CONDA_TOKEN }}
+
+  conda-build-osx-arm64:
+    runs-on: osx-14
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: s-weigand/setup-conda@v1
+      - run: |
+          export PYTHON_VERSION=${{ matrix.python-version }}
+          conda install -y conda-build anaconda-client
+          conda config --set anaconda_upload no
+          conda config --add channels conda-forge
+          export ANACONDA_API_TOKEN=${{ secrets.CONDA_TOKEN }}
+          PACKAGE_PATH=$(conda build . --python ${{ matrix.python-version }} --output)
+          conda build . --python ${{ matrix.python-version }}
+          if [ "${{ matrix.python-version }}" == "3.11" ]; then
+            anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label main --label py3.11 --force
+          else
+            anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label py${{ matrix.python-version }} --force
+          fi
 

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '21 21 * * 5'
   push:
-    branches: [ master, build-conda-fix-2 ]
+    branches: [ master ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   release:
@@ -68,7 +68,7 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
             ANACONDA_API_TOKEN=${{ secrets.CONDA_TOKEN }}
 
-  conda-build-osx-arm64:
+  conda-build-osx:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -69,7 +69,7 @@ jobs:
             ANACONDA_API_TOKEN=${{ secrets.CONDA_TOKEN }}
 
   conda-build-osx-arm64:
-    runs-on: osx-14
+    runs-on: macos-14
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -69,10 +69,11 @@ jobs:
             ANACONDA_API_TOKEN=${{ secrets.CONDA_TOKEN }}
 
   conda-build-osx-arm64:
-    runs-on: macos-14
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
+        os: ["macos-14", "macos-13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -80,6 +80,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
+          channels: conda-forge,defaults
+          activate-environment: anaconda-client-env
           python-version: ${{ matrix.python-version }}
       - run: |
           export PYTHON_VERSION=${{ matrix.python-version }}

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -79,15 +79,15 @@ jobs:
           fetch-depth: 0
       - uses: conda-incubator/setup-miniconda@v3
         with:
+          python-version: ${{ matrix.python-version }}
           auto-update-conda: true
           channels: conda-forge,defaults
           activate-environment: anaconda-client-env
-          python-version: ${{ matrix.python-version }}
-      - run: |
+      - shell: bash -el {0}
+        run: |
           export PYTHON_VERSION=${{ matrix.python-version }}
           conda install -y conda-build anaconda-client
           conda config --set anaconda_upload no
-          conda config --add channels conda-forge
           export ANACONDA_API_TOKEN=${{ secrets.CONDA_TOKEN }}
           PACKAGE_PATH=$(conda build . --python ${{ matrix.python-version }} --output)
           conda build . --python ${{ matrix.python-version }}

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -77,11 +77,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      - uses: s-weigand/setup-conda@v1
       - run: |
           export PYTHON_VERSION=${{ matrix.python-version }}
           conda install -y conda-build anaconda-client


### PR DESCRIPTION
It seems GitHub now has arm runners when using macos-14. Testing it out here.