### PR TITLE
Bug fixes to snr module and related C++ code

### DIFF
--- a/cxx/include/mspass/algorithms/amplitudes.h
+++ b/cxx/include/mspass/algorithms/amplitudes.h
@@ -332,7 +332,11 @@ public:
   };
   /*! Return bandwidth in dB. */
   double bandwidth() const {
-    if (f_range <= 0.0)
+    /* All these conditionals are necessary for handling unexpected
+     * values.   0 is effectively and error return.  Without these
+     * the function can return NaN or generate floating point exceptions. */
+    if ((f_range <= 0.0) || (high_edge_f<=low_edge_f)
+      || (high_edge_f < 0.0) || (low_edge_f < 0.0) )
       return 0.0;
     else {
       double ratio = high_edge_f / low_edge_f;

--- a/cxx/src/lib/algorithms/deconvolution/MTPowerSpectrumEngine.cc
+++ b/cxx/src/lib/algorithms/deconvolution/MTPowerSpectrumEngine.cc
@@ -245,10 +245,20 @@ vector<double> MTPowerSpectrumEngine::apply(const vector<double> &d) {
   double specssq(0.0), scale;
   for (auto p = result.begin(); p != result.end(); ++p)
     specssq += (*p);
-  scale = ssq / (specssq * this->df());
-  /* Scaling for fft implementation - Established from zero pad tests it has
-  to be this factor */
-  scale /= static_cast<double>(d.size());
+  /* test for zeros to avoid divide by zero or a NaN. 
+   * result will be all zeros this way.  Without we get all NaNs
+   * in the spectrum*/
+  if((ssq<=0.0) || (specssq<=0.0))
+  {
+    scale = 1.0;
+  }
+  else
+  {
+    scale = ssq / (specssq * this->df());
+    /* Scaling for fft implementation - Established from zero pad tests it has
+    to be this factor.   */
+    scale /= static_cast<double>(d.size());
+  }
   for (j = 0; j < this->nf(); ++j)
     result[j] *= scale;
   return result;


### PR DESCRIPTION
This branch implements bug fixes I found in more extensive testing of the snr module function broadband_snr_QC with more marginal signal to noise ratio data.   Testing uncovered a few problems this branch fixes:
1.  broadband_snr_QC was aborting with some kinds of invalid returns from the EstimateBandwidth function.   I added some error handlers in both functions that seem to resolve that problem.
2. There was problem in the MTPowerSpectrum engine C++ code in handling the situation where it was given an array of all 0s.  It has a small section of code that normalizes the spectrum level to match the input using Parseval' theorem (a standard time series analysis formula).  Problem was it returned a NaN with the algorithm used because the L2 norm of both the data and spectrum were zero and the normalzation uses a ratio of the two.   Resolved by trapping the all 0 condition and not trying to do scaling in that situation.
3. There was an older bug in the C++ code I had worked around in the srn module earlier.  The BandwidthData class has a bandwidth method that would return an NaN in certain error conditions that needed to be trapped (e.g. invalid input with the low frequency corner greater than the high frequency corner).   This revision should resolve that bug. 

I haven't run testing on this because the changes to the C++ code could conceivably have broader impacts, but I don't really think so.  I'm going to see if the github push works here.  If it does we should merge this commit after I also do some tidying of snr.py with black.