### PR TITLE
fix typo in exception line

### DIFF
--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -234,9 +234,7 @@ class Client:
                         "Fatal",
                     )
         else:
-            print(
-                "There is no spark or dask installed, this client has no scheduler"
-            )
+            print("There is no spark or dask installed, this client has no scheduler")
 
     def get_database_client(self):
         """

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -4218,7 +4218,7 @@ class Database(pymongo.database.Database):
                     message += "C++ function _fread_from_file failed while reading Seismogram sample data from file={}".format(
                         dfile
                     )
-                    raise MsPASSError(message,ErrorSeverity.Fatal) from merr
+                    raise MsPASSError(message, ErrorSeverity.Fatal) from merr
 
         else:
             fname = os.path.join(dir, dfile)

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -4218,7 +4218,7 @@ class Database(pymongo.database.Database):
                     message += "C++ function _fread_from_file failed while reading Seismogram sample data from file={}".format(
                         dfile
                     )
-                    raise MsPASSError(message.ErrorSeverity.Fatal) from merr
+                    raise MsPASSError(message,ErrorSeverity.Fatal) from merr
 
         else:
             fname = os.path.join(dir, dfile)


### PR DESCRIPTION
hit this error in a run and realized it was just a typo - period should have been a comma.

BTW this suggests we need to run the equivalent of lint on our entire python code base.   I know there are such tools but I don't know what would be best to catch this type of usage error.   It wasn't caught because it wasn't a syntax error.   It might be impossible for current generation tools of that type to catch this particular type of typo.