### PR TITLE
bug fix for snr algorithms

### DIFF
--- a/cxx/include/mspass/algorithms/amplitudes.h
+++ b/cxx/include/mspass/algorithms/amplitudes.h
@@ -332,7 +332,11 @@ public:
   };
   /*! Return bandwidth in dB. */
   double bandwidth() const {
-    if (f_range <= 0.0)
+    /* All these conditionals are necessary for handling unexpected
+     * values.   0 is effectively and error return.  Without these
+     * the function can return NaN or generate floating point exceptions. */
+    if ((f_range <= 0.0) || (high_edge_f<=low_edge_f)
+      || (high_edge_f < 0.0) || (low_edge_f < 0.0) )
       return 0.0;
     else {
       double ratio = high_edge_f / low_edge_f;

--- a/cxx/src/lib/algorithms/deconvolution/MTPowerSpectrumEngine.cc
+++ b/cxx/src/lib/algorithms/deconvolution/MTPowerSpectrumEngine.cc
@@ -245,10 +245,20 @@ vector<double> MTPowerSpectrumEngine::apply(const vector<double> &d) {
   double specssq(0.0), scale;
   for (auto p = result.begin(); p != result.end(); ++p)
     specssq += (*p);
-  scale = ssq / (specssq * this->df());
-  /* Scaling for fft implementation - Established from zero pad tests it has
-  to be this factor */
-  scale /= static_cast<double>(d.size());
+  /* test for zeros to avoid divide by zero or a NaN. 
+   * result will be all zeros this way.  Without we get all NaNs
+   * in the spectrum*/
+  if((ssq<=0.0) || (specssq<=0.0))
+  {
+    scale = 1.0;
+  }
+  else
+  {
+    scale = ssq / (specssq * this->df());
+    /* Scaling for fft implementation - Established from zero pad tests it has
+    to be this factor.   */
+    scale /= static_cast<double>(d.size());
+  }
   for (j = 0; j < this->nf(); ++j)
     result[j] *= scale;
   return result;

--- a/cxx/src/lib/algorithms/snr.cc
+++ b/cxx/src/lib/algorithms/snr.cc
@@ -143,14 +143,12 @@ BandwidthData EstimateBandwidth(const double signal_df, const PowerSpectrum &s,
 }
 Metadata BandwidthStatistics(const PowerSpectrum &s, const PowerSpectrum &n,
                              const BandwidthData &bwd) {
-  /* As noted above this correction is needed for an irregular window size*/
-  double window_length_correction =
-      static_cast<double>(s.nf()) / static_cast<double>(n.nf());
   Metadata result;
   /* the algorithm below will fail if either of these conditions is true so
   we trap that and return a null result.   Caller must handle the null
   return correctly*/
-  if ((bwd.f_range <= 0.0) || ((bwd.high_edge_f - bwd.low_edge_f) < s.df())) {
+  if ((bwd.f_range <= 0.0) || ((bwd.high_edge_f - bwd.low_edge_f) < s.df())
+       || s.dead() || n.dead() || s.nf()<=0 || n.nf()<=0) {
     result.put_double("median_snr", 0.0);
     result.put_double("maximum_snr", 0.0);
     result.put_double("minimum_snr", 0.0);
@@ -160,6 +158,9 @@ Metadata BandwidthStatistics(const PowerSpectrum &s, const PowerSpectrum &n,
     result.put_bool("stats_are_valid", false);
     return result;
   }
+  /* As noted above this correction is needed for an irregular window size*/
+  double window_length_correction =
+      static_cast<double>(s.nf()) / static_cast<double>(n.nf());
   std::vector<double> bandsnr;
   double f;
   for (f = bwd.low_edge_f; f < bwd.high_edge_f && f < s.Nyquist();

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -19,9 +19,9 @@ from mspasspy.algorithms.signals import filter
 from mspasspy.algorithms.window import WindowData
 
 # debug
-#import matplotlib.pyplot as plt
-#from mspasspy.util.seismic import print_metadata
-#import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
+# from mspasspy.util.seismic import print_metadata
+# import matplotlib.pyplot as plt
 
 
 def EstimateBandwidth(
@@ -153,14 +153,14 @@ def EstimateBandwidth(
             if Snow <= 0.0:
                 snrdata[i] = 1.0
             elif Nnow <= 0.0:
-                if Snow>0:
+                if Snow > 0:
                     snrdata[i] = SNR_CEILING
                 else:
                     # this would give an NaN otherwise so flag it as bag
                     # by setting it to 1
                     snrdata[i] = 1.0
             else:
-                snrdata[i] = Snow/Nnow
+                snrdata[i] = Snow / Nnow
         else:
             snrdata[i] = 1.0
     # S and N are power, convert to amplitude
@@ -662,28 +662,32 @@ def FD_snr_estimator(
         N = nengine.apply(n)
         S = sengine.apply(s)
         # the apply methods can fail.  They flag that with a return  marked dead
-	# we append the elog messages to this datum, kill it, and return if that 
+        # we append the elog messages to this datum, kill it, and return if that
         # happens
         if N.dead() or S.dead():
             if S.dead():
                 # this elog should have a message with further info on why it was killed
                 my_logger += S.elog
-                my_logger.log_error(algname,
-                                    "spectrum esimator returned signal spectrum marked dead",
-                                    ErrorSeverity.Invalid)
+                my_logger.log_error(
+                    algname,
+                    "spectrum esimator returned signal spectrum marked dead",
+                    ErrorSeverity.Invalid,
+                )
             if N.dead():
-               my_logger += N.elog
-               my_logger.log_error(algname,
-                                   "spectrum esimator returned noise spectrum marked dead",
-                                   ErrorSeverity.Invalid)
-            return [dict(),my_logger]
+                my_logger += N.elog
+                my_logger.log_error(
+                    algname,
+                    "spectrum esimator returned noise spectrum marked dead",
+                    ErrorSeverity.Invalid,
+                )
+            return [dict(), my_logger]
 
         bwd = EstimateBandwidth(S, N, snr_threshold=band_cutoff_snr, f0=f0)
         # The low edge can be zero but that will not work correctly with the
         # bandwidth method of bwd.  That C++ function has a bug in that it doesn't
         # handle that highly possible error condition.  This is a workaround
         if bwd.low_edge_f <= 0.0:
-            # handle completely null result 
+            # handle completely null result
             if bwd.high_edge_f > 0.0:
                 bandwidth = 20.0 * np.log10(bwd.high_edge_f / S.df())
             else:
@@ -692,8 +696,10 @@ def FD_snr_estimator(
             bandwidth = bwd.bandwidth()
         # here we return empty result if the bandwidth is too low
         if bandwidth < signal_detection_minimum_bandwidth:
-            message = "Estimated bandwidth={} below detection minimum={}".format(bandwidth,signal_detection_minimum_bandwidth)
-            my_logger.log_error(algname,message,ErrorSeverity.Invalid)
+            message = "Estimated bandwidth={} below detection minimum={}".format(
+                bandwidth, signal_detection_minimum_bandwidth
+            )
+            my_logger.log_error(algname, message, ErrorSeverity.Invalid)
             return [dict(), my_logger]
         # These estimates are always computed and posted once we pass the above test for validity
         snrdata["low_f_band_edge"] = bwd.low_edge_f
@@ -754,8 +760,18 @@ def FD_snr_estimator(
         )
         filtered_data = TimeSeries(data_object)
         BWfilt.apply(filtered_data)
-        nfilt = WindowData(filtered_data, noise_window.start, noise_window.end,short_segment_handling="truncate")
-        sfilt = WindowData(filtered_data, signal_window.start, signal_window.end,short_segment_handling="truncate")
+        nfilt = WindowData(
+            filtered_data,
+            noise_window.start,
+            noise_window.end,
+            short_segment_handling="truncate",
+        )
+        sfilt = WindowData(
+            filtered_data,
+            signal_window.start,
+            signal_window.end,
+            short_segment_handling="truncate",
+        )
 
         # this is needed externally as a signal to use a lowpass instead of
         # bandpass to recreate the filtered data
@@ -1247,8 +1263,8 @@ def broadband_snr_QC(
     if data_to_process.time_is_UTC():
         data_to_process.ator(arrival_time)
     # debug
-    #plt.plot(data_to_process.time_axis(),data_to_process.data)
-    #plt.show()
+    # plt.plot(data_to_process.time_axis(),data_to_process.data)
+    # plt.show()
     [snrdata, elog] = FD_snr_estimator(
         data_to_process,
         noise_window=noise_window,
@@ -1287,7 +1303,7 @@ def broadband_snr_QC(
     snrdata["snr_noise_window_start"] = arrival_time + noise_window.start
     snrdata["snr_noise_window_end"] = arrival_time + noise_window.end
     # debug
-    #print_metadata(snrdata)
+    # print_metadata(snrdata)
 
     # These cross-referencing keys may not always be defined when a phase
     # time is based on a pick so we add these cautiously

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -806,10 +806,11 @@ def FD_snr_estimator(
                 except MsPASSError as err:
                     # This handler is entered only if BandwidthStatistics
                     # throws an exception.  Currently that can only happen
-                    # if an internal C class VectorStatistics throws 
-                    # an exception.  The internal logic shouldn't let that 
+                    # if an internal C class VectorStatistics throws
+                    # an exception.  The internal logic shouldn't let that
                     # happen but this is a safety in case it does.
-                    newmessage = _reformat_mspass_error(err,
+                    newmessage = _reformat_mspass_error(
+                        err,
                         "BandwithStatistics threw the following error\n",
                         "Five snr_stats attributes were not computed",
                     )

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -804,11 +804,13 @@ def FD_snr_estimator(
                             ErrorSeverity.Complaint,
                         )
                 except MsPASSError as err:
-                    # This handler currently would never be entered but
-                    # left in place to keep code more robust in the event
-                    # of a change
-                    newmessage = _reformat_mspass_error(
-                        "BandwithStatistics throw the following error\n",
+                    # This handler is entered only if BandwidthStatistics
+                    # throws an exception.  Currently that can only happen
+                    # if an internal C class VectorStatistics throws 
+                    # an exception.  The internal logic shouldn't let that 
+                    # happen but this is a safety in case it does.
+                    newmessage = _reformat_mspass_error(err,
+                        "BandwithStatistics threw the following error\n",
                         "Five snr_stats attributes were not computed",
                     )
                     my_logger.log_error(algname, newmessage, err.severity)

--- a/python/tests/algorithms/test_snr.py
+++ b/python/tests/algorithms/test_snr.py
@@ -84,8 +84,8 @@ def verify_snr_outputs_match(so1, so2):
 
 def test_snr_functions():
     """
-    The snr module has a set of simple snr metrics tested by 
-    this function.   
+    The snr module has a set of simple snr metrics tested by
+    this function.
     """
     with open("python/tests/data/snrtestdata", "rb") as pickle_file:
         ts0 = pickle.load(pickle_file)
@@ -112,6 +112,7 @@ def test_snr_functions():
     assert np.isclose(snrmad_rms, 6.278840062165531)
     assert np.isclose(snrperc_rms, 11.237789966979753)
 
+
 def test_FD_snr_estimator():
     """
     Test function for snr module.   This function is currently incomplete as it
@@ -137,7 +138,7 @@ def test_FD_snr_estimator():
         f0=1.0,
         band_cutoff_snr=2.0,
     )
-    #print(json_util.dumps(fd_snr_output[0], indent=2))
+    # print(json_util.dumps(fd_snr_output[0], indent=2))
 
     elog = fd_snr_output[1]
     assert elog.size() == 0
@@ -234,6 +235,7 @@ def test_FD_snr_estimator():
     assert sigspec.nf() == 6002
     assert nspec.nf() == 15002
 
+
 def test_FD_snr_estimator_error_handlers():
     """
     As the name implies this tests error handling features of FD_snr_estimator.
@@ -254,59 +256,59 @@ def test_FD_snr_estimator_error_handlers():
         f0=1.0,
         band_cutoff_snr=2.0,
     )
-    # should return an empty dict in 0 for this condition 
+    # should return an empty dict in 0 for this condition
     # with a posted error message in 1
     assert len(fd_snr_output[0]) == 0
-    assert fd_snr_output[1].size()>0
+    assert fd_snr_output[1].size() > 0
 
     # test a handlers that throw exceptions
 
-    with pytest.raises(MsPASSError,match="Received invalid data object"):
+    with pytest.raises(MsPASSError, match="Received invalid data object"):
         fd_snr_output = FD_snr_estimator(
-                "badarg0",
-                noise_window=nwin,
-                signal_window=swin,
-                f0=1.0,
-                band_cutoff_snr=2.0,
-            )
+            "badarg0",
+            noise_window=nwin,
+            signal_window=swin,
+            f0=1.0,
+            band_cutoff_snr=2.0,
+        )
     # tests a rare user error entering an invalid number of tapes
     ts = TimeSeries(ts0)
-    with pytest.raises(MsPASSError,match="ntapers="):
+    with pytest.raises(MsPASSError, match="ntapers="):
         fd_snr_output = FD_snr_estimator(
-                ts,
-                ntapers=50,
-                noise_window=nwin,
-                signal_window=swin,
-                f0=1.0,
-                band_cutoff_snr=2.0,
-            )
+            ts,
+            ntapers=50,
+            noise_window=nwin,
+            signal_window=swin,
+            f0=1.0,
+            band_cutoff_snr=2.0,
+        )
     # Test handling of dead datum
     ts = TimeSeries(ts0)
     ts.kill()
     fd_snr_output = FD_snr_estimator(
-                ts,
-                noise_window=nwin,
-                signal_window=swin,
-                f0=1.0,
-                band_cutoff_snr=2.0,
-                )
-    assert len(fd_snr_output[0])==0
-    assert fd_snr_output[1].size()>0
+        ts,
+        noise_window=nwin,
+        signal_window=swin,
+        f0=1.0,
+        band_cutoff_snr=2.0,
+    )
+    assert len(fd_snr_output[0]) == 0
+    assert fd_snr_output[1].size() > 0
 
 
 def test_arrival_functions():
     """
     This function tests the arrival_snr function and broadband_snr_QC
-    functions that are higher level functions using the other functions 
-    in this module to compute a user selected set of metrics.  We do 
-    them together to validate outputs against a master run using 
-    FD_snr_estimator. 
+    functions that are higher level functions using the other functions
+    in this module to compute a user selected set of metrics.  We do
+    them together to validate outputs against a master run using
+    FD_snr_estimator.
     """
     with open("python/tests/data/snrtestdata", "rb") as pickle_file:
         ts0 = pickle.load(pickle_file)
         ts = TimeSeries(ts0)  # use this as working copy
-        
-    # this reruns FD_estimator as above to create the master 
+
+    # this reruns FD_estimator as above to create the master
     # pattern of snr metrics validated
     nwin = TimeWindow(-200.0, -50.0)
     swin = TimeWindow(-10.0, 50.0)
@@ -388,7 +390,8 @@ def test_arrival_functions():
     )
     assert idout2 == idout
 
-#test_snr_functions()
-#test_FD_snr_estimator()
-#test_arrival_functions()
-#test_FD_snr_estimator_error_handlers()
+
+# test_snr_functions()
+# test_FD_snr_estimator()
+# test_arrival_functions()
+# test_FD_snr_estimator_error_handlers()

--- a/python/tests/algorithms/test_snr.py
+++ b/python/tests/algorithms/test_snr.py
@@ -1,5 +1,5 @@
-from mspasspy.ccore.algorithms.deconvolution import MTPowerSpectrumEngine
-from mspasspy.ccore.seismic import TimeSeries, TimeReferenceType
+from mspasspy.ccore.seismic import TimeSeries, TimeReferenceType, DoubleVector
+from mspasspy.ccore.utility import MsPASSError
 from mspasspy.ccore.algorithms.basic import TimeWindow
 from mspasspy.algorithms.snr import (
     snr,
@@ -10,11 +10,10 @@ from mspasspy.algorithms.snr import (
 )
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
+from bson import json_util
 import numpy as np
-from scipy import signal
-from bson import json_util, ObjectId
 import pickle
-
+import pytest
 
 ######################################################################
 # This block of code was used to create the test file for this
@@ -83,24 +82,19 @@ def verify_snr_outputs_match(so1, so2):
         assert np.isclose(so1[k], so2[k])
 
 
-def test_snr():
+def test_snr_functions():
     """
-    Test function for snr module.   This function is currently incomplete as it
-    needs to test a new implemenation of the EstimateBandwidth function
-    independent from the higher level functions tested here.   Most of that
-    function is tested by this one since some of the higher level functions use
-    the EstimateBandwidth function.
-
-    TODO:  the biggest gap her is that most of the error handlers are tested.
+    The snr module has a set of simple snr metrics tested by 
+    this function.   
     """
     with open("python/tests/data/snrtestdata", "rb") as pickle_file:
-        ts = pickle.load(pickle_file)
+        ts0 = pickle.load(pickle_file)
+    ts = TimeSeries(ts0)
     nwin = TimeWindow(-200.0, -50.0)
     # appropriate for perc and peak
     swin = TimeWindow(-10.0, 50.0)
     # used for rms and mad for this test
     swin2 = TimeWindow(-0.5, 10.0)
-
     snrrms = snr(ts, nwin, swin2, noise_metric="rms", signal_metric="rms")
     print("snr_rms=", snrrms)
     snrpeak_rms = snr(ts, nwin, swin, noise_metric="rms", signal_metric="peak")
@@ -118,6 +112,23 @@ def test_snr():
     assert np.isclose(snrmad_rms, 6.278840062165531)
     assert np.isclose(snrperc_rms, 11.237789966979753)
 
+def test_FD_snr_estimator():
+    """
+    Test function for snr module.   This function is currently incomplete as it
+    needs to test a new implemenation of the EstimateBandwidth function
+    independent from the higher level functions tested here.   Most of that
+    function is tested by this one since some of the higher level functions use
+    the EstimateBandwidth function.
+    """
+    with open("python/tests/data/snrtestdata", "rb") as pickle_file:
+        ts0 = pickle.load(pickle_file)
+        ts = TimeSeries(ts0)  # use this as working copy
+    nwin = TimeWindow(-200.0, -50.0)
+    # appropriate for perc and peak
+    swin = TimeWindow(-10.0, 50.0)
+    # used for rms and mad for this test
+    swin2 = TimeWindow(-0.5, 10.0)
+
     print("Output of FD_snr_estimator with default parameters")
     fd_snr_output = FD_snr_estimator(
         ts,
@@ -126,7 +137,7 @@ def test_snr():
         f0=1.0,
         band_cutoff_snr=2.0,
     )
-    print(json_util.dumps(fd_snr_output[0], indent=2))
+    #print(json_util.dumps(fd_snr_output[0], indent=2))
 
     elog = fd_snr_output[1]
     assert elog.size() == 0
@@ -207,9 +218,8 @@ def test_snr():
     tval = fd_snr_output[0]["snr_filtered_mad"]
     assert np.isclose(tval, 1.2763130717405682)
 
-    master = fd_snr_output[0]
-
     print("Repeat testing save_spectrum option")
+    ts = TimeSeries(ts0)
     # This one is for interactive testing - do no include in pytest
     fd_snr_output = FD_snr_estimator(
         ts, noise_window=nwin, signal_window=swin, save_spectra=True
@@ -224,6 +234,98 @@ def test_snr():
     assert sigspec.nf() == 6002
     assert nspec.nf() == 15002
 
+def test_FD_snr_estimator_error_handlers():
+    """
+    As the name implies this tests error handling features of FD_snr_estimator.
+    """
+    with open("python/tests/data/snrtestdata", "rb") as pickle_file:
+        ts0 = pickle.load(pickle_file)
+        ts = TimeSeries(ts0)  # use this as working copy
+    # test handling of a vector of all zero - earlier versions caused an NaN
+    # in this situation
+    d0 = np.zeros(ts.npts)
+    ts.data = DoubleVector(d0)
+    nwin = TimeWindow(-200.0, -50.0)
+    swin = TimeWindow(-10.0, 50.0)
+    fd_snr_output = FD_snr_estimator(
+        ts,
+        noise_window=nwin,
+        signal_window=swin,
+        f0=1.0,
+        band_cutoff_snr=2.0,
+    )
+    # should return an empty dict in 0 for this condition 
+    # with a posted error message in 1
+    assert len(fd_snr_output[0]) == 0
+    assert fd_snr_output[1].size()>0
+
+    # test a handlers that throw exceptions
+
+    with pytest.raises(MsPASSError,match="Received invalid data object"):
+        fd_snr_output = FD_snr_estimator(
+                "badarg0",
+                noise_window=nwin,
+                signal_window=swin,
+                f0=1.0,
+                band_cutoff_snr=2.0,
+            )
+    # tests a rare user error entering an invalid number of tapes
+    ts = TimeSeries(ts0)
+    with pytest.raises(MsPASSError,match="ntapers="):
+        fd_snr_output = FD_snr_estimator(
+                ts,
+                ntapers=50,
+                noise_window=nwin,
+                signal_window=swin,
+                f0=1.0,
+                band_cutoff_snr=2.0,
+            )
+    # Test handling of dead datum
+    ts = TimeSeries(ts0)
+    ts.kill()
+    fd_snr_output = FD_snr_estimator(
+                ts,
+                noise_window=nwin,
+                signal_window=swin,
+                f0=1.0,
+                band_cutoff_snr=2.0,
+                )
+    assert len(fd_snr_output[0])==0
+    assert fd_snr_output[1].size()>0
+
+
+def test_arrival_functions():
+    """
+    This function tests the arrival_snr function and broadband_snr_QC
+    functions that are higher level functions using the other functions 
+    in this module to compute a user selected set of metrics.  We do 
+    them together to validate outputs against a master run using 
+    FD_snr_estimator. 
+    """
+    with open("python/tests/data/snrtestdata", "rb") as pickle_file:
+        ts0 = pickle.load(pickle_file)
+        ts = TimeSeries(ts0)  # use this as working copy
+        
+    # this reruns FD_estimator as above to create the master 
+    # pattern of snr metrics validated
+    nwin = TimeWindow(-200.0, -50.0)
+    swin = TimeWindow(-10.0, 50.0)
+    fd_snr_output = FD_snr_estimator(
+        ts,
+        noise_window=nwin,
+        signal_window=swin,
+        band_cutoff_snr=2.0,
+        optional_metrics=[
+            "snr_stats",
+            "filtered_envelope",
+            "filtered_L2",
+            "filtered_Linf",
+            "filtered_MAD",
+            "filtered_perc",
+        ],
+    )
+    master = fd_snr_output[0]
+
     print("Testing arrival_snr function with autoshift")
     # Now test arrival_snr.  That function is mainly a front end to
     # FD_snr_estimator to handle time shifting for an arrival window.
@@ -231,7 +333,7 @@ def test_snr():
     # We just change t0 but don't mess with time reference as it isn't
     # required here.  Beware that could change down the road and
     # break this test as that is an implementation detail
-    ts2 = TimeSeries(ts)
+    ts2 = TimeSeries(ts0)
     ts2.t0 = 100000.0 + ts.t0
     ts2["Ptime"] = 100000.0
     ts2.tref = TimeReferenceType.UTC
@@ -256,6 +358,7 @@ def test_snr():
     # Finally test the database function to save results of previous
     # function to an arrival collection.
     dbclient = DBClient("localhost")
+    dbclient.drop_database("test_snrQC")
     db = dbclient.get_database("test_snrQC")
     doc_to_save = asnr_out3["Parrival"]
     # Fake the id as if these data had been read from db.  The
@@ -284,3 +387,8 @@ def test_snr():
         update_id=idout,
     )
     assert idout2 == idout
+
+#test_snr_functions()
+#test_FD_snr_estimator()
+#test_arrival_functions()
+#test_FD_snr_estimator_error_handlers()


### PR DESCRIPTION
This fixes a bug uncovered from processing a large data set.  Some situation I haven't unraveled sent a dead spectrum to a C++ function (repaired in this branch) that caused an unexpected exception to be thrown.   That caused an error handler in the snr.py module to be entered that had a mistake in usage.   The comments noted that the handler shouldn't be needed but was added for safety.  Maybe good it did have an error as it revealed the error in the C++ code.  

I did not add a pytest function for the error handler because it still is a handler that is there strictly as a safety valve.   I have no reason to think this pull request won't pass all tests so assuming that is true I urge you to merge it immediately.