### PR TITLE
feat: make seisbench dependency optional 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,7 +49,7 @@ jobs:
         echo "/opt/spark-3.0.0-bin-hadoop2.7/bin" >> $GITHUB_PATH
         python -m pip install --upgrade --upgrade-strategy eager pyspark pytest-spark
     - name: Install
-      run: python -m pip install -C--global-option=build -C--global-option=--debug -v .
+      run: python -m pip install -C--global-option=build -C--global-option=--debug -v '.[seisbench]'
     - name: Test with pytest
       run: |
         export MSPASS_HOME=$(pwd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ authors = [
     {name = "Ian Wang", email = "yinzhi.wang.cug@gmail.com"},
     {name = "Gary Pavlis", email = "pavlis@indiana.edu"},
 ]
-dynamic = ["dependencies", "scripts", "version"]
+dynamic = ["dependencies", "scripts", "version", "optional-dependencies"]
+requires-python = ">=3.8"
 
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm>=8", "wheel", "numpy"]
@@ -17,17 +18,6 @@ dependencies = {file = ["requirements.txt"]}
 [tool.setuptools-extensions]
 cmake-extension = "setup:CMakeExtension"
 cmake-build = "setup:CMakeBuild"
-
-[tool.poetry.dependencies]
-python = "^3.8"
-
-[tool.poetry.extras]
-complete = ["numpy", "pandas", "scipy", "matplotlib"]
-
-[tool.poetry.scripts]
-mspass-dbclean = "mspasspy.db.script.dbclean:main"
-mspass-dbverify = "mspasspy.db.script.dbverify:main"
-mspass-normalize_mseed = "mspasspy.db.script.normalize_mseed:main"
 
 [tool.setuptools_scm]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,3 @@ pandas==1.5.3
 numba
 multitaper
 ipympl
-seisbench==0.4.1; python_version < '3.9'
-seisbench>0.4.1; python_version >= '3.9'

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,12 @@ ENTRY_POINTS = {
     ],
 }
 
+complete_deps = ["numpy", "pandas", "scipy", "matplotlib"]
+seisbench_deps = [
+    "seisbench==0.4.1; python_version < '3.9'",
+    "seisbench>0.4.1; python_version >= '3.9'",
+]
+
 setup(
     name="mspasspy",
     ext_modules=[CMakeExtension("mspasspy.ccore")],
@@ -98,5 +104,10 @@ setup(
     ),
     package_data={"": ["*.yaml", "*.pf"]},
     include_package_data=True,
-    install_requires=["pyyaml"],
+    install_requires=[],
+    python_requires=">=3.8",
+    extras_require={
+        "complete": complete_deps,
+        "seisbench": complete_deps + seisbench_deps,
+    }
 )


### PR DESCRIPTION
## What
To make the `seisbench` dependency optional so that the size of the standard installment can be reduced.

## Next steps:
Also need to update the container definition as part of this pr, so that dev container can have seisbench installed

## Testing
Ran the following commands and verified seisbench is not installed in the first one
```
python3 -m pip install .
python3 -m pip install '.[seisbench]'
```