### PR TITLE
Handles import with exception

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -15,6 +15,7 @@ import fcntl
 
 try:
     import dask.dataframe as daskdf
+
     _mspasspy_has_dask = True
 except ImportError:
     _mspasspy_has_dask = False

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -14,23 +14,11 @@ import pandas as pd
 import fcntl
 
 try:
-    import dask.bag as daskbag
-
+    import dask.dataframe as daskdf
     _mspasspy_has_dask = True
 except ImportError:
     _mspasspy_has_dask = False
 
-try:
-    import dask.dataframe as daskdf
-except ImportError:
-    _mspasspy_has_dask = False
-
-try:
-    import pyspark
-
-    _mspasspy_has_pyspark = True
-except ImportError:
-    _mspasspy_has_pyspark = False
 
 import gridfs
 import pymongo
@@ -5864,7 +5852,7 @@ class Database(pymongo.database.Database):
         """
         dbcol = self[collection]
 
-        if parallel:
+        if parallel and _mspasspy_has_dask:
             df = daskdf.from_pandas(df, chunksize=1, sort=False)
 
         if not one_to_one:
@@ -5880,7 +5868,7 @@ class Database(pymongo.database.Database):
                     df[key] = df[key].mask(df[key] == val, None)
 
         """
-        if parallel:
+        if parallel and _mspasspy_has_dask:
             df = daskdf.from_pandas(df, chunksize=1, sort=False)
             df = df.apply(lambda x: x.dropna(), axis=1).compute()
         else:

--- a/python/mspasspy/io/distributed.py
+++ b/python/mspasspy/io/distributed.py
@@ -668,7 +668,7 @@ def read_distributed_data(
                 plist = spark_context.parallelize(
                     data.to_dict("records"), numSlices=npartitions
                 )
-            elif _mspasspy_has_dask:
+            else:
                 # Seems we ahve to convert a pandas df to a dask
                 # df to have access to the "to_bag" method of dask
                 # DataFrame.   It may be better to write a small

--- a/python/mspasspy/io/distributed.py
+++ b/python/mspasspy/io/distributed.py
@@ -24,18 +24,20 @@ from mspasspy.ccore.utility import (
 
 try:
     import dask
+
     _mspasspy_has_dask = True
 except ImportError:
     _mspasspy_has_dask = False
 try:
     import pyspark
+
     _mspasspy_has_pyspark = True
 except ImportError:
     _mspasspy_has_pyspark = False
 
 if not _mspasspy_has_dask and not _mspasspy_has_pyspark:
-    message = (
-        "{} requires either dask or pyspark module. Please install dask or pyspark".format(__name__)
+    message = "{} requires either dask or pyspark module. Please install dask or pyspark".format(
+        __name__
     )
     raise ModuleNotFoundError(message)
 
@@ -475,7 +477,9 @@ def read_distributed_data(
         message += "Must be either 'dask' or 'spark'"
         raise ValueError(message)
     if scheduler == "spark" and not _mspasspy_has_pyspark:
-        print("WARNING(read_distributed_data): pyspark not found, will use dask instead. The scheduler argument is ignored.")
+        print(
+            "WARNING(read_distributed_data): pyspark not found, will use dask instead. The scheduler argument is ignored."
+        )
         scheduler = "dask"
 
     if isinstance(data, list):
@@ -508,7 +512,11 @@ def read_distributed_data(
         ensemble_mode = False
         dataframe_input = False
         db = data
-    elif isinstance(data, pd.DataFrame) or (_mspasspy_has_dask and isinstance(data, dask.dataframe.core.DataFrame)) or (_mspasspy_has_pyspark and isinstance(data, pyspark.sql.dataframe.DataFrame)):
+    elif (
+        isinstance(data, pd.DataFrame)
+        or (_mspasspy_has_dask and isinstance(data, dask.dataframe.core.DataFrame))
+        or (_mspasspy_has_pyspark and isinstance(data, pyspark.sql.dataframe.DataFrame))
+    ):
         ensemble_mode = False
         dataframe_input = True
         if isinstance(db, Database):
@@ -1526,7 +1534,9 @@ def write_distributed_data(
             message += "Must be either dask or spark"
             raise ValueError(message)
         if scheduler == "spark" and not _mspasspy_has_pyspark:
-            print("WARNING(write_distributed_data): pyspark not found, will use dask instead. The scheduler argument is ignored.")
+            print(
+                "WARNING(write_distributed_data): pyspark not found, will use dask instead. The scheduler argument is ignored."
+            )
             scheduler = "dask"
     else:
         scheduler = "dask"


### PR DESCRIPTION
The distributed module will error out when either dask or pyspark is not installed. This strict dependency of two packages is not necessary. We need to handle the import with try clause instead.