### PR TITLE
Add calib class

### DIFF
--- a/python/mspasspy/algorithms/calib.py
+++ b/python/mspasspy/algorithms/calib.py
@@ -1,101 +1,105 @@
 import pickle
 import numpy as np
-from mspasspy.ccore.seismic import TimeSeries,TimeSeriesEnsemble
-from mspasspy.ccore.utility import MsPASSError,ErrorSeverity
+from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
+from mspasspy.ccore.utility import MsPASSError, ErrorSeverity
 from obspy import UTCDateTime
+
+
 class ApplyCalibEngine:
     """
-    A special case of response correction is a simple scalar multiply by a 
-    constant used to convert data from raw counts to the (now) standard units 
-    of nm/s.  For many applications using broadband data that correction 
-    is sufficient to assure ensembles of signals are on a common amplitude 
-    scale.  A basic rule if the passband of the processing is inside the 
-    instrument passband a full response correction is not alway necessary. 
-    A case in point is reeiver function processing where the passband of 
+    A special case of response correction is a simple scalar multiply by a
+    constant used to convert data from raw counts to the (now) standard units
+    of nm/s.  For many applications using broadband data that correction
+    is sufficient to assure ensembles of signals are on a common amplitude
+    scale.  A basic rule if the passband of the processing is inside the
+    instrument passband a full response correction is not alway necessary.
+    A case in point is reeiver function processing where the passband of
     actual data is inside the passband of most "broadband sensors".
-    
+
     This class can be used to process TimeSeries or TimeSeriesEnsemble
     objects to convert data from raw counts to units of nm/s.
-    
-    The effort required to extract the conversion factor from the 
-    archain response format of seed and station xml is not trivial.   
-    We rely here on the conversion of downloaded station metadata from 
-    fdsn sources via web services and obspy's downloading methods.   
-    Obspy converts that archain data to what they call an Inventory 
-    object.  In MsPASS we disaggregate the complicated Inventory object 
-    into a set of MongoDB documents with one entry for each 
-    seed time period fr each channel of data.   Inside that document is a 
-    an attibute with the tag "serialized_channel_data" that contains 
-    the detailed response data serialized with pickle.   The 
-    constructor for this object runs pickle.loads on that data to yield 
+
+    The effort required to extract the conversion factor from the
+    archain response format of seed and station xml is not trivial.
+    We rely here on the conversion of downloaded station metadata from
+    fdsn sources via web services and obspy's downloading methods.
+    Obspy converts that archain data to what they call an Inventory
+    object.  In MsPASS we disaggregate the complicated Inventory object
+    into a set of MongoDB documents with one entry for each
+    seed time period fr each channel of data.   Inside that document is a
+    an attibute with the tag "serialized_channel_data" that contains
+    the detailed response data serialized with pickle.   The
+    constructor for this object runs pickle.loads on that data to yield
     an obspy Response object.  We only extract the "sensitivity" value from
-    Response.   A major complication is unit restrictions and invalid 
-    Response objects.  These are handled by the constructor as described 
-    below.   The current implementation can only handle Response objects 
-    with "input units" of meters per second and "output units" of counts. 
-    Note input and output is because the Response object uses 
-    sensitivity = 1/calib.  i.e. sensitivity is the scale to convert 
-    physical units to counts which backward from what this class is 
+    Response.   A major complication is unit restrictions and invalid
+    Response objects.  These are handled by the constructor as described
+    below.   The current implementation can only handle Response objects
+    with "input units" of meters per second and "output units" of counts.
+    Note input and output is because the Response object uses
+    sensitivity = 1/calib.  i.e. sensitivity is the scale to convert
+    physical units to counts which backward from what this class is
     designed for - converting counts to physical units of nm/s.
     """
-    
-    def __init__(self,
-                 db,
-                 query=None,
-                 collection="channel",
-                 ounits=["counts","COUNTS","count","COUNT"],
-                 iunits=["m/s","M/S"],   
-                 response_data_key="serialized_channel_data",
-                 verbose=False):
+
+    def __init__(
+        self,
+        db,
+        query=None,
+        collection="channel",
+        ounits=["counts", "COUNTS", "count", "COUNT"],
+        iunits=["m/s", "M/S"],
+        response_data_key="serialized_channel_data",
+        verbose=False,
+    ):
         """
-        Constructor for this object loads the serialized response data 
-        and builds an internal cache to cross-reference channel_id with 
-        calib values.  
-        
-        :param db:  MongoDB Database handle assumed to contained a 
-           channell collection created from an Inventory object with 
+        Constructor for this object loads the serialized response data
+        and builds an internal cache to cross-reference channel_id with
+        calib values.
+
+        :param db:  MongoDB Database handle assumed to contained a
+           channell collection created from an Inventory object with
            the MsPASS database method `save_inventory`.
-        :param query:  optional MongoDB query operator to apply to 
-           collection before using.  Size, for exampe, might be reduced 
+        :param query:  optional MongoDB query operator to apply to
+           collection before using.  Size, for exampe, might be reduced
            by using a time range query.
-        :type query:  python dictionary.  Default is None which is taken 
+        :type query:  python dictionary.  Default is None which is taken
            to mean use the entire colleciton without a query.
-        :param collection:  optional alternative collection name.  
+        :param collection:  optional alternative collection name.
            Rarely if ever should be changed as the code here has dependence
-           on MsPASS specific keys and the way we disaggregate obspy's 
+           on MsPASS specific keys and the way we disaggregate obspy's
            Inventory object.
-        :type collection:  str (default "channel") 
-        :param ounits:  list of acceptable "output unit" definitions, 
+        :type collection:  str (default "channel")
+        :param ounits:  list of acceptable "output unit" definitions,
            The default is various perturbation of"counts" .
         :type ounits:  list of string defining acceptable units.
-        :param iunits:   list of acceptable names for "input units" in 
-          the Response data structure.   Default is known to work with 
-          most FDSN data for velocity instruments.   You would  likely 
+        :param iunits:   list of acceptable names for "input units" in
+          the Response data structure.   Default is known to work with
+          most FDSN data for velocity instruments.   You would  likely
           change this list only if you wanted to wanted to use
           accelerometer data or some other nonstandard unit data.
-          Note "input units" in FDSN jargon is kind of confusing in this 
-          context as the purpose of this object is to convert raw data to 
-          physical units so this object's output is actually the units 
+          Note "input units" in FDSN jargon is kind of confusing in this
+          context as the purpose of this object is to convert raw data to
+          physical units so this object's output is actually the units
           of iunits.
-        :type inunits:  list of string names that must match xml posted 
+        :type inunits:  list of string names that must match xml posted
           units.  The default should almost always be sufficient.
-        :param response_data_key: key used to access the serialized 
+        :param response_data_key: key used to access the serialized
           response data from each MongoDB document parsed by this construtor.
-        :type response_data_key:  str (default is key sed in mspass and should 
+        :type response_data_key:  str (default is key sed in mspass and should
           not normally be chaged. )
-        :param verbose:  When set True (default is False) will print 
-          error messages when it finds response data it cannot handle.  
-          Turned off by default because a database with a few thousand 
-          channels can generate a lot of error if you mix up acceleration 
-          data with normal velocity sensor data.  This class will not 
-          handle acceleration channels as converting acceleration data to 
-          velocity data is true response correction not a simple calib 
-          correction.   
+        :param verbose:  When set True (default is False) will print
+          error messages when it finds response data it cannot handle.
+          Turned off by default because a database with a few thousand
+          channels can generate a lot of error if you mix up acceleration
+          data with normal velocity sensor data.  This class will not
+          handle acceleration channels as converting acceleration data to
+          velocity data is true response correction not a simple calib
+          correction.
         """
         if query:
-            cursor=db[collection].find(query)
+            cursor = db[collection].find(query)
         else:
-            cursor=db[collection].find({})
+            cursor = db[collection].find({})
         self.calib = dict()
         for doc in cursor:
             if response_data_key in doc:
@@ -103,12 +107,12 @@ class ApplyCalibEngine:
                 resp = chandata.response
                 sens = resp.instrument_sensitivity
                 if sens is None and verbose:
-                    stastr=self._parse_stadata(doc)
-                    print(stastr," invalid instrument response") 
-                    print("pickle.loads returned this:  ",str(resp))
+                    stastr = self._parse_stadata(doc)
+                    print(stastr, " invalid instrument response")
+                    print("pickle.loads returned this:  ", str(resp))
                 elif sens:
                     if verbose:
-                        message = self._parse_stadata(doc)+":  "
+                        message = self._parse_stadata(doc) + ":  "
                     if sens.input_units and sens.output_units:
                         if sens.input_units in iunits:
                             if sens.output_units in ounits:
@@ -117,61 +121,69 @@ class ApplyCalibEngine:
                                         message += "units ok but sensitivity value is undefined"
                                         print(message)
                                 else:
-                                    id = doc['_id']
-                                    # inventory saves a "sensitivity" value 
+                                    id = doc["_id"]
+                                    # inventory saves a "sensitivity" value
                                     # which is he reciprocal of calib
-                                    self.calib[str(id)] = 1e9/sens.value
+                                    self.calib[str(id)] = 1e9 / sens.value
                             elif verbose:
                                 message += "Illegal output_unit value="
-                                message += sens.output_units +"\n"
+                                message += sens.output_units + "\n"
                                 print(message)
                         elif verbose:
                             message += "Illegal input_units value="
                             message += sens.input_units + "\n"
                             print(message)
                     elif verbose:
-                        message += "sensitivity data is undefined in this response object"
+                        message += (
+                            "sensitivity data is undefined in this response object"
+                        )
                         print(message)
             elif verbose:
-                stastr=self._parse_stadata(doc)
-                print(stastr," does not contain pickled response data - keey=",
-                      response_data_key)
+                stastr = self._parse_stadata(doc)
+                print(
+                    stastr,
+                    " does not contain pickled response data - keey=",
+                    response_data_key,
+                )
         if len(self.calib) == 0:
-            message = "ApplyCalibEngine construtor:  Database has no valid response data"
-            raise MsPASSError(message,ErrorSeverity.Invalid)
-    def apply_calib(self,d,id_key="channel_id",kill_if_undefined=True):
+            message = (
+                "ApplyCalibEngine construtor:  Database has no valid response data"
+            )
+            raise MsPASSError(message, ErrorSeverity.Invalid)
+
+    def apply_calib(self, d, id_key="channel_id", kill_if_undefined=True):
         """
-        Use this method to apply a calib value to a TimeSeries or all the 
-        live members of a TimeSeriesEnsemble. 
-        
-        This is the processing function used for applying calibration. 
-        It is a method instead of a function because the class allows the 
-        calib values to be cached inside the object.   The input(s) must 
-        contain a MongoDB ObjectId that can be matched with the ids 
-        loaded in the cache by the constructor.   By default the key 
+        Use this method to apply a calib value to a TimeSeries or all the
+        live members of a TimeSeriesEnsemble.
+
+        This is the processing function used for applying calibration.
+        It is a method instead of a function because the class allows the
+        calib values to be cached inside the object.   The input(s) must
+        contain a MongoDB ObjectId that can be matched with the ids
+        loaded in the cache by the constructor.   By default the key
         used is "channel_id".  That can be changed with the "id_key"
-        argument.  If a match is found all 
-        the sample valued are multiplied by calib AND the calib attribute is 
-        set.   Note a complaint will be issued if calib was found to already 
+        argument.  If a match is found all
+        the sample valued are multiplied by calib AND the calib attribute is
+        set.   Note a complaint will be issued if calib was found to already
         be defined in  AND is not 1.0 (a default sometimes appropriate)
-        
-        This method can easily become a mass murderer.   By default any 
-        datum with an undefined calib value in the cache of this object will 
-        be marked dead on return with a error message posted to its elog 
-        container.  If the `kill_if_undefined` argument is set False 
-        such data will not be killed but an elog message will be posted 
-        marked complaint.  
-        
+
+        This method can easily become a mass murderer.   By default any
+        datum with an undefined calib value in the cache of this object will
+        be marked dead on return with a error message posted to its elog
+        container.  If the `kill_if_undefined` argument is set False
+        such data will not be killed but an elog message will be posted
+        marked complaint.
+
         :param d:  input data to process
-        :type d:  `TimeSeries` or `TimeSeriesEnsemle`  This method will 
+        :type d:  `TimeSeries` or `TimeSeriesEnsemle`  This method will
            raise a ValueError exception if d is anything else.
-        :param kill_if_undefined:  bolean that when True (default) will 
-           cause any datum for which a matching calib cannot be found to be 
-           killed.   Note this operation is atomic so for ensembles only 
-           members that fail the match will be killed.  
+        :param kill_if_undefined:  bolean that when True (default) will
+           cause any datum for which a matching calib cannot be found to be
+           killed.   Note this operation is atomic so for ensembles only
+           members that fail the match will be killed.
         :return:  copy of input with amplitudes multiplied by calib factor.
         """
-        if isinstance(d,TimeSeries):
+        if isinstance(d, TimeSeries):
             alg = "ApplyCalibEngine.apply_calib"
             if d.live:
                 if id_key in d:
@@ -179,70 +191,76 @@ class ApplyCalibEngine:
                     if idstr in self.calib:
                         this_calib = self.calib[idstr]
                         if "calib" in d:
-                            if not np.isclose(d["calib"],1.0):
-                                old_calib = d['calib']
-                                new_metadata_calib=old_calib*this_calib
-                                message = "calib was already defined in this datum as {}\n".format(d['calib'])
-                                message += "Data will be multiplied by calib defined in this object={}\n".format(this_calib)
-                                message += "New calib in header = {}\n".format(new_metadata_calib)
+                            if not np.isclose(d["calib"], 1.0):
+                                old_calib = d["calib"]
+                                new_metadata_calib = old_calib * this_calib
+                                message = "calib was already defined in this datum as {}\n".format(
+                                    d["calib"]
+                                )
+                                message += "Data will be multiplied by calib defined in this object={}\n".format(
+                                    this_calib
+                                )
+                                message += "New calib in header = {}\n".format(
+                                    new_metadata_calib
+                                )
                                 message += "Amplitudes may be wrong with this datum"
-                                d.elog.log_error(alg,message,ErrorSeverity.Complaint)
-                                d['calib'] = new_metadata_calib
+                                d.elog.log_error(alg, message, ErrorSeverity.Complaint)
+                                d["calib"] = new_metadata_calib
                             else:
-                                d['calib'] = this_calib
-                        d.data *= this_calib  
+                                d["calib"] = this_calib
+                        d.data *= this_calib
                     else:
                         message = "calib factor could not be determined\n"
                         message += "Response data missing or flawed"
                         if kill_if_undefined:
-                            d.elog.log_error(alg,message,ErrorSeverity.Invalid)
+                            d.elog.log_error(alg, message, ErrorSeverity.Invalid)
                             d.kill()
                         else:
-                            d.elog.log_error(alg,message,ErrorSeverity.Complaint)
+                            d.elog.log_error(alg, message, ErrorSeverity.Complaint)
                 else:
                     message = "Missing required channel_id need to get calib factor"
                     if kill_if_undefined:
-                        d.elog.log_error(alg,message,ErrorSeverity.Invalid)
+                        d.elog.log_error(alg, message, ErrorSeverity.Invalid)
                         d.kill()
                     else:
-                        d.elog.log_error(alg,message,ErrorSeverity.Complaint)
-        elif isinstance(d,TimeSeriesEnsemble):
+                        d.elog.log_error(alg, message, ErrorSeverity.Complaint)
+        elif isinstance(d, TimeSeriesEnsemble):
             for i in range(len(d.member)):
                 d.member[i] = self.apply_calib(d.member[i])
         else:
             message = "Illegal input data type={}".format(str(type(d)))
             raise ValueError(message)
         return d
+
     def size(self):
         """
         Return size of the cache of calib values stored in the object.
         """
-        return len(self.calib) 
-    def _parse_stadata(self,doc,null_value="Undefined")->str:
+        return len(self.calib)
+
+    def _parse_stadata(self, doc, null_value="Undefined") -> str:
         """
-        Internal method to cautiously parse document doc to 
-        always a string of the form net:sta:chan:loc.  Any keys 
+        Internal method to cautiously parse document doc to
+        always a string of the form net:sta:chan:loc.  Any keys
         not defined will be replaced with null_value string.
         """
-        outstr=""
-        count=0
-        for k in ['net','sta','chan','loc']:
+        outstr = ""
+        count = 0
+        for k in ["net", "sta", "chan", "loc"]:
             if k in doc:
                 outstr += doc[k]
             else:
                 outstr += null_value
-            if count<3:
+            if count < 3:
                 outstr += ":"
             count += 1
         outstr += " for time range "
-        count=0
-        for k in ["starttime","endtime"]:
-            if k in doc: 
+        count = 0
+        for k in ["starttime", "endtime"]:
+            if k in doc:
                 outstr += str(UTCDateTime(doc[k]))
             else:
                 outstr += null_value
-            if count==0:
+            if count == 0:
                 outstr += "->"
         return outstr
-
-    

--- a/python/mspasspy/algorithms/calib.py
+++ b/python/mspasspy/algorithms/calib.py
@@ -1,0 +1,248 @@
+import pickle
+import numpy as np
+from mspasspy.ccore.seismic import TimeSeries,TimeSeriesEnsemble
+from mspasspy.ccore.utility import MsPASSError,ErrorSeverity
+from obspy import UTCDateTime
+class ApplyCalibEngine:
+    """
+    A special case of response correction is a simple scalar multiply by a 
+    constant used to convert data from raw counts to the (now) standard units 
+    of nm/s.  For many applications using broadband data that correction 
+    is sufficient to assure ensembles of signals are on a common amplitude 
+    scale.  A basic rule if the passband of the processing is inside the 
+    instrument passband a full response correction is not alway necessary. 
+    A case in point is reeiver function processing where the passband of 
+    actual data is inside the passband of most "broadband sensors".
+    
+    This class can be used to process TimeSeries or TimeSeriesEnsemble
+    objects to convert data from raw counts to units of nm/s.
+    
+    The effort required to extract the conversion factor from the 
+    archain response format of seed and station xml is not trivial.   
+    We rely here on the conversion of downloaded station metadata from 
+    fdsn sources via web services and obspy's downloading methods.   
+    Obspy converts that archain data to what they call an Inventory 
+    object.  In MsPASS we disaggregate the complicated Inventory object 
+    into a set of MongoDB documents with one entry for each 
+    seed time period fr each channel of data.   Inside that document is a 
+    an attibute with the tag "serialized_channel_data" that contains 
+    the detailed response data serialized with pickle.   The 
+    constructor for this object runs pickle.loads on that data to yield 
+    an obspy Response object.  We only extract the "sensitivity" value from
+    Response.   A major complication is unit restrictions and invalid 
+    Response objects.  These are handled by the constructor as described 
+    below.   The current implementation can only handle Response objects 
+    with "input units" of meters per second and "output units" of counts. 
+    Note input and output is because the Response object uses 
+    sensitivity = 1/calib.  i.e. sensitivity is the scale to convert 
+    physical units to counts which backward from what this class is 
+    designed for - converting counts to physical units of nm/s.
+    """
+    
+    def __init__(self,
+                 db,
+                 query=None,
+                 collection="channel",
+                 ounits=["counts","COUNTS","count","COUNT"],
+                 iunits=["m/s","M/S"],   
+                 response_data_key="serialized_channel_data",
+                 verbose=False):
+        """
+        Constructor for this object loads the serialized response data 
+        and builds an internal cache to cross-reference channel_id with 
+        calib values.  
+        
+        :param db:  MongoDB Database handle assumed to contained a 
+           channell collection created from an Inventory object with 
+           the MsPASS database method `save_inventory`.
+        :param query:  optional MongoDB query operator to apply to 
+           collection before using.  Size, for exampe, might be reduced 
+           by using a time range query.
+        :type query:  python dictionary.  Default is None which is taken 
+           to mean use the entire colleciton without a query.
+        :param collection:  optional alternative collection name.  
+           Rarely if ever should be changed as the code here has dependence
+           on MsPASS specific keys and the way we disaggregate obspy's 
+           Inventory object.
+        :type collection:  str (default "channel") 
+        :param ounits:  list of acceptable "output unit" definitions, 
+           The default is various perturbation of"counts" .
+        :type ounits:  list of string defining acceptable units.
+        :param iunits:   list of acceptable names for "input units" in 
+          the Response data structure.   Default is known to work with 
+          most FDSN data for velocity instruments.   You would  likely 
+          change this list only if you wanted to wanted to use
+          accelerometer data or some other nonstandard unit data.
+          Note "input units" in FDSN jargon is kind of confusing in this 
+          context as the purpose of this object is to convert raw data to 
+          physical units so this object's output is actually the units 
+          of iunits.
+        :type inunits:  list of string names that must match xml posted 
+          units.  The default should almost always be sufficient.
+        :param response_data_key: key used to access the serialized 
+          response data from each MongoDB document parsed by this construtor.
+        :type response_data_key:  str (default is key sed in mspass and should 
+          not normally be chaged. )
+        :param verbose:  When set True (default is False) will print 
+          error messages when it finds response data it cannot handle.  
+          Turned off by default because a database with a few thousand 
+          channels can generate a lot of error if you mix up acceleration 
+          data with normal velocity sensor data.  This class will not 
+          handle acceleration channels as converting acceleration data to 
+          velocity data is true response correction not a simple calib 
+          correction.   
+        """
+        if query:
+            cursor=db[collection].find(query)
+        else:
+            cursor=db[collection].find({})
+        self.calib = dict()
+        for doc in cursor:
+            if response_data_key in doc:
+                chandata = pickle.loads(doc[response_data_key])
+                resp = chandata.response
+                sens = resp.instrument_sensitivity
+                if sens is None and verbose:
+                    stastr=self._parse_stadata(doc)
+                    print(stastr," invalid instrument response") 
+                    print("pickle.loads returned this:  ",str(resp))
+                elif sens:
+                    if verbose:
+                        message = self._parse_stadata(doc)+":  "
+                    if sens.input_units and sens.output_units:
+                        if sens.input_units in iunits:
+                            if sens.output_units in ounits:
+                                if sens.value is None:
+                                    if verbose:
+                                        message += "units ok but sensitivity value is undefined"
+                                        print(message)
+                                else:
+                                    id = doc['_id']
+                                    # inventory saves a "sensitivity" value 
+                                    # which is he reciprocal of calib
+                                    self.calib[str(id)] = 1e9/sens.value
+                            elif verbose:
+                                message += "Illegal output_unit value="
+                                message += sens.output_units +"\n"
+                                print(message)
+                        elif verbose:
+                            message += "Illegal input_units value="
+                            message += sens.input_units + "\n"
+                            print(message)
+                    elif verbose:
+                        message += "sensitivity data is undefined in this response object"
+                        print(message)
+            elif verbose:
+                stastr=self._parse_stadata(doc)
+                print(stastr," does not contain pickled response data - keey=",
+                      response_data_key)
+        if len(self.calib) == 0:
+            message = "ApplyCalibEngine construtor:  Database has no valid response data"
+            raise MsPASSError(message,ErrorSeverity.Invalid)
+    def apply_calib(self,d,id_key="channel_id",kill_if_undefined=True):
+        """
+        Use this method to apply a calib value to a TimeSeries or all the 
+        live members of a TimeSeriesEnsemble. 
+        
+        This is the processing function used for applying calibration. 
+        It is a method instead of a function because the class allows the 
+        calib values to be cached inside the object.   The input(s) must 
+        contain a MongoDB ObjectId that can be matched with the ids 
+        loaded in the cache by the constructor.   By default the key 
+        used is "channel_id".  That can be changed with the "id_key"
+        argument.  If a match is found all 
+        the sample valued are multiplied by calib AND the calib attribute is 
+        set.   Note a complaint will be issued if calib was found to already 
+        be defined in  AND is not 1.0 (a default sometimes appropriate)
+        
+        This method can easily become a mass murderer.   By default any 
+        datum with an undefined calib value in the cache of this object will 
+        be marked dead on return with a error message posted to its elog 
+        container.  If the `kill_if_undefined` argument is set False 
+        such data will not be killed but an elog message will be posted 
+        marked complaint.  
+        
+        :param d:  input data to process
+        :type d:  `TimeSeries` or `TimeSeriesEnsemle`  This method will 
+           raise a ValueError exception if d is anything else.
+        :param kill_if_undefined:  bolean that when True (default) will 
+           cause any datum for which a matching calib cannot be found to be 
+           killed.   Note this operation is atomic so for ensembles only 
+           members that fail the match will be killed.  
+        :return:  copy of input with amplitudes multiplied by calib factor.
+        """
+        if isinstance(d,TimeSeries):
+            alg = "ApplyCalibEngine.apply_calib"
+            if d.live:
+                if id_key in d:
+                    idstr = str(d[id_key])
+                    if idstr in self.calib:
+                        this_calib = self.calib[idstr]
+                        if "calib" in d:
+                            if not np.isclose(d["calib"],1.0):
+                                old_calib = d['calib']
+                                new_metadata_calib=old_calib*this_calib
+                                message = "calib was already defined in this datum as {}\n".format(d['calib'])
+                                message += "Data will be multiplied by calib defined in this object={}\n".format(this_calib)
+                                message += "New calib in header = {}\n".format(new_metadata_calib)
+                                message += "Amplitudes may be wrong with this datum"
+                                d.elog.log_error(alg,message,ErrorSeverity.Complaint)
+                                d['calib'] = new_metadata_calib
+                            else:
+                                d['calib'] = this_calib
+                        d.data *= this_calib  
+                    else:
+                        message = "calib factor could not be determined\n"
+                        message += "Response data missing or flawed"
+                        if kill_if_undefined:
+                            d.elog.log_error(alg,message,ErrorSeverity.Invalid)
+                            d.kill()
+                        else:
+                            d.elog.log_error(alg,message,ErrorSeverity.Complaint)
+                else:
+                    message = "Missing required channel_id need to get calib factor"
+                    if kill_if_undefined:
+                        d.elog.log_error(alg,message,ErrorSeverity.Invalid)
+                        d.kill()
+                    else:
+                        d.elog.log_error(alg,message,ErrorSeverity.Complaint)
+        elif isinstance(d,TimeSeriesEnsemble):
+            for i in range(len(d.member)):
+                d.member[i] = self.apply_calib(d.member[i])
+        else:
+            message = "Illegal input data type={}".format(str(type(d)))
+            raise ValueError(message)
+        return d
+    def size(self):
+        """
+        Return size of the cache of calib values stored in the object.
+        """
+        return len(self.calib) 
+    def _parse_stadata(self,doc,null_value="Undefined")->str:
+        """
+        Internal method to cautiously parse document doc to 
+        always a string of the form net:sta:chan:loc.  Any keys 
+        not defined will be replaced with null_value string.
+        """
+        outstr=""
+        count=0
+        for k in ['net','sta','chan','loc']:
+            if k in doc:
+                outstr += doc[k]
+            else:
+                outstr += null_value
+            if count<3:
+                outstr += ":"
+            count += 1
+        outstr += " for time range "
+        count=0
+        for k in ["starttime","endtime"]:
+            if k in doc: 
+                outstr += str(UTCDateTime(doc[k]))
+            else:
+                outstr += null_value
+            if count==0:
+                outstr += "->"
+        return outstr
+
+    

--- a/python/tests/algorithms/test_calib.py
+++ b/python/tests/algorithms/test_calib.py
@@ -7,7 +7,8 @@ Created on Thu Jan 23 07:50:25 2025
 
 @author: pavlis
 """
-from mspasspy.algoriths.calib import ApplyCalibEngine
+from mspasspy.algorithms.calib import ApplyCalibEngine
+import sys
 
 sys.path.append("python/tests")
 from helper import get_live_timeseries
@@ -23,13 +24,12 @@ from obspy import read_inventory, UTCDateTime
 import pytest
 
 
-class test_ApplyCalibEngine:
+class TestApplyCalibEngine:
     def setup_class(self):
         client = DBClient()
         client.drop_database("test_calib")
         self.db = client.get_database("test_calib")
-        # xmlfile = "./python/tests/data/calib_teststa.xml"
-        xmlfile = "calib_teststa.xml"
+        xmlfile = "./python/tests/data/calib_teststa.xml"
         inv = read_inventory(xmlfile, format="STATIONXML")
         self.db.save_inventory(inv)
         self.ts = get_live_timeseries()
@@ -176,10 +176,3 @@ class test_ApplyCalibEngine:
             else:
                 # dead data should be ignored
                 assert np.isclose(d.data, 1.0).all()
-
-
-# for debugging tests outside pytest
-tester = test_ApplyCalibEngine()
-tester.setup_class()
-# tester.test_constructor()
-tester.test_apply()

--- a/python/tests/algorithms/test_calib.py
+++ b/python/tests/algorithms/test_calib.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This a pytest script to tesst the class called ApplyCalibEngine.  
+
+Created on Thu Jan 23 07:50:25 2025
+
+@author: pavlis
+"""
+from mspasspy.algoriths.calib import ApplyCalibEngine
+
+sys.path.append("python/tests")
+from helper import get_live_timeseries
+
+from mspasspy.db.client import DBClient
+from mspasspy.ccore.seismic import TimeSeriesEnsemble, TimeSeries, DoubleVector
+from mspasspy.ccore.utility import MsPASSError
+
+import numpy as np
+
+from obspy import read_inventory, UTCDateTime
+
+import pytest
+
+
+class test_ApplyCalibEngine:
+    def setup_class(self):
+        client = DBClient()
+        client.drop_database("test_calib")
+        self.db = client.get_database("test_calib")
+        # xmlfile = "./python/tests/data/calib_teststa.xml"
+        xmlfile = "calib_teststa.xml"
+        inv = read_inventory(xmlfile, format="STATIONXML")
+        self.db.save_inventory(inv)
+        self.ts = get_live_timeseries()
+
+    def teardown_class(self):
+        client = DBClient()
+        client.drop_database("test_calib")
+
+    def test_constructor(self):
+        """
+        This method does a partial test of the constructor.  Some
+        error handlers are difficult to simulate that handle bad
+        response data.  This tests the most common known issues
+        that are hadled.
+        """
+        # this should be clean for the test data
+        engine = ApplyCalibEngine(self.db)
+        # the actual test data have more entries than this
+        # many channels are dropped because they are ot velocity channels
+        # the test file creates 324 entries of which 192 are acceptible
+        # to this application
+        assert len(engine.calib) == 192  # number of entries in test file
+
+        # These will all raise an exception from no data surviving
+        # the first somewhat duplicates above but is worh doing
+        # to tess excepion handling
+        with pytest.raises(MsPASSError, match="Database has no valid response data"):
+            engine = ApplyCalibEngine(self.db, ounits=["foobar"], verbose=False)
+        with pytest.raises(MsPASSError, match="Database has no valid response data"):
+            engine = ApplyCalibEngine(self.db, ounits=["foobar"], verbose=True)
+
+        # I don't tink the test data test this condition so we repeat
+        # similar to above
+        with pytest.raises(MsPASSError, match="Database has no valid response data"):
+            engine = ApplyCalibEngine(
+                self.db, response_data_key="foobar", verbose=False
+            )
+        with pytest.raises(MsPASSError, match="Database has no valid response data"):
+            engine = ApplyCalibEngine(self.db, response_data_key="foobar", verbose=True)
+
+        # TODO:  could add a bad response file to test file to test handling
+        # of block where the response data is invalid.
+
+    def test_apply(self):
+        # create coopies of test timeseries that will match channel docs
+        # note testing this TimeSeriesEnsemble also tests the atomic
+        # section of apply as apply calls itself in a loop for ensembles
+        e = TimeSeriesEnsemble()
+        # build an ensemle of BHZ::00 channels - all should work
+        # the weird endtime query is needed becaue the ANMO data is flawed
+        cursor = self.db.channel.find(
+            {
+                "chan": "BHZ",
+                "loc": "00",
+                "endtime": {"$gt": UTCDateTime("2002-01-01").timestamp},
+            },
+        )
+
+        for doc in cursor:
+            # print_metadata(doc)
+            print(
+                doc["sta"], UTCDateTime(doc["starttime"]), UTCDateTime(doc["endtime"])
+            )
+            ts = TimeSeries(self.ts)
+            # all the test data have loc set - watch out if you change it
+            for k in ["net", "sta", "chan", "loc"]:
+                ts[k] = doc[k]
+            ts.erase("calib")
+            ts["channel_id"] = doc["_id"]
+            # ts has random numbers - replace with ones
+            ts.data = DoubleVector(np.ones(ts.npts))
+            e.member.append(ts)
+        # copy to allow refreshing e below
+        e0 = TimeSeriesEnsemble(e)
+
+        engine = ApplyCalibEngine(self.db)
+        # These were extracted from test file
+        # if the test data changes these willl need to change
+        calib_expected = {
+            "ADK": float(0.9347279474309003),
+            "AFI": float(1.1048783694646975),
+            "ANMO": float(1.1564985387640963),
+        }
+        e = engine.apply_calib(e)
+        self._validate_BHZ(e)
+
+        # test handling of dead data
+        e = TimeSeriesEnsemble(e0)
+        e.member[1].kill()
+        e = engine.apply_calib(e)
+        self._validate_BHZ(e)
+
+        # test error handlers
+        # first when calib is already present it is altered but
+        # sample data should only be multiplied by match used
+        # b apply_calib
+        e = TimeSeriesEnsemble(e0)
+        for i in range(len(e.member)):
+            e.member[i]["calib"] = 2.0
+        e = engine.apply_calib(e)
+        self._validate_BHZ(e)
+        for d in e.member:
+            sta = d["sta"]
+            calib = d["calib"]
+            assert np.isclose(calib, calib_expected[sta] * 2.0)
+            # each entry should have an elog entry
+            assert d.elog.size() > 0
+
+        ts0 = TimeSeries(e0.member[0])
+        # test behavior when channel_id is not defined
+        ts = TimeSeries(ts0)
+        ts.erase("channel_id")
+        ts = engine.apply_calib(ts)
+        assert ts.dead()
+        assert ts.elog.size() > 0
+
+        ts = TimeSeries(ts0)
+        ts.erase("channel_id")
+        ts = engine.apply_calib(ts, kill_if_undefined=False)
+        assert ts.live
+        assert ts.elog.size() > 0
+
+        # test illegal type for arg0
+        with pytest.raises(ValueError, match="Illegal input data type"):
+            engine.apply_calib("foo")
+
+    def _validate_BHZ(self, e):
+        """
+        Validates ensemble procssed by apply_calib with
+        hard wired constants for response files used in this
+        test.  Multiplier just be 1.0 for default behavior.
+        apply_calib multiplies any existing calib value so we use
+        that in one test to check that behavior.
+        """
+        calib_expected = {
+            "ADK": float(0.9347279474309003),
+            "AFI": float(1.1048783694646975),
+            "ANMO": float(1.1564985387640963),
+        }
+        for d in e.member:
+            if d.live:
+                ce = calib_expected[d["sta"]]
+                assert np.isclose(d.data, ce).all()
+            else:
+                # dead data should be ignored
+                assert np.isclose(d.data, 1.0).all()
+
+
+# for debugging tests outside pytest
+tester = test_ApplyCalibEngine()
+tester.setup_class()
+# tester.test_constructor()
+tester.test_apply()


### PR DESCRIPTION
Adds new calib module to algorithms.  Implemented as a class with a dictionary cache for efficient matching.   Not done as a subclass of Matcher as the main use is quite different.  That is, the `apply_calib` of the class converts TimeSeries data to physical units of nm/s by multiplication by a "calib" factor.  Conceptually similar to Antelope's "apply_calib" function.   

This pull request also contains a very complete set of tests.  The same module has also been applied to 3.5 million TimeSeries in recent testing.  If it passes the tests here it should be merged.