### PR TITLE
Revert "feat: make seisbench dependency optional  (#578)"

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,7 +49,7 @@ jobs:
         echo "/opt/spark-3.0.0-bin-hadoop2.7/bin" >> $GITHUB_PATH
         python -m pip install --upgrade --upgrade-strategy eager pyspark pytest-spark
     - name: Install
-      run: python -m pip install -C--global-option=build -C--global-option=--debug -v '.[seisbench]'
+      run: python -m pip install -C--global-option=build -C--global-option=--debug -v .
     - name: Test with pytest
       run: |
         export MSPASS_HOME=$(pwd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ authors = [
     {name = "Ian Wang", email = "yinzhi.wang.cug@gmail.com"},
     {name = "Gary Pavlis", email = "pavlis@indiana.edu"},
 ]
-dynamic = ["dependencies", "scripts", "version", "optional-dependencies"]
-requires-python = ">=3.8"
+dynamic = ["dependencies", "scripts", "version"]
 
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm>=8", "wheel", "numpy"]
@@ -18,6 +17,17 @@ dependencies = {file = ["requirements.txt"]}
 [tool.setuptools-extensions]
 cmake-extension = "setup:CMakeExtension"
 cmake-build = "setup:CMakeBuild"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[tool.poetry.extras]
+complete = ["numpy", "pandas", "scipy", "matplotlib"]
+
+[tool.poetry.scripts]
+mspass-dbclean = "mspasspy.db.script.dbclean:main"
+mspass-dbverify = "mspasspy.db.script.dbverify:main"
+mspass-normalize_mseed = "mspasspy.db.script.normalize_mseed:main"
 
 [tool.setuptools_scm]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ pandas==1.5.3
 numba
 multitaper
 ipympl
+seisbench==0.4.1; python_version < '3.9'
+seisbench>0.4.1; python_version >= '3.9'

--- a/setup.py
+++ b/setup.py
@@ -86,12 +86,6 @@ ENTRY_POINTS = {
     ],
 }
 
-complete_deps = ["numpy", "pandas", "scipy", "matplotlib"]
-seisbench_deps = [
-    "seisbench==0.4.1; python_version < '3.9'",
-    "seisbench>0.4.1; python_version >= '3.9'",
-]
-
 setup(
     name="mspasspy",
     ext_modules=[CMakeExtension("mspasspy.ccore")],
@@ -104,10 +98,5 @@ setup(
     ),
     package_data={"": ["*.yaml", "*.pf"]},
     include_package_data=True,
-    install_requires=[],
-    python_requires=">=3.8",
-    extras_require={
-        "complete": complete_deps,
-        "seisbench": complete_deps + seisbench_deps,
-    }
+    install_requires=["pyyaml"],
 )


### PR DESCRIPTION
This reverts commit a4ced3a1f6dbb157993298a30065cdad0a3cc81c.

This commit failed python package build post merging due to 
```
=========================== short test summary info ============================
ERROR python/tests/algorithms/ml/test_arrival.py - requests.exceptions.SSLError: HTTPSConnectionPool(host='hifis-storage.desy.de', port=2880): Max retries exceeded with url: /Helmholtz/HelmholtzAI/SeisBench/models/v3/phasenet (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1131)')))
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
============================== 1 error in 14.03s ===============================
```