### PR TITLE
Fix boost download url problem

### DIFF
--- a/cxx/cmake/boost-download.cmake
+++ b/cxx/cmake/boost-download.cmake
@@ -8,9 +8,10 @@ ExternalProject_Add(
   boost
   SOURCE_DIR "@BOOST_DOWNLOAD_ROOT@/boost-src"
   URL
-    https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.gz
+    https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz
   URL_HASH
     SHA256=2575e74ffc3ef1cd0babac2c1ee8bdb5782a0ee672b1912da40e5b4b591ca01f
+
   CONFIGURE_COMMAND ./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-toolset=gcc
   BUILD_COMMAND ./b2 cxxflags=-fPIC --with-serialization -j 8
   BUILD_IN_SOURCE 1


### PR DESCRIPTION
This should resolve a problem where the url we were using was not the master from boost.org.  It appears the file there was updated and the hash, which was right for boost.org, was wrong for that url.   This changes the url to boost.org and the correct hash for the version downloaded.