### PR TITLE
Enhance decorators - discussion #616

### DIFF
--- a/python/mspasspy/algorithms/CNRDecon.py
+++ b/python/mspasspy/algorithms/CNRDecon.py
@@ -194,6 +194,7 @@ def CNRRFDecon(
     bandwidth_keys=["low_f_band_edge", "high_f_band_edge"],
     QCdata_key="CNRFDecon_properties",
     return_wavelet=False,
+    *args,
     object_history=False,
     alg_name="CNRRFDecon",
     alg_id=None,
@@ -527,7 +528,9 @@ def CNRArrayDecon(
     bandwidth_subdocument_key=None,
     bandwidth_keys=["low_f_band_edge", "high_f_band_edge"],
     return_wavelet=False,
+    *args,
     handles_ensembles=True,
+    **kwargs,
 ) -> tuple:
     """
     Notes:  delete when writing final docstring

--- a/python/mspasspy/algorithms/CNRDecon.py
+++ b/python/mspasspy/algorithms/CNRDecon.py
@@ -201,6 +201,8 @@ def CNRRFDecon(
     inplace_return=False,
     handles_ensembles=False,
     function_return_key=None,
+    checks_arg0_type=True,
+    handles_dead_data=True,
     **kwargs,
 ) -> tuple:
     """

--- a/python/mspasspy/algorithms/CNRDecon.py
+++ b/python/mspasspy/algorithms/CNRDecon.py
@@ -14,6 +14,7 @@ Created on Tue May 28 19:22:10 2024
 """
 import numpy as np
 
+from mspasspy.util.decorators import mspass_func_wrapper
 from mspasspy.ccore.seismic import TimeSeries, Seismogram, SeismogramEnsemble
 from mspasspy.ccore.algorithms.basic import _WindowData3C
 from mspasspy.ccore.utility import ErrorSeverity
@@ -179,7 +180,7 @@ def prediction_error(engine, wavelet) -> float:
     err = ao - io
     return np.linalg.norm(err.data) / np.linalg.norm(io.data)
 
-
+@mspass_func_wrapper
 def CNRRFDecon(
     seis,
     engine,
@@ -192,6 +193,14 @@ def CNRRFDecon(
     bandwidth_keys=["low_f_band_edge", "high_f_band_edge"],
     QCdata_key="CNRFDecon_properties",
     return_wavelet=False,
+    object_history=False,
+    alg_name="CNRRFDecon",
+    alg_id=None,
+    dryrun=False,
+    inplace_return=False,
+    handles_ensembles=False,
+    function_return_key=None,
+    **kwargs,
 ) -> tuple:
     """
     Uses the CNRRFDeconEngine instance passed as `engine` to

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -9,6 +9,7 @@ Created on Tue Jul  9 05:37:40 2024
 """
 import numpy as np
 from scipy import signal
+from mspasspy.util.decorators import mspass_func_wrapper
 from mspasspy.ccore.algorithms.amplitudes import (
     MADAmplitude,
     RMSAmplitude,
@@ -194,6 +195,7 @@ def _compute_default_robust_window(
     return TimeWindow(starttime, endtime)
 
 
+@mspass_func_wrapper
 def MCXcorPrepP(
     ensemble,
     noise_window,
@@ -214,6 +216,7 @@ def MCXcorPrepP(
     search_window_fraction=0.9,
     minimum_coda_duration=5.0,
     correlation_window_start=-3.0,
+    handles_ensembles=True,
 ) -> TimeSeriesEnsemble:
     """
     Function used to preprocess an ensemble  to prepare input for
@@ -1086,6 +1089,7 @@ def beam_align(ensemble, beam, window=None, time_shift_limit=10.0):
     return ensemble
 
 
+@mspass_func_wrapper
 def align_and_stack(
     ensemble,
     beam,
@@ -1104,6 +1108,7 @@ def align_and_stack(
     convergence=0.01,
     residual_norm_floor=0.1,
     demean_residuals=True,
+    handles_ensembles=True,
 ) -> tuple:
     """
     This function uses an initial estimate of the array stack passed as
@@ -1841,6 +1846,7 @@ def phase_time(
         return -1.0
 
 
+@mspass_func_wrapper
 def post_MCXcor_metrics(
     d,
     beam,
@@ -2082,7 +2088,8 @@ def demean_residuals(
     return ensemble
 
 
-def remove_incident_wavefield(d, beam):
+@mspass_func_wrapper
+def remove_incident_wavefield(d, beam, handles_ensembles=True):
     """
     Remove incident wavefield for teleseismic P wave data using a beam estimate.
 

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -2102,7 +2102,7 @@ def demean_residuals(
 
 
 @mspass_func_wrapper
-def remove_incident_wavefield(d, beam, *args, handles_ensembles=True,**kwargs):
+def remove_incident_wavefield(d, beam, *args, handles_ensembles=True, **kwargs):
     """
     Remove incident wavefield for teleseismic P wave data using a beam estimate.
 

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -216,9 +216,11 @@ def MCXcorPrepP(
     search_window_fraction=0.9,
     minimum_coda_duration=5.0,
     correlation_window_start=-3.0,
+    *args,
     handles_ensembles=True,
     checks_arg0_type=True,
-    handles_dead_data=False,
+    handles_dead_data=True,
+    **kwargs,
 ) -> TimeSeriesEnsemble:
     """
     Function used to preprocess an ensemble  to prepare input for
@@ -1110,9 +1112,11 @@ def align_and_stack(
     convergence=0.01,
     residual_norm_floor=0.1,
     demean_residuals=True,
+    *args,
     handles_ensembles=True,
     checks_arg0_type=True,
     handles_dead_data=True,
+    **kwargs,
 ) -> tuple:
     """
     This function uses an initial estimate of the array stack passed as
@@ -1863,9 +1867,11 @@ def post_MCXcor_metrics(
     window=None,
     phase_time_key="Ptime",
     time_shift_key="arrival_time_correction",
+    *args,
     handles_ensembles=False,
     checks_arg0_type=False,
     handles_dead_data=False,
+    **kwargs,
 ) -> TimeSeries:
     """
     Computes and posts a set of standard QC metrics for result of multichannel cross-correlation
@@ -2096,7 +2102,7 @@ def demean_residuals(
 
 
 @mspass_func_wrapper
-def remove_incident_wavefield(d, beam, handles_ensembles=True):
+def remove_incident_wavefield(d, beam, *args, handles_ensembles=True,**kwargs):
     """
     Remove incident wavefield for teleseismic P wave data using a beam estimate.
 

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -217,6 +217,8 @@ def MCXcorPrepP(
     minimum_coda_duration=5.0,
     correlation_window_start=-3.0,
     handles_ensembles=True,
+    checks_arg0_type=True,
+    handles_dead_data=False,
 ) -> TimeSeriesEnsemble:
     """
     Function used to preprocess an ensemble  to prepare input for
@@ -1109,6 +1111,8 @@ def align_and_stack(
     residual_norm_floor=0.1,
     demean_residuals=True,
     handles_ensembles=True,
+    checks_arg0_type=True,
+    handles_dead_data=True,
 ) -> tuple:
     """
     This function uses an initial estimate of the array stack passed as
@@ -1859,6 +1863,9 @@ def post_MCXcor_metrics(
     window=None,
     phase_time_key="Ptime",
     time_shift_key="arrival_time_correction",
+    handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=False,
 ) -> TimeSeries:
     """
     Computes and posts a set of standard QC metrics for result of multichannel cross-correlation

--- a/python/mspasspy/algorithms/MTPowerSpectrumEngine.py
+++ b/python/mspasspy/algorithms/MTPowerSpectrumEngine.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 from multitaper.mtspec import MTSpec
-from mspasspy.util.decorators import mspass_method_wrapper
 from mspasspy.ccore.utility import MsPASSError, ErrorSeverity, Metadata
 from mspasspy.ccore.seismic import TimeSeries, DoubleVector, PowerSpectrum
 
@@ -58,10 +57,11 @@ class MTPowerSpectrumEngine:
         self.lamb = None  # constructor for MTSpec set this
         self.MTSpec_instance = None
 
-    @mspass_method_wrapper
+ 
     def apply(self, d, dt=1.0):
         """
-        need to support vector input or a TimeSeries - returns a PowerSpectrum
+        needs to support vector input or a TimeSeries - returns a PowerSpectrum
+        Cannot use mspass decorator because it supports raw data vectors
 
         """
         # All inputs end up filling a numpy array passed to MTSpec below

--- a/python/mspasspy/algorithms/MTPowerSpectrumEngine.py
+++ b/python/mspasspy/algorithms/MTPowerSpectrumEngine.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 from multitaper.mtspec import MTSpec
+from mspasspy.util.decorators import mspass_method_wrapper
 from mspasspy.ccore.utility import MsPASSError, ErrorSeverity, Metadata
 from mspasspy.ccore.seismic import TimeSeries, DoubleVector, PowerSpectrum
 
@@ -57,6 +58,7 @@ class MTPowerSpectrumEngine:
         self.lamb = None  # constructor for MTSpec set this
         self.MTSpec_instance = None
 
+    @mspass_method_wrapper
     def apply(self, d, dt=1.0):
         """
         need to support vector input or a TimeSeries - returns a PowerSpectrum

--- a/python/mspasspy/algorithms/MTPowerSpectrumEngine.py
+++ b/python/mspasspy/algorithms/MTPowerSpectrumEngine.py
@@ -57,7 +57,6 @@ class MTPowerSpectrumEngine:
         self.lamb = None  # constructor for MTSpec set this
         self.MTSpec_instance = None
 
- 
     def apply(self, d, dt=1.0):
         """
         needs to support vector input or a TimeSeries - returns a PowerSpectrum

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -400,6 +400,9 @@ def RFdecon(
     alg_name="RFdecon",
     alg_id=None,
     dryrun=False,
+    handles_ensembles=False,
+    checks_arg0_type=True,
+    handles_dead_data=True,
 ):
     """
     Use this function to compute conventional receiver functions

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -396,6 +396,7 @@ def RFdecon(
     wcomp=2,
     ncomp=2,
     QCdocument_key="RFdecon_properties",
+    *args,
     object_history=False,
     alg_name="RFdecon",
     alg_id=None,
@@ -403,6 +404,7 @@ def RFdecon(
     handles_ensembles=False,
     checks_arg0_type=True,
     handles_dead_data=True,
+    **kwargs,
 ):
     """
     Use this function to compute conventional receiver functions

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -547,6 +547,7 @@ def transform_to_RTZ(
     phi=None,
     angle_units="degrees",
     key_is_backazimuth=True,
+    *args,
     object_history=False,
     alg_name=None,
     alg_id=None,
@@ -556,6 +557,7 @@ def transform_to_RTZ(
     handles_ensembles=True,
     checks_arg0_type=False,
     handles_dead_data=False,
+    **kwargs,
 ):
     """
     Applies coordinate transform to RTZ version of ray coordinates.
@@ -677,6 +679,7 @@ def transform_to_LQT(
     phi=None,
     theta=None,
     angle_units="degrees",
+    *args,
     object_history=False,
     alg_name=None,
     alg_id=None,
@@ -686,6 +689,7 @@ def transform_to_LQT(
     handles_ensembles=False,
     checks_arg0_type=False,
     handles_dead_data=False,
+    **kwargs,
 ):
     """
     Applies coordinate transform to LQT version of ray coordinates.

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -103,18 +103,18 @@ def ator(
     to a relative time standard.  Examples are conversions to travel
     time using an event origin time or shifting to an arrival time
     reference frame. This operation simply switches the tref
-    variable and alters t0 by tshift.  Note the special feature 
-    of how arg0 is handled.   If it is a string it assumed to be a 
-    Metadata key to use to fetch the time shift value from the data object's 
+    variable and alters t0 by tshift.  Note the special feature
+    of how arg0 is handled.   If it is a string it assumed to be a
+    Metadata key to use to fetch the time shift value from the data object's
     Metadata container.   If it is number it is used directly.'
 
     :param data: data object to be converted.
     :type data: either :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`
-    :param tshift: used to define time shift to apply.   If value is string 
-       the function assumes it is a metadata key it can use to extract the 
+    :param tshift: used to define time shift to apply.   If value is string
+       the function assumes it is a metadata key it can use to extract the
        requred value from the data's metadata container.  If it is a floating
-       point number it is used directly.   Anything else will result in a 
-       TypeError exception.  If a string is used but the key is not defined 
+       point number it is used directly.   Anything else will result in a
+       TypeError exception.  If a string is used but the key is not defined
        the datum will be killed with an elog message.
     :type tshift: :class:`float` or a string to use as a metdata key (see above)
     :param object_history: True to preserve the processing history. For details, refer to
@@ -129,15 +129,17 @@ def ator(
      return something that is appropriate to save as Metadata.  If so, use this argument to
      define the key used to set that field in the data that is returned.
     """
-    if isinstance(tshift,float):
+    if isinstance(tshift, float):
         data.ator(tshift)
-    elif isinstance(tshift,str):
+    elif isinstance(tshift, str):
         if tshift in data:
-            timeshift=data[tshift]
+            timeshift = data[tshift]
             data.ator(timeshift)
         else:
-            message = "arg0 string defines key={} not defined in Metadata container of this datum\n".format(tshift)
-            data.elog.log_error("ator",message,ErrorSeverity.Invalid)
+            message = "arg0 string defines key={} not defined in Metadata container of this datum\n".format(
+                tshift
+            )
+            data.elog.log_error("ator", message, ErrorSeverity.Invalid)
             data.kill()
     else:
         message = "ator:  usage error\n"

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -25,6 +25,8 @@ def ExtractComponent(
     dryrun=False,
     inplace_return=False,
     handles_ensembles=True,
+    checks_arg0_type=True,
+    handles_dead_data=True,
     function_return_key=None,
     **kwargs,
 ):
@@ -93,6 +95,8 @@ def ator(
     dryrun=False,
     inplace_return=True,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=True,
     function_return_key=None,
     **kwargs,
 ):
@@ -129,7 +133,7 @@ def ator(
      return something that is appropriate to save as Metadata.  If so, use this argument to
      define the key used to set that field in the data that is returned.
     """
-    if isinstance(tshift, float):
+    if isinstance(tshift, (float, int)):
         data.ator(tshift)
     elif isinstance(tshift, str):
         if tshift in data:
@@ -158,6 +162,8 @@ def rtoa(
     inplace_return=True,
     function_return_key=None,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=True,
     **kwargs,
 ):
     """
@@ -199,6 +205,8 @@ def rotate(
     inplace_return=True,
     function_return_key=None,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=True,
     **kwargs,
 ):
     """
@@ -245,6 +253,8 @@ def rotate_to_standard(
     inplace_return=True,
     function_return_key=None,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=True,
     **kwargs,
 ):
     """
@@ -303,6 +313,8 @@ def free_surface_transformation(
     inplace_return=True,
     function_return_key=None,
     handles_ensembles=True,
+    checks_arg0_type=True,
+    handles_dead_data=True,
     **kwargs,
 ):
     """
@@ -498,6 +510,8 @@ def transform(
     inplace_return=True,
     function_return_key=None,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=True,
     **kwargs,
 ):
     """
@@ -540,6 +554,8 @@ def transform_to_RTZ(
     inplace_return=False,
     function_return_key=None,
     handles_ensembles=True,
+    checks_arg0_type=False,
+    handles_dead_data=False,
 ):
     """
     Applies coordinate transform to RTZ version of ray coordinates.
@@ -668,6 +684,8 @@ def transform_to_LQT(
     inplace_return=False,
     function_return_key=None,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=False,
 ):
     """
     Applies coordinate transform to LQT version of ray coordinates.
@@ -840,6 +858,8 @@ def linear_taper(
     inplace_return=True,
     function_return_key=None,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=False,
     **kwargs,
 ):
     """
@@ -891,6 +911,8 @@ def cosine_taper(
     inplace_return=True,
     function_return_key=None,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=False,
     **kwargs,
 ):
     """
@@ -941,6 +963,8 @@ def vector_taper(
     inplace_return=True,
     function_return_key=None,
     handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=False,
     **kwargs,
 ):
     """

--- a/python/mspasspy/algorithms/basic.py
+++ b/python/mspasspy/algorithms/basic.py
@@ -24,6 +24,7 @@ def ExtractComponent(
     alg_id=None,
     dryrun=False,
     inplace_return=False,
+    handles_ensembles=True,
     function_return_key=None,
     **kwargs,
 ):
@@ -91,6 +92,7 @@ def ator(
     alg_id=None,
     dryrun=False,
     inplace_return=True,
+    handles_ensembles=False,
     function_return_key=None,
     **kwargs,
 ):
@@ -101,12 +103,20 @@ def ator(
     to a relative time standard.  Examples are conversions to travel
     time using an event origin time or shifting to an arrival time
     reference frame. This operation simply switches the tref
-    variable and alters t0 by tshift.
+    variable and alters t0 by tshift.  Note the special feature 
+    of how arg0 is handled.   If it is a string it assumed to be a 
+    Metadata key to use to fetch the time shift value from the data object's 
+    Metadata container.   If it is number it is used directly.'
 
     :param data: data object to be converted.
     :type data: either :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`
-    :param tshift: time shift applied to data before switching data to relative time mode.
-    :type tshift: :class:`float`
+    :param tshift: used to define time shift to apply.   If value is string 
+       the function assumes it is a metadata key it can use to extract the 
+       requred value from the data's metadata container.  If it is a floating
+       point number it is used directly.   Anything else will result in a 
+       TypeError exception.  If a string is used but the key is not defined 
+       the datum will be killed with an elog message.
+    :type tshift: :class:`float` or a string to use as a metdata key (see above)
     :param object_history: True to preserve the processing history. For details, refer to
      :class:`~mspasspy.util.decorators.mspass_func_wrapper`.
     :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
@@ -119,7 +129,20 @@ def ator(
      return something that is appropriate to save as Metadata.  If so, use this argument to
      define the key used to set that field in the data that is returned.
     """
-    data.ator(tshift)
+    if isinstance(tshift,float):
+        data.ator(tshift)
+    elif isinstance(tshift,str):
+        if tshift in data:
+            timeshift=data[tshift]
+            data.ator(timeshift)
+        else:
+            message = "arg0 string defines key={} not defined in Metadata container of this datum\n".format(tshift)
+            data.elog.log_error("ator",message,ErrorSeverity.Invalid)
+            data.kill()
+    else:
+        message = "ator:  usage error\n"
+        message += "Invalid type for arg0={}\n".format(str(type(tshift)))
+        raise ValueError(message)
 
 
 @mspass_func_wrapper
@@ -132,6 +155,7 @@ def rtoa(
     dryrun=False,
     inplace_return=True,
     function_return_key=None,
+    handles_ensembles=False,
     **kwargs,
 ):
     """
@@ -172,6 +196,7 @@ def rotate(
     dryrun=False,
     inplace_return=True,
     function_return_key=None,
+    handles_ensembles=False,
     **kwargs,
 ):
     """
@@ -217,6 +242,7 @@ def rotate_to_standard(
     dryrun=False,
     inplace_return=True,
     function_return_key=None,
+    handles_ensembles=False,
     **kwargs,
 ):
     """
@@ -274,6 +300,7 @@ def free_surface_transformation(
     dryrun=False,
     inplace_return=True,
     function_return_key=None,
+    handles_ensembles=True,
     **kwargs,
 ):
     """
@@ -468,6 +495,7 @@ def transform(
     dryrun=False,
     inplace_return=True,
     function_return_key=None,
+    handles_ensembles=False,
     **kwargs,
 ):
     """
@@ -509,6 +537,7 @@ def transform_to_RTZ(
     dryrun=False,
     inplace_return=False,
     function_return_key=None,
+    handles_ensembles=True,
 ):
     """
     Applies coordinate transform to RTZ version of ray coordinates.
@@ -636,6 +665,7 @@ def transform_to_LQT(
     dryrun=False,
     inplace_return=False,
     function_return_key=None,
+    handles_ensembles=False,
 ):
     """
     Applies coordinate transform to LQT version of ray coordinates.
@@ -807,6 +837,7 @@ def linear_taper(
     dryrun=False,
     inplace_return=True,
     function_return_key=None,
+    handles_ensembles=False,
     **kwargs,
 ):
     """
@@ -857,6 +888,7 @@ def cosine_taper(
     dryrun=False,
     inplace_return=True,
     function_return_key=None,
+    handles_ensembles=False,
     **kwargs,
 ):
     """
@@ -906,6 +938,7 @@ def vector_taper(
     dryrun=False,
     inplace_return=True,
     function_return_key=None,
+    handles_ensembles=False,
     **kwargs,
 ):
     """

--- a/python/mspasspy/algorithms/calib.py
+++ b/python/mspasspy/algorithms/calib.py
@@ -153,16 +153,17 @@ class ApplyCalibEngine:
             raise MsPASSError(message, ErrorSeverity.Invalid)
 
     @mspass_method_wrapper
-    def apply_calib(self, 
-          d, 
-          id_key="channel_id", 
-          kill_if_undefined=True,
-          *args,
-          handles_ensembles=True,
-          checks_arg0_type=True,
-          handles_dead_data=True,
-          **kwargs,
-        ):
+    def apply_calib(
+        self,
+        d,
+        id_key="channel_id",
+        kill_if_undefined=True,
+        *args,
+        handles_ensembles=True,
+        checks_arg0_type=True,
+        handles_dead_data=True,
+        **kwargs,
+    ):
         """
         Use this method to apply a calib value to a TimeSeries or all the
         live members of a TimeSeriesEnsemble.

--- a/python/mspasspy/algorithms/calib.py
+++ b/python/mspasspy/algorithms/calib.py
@@ -2,6 +2,7 @@ import pickle
 import numpy as np
 from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
 from mspasspy.ccore.utility import MsPASSError, ErrorSeverity
+from mspasspy.util.decorators import mspass_method_wrapper
 from obspy import UTCDateTime
 
 
@@ -151,7 +152,17 @@ class ApplyCalibEngine:
             )
             raise MsPASSError(message, ErrorSeverity.Invalid)
 
-    def apply_calib(self, d, id_key="channel_id", kill_if_undefined=True):
+    @mspass_method_wrapper
+    def apply_calib(self, 
+          d, 
+          id_key="channel_id", 
+          kill_if_undefined=True,
+          *args,
+          handles_ensembles=True,
+          checks_arg0_type=True,
+          handles_dead_data=True,
+          **kwargs,
+        ):
         """
         Use this method to apply a calib value to a TimeSeries or all the
         live members of a TimeSeriesEnsemble.

--- a/python/mspasspy/algorithms/edit.py
+++ b/python/mspasspy/algorithms/edit.py
@@ -156,7 +156,9 @@ class MetadataGT(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] > value stored with the class.
@@ -219,7 +221,9 @@ class MetadataGE(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] >= value stored with the class.
@@ -280,7 +284,9 @@ class MetadataLT(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] > value stored with the class.
@@ -341,7 +347,9 @@ class MetadataLE(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] <= value stored with the class.
@@ -404,7 +412,9 @@ class MetadataEQ(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] == value stored with the class.
@@ -467,7 +477,9 @@ class MetadataNE(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] != value stored with the class.
@@ -520,7 +532,9 @@ class MetadataDefined(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if self.key is defined for this datum
@@ -662,7 +676,9 @@ class MetadataInterval(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] <= value stored with the class.
@@ -776,7 +792,9 @@ class FiringSquad(Executioner):
             self.executioners.append(ex)
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
+    def kill_if_true(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of base class method.  In this case failure is
         defined as not passing one of the set of tests loaded  when
@@ -1053,7 +1071,9 @@ class SetValue(MetadataOperator):
         self.value = constant_value
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Used to apply this operator to Metadata of a MsPASS data object.
         Use of decorator adds common MsPASS arguments as call options.
@@ -1120,7 +1140,9 @@ class Add(MetadataOperator):
         self.value = value_to_add
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Add Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1198,7 +1220,9 @@ class Multiply(MetadataOperator):
         self.value = value_to_multiply
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Multiply Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1275,7 +1299,9 @@ class Subtract(MetadataOperator):
         self.value = value_to_subtract
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Subtract Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1353,7 +1379,9 @@ class Divide(MetadataOperator):
         self.value = value_to_divide
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Divide Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1438,7 +1466,9 @@ class IntegerDivide(MetadataOperator):
         self.value = value
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata IntegerDivide Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1527,7 +1557,9 @@ class Mod(MetadataOperator):
         self.value = value
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Mod Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1620,7 +1652,9 @@ class Add2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Add2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1720,7 +1754,9 @@ class Multiply2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Multiply2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1820,7 +1856,9 @@ class Subtract2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Subtract2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1920,7 +1958,9 @@ class Divide2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Divide2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -2020,7 +2060,9 @@ class IntegerDivide2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata IntegerDivide2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -2120,7 +2162,9 @@ class Mod2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         elognametag = "Metadata Mod2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -2237,7 +2281,9 @@ class MetadataOperatorChain(MetadataOperator):
             self.oplist.append(ex)
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, handles_ensembles=True):
+    def apply(
+        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+    ):
         """
         Implementation of base class method.  In this case failure is
         defined as not passing one of the set of tests loaded  when

--- a/python/mspasspy/algorithms/edit.py
+++ b/python/mspasspy/algorithms/edit.py
@@ -157,7 +157,13 @@ class MetadataGT(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self,
+        d,
+        apply_to_members=False,
+        *args,
+        handles_ensembles=True,
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of this abstract method for this tester.
@@ -222,7 +228,13 @@ class MetadataGE(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of this abstract method for this tester.
@@ -285,7 +297,13 @@ class MetadataLT(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False,
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of this abstract method for this tester.
@@ -348,7 +366,13 @@ class MetadataLE(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of this abstract method for this tester.
@@ -413,7 +437,13 @@ class MetadataEQ(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of this abstract method for this tester.
@@ -478,7 +508,13 @@ class MetadataNE(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of this abstract method for this tester.
@@ -533,7 +569,13 @@ class MetadataDefined(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of this abstract method for this tester.
@@ -587,7 +629,15 @@ class MetadataUndefined(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
+        ):
         """
         Implementation of this abstract method for this tester.
         Kills d if self.key is not defined for this datum
@@ -677,7 +727,13 @@ class MetadataInterval(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of this abstract method for this tester.
@@ -793,7 +849,13 @@ class FiringSquad(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of base class method.  In this case failure is
@@ -982,7 +1044,9 @@ class ChangeKey(MetadataOperator):
         apply_to_members=False,
         fast_mode=False,
         verbose=False,
+        *args,
         handles_enembles=True,
+        **kwargs,
     ):
         if _input_is_valid(d):
             if d.dead():
@@ -1072,7 +1136,13 @@ class SetValue(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Used to apply this operator to Metadata of a MsPASS data object.
@@ -1141,7 +1211,13 @@ class Add(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Add Operator"
         if _input_is_valid(d):
@@ -1221,7 +1297,13 @@ class Multiply(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Multiply Operator"
         if _input_is_valid(d):
@@ -1300,7 +1382,13 @@ class Subtract(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Subtract Operator"
         if _input_is_valid(d):
@@ -1380,7 +1468,13 @@ class Divide(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Divide Operator"
         if _input_is_valid(d):
@@ -1467,7 +1561,13 @@ class IntegerDivide(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata IntegerDivide Operator"
         if _input_is_valid(d):
@@ -1558,7 +1658,13 @@ class Mod(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Mod Operator"
         if _input_is_valid(d):
@@ -1653,7 +1759,13 @@ class Add2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Add2 Operator"
         if _input_is_valid(d):
@@ -1755,7 +1867,13 @@ class Multiply2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Multiply2 Operator"
         if _input_is_valid(d):
@@ -1857,7 +1975,13 @@ class Subtract2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Subtract2 Operator"
         if _input_is_valid(d):
@@ -1959,7 +2083,13 @@ class Divide2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Divide2 Operator"
         if _input_is_valid(d):
@@ -2061,7 +2191,13 @@ class IntegerDivide2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata IntegerDivide2 Operator"
         if _input_is_valid(d):
@@ -2163,7 +2299,13 @@ class Mod2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         elognametag = "Metadata Mod2 Operator"
         if _input_is_valid(d):
@@ -2282,7 +2424,13 @@ class MetadataOperatorChain(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, d, apply_to_members=False, handles_ensembles=True, checks_arg0_type=True
+        self, 
+        d, 
+        apply_to_members=False, 
+        *args,
+        handles_ensembles=True, 
+        checks_arg0_type=True,
+        **kwargs,
     ):
         """
         Implementation of base class method.  In this case failure is

--- a/python/mspasspy/algorithms/edit.py
+++ b/python/mspasspy/algorithms/edit.py
@@ -228,11 +228,11 @@ class MetadataGE(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -297,11 +297,11 @@ class MetadataLT(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
+        self,
+        d,
         apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -366,11 +366,11 @@ class MetadataLE(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -437,11 +437,11 @@ class MetadataEQ(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -508,11 +508,11 @@ class MetadataNE(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -569,11 +569,11 @@ class MetadataDefined(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -630,14 +630,14 @@ class MetadataUndefined(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
-        ):
+    ):
         """
         Implementation of this abstract method for this tester.
         Kills d if self.key is not defined for this datum
@@ -727,11 +727,11 @@ class MetadataInterval(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -849,11 +849,11 @@ class FiringSquad(Executioner):
 
     @mspass_method_wrapper
     def kill_if_true(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1136,11 +1136,11 @@ class SetValue(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1211,11 +1211,11 @@ class Add(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1297,11 +1297,11 @@ class Multiply(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1382,11 +1382,11 @@ class Subtract(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1468,11 +1468,11 @@ class Divide(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1561,11 +1561,11 @@ class IntegerDivide(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1658,11 +1658,11 @@ class Mod(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1759,11 +1759,11 @@ class Add2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1867,11 +1867,11 @@ class Multiply2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -1975,11 +1975,11 @@ class Subtract2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -2083,11 +2083,11 @@ class Divide2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -2191,11 +2191,11 @@ class IntegerDivide2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -2299,11 +2299,11 @@ class Mod2(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):
@@ -2424,11 +2424,11 @@ class MetadataOperatorChain(MetadataOperator):
 
     @mspass_method_wrapper
     def apply(
-        self, 
-        d, 
-        apply_to_members=False, 
+        self,
+        d,
+        apply_to_members=False,
         *args,
-        handles_ensembles=True, 
+        handles_ensembles=True,
         checks_arg0_type=True,
         **kwargs,
     ):

--- a/python/mspasspy/algorithms/edit.py
+++ b/python/mspasspy/algorithms/edit.py
@@ -156,7 +156,7 @@ class MetadataGT(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] > value stored with the class.
@@ -219,7 +219,7 @@ class MetadataGE(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] >= value stored with the class.
@@ -280,7 +280,7 @@ class MetadataLT(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] > value stored with the class.
@@ -341,7 +341,7 @@ class MetadataLE(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] <= value stored with the class.
@@ -404,7 +404,7 @@ class MetadataEQ(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] == value stored with the class.
@@ -467,7 +467,7 @@ class MetadataNE(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] != value stored with the class.
@@ -520,7 +520,7 @@ class MetadataDefined(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of this abstract method for this tester.
         Kills d if self.key is defined for this datum
@@ -662,7 +662,7 @@ class MetadataInterval(Executioner):
         self.verbose = verbose
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of this abstract method for this tester.
         Kills d if the d[self.key] <= value stored with the class.
@@ -776,7 +776,7 @@ class FiringSquad(Executioner):
             self.executioners.append(ex)
 
     @mspass_method_wrapper
-    def kill_if_true(self, d, apply_to_members=False):
+    def kill_if_true(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of base class method.  In this case failure is
         defined as not passing one of the set of tests loaded  when
@@ -958,7 +958,14 @@ class ChangeKey(MetadataOperator):
             raise MsPASSError(message, ErrorSeverity.Fatal)
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False, fast_mode=False, verbose=False):
+    def apply(
+        self,
+        d,
+        apply_to_members=False,
+        fast_mode=False,
+        verbose=False,
+        handles_enembles=True,
+    ):
         if _input_is_valid(d):
             if d.dead():
                 return d
@@ -1046,7 +1053,7 @@ class SetValue(MetadataOperator):
         self.value = constant_value
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Used to apply this operator to Metadata of a MsPASS data object.
         Use of decorator adds common MsPASS arguments as call options.
@@ -1113,7 +1120,7 @@ class Add(MetadataOperator):
         self.value = value_to_add
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Add Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1191,7 +1198,7 @@ class Multiply(MetadataOperator):
         self.value = value_to_multiply
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Multiply Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1268,7 +1275,7 @@ class Subtract(MetadataOperator):
         self.value = value_to_subtract
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Subtract Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1346,7 +1353,7 @@ class Divide(MetadataOperator):
         self.value = value_to_divide
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Divide Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1431,7 +1438,7 @@ class IntegerDivide(MetadataOperator):
         self.value = value
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata IntegerDivide Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1520,7 +1527,7 @@ class Mod(MetadataOperator):
         self.value = value
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Mod Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1613,7 +1620,7 @@ class Add2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Add2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1713,7 +1720,7 @@ class Multiply2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Multiply2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1813,7 +1820,7 @@ class Subtract2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Subtract2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -1913,7 +1920,7 @@ class Divide2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Divide2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -2013,7 +2020,7 @@ class IntegerDivide2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata IntegerDivide2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -2113,7 +2120,7 @@ class Mod2(MetadataOperator):
         self.key2 = key2
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         elognametag = "Metadata Mod2 Operator"
         if _input_is_valid(d):
             if d.dead():
@@ -2230,7 +2237,7 @@ class MetadataOperatorChain(MetadataOperator):
             self.oplist.append(ex)
 
     @mspass_method_wrapper
-    def apply(self, d, apply_to_members=False):
+    def apply(self, d, apply_to_members=False, handles_ensembles=True):
         """
         Implementation of base class method.  In this case failure is
         defined as not passing one of the set of tests loaded  when

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -187,7 +187,7 @@ class ScipyResampler(BasicResampler):
         self.window = window
 
     @mspass_method_wrapper
-    def resample(self, mspass_object):
+    def resample(self, mspass_object, checks_arg0_type=True):
         """
         Applies the scipy.signal.resample function to all data held in
         a mspass container passed through arg0 (mspass_object).
@@ -327,7 +327,7 @@ class ScipyDecimator(BasicResampler):
         return message
 
     @mspass_method_wrapper
-    def resample(self, mspass_object, handles_ensembles=True):
+    def resample(self, mspass_object, checks_arg0_type=True):
         """
         Implementation of required abstract method for this operator.
         The only argument is mspass_object.   The operator will downsample
@@ -427,6 +427,10 @@ class ScipyDecimator(BasicResampler):
 
 
 @mspass_func_wrapper
+# note handles_dead_data could be left at default True only because 
+# resampling operators in this module all handle dead data cleanly. 
+# set False for efficiency and to be more robust with other implementations
+# of decimator or resampler
 def resample(
     mspass_object,
     decimator,
@@ -439,6 +443,8 @@ def resample(
     inplace_return=False,
     function_return_key=None,
     handles_ensembles=True,
+    checks_arg0_type=True,
+    handles_dead_data=False,
 ):
     """
     Resample any valid data object to a common sample rate (sample interval).

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from mspasspy.util.decorators import mspass_func_wrapper
+from mspasspy.util.decorators import mspass_func_wrapper, mspass_method_wrapper
 from mspasspy.ccore.utility import MsPASSError, ErrorSeverity, dmatrix
 from mspasspy.ccore.seismic import (
     TimeSeries,
@@ -127,7 +127,7 @@ class BasicResampler(ABC):
             return -1
 
     @abstractmethod
-    def resample(self, mspass_object):
+    def resample(self, mspass_object, handles_ensembles=True):
         """
         Main operator a concrete class must implement.  It should accept
         any mspass data object and return a clone that has been resampled
@@ -186,6 +186,7 @@ class ScipyResampler(BasicResampler):
         super().__init__(sampling_rate=sampling_rate)
         self.window = window
 
+    @mspass_method_wrapper
     def resample(self, mspass_object):
         """
         Applies the scipy.signal.resample function to all data held in
@@ -325,7 +326,8 @@ class ScipyDecimator(BasicResampler):
             )
         return message
 
-    def resample(self, mspass_object):
+    @mspass_method_wrapper
+    def resample(self, mspass_object, handles_ensembles=True):
         """
         Implementation of required abstract method for this operator.
         The only argument is mspass_object.   The operator will downsample
@@ -436,6 +438,7 @@ def resample(
     dryrun=False,
     inplace_return=False,
     function_return_key=None,
+    handles_ensembles=True,
 ):
     """
     Resample any valid data object to a common sample rate (sample interval).

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -187,7 +187,7 @@ class ScipyResampler(BasicResampler):
         self.window = window
 
     @mspass_method_wrapper
-    def resample(self, mspass_object, checks_arg0_type=True):
+    def resample(self, mspass_object, *args, checks_arg0_type=True, **kwargs):
         """
         Applies the scipy.signal.resample function to all data held in
         a mspass container passed through arg0 (mspass_object).
@@ -327,7 +327,7 @@ class ScipyDecimator(BasicResampler):
         return message
 
     @mspass_method_wrapper
-    def resample(self, mspass_object, checks_arg0_type=True):
+    def resample(self, mspass_object, *args, checks_arg0_type=True, **kwargs):
         """
         Implementation of required abstract method for this operator.
         The only argument is mspass_object.   The operator will downsample
@@ -436,6 +436,7 @@ def resample(
     decimator,
     resampler,
     verify_operators=True,
+    *args,
     object_history=False,
     alg_name="resample",
     alg_id=None,
@@ -445,6 +446,7 @@ def resample(
     handles_ensembles=True,
     checks_arg0_type=True,
     handles_dead_data=False,
+    **kwargs,
 ):
     """
     Resample any valid data object to a common sample rate (sample interval).

--- a/python/mspasspy/algorithms/resample.py
+++ b/python/mspasspy/algorithms/resample.py
@@ -427,8 +427,8 @@ class ScipyDecimator(BasicResampler):
 
 
 @mspass_func_wrapper
-# note handles_dead_data could be left at default True only because 
-# resampling operators in this module all handle dead data cleanly. 
+# note handles_dead_data could be left at default True only because
+# resampling operators in this module all handle dead data cleanly.
 # set False for efficiency and to be more robust with other implementations
 # of decimator or resampler
 def resample(

--- a/python/mspasspy/algorithms/signals.py
+++ b/python/mspasspy/algorithms/signals.py
@@ -35,12 +35,12 @@ def filter(
 ):
     """
     Applies a time invariant filter to a MsPASS data object.
-    
-    This entry is a wrapper around the obspy filter function.  It accepts the 
-    same arguments as the obspy function and runs the same implementation. 
-    See their documentation for details, but note the idiosyncracy of 
-    their API is inherited.  Because different types of filters are 
-    enabled by the setting of the "type" argument, what kwarg values are 
+
+    This entry is a wrapper around the obspy filter function.  It accepts the
+    same arguments as the obspy function and runs the same implementation.
+    See their documentation for details, but note the idiosyncracy of
+    their API is inherited.  Because different types of filters are
+    enabled by the setting of the "type" argument, what kwarg values are
     referenced depend upon the value of "type".   In particular, note:
         - "bandpass" requires values for "freqmin" and "freqmax as corner frequenices
         - "lowpass" requires only a value for "freq" to define the one corner

--- a/python/mspasspy/algorithms/signals.py
+++ b/python/mspasspy/algorithms/signals.py
@@ -30,11 +30,22 @@ def filter(
     alg_id=None,
     dryrun=False,
     inplace_return=True,
+    handles_ensembles=True,
     **options,
 ):
     """
-    This function filters the data of mspasspy objects. Note it is wrapped by mspass_func_wrapper, so the processing
-    history and error logs can be preserved.
+    Applies a time invariant filter to a MsPASS data object.
+    
+    This entry is a wrapper around the obspy filter function.  It accepts the 
+    same arguments as the obspy function and runs the same implementation. 
+    See their documentation for details, but note the idiosyncracy of 
+    their API is inherited.  Because different types of filters are 
+    enabled by the setting of the "type" argument, what kwarg values are 
+    referenced depend upon the value of "type".   In particular, note:
+        - "bandpass" requires values for "freqmin" and "freqmax as corner frequenices
+        - "lowpass" requires only a value for "freq" to define the one corner
+        - "highpass" also requres only the value "freq" for the low corner
+    There are other options described in the obspy documentation.
 
     :param data: input data, only mspasspy data objects are accepted, i.e. TimeSeries, Seismogram, Ensemble.
     :param type: type of filter, 'bandpass', 'bandstop', 'lowpass', 'highpass', 'lowpass_cheby_2', 'lowpass_fir',
@@ -69,6 +80,7 @@ def detrend(
     alg_id=None,
     dryrun=False,
     inplace_return=True,
+    handles_ensembles=True,
     type="simple",
     **options,
 ):
@@ -109,6 +121,7 @@ def interpolate(
     alg_id=None,
     dryrun=False,
     inplace_return=True,
+    handles_ensembles=True,
     method="weighted_average_slopes",
     starttime=None,
     npts=None,

--- a/python/mspasspy/algorithms/signals.py
+++ b/python/mspasspy/algorithms/signals.py
@@ -30,7 +30,7 @@ def filter(
     alg_id=None,
     dryrun=False,
     inplace_return=True,
-    handles_ensembles=True,
+    handles_dead_data=False,
     **options,
 ):
     """
@@ -80,7 +80,7 @@ def detrend(
     alg_id=None,
     dryrun=False,
     inplace_return=True,
-    handles_ensembles=True,
+    handles_dead_data=False,
     type="simple",
     **options,
 ):
@@ -121,7 +121,7 @@ def interpolate(
     alg_id=None,
     dryrun=False,
     inplace_return=True,
-    handles_ensembles=True,
+    handles_dead_data=False,
     method="weighted_average_slopes",
     starttime=None,
     npts=None,
@@ -242,6 +242,7 @@ def correlate_stream_template(
     dryrun=False,
     template_time=None,
     return_type="seismogram",
+    handles_dead_data=True,
     **kwargs,
 ):
     res = obspy.signal.cross_correlation.correlate_stream_template(
@@ -274,6 +275,7 @@ def correlation_detector(
     details=None,
     plot=None,
     return_type="seismogram",
+    handles_dead_data=False,
     **kwargs,
 ):
     tem_list = []
@@ -316,6 +318,7 @@ def templates_max_similarity(
     alg_name="templates_max_similarity",
     alg_id=None,
     dryrun=False,
+    handles_dead_data=False,
 ):
     tem_list = []
     for template in streams_templates:
@@ -353,6 +356,7 @@ def xcorr_max(
     alg_id=None,
     dryrun=False,
     abs_max=True,
+    handles_dead_data=False,
 ):
     return obspy.signal.cross_correlation.xcorr_max(data, abs_max)
 

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -268,6 +268,9 @@ def snr(
     noise_metric="mad",
     signal_metric="mad",
     perc=95.0,
+    handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=False,
 ):
     """
     Compute time-domain based signal-to-noise ratio with a specified metric.
@@ -415,7 +418,8 @@ def _reformat_mspass_error(
     return log_message
 
 
-@mspass_func_wrapper
+# Do not use mspass_func_decorator here because it is mainly aninternal 
+# engine used by more usable functions in this module
 def FD_snr_estimator(
     data_object,
     noise_window=TimeWindow(-130.0, -5.0),
@@ -930,6 +934,9 @@ def arrival_snr(
         "filtered_MAD",
         "filtered_perc",
     ],
+    handles_ensembles=False,
+    checks_arg0_type=True,
+    handles_dead_data=True,
 ):
     """
     Specialization of FD_snr_estimator.   A common situation where snr
@@ -1095,6 +1102,9 @@ def broadband_snr_QC(
     taup_model=None,
     source_collection="source",
     receiver_collection=None,
+    handles_ensembles=False,
+    checks_arg0_type=True,
+    handles_dead_data=True,
 ):
     """
     Compute a series of metrics that can be used for quality control
@@ -1200,8 +1210,7 @@ def broadband_snr_QC(
     :return:  the data_object modified by insertion of the snr QC data
       in the object's Metadata under the key defined by metadata_output_key.
     """
-    if data_object.dead():
-        return data_object
+
     if isinstance(data_object, TimeSeries):
         # We need to make a copy of a TimeSeries object to assure the only
         # thing we change is the Metadata we add to the return
@@ -1231,6 +1240,8 @@ def broadband_snr_QC(
             + "Input must be either TimeSeries or a Seismogram object",
             ErrorSeverity.Fatal,
         )
+    if data_object.dead():
+        return data_object
     if use_measured_arrival_time:
         arrival_time = data_object[measured_arrival_time_key]
     else:

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -420,7 +420,7 @@ def _reformat_mspass_error(
     return log_message
 
 
-# Do not use mspass_func_decorator here because it is mainly aninternal 
+# Do not use mspass_func_decorator here because it is mainly aninternal
 # engine used by more usable functions in this module
 def FD_snr_estimator(
     data_object,

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -17,6 +17,7 @@ from mspasspy.ccore.algorithms.amplitudes import (
 from mspasspy.ccore.algorithms.basic import TimeWindow, Butterworth, _ExtractComponent
 from mspasspy.algorithms.signals import filter
 from mspasspy.algorithms.window import WindowData
+from mspasspy.util.decorators import mspass_func_wrapper
 
 # debug
 # import matplotlib.pyplot as plt
@@ -259,6 +260,7 @@ def _safe_snr_calculation(s, n):
         return s / n
 
 
+@mspass_func_wrapper
 def snr(
     data_object,
     noise_window=TimeWindow(-130.0, -5.0),
@@ -413,6 +415,7 @@ def _reformat_mspass_error(
     return log_message
 
 
+@mspass_func_wrapper
 def FD_snr_estimator(
     data_object,
     noise_window=TimeWindow(-130.0, -5.0),
@@ -899,6 +902,7 @@ def FD_snr_estimator(
     return [snrdata, my_logger]
 
 
+@mspass_func_wrapper
 def arrival_snr(
     data_object,
     noise_window=TimeWindow(-130.0, -5.0),
@@ -1058,6 +1062,7 @@ def arrival_snr(
     return data_object
 
 
+@mspass_func_wrapper
 def broadband_snr_QC(
     data_object,
     component=2,
@@ -1584,6 +1589,7 @@ def visualize_qcdata(
     :type qc_subdoc_key:  string or None.  Default "Parrival"
        is default of `broadband_arrival_QC`.
     """
+    import matplotlib.pyplot as plt
 
     def pts2box(xmin, xmax, ymin, ymax) -> tuple:
         """

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -268,9 +268,11 @@ def snr(
     noise_metric="mad",
     signal_metric="mad",
     perc=95.0,
+    *args,
     handles_ensembles=False,
     checks_arg0_type=False,
     handles_dead_data=False,
+    **kwargs,
 ):
     """
     Compute time-domain based signal-to-noise ratio with a specified metric.
@@ -934,9 +936,11 @@ def arrival_snr(
         "filtered_MAD",
         "filtered_perc",
     ],
+    *args,
     handles_ensembles=False,
     checks_arg0_type=True,
     handles_dead_data=True,
+    **kwargs,
 ):
     """
     Specialization of FD_snr_estimator.   A common situation where snr
@@ -1102,9 +1106,11 @@ def broadband_snr_QC(
     taup_model=None,
     source_collection="source",
     receiver_collection=None,
+    *args,
     handles_ensembles=False,
     checks_arg0_type=True,
     handles_dead_data=True,
+    **kwargs,
 ):
     """
     Compute a series of metrics that can be used for quality control

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -85,14 +85,16 @@ def scale(
     level=1.0,
     scale_by_section=False,
     use_mean=False,
+    *args,
     object_history=False,
     alg_name="scale",
     alg_id=None,
     dryrun=False,
     function_return_key=None,
-    handles_ensembles=False,
+    handles_ensembles=True,
     checks_arg0_type=True,
     handles_dead_data=True,
+    **kwargs,
 ):
     """
     Top level function interface to data scaling methods.
@@ -1188,7 +1190,16 @@ class TopMute:
         self.t0 = t0
 
     @mspass_method_wrapper
-    def apply(self, d, object_history=False, instance=None):
+    def apply(self, 
+              d, 
+              object_history=False, 
+              instance=None,
+              *args,
+              checks_arg0_type=True,
+              handles_ensembles=False,
+              handles_dead_data=True,
+              **kwargs,
+        ):
         """
         Use thie method to apply the defined top mute to one of the MsPASS
         atomic data objects. The method does a sanity check on the input
@@ -1208,10 +1219,9 @@ class TopMute:
           come from the global history manager or be set manually.
         """
         if not isinstance(d, TimeSeries) and not isinstance(d, Seismogram):
-            raise MsPASSError(
-                "TopMute.apply:  usage error.  Input data must be a TimeSeries or Seismogram object",
-                ErrorSeverity.Invalid,
-            )
+            message = "TopMute.apply:  usage error.  Input data must be a TimeSeries or Seismogram object"
+            message += "Actual type of arg={}".format(type(d))
+            raise TypeError(message)
         if d.dead():
             return d
         if d.t0 > self.t0:

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -26,7 +26,7 @@ from mspasspy.ccore.algorithms.amplitudes import (
     _scale_ensemble_members,
     ScalingMethod,
 )
-from mspasspy.util.decorators import mspass_func_wrapper
+from mspasspy.util.decorators import mspass_func_wrapper, mspass_method_wrapper
 
 
 def ensemble_error_post(d, alg, message, severity):
@@ -589,6 +589,7 @@ def WindowData(
     alg_name="WindowData",
     alg_id=None,
     dryrun=False,
+    handles_ensemble=True,
 ):
     """
     Apply a window operation to cut out data within a specified time range
@@ -1200,6 +1201,7 @@ class TopMute:
         self.processor = _TopMute(t0, t1, type)
         self.t0 = t0
 
+    @mspass_method_wrapper
     def apply(self, d, object_history=False, instance=None):
         """
         Use thie method to apply the defined top mute to one of the MsPASS

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -293,6 +293,7 @@ def scale(
         else:
             ensemble_error_post(d, alg_name, message, ErrorSeverity.Invalid)
 
+
 # not decorated for reasons given in docstring below
 def WindowDataAtomic(
     d,
@@ -304,7 +305,7 @@ def WindowDataAtomic(
 ):
     """
     Cut atomic data to a shorter time segment defined by a time range.
-    
+
     Cutting a smaller waveform segment from a larger waveform segment
     is a very common seismic data processing task.  Handling that low
     level operation needs to be done efficiently but with a reasonable
@@ -361,9 +362,9 @@ def WindowDataAtomic(
     value only to the nearest sample.   That way time computed with the
     time method (endtime is a special case for sample npts-1)
     will have subsample accuracy.
-    
-    Note:  This function should not normally be used.  WindowData 
-    calls it directy for atomic inputs and adds only a tiny overhead.  
+
+    Note:  This function should not normally be used.  WindowData
+    calls it directy for atomic inputs and adds only a tiny overhead.
     It can still be used as long as you don't need object-level history.'
 
     :param d: is the input data.  d must be either a
@@ -407,7 +408,7 @@ def WindowDataAtomic(
     output.  When False recovery will be done silently.  Note when
     `short_segment_handling` is set to "kill" logging is not optional and
     kill will always create an error log entry.
-    
+
     :return: copy of d with sample range reduced to twin range.  Returns
       an empty version of the parent data type (default constructor) if
       the input is marked dead
@@ -1190,16 +1191,17 @@ class TopMute:
         self.t0 = t0
 
     @mspass_method_wrapper
-    def apply(self, 
-              d, 
-              object_history=False, 
-              instance=None,
-              *args,
-              checks_arg0_type=True,
-              handles_ensembles=False,
-              handles_dead_data=True,
-              **kwargs,
-        ):
+    def apply(
+        self,
+        d,
+        object_history=False,
+        instance=None,
+        *args,
+        checks_arg0_type=True,
+        handles_ensembles=False,
+        handles_dead_data=True,
+        **kwargs,
+    ):
         """
         Use thie method to apply the defined top mute to one of the MsPASS
         atomic data objects. The method does a sanity check on the input

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3266,13 +3266,14 @@ class ArrivalMatcher(DataFrameCacheMatcher):
 
 
 @mspass_func_wrapper
-def normalize(mspass_object, 
-              matcher, 
-              kill_on_failure=True,
-              handles_ensembles=False,
-              checks_arg0_type=False,
-              handles_dead_data=True,
-              ):
+def normalize(
+    mspass_object,
+    matcher,
+    kill_on_failure=True,
+    handles_ensembles=False,
+    checks_arg0_type=False,
+    handles_dead_data=True,
+):
     """
     Generic function to do in line normalization with dask/spark map operator.
 
@@ -3294,12 +3295,12 @@ def normalize(mspass_object,
     into the dask bag we will call dataset.  We can normalize
     that data within a workflow as follows:
         dataset = dataset.map(normalize,matcher)
-        
-    An important warning about ensembles. If the function receives an 
-    ensemble by default it will enter a loop to apply the normalization 
-    to all "member" objects of the ensemble.   If you need to insert 
-    the normalizatio parameters into the ensemble's Metadata container 
-    instead of all the members set `handles_ensembles=True`.  
+
+    An important warning about ensembles. If the function receives an
+    ensemble by default it will enter a loop to apply the normalization
+    to all "member" objects of the ensemble.   If you need to insert
+    the normalizatio parameters into the ensemble's Metadata container
+    instead of all the members set `handles_ensembles=True`.
 
     :param mspass_object:  data to be normalized
     :type mspass_object:  For all mspass matchers this
@@ -3317,8 +3318,8 @@ def normalize(mspass_object,
     :param kill_on_failure:  when True if the call to the find_one
       method of matcher fails the datum returned will be marked dead.
     :type kill_on_failure:  boolean
-    
-    :param handles_ensembles:  boolean controlling how the function is 
+
+    :param handles_ensembles:  boolean controlling how the function is
       applied with ensembles - see above.
 
     :return:  copy of mspass_object.  dead data are returned immediately.

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3266,7 +3266,13 @@ class ArrivalMatcher(DataFrameCacheMatcher):
 
 
 @mspass_func_wrapper
-def normalize(mspass_object, matcher, kill_on_failure=True):
+def normalize(mspass_object, 
+              matcher, 
+              kill_on_failure=True,
+              handles_ensembles=False,
+              checks_arg0_type=False,
+              handles_dead_data=True,
+              ):
     """
     Generic function to do in line normalization with dask/spark map operator.
 
@@ -3288,6 +3294,12 @@ def normalize(mspass_object, matcher, kill_on_failure=True):
     into the dask bag we will call dataset.  We can normalize
     that data within a workflow as follows:
         dataset = dataset.map(normalize,matcher)
+        
+    An important warning about ensembles. If the function receives an 
+    ensemble by default it will enter a loop to apply the normalization 
+    to all "member" objects of the ensemble.   If you need to insert 
+    the normalizatio parameters into the ensemble's Metadata container 
+    instead of all the members set `handles_ensembles=True`.  
 
     :param mspass_object:  data to be normalized
     :type mspass_object:  For all mspass matchers this
@@ -3303,8 +3315,11 @@ def normalize(mspass_object, matcher, kill_on_failure=True):
     :type matcher:  must be a concrete subclass of BasicMatcher
 
     :param kill_on_failure:  when True if the call to the find_one
-    method of matcher fails the datum returned will be marked dead.
+      method of matcher fails the datum returned will be marked dead.
     :type kill_on_failure:  boolean
+    
+    :param handles_ensembles:  boolean controlling how the function is 
+      applied with ensembles - see above.
 
     :return:  copy of mspass_object.  dead data are returned immediately.
     if kill_on_failure is true the result may be killed on return.

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -11,6 +11,7 @@ from mspasspy.ccore.seismic import (
 )
 from mspasspy.util.seismic import number_live
 from mspasspy.algorithms.basic import ExtractComponent
+
 # set as this alias to avoid collision with internal scale
 # not sure that is necessary but this makes context clearer
 from mspasspy.algorithms.window import scale as mspass_scale_function
@@ -542,18 +543,20 @@ class SectionPlotter:
                 + " which is illegal.  Run change_style method"
             )
 
+
 class BasicSeismicPlotter(ABC):
     """
-    Base class for MsPASS graphics objects used to visualize seismic 
-    data with the geometry of time as the x axis.  That produces 
-    graphics with seismograms horizontal as opposed to record sections 
-    where the time axis is y.   
-    
+    Base class for MsPASS graphics objects used to visualize seismic
+    data with the geometry of time as the x axis.  That produces
+    graphics with seismograms horizontal as opposed to record sections
+    where the time axis is y.
+
     This base class should never be instantiated by itself.   It contains
-    methods that can be reused by different implementations in a class 
-    hierarchy.   
+    methods that can be reused by different implementations in a class
+    hierarchy.
     """
-    def __init__(self,scale=1.0,normalize=False,title=None):
+
+    def __init__(self, scale=1.0, normalize=False, title=None):
         self.scale = scale
         self.title = title
         self.normalize = normalize
@@ -591,7 +594,7 @@ class BasicSeismicPlotter(ABC):
         else:
             message = "BasicSeismicPlotter._deepcopy:  "
             message += "received unsupported data type={}".format(str(type(d)))
-            raise MsPASSError(message,ErrorSeverity.Invalid)
+            raise MsPASSError(message, ErrorSeverity.Invalid)
 
     def set_topdown(self):
         """
@@ -629,18 +632,17 @@ class BasicSeismicPlotter(ABC):
         else:
             message = "BasicSeismicPlotter._deepcopy:  "
             message += "received unsupported data type={}".format(str(type(d)))
-            raise MsPASSError(message,ErrorSeverity.Invalid)
+            raise MsPASSError(message, ErrorSeverity.Invalid)
+
     @abstractmethod
     def plot():
         """
-        Alll concrete implementations must implement this method to do 
+        Alll concrete implementations must implement this method to do
         some plotting.
         """
         pass
 
 
-        
-    
 class SeismicPlotter(BasicSeismicPlotter):
     """
     SeismicPlotter is used to plot mspass data objects in the
@@ -665,11 +667,11 @@ class SeismicPlotter(BasicSeismicPlotter):
     to the change_style method, should be done before calling plot.
     """
 
-    def __init__(self, scale=1.0, normalize=False, title=None, style='wtvaimg'):
+    def __init__(self, scale=1.0, normalize=False, title=None, style="wtvaimg"):
         """
         Constructor for this object.   It mostly sets defaults but
         has a few common optional parameters to set at construction
-        time.  
+        time.
         :param scale:  optional scale factor to apply to data before plotting
           (default assumes data have been scaled to amplitude of order 1)
         :type scale: float (default 1.0)
@@ -683,7 +685,7 @@ class SeismicPlotter(BasicSeismicPlotter):
           with a variant of this title string adding ":n" where n is
           the component number (0,1,2).
         :type title: string (default None makes no plot title)
-        :param style:  plot style to one of the accepted style names. 
+        :param style:  plot style to one of the accepted style names.
           That is one of: ["wt","wtva","img","wtvaimg"]
         :type style:  string (one of list above or a TypeError exceptin
           is thrown)
@@ -692,7 +694,7 @@ class SeismicPlotter(BasicSeismicPlotter):
             scale=scale,
             title=title,
             normalize=normalize,
-            )
+        )
 
         self._fill_color = "k"  # black in matplotlib
         self._color_map = "seismic"
@@ -709,35 +711,36 @@ class SeismicPlotter(BasicSeismicPlotter):
         # Should be smaller than 1/screem horizontal pixel maximum size
         self._RANGE_RATIO_TEST = 0.0001
         self._default_single_ts_aspect = 0.25
-        if style in ["wt","wtva","img","wtvaimg"]:
-            # use change_style to simply default style as this does more than 
+        if style in ["wt", "wtva", "img", "wtvaimg"]:
+            # use change_style to simply default style as this does more than
             # just set a string name
             self.change_style(style)
         else:
             message = "SeismicPlotter constuctor:  "
             message += "Illegal valeu for style={}\n".format(style)
-            message ++ "Must string froom this list of keywords:"
-            message +="wt, wtva, img, wtvaimg"
+            message + +"Must string froom this list of keywords:"
+            message += "wt, wtva, img, wtvaimg"
             raise TypeError(message)
         # These are set whenever a plot is made.
-        # None signals they aren't yet defined and need to be 
-        # initialized. 
+        # None signals they aren't yet defined and need to be
+        # initialized.
         self.figure = None
         self.figure_handles = None
 
     def get_plot_gcf(self):
         """
-        Returns the matplotlib figure handle of the canvas used for all 
-        plots but that for a SeismogramEnsemble.   Useful only for 
+        Returns the matplotlib figure handle of the canvas used for all
+        plots but that for a SeismogramEnsemble.   Useful only for
         subclasses that need to manipulate the handle.
         """
         return self.figure
-    def get_3Censemble_gcf(self)->tuple:
+
+    def get_3Censemble_gcf(self) -> tuple:
         """
-        Returns the matplotlb figure handles for handlng 
-        SeismogramEnsemble data.  This plotter draws 3c data in three 
-        different figure handles with number tags 0, 1, and 2 for 
-        each component.  Useful method mainly for subclasses of 
+        Returns the matplotlb figure handles for handlng
+        SeismogramEnsemble data.  This plotter draws 3c data in three
+        different figure handles with number tags 0, 1, and 2 for
+        each component.  Useful method mainly for subclasses of
         this class.
         """
         return self.figure_handles
@@ -811,7 +814,6 @@ class SeismicPlotter(BasicSeismicPlotter):
             )
         self.style = newstyle
 
-
     def plot(self, d):
         # make copy always to prevent unintentional scaling of input data
         if self.normalize:
@@ -835,7 +837,6 @@ class SeismicPlotter(BasicSeismicPlotter):
                 + " is invalid\nThis should not happen"
             )
 
- 
     def _add_3C_titles(self):
         """
         Private method to add titles with plt.title to 3C ensemble data.
@@ -1150,43 +1151,41 @@ class SeismicPlotter(BasicSeismicPlotter):
         )
         return plt.gcf()
 
+
 class LargeEnsemblePlotter(SeismicPlotter):
     """
-    This is a special class to handle ensembles.   It forces a solution 
+    This is a special class to handle ensembles.   It forces a solution
     that can be mysterous for a naive use of the more general SeismicPlotter.
-    That is, with a large ensemble the plot can easily come out a black 
-    image when the number of ensemble members are of the order of 1/10 
-    or more of the number of pixels defining the y axis.  The way thsi 
+    That is, with a large ensemble the plot can easily come out a black
+    image when the number of ensemble members are of the order of 1/10
+    or more of the number of pixels defining the y axis.  The way thsi
     subclass addresses that is by forcing the following:
         1.  It normally produces multiple plots to display data in blocks.
             sac users can think of this like theh "perplot" argument used
             in the sac ppk function.
         2.  It defaults to wiggle trace only plots to improve performance.
-        3.  It defaults to automatic scaling assuming that for many 
+        3.  It defaults to automatic scaling assuming that for many
             inputs something always needs to be scaled
         4.  It will only accept ensemble objects
-        
-    Note since this is a subclass of SeismicPlotter, Seismogram enembles 
-    will be plotted in three different figure windows.  
 
-    Be warned large ensembles can produce a very large number of plots 
-    with a single call to the plot method of this class.  With interactive 
-    use you may need to click on a lot of windows to see all the data and 
-    for notebooks you can quickly create a huge notebook.  All plotting 
+    Note since this is a subclass of SeismicPlotter, Seismogram enembles
+    will be plotted in three different figure windows.
+
+    Be warned large ensembles can produce a very large number of plots
+    with a single call to the plot method of this class.  With interactive
+    use you may need to click on a lot of windows to see all the data and
+    for notebooks you can quickly create a huge notebook.  All plotting
     for large data sets must be done with caution.
     """
-    def __init__(self, 
-                 scale=0.5, 
-                 normalize=True, 
-                 title=None,
-                 members_per_frame=20):
+
+    def __init__(self, scale=0.5, normalize=True, title=None, members_per_frame=20):
         """
         Constructor for this object.   It mostly sets defaults but
         has a few common optional parameters to set at construction
         time.  Note style is intentionally not a constructor
         parameter because of parameter interdependence.  The default
         plot style is "wt" to maximize performance. You can use the
-        change_stye method inherited from SeismicPlotter to make 
+        change_stye method inherited from SeismicPlotter to make
         the plots a different style.
 
         :param scale:  optional scale factor to apply to data before plotting
@@ -1202,65 +1201,68 @@ class LargeEnsemblePlotter(SeismicPlotter):
           with a variant of this title string adding ":n" where n is
           the component number (0,1,2).
         :type title: string (default None makes no plot title)
-        :param members_per_frame:  Number of 
+        :param members_per_frame:  Number of
         """
         super().__init__(
             scale=scale,
             title=title,
             normalize=normalize,
-            )
-        self.change_style('wt')
+        )
+        self.change_style("wt")
         self.members_per_frame = members_per_frame
-        
-    def plot(self, ens,skip_the_dead=True):
+
+    def plot(self, ens, skip_the_dead=True):
         """
-        Plots esembles in groups of size defined by the instance. 
-        
-        This plot method overrides the plot method of SeismicPlotter 
-        but actually uses the same functions to make the plots.  
-        It does so  using a trick to run the "super" function.   
-        When run interactively the function will block with 
-        each frame until the window(s) is(are) closed.   In a notebook 
+        Plots esembles in groups of size defined by the instance.
+
+        This plot method overrides the plot method of SeismicPlotter
+        but actually uses the same functions to make the plots.
+        It does so  using a trick to run the "super" function.
+        When run interactively the function will block with
+        each frame until the window(s) is(are) closed.   In a notebook
         the frames will all be rendered sequentially into the notebook.
-        
-        As far as I can tell a limitation of the matplotlib is that 
-        to allow an event loop for zoom and pan operatios on the plot 
-        the window has to be closed in interactive mode.  It would be 
-        nice to not have to have the window have to pop up for each frame 
+
+        As far as I can tell a limitation of the matplotlib is that
+        to allow an event loop for zoom and pan operatios on the plot
+        the window has to be closed in interactive mode.  It would be
+        nice to not have to have the window have to pop up for each frame
         but I (glp) can't see how to do that - it may be impossible without
         a major rewrite.
-        
-        Note if the input ensemble is marked dead or has no live members 
-        a informational message will be "printed" (print staement) and 
+
+        Note if the input ensemble is marked dead or has no live members
+        a informational message will be "printed" (print staement) and
         nothing will be plotted.
-        
+
         :param ens:  Ensemble to be plotted
-        :type ens:  Must be either a TimeSeriesEnsemble of SeismogramEnsemle 
+        :type ens:  Must be either a TimeSeriesEnsemble of SeismogramEnsemle
            or the method will throw a TypeError exception.
-        :param skip_the_dead:  Boolean controllng how dead data are 
+        :param skip_the_dead:  Boolean controllng how dead data are
            handed.  When True (default) dead data will be silently skippped.
-           When False all dead data will create an empty plot cell in 
-           the position of the body. 
-           
+           When False all dead data will create an empty plot cell in
+           the position of the body.
+
         """
         alg = "LargeEnsemblePlotter.plot"
-        if not isinstance(ens,(TimeSeriesEnsemble,SeismogramEnsemble)):
+        if not isinstance(ens, (TimeSeriesEnsemble, SeismogramEnsemble)):
             message = "LargeEnsemblePlotter.plot:  "
             message += "Illegal type for arg0={}\n".format(str(type(ens)))
             message += "Can only plot seismic ensemble objects"
             raise TypeError(message)
-            
+
         if ens.dead():
-            print(alg + "received ensemble marked dead - cannot  plot ensemble marked dead")
+            print(
+                alg
+                + "received ensemble marked dead - cannot  plot ensemble marked dead"
+            )
             return
         N = len(ens.member)
         Nlive = number_live(ens)
         if Nlive <= 0:
             print(alg + " ensemble has no live members - nothing to plot")
-        if isinstance(ens,TimeSeriesEnsemble):
-            e2plot=TimeSeriesEnsemble()
+        if isinstance(ens, TimeSeriesEnsemble):
+            e2plot = TimeSeriesEnsemble()
         else:
-            e2plot=SeismogramEnsemble()
+            e2plot = SeismogramEnsemble()
         count = 0
         frame_number = 0
         for i in range(len(ens.member)):
@@ -1268,26 +1270,27 @@ class LargeEnsemblePlotter(SeismicPlotter):
             d = ens.member[i]
             if skip_the_dead and d.dead():
                 # ddebug
-                print("skipping member ",i)
+                print("skipping member ", i)
                 continue
-            if count < self.members_per_frame and i != (N-1):
+            if count < self.members_per_frame and i != (N - 1):
                 e2plot.member.append(d)
                 count += 1
             else:
                 if frame_number > 0:
                     self._clear_figure_canvases()
                 super().plot(e2plot)
-                # show blocks in interactive mode untill the framem iis 
-                # closed.  I think in a notebook it make the plot and 
-                # continue on producing multiple plot frames. 
+                # show blocks in interactive mode untill the framem iis
+                # closed.  I think in a notebook it make the plot and
+                # continue on producing multiple plot frames.
                 plt.show()
                 frame_number += 1
                 count = 0
                 e2plot.member.clear()
+
     def _clear_figure_canvases(self):
         """
-        Private method used to clear the canvas for any active graphhics. 
-        Complicated by the fact tha SeismicPlotter use a single canvas 
+        Private method used to clear the canvas for any active graphhics.
+        Complicated by the fact tha SeismicPlotter use a single canvas
         for TimeSeriesEnsemble plots and 3 canvases for SeismogramEnsembles.
         """
         gcf = self.get_plot_gcf()
@@ -1297,5 +1300,3 @@ class LargeEnsemblePlotter(SeismicPlotter):
         if handles:
             for gcf in handles:
                 gcf.clear()
-       
-        

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -154,7 +154,9 @@ def mspass_func_wrapper(
         if not isinstance(
                 data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
             ):
-            raise TypeError("mspass_func_wrapper only accepts mspass object as data input")
+            message = "mspass_func_wrapper only accepts mspass object as data input\n"
+            message += "Actual type of arg0={}".format(str(type(data)))
+            raise TypeError(message)
         else:
             if data.dead():
                 return data
@@ -305,16 +307,16 @@ def mspass_func_wrapper_multi(
     if not isinstance(
         data1, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
     ):
-        raise TypeError(
-            "mspass_func_wrapper_multi only accepts mspass object as data input"
-        )
+        message = "mspass_func_wrapper_multi only accepts mspass object as data input\n"
+        message += "Actual type of arg0={}".format(str(type(data1)))
+        raise TypeError(message)
 
     if not isinstance(
         data2, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
     ):
-        raise TypeError(
-            "mspass_func_wrapper_multi only accepts mspass object as data input"
-        )
+        message = "mspass_func_wrapper_multi only accepts mspass object as data input\n"
+        message += "Actual type of arg0={}".format(str(type(data2)))
+        raise TypeError(message)
 
     if not alg_name:
         alg_name = func.__name__
@@ -436,7 +438,9 @@ def mspass_method_wrapper(
         if not isinstance(
                 data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
             ):
-            raise TypeError("mspass_method_wrapper only accepts mspass object as data input")
+            message = "mspass_method_wrapper only accepts mspass object as data input\n"
+            message += "Actual type of arg0={}".format(str(type(data)))
+            raise TypeError(message)
         else:
             if data.dead():
                 return data

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -35,15 +35,15 @@ def mspass_func_wrapper(
     error logs into the mspasspy objects. By wrapping your function using this decorator, you can save some workload.
     Runtime error won't be raised in order to be efficient in map-reduce operations. MspassError with a severity Fatal
     will be raised, others won't be raised.
-    
-    A large fraction of algorithms used in mspass are "atomic" meaning 
+
+    A large fraction of algorithms used in mspass are "atomic" meaning
     they only operator on TimeSeries and/or Seismogram objects.   In mspass
-    an "ensemble" is a container with multiple atomic objects.  This decorator 
-    can then also be used to adapt an atomic algorithm to work automatically 
+    an "ensemble" is a container with multiple atomic objects.  This decorator
+    can then also be used to adapt an atomic algorithm to work automatically
     with ensembles.   When using the decorator if the funtion being decorated
-    works only on atomic data set the boolean `handles_ensembles` should be 
-    set as False (the default).  Set it True only for functions that handle 
-    ensembles as the type of arg0.  
+    works only on atomic data set the boolean `handles_ensembles` should be
+    set as False (the default).  Set it True only for functions that handle
+    ensembles as the type of arg0.
 
     :param func: target function
     :param data: input data, only mspasspy data objects are accepted, i.e. TimeSeries, Seismogram, Ensemble.
@@ -74,12 +74,12 @@ def mspass_func_wrapper(
        downstream problems.  The default for this parameter is None, which
        is taken to mean any return of the wrapped function will be ignored.  Note
        that when function_return_key is anything but None, it is assumed the
-       returned object is the (usually modified) data object.  NOTE:  this 
-       options is NOT supported for ensembles.   If you set this value for 
+       returned object is the (usually modified) data object.  NOTE:  this
+       options is NOT supported for ensembles.   If you set this value for
        ensemble input this decorator will throw a ValueError exception.
-    :param handles_ensembes:  set True if the function this is applied to 
-      can hangle ensemble objects directly.   When False, which is the default 
-      this decorator applies the atomic function to each ensemble member in 
+    :param handles_ensembes:  set True if the function this is applied to
+      can hangle ensemble objects directly.   When False, which is the default
+      this decorator applies the atomic function to each ensemble member in
       a loop over membes.
     :param kwargs: extra kv arguments
     :return: origin data or the output of func
@@ -89,9 +89,13 @@ def mspass_func_wrapper(
     ):
         raise TypeError("mspass_func_wrapper only accepts mspass object as data input")
 
-    if function_return_key and isinstance(data,(TimeSeriesEnsemble, SeismogramEnsemble)):
+    if function_return_key and isinstance(
+        data, (TimeSeriesEnsemble, SeismogramEnsemble)
+    ):
         message = "Usage error:  "
-        message += "function_return_key was defined as {} but input type is an ensemble.\n".format(function_return_key)
+        message += "function_return_key was defined as {} but input type is an ensemble.\n".format(
+            function_return_key
+        )
         message += "That options is not allowed for ensembles in any function"
         raise ValueError(message)
     if not alg_name:
@@ -125,21 +129,21 @@ def mspass_func_wrapper(
                         + str(type(function_return_key))
                         + "\nReturn value not saved in Metadata",
                         ErrorSeverity.Complaint,
-                        )
+                    )
                 if not inplace_return:
                     data.elog.log_error(
                         alg_name,
                         "Inconsistent arguments; inplace_return was set False and function_return_key was not None.\nAssuming inplace_return == True is correct",
                         ErrorSeverity.Complaint,
-                        )
+                    )
                 return data
             elif inplace_return:
                 return data
             else:
                 return res
         else:
-            # this block is only for ensembles - the run_only_once boolean 
-            # means we enter here only if this is an ensmble and the 
+            # this block is only for ensembles - the run_only_once boolean
+            # means we enter here only if this is an ensmble and the
             # boolean handles_ensembles is false
             N = len(data.member)
             for i in range(N):
@@ -149,8 +153,8 @@ def mspass_func_wrapper(
                 data.member[i] = d
                 if object_history:
                     logging_helper.info(data.member[i], alg_id, alg_name)
-            # Note the in place return concept does not apply to 
-            # ensemles - all are in place by defintion if passed through 
+            # Note the in place return concept does not apply to
+            # ensemles - all are in place by defintion if passed through
             # this wrapper
             return data
     except RuntimeError as err:
@@ -288,15 +292,15 @@ def mspass_method_wrapper(
     This decorator executes the target method on the input data.  It is used
     mainly to reduce duplicate code to perserve history and error logs
     with mspass object.
-    
-    A large fraction of algorithms used in mspass are "atomic" meaning 
+
+    A large fraction of algorithms used in mspass are "atomic" meaning
     they only operator on TimeSeries and/or Seismogram objects.   In mspass
-    an "ensemble" is a container with multiple atomic objects.  This decorator 
-    can then also be used to adapt an atomic algorithm to work automatically 
+    an "ensemble" is a container with multiple atomic objects.  This decorator
+    can then also be used to adapt an atomic algorithm to work automatically
     with ensembles.   When using the decorator if the funtion being decorated
-    works only on atomic data set the boolean `handles_ensembles` should be 
-    set as False (the default).  Set it True only for functions that handle 
-    ensembles as the type of arg0.  
+    works only on atomic data set the boolean `handles_ensembles` should be
+    set as False (the default).  Set it True only for functions that handle
+    ensembles as the type of arg0.
 
     :param func: target function
     :param selfarg:  the self pointer for the class with which this method is associated
@@ -329,9 +333,9 @@ def mspass_method_wrapper(
        is taken to mean any return of the wrapped function will be ignored.  Note
        that when function_return_key is anything but None, it is assumed the
        returned object is the (usually modified) data object.
-     :param handles_ensembes:  set True if the function this is applied to 
-       can hangle ensemble objects directly.   When False, which is the default 
-       this decorator applies the atomic function to each ensemble member in 
+     :param handles_ensembes:  set True if the function this is applied to
+       can hangle ensemble objects directly.   When False, which is the default
+       this decorator applies the atomic function to each ensemble member in
        a loop over membes.
     :param kwargs: extra kv arguments
     :return: origin data or the output of func
@@ -350,9 +354,13 @@ def mspass_method_wrapper(
 
     if object_history and alg_id is None:
         raise ValueError(alg_name + ": object_history was true but alg_id not defined")
-    if function_return_key and isinstance(data,(TimeSeriesEnsemble, SeismogramEnsemble)):
+    if function_return_key and isinstance(
+        data, (TimeSeriesEnsemble, SeismogramEnsemble)
+    ):
         message = "Usage error:  "
-        message += "function_return_key was defined as {} but input type is an ensemble.\n".format(function_return_key)
+        message += "function_return_key was defined as {} but input type is an ensemble.\n".format(
+            function_return_key
+        )
         message += "That options is not allowed for ensembles in any class method"
         raise ValueError(message)
     if dryrun:
@@ -360,7 +368,7 @@ def mspass_method_wrapper(
 
     if is_input_dead(data):
         return data
-    
+
     if isinstance(data, (Seismogram, TimeSeries)) or handles_ensembles:
         run_only_once = True
     else:
@@ -386,7 +394,7 @@ def mspass_method_wrapper(
                     data.elog.log_error(
                         alg_name,
                         "Inconsistent arguments; inplace_return was set False and function_return_key was not None.\nAssuming inplace_return == True is correct",
-                       ErrorSeverity.Complaint,
+                        ErrorSeverity.Complaint,
                     )
                 return data
             elif inplace_return:
@@ -394,8 +402,8 @@ def mspass_method_wrapper(
             else:
                 return res
         else:
-            # this block is only for ensembles - the run_only_once boolean 
-            # means we enter here only if this is an ensmble and the 
+            # this block is only for ensembles - the run_only_once boolean
+            # means we enter here only if this is an ensmble and the
             # boolean handles_ensembles is false
             N = len(data.member)
             for i in range(N):
@@ -405,8 +413,8 @@ def mspass_method_wrapper(
                 data.member[i] = d
                 if object_history:
                     logging_helper.info(data.member[i], alg_id, alg_name)
-            # Note the in place return concept does not apply to 
-            # ensemles - all are in place by defintion if passed through 
+            # Note the in place return concept does not apply to
+            # ensemles - all are in place by defintion if passed through
             # this wrapper
             return data
     except RuntimeError as err:

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -30,96 +30,96 @@ def mspass_func_wrapper(
     handles_dead_data=True,
     **kwargs,
 ):
-    """ 
+    """
     Decorator wrapper to adapt a simple function to the mspass parallel processing framework.
 
-    This decorator can be used to adapt a processing function to the 
-    mspass framework.  It can be used to handle the following nonstandard 
+    This decorator can be used to adapt a processing function to the
+    mspass framework.  It can be used to handle the following nonstandard
     functionality that would not appear in a function outside of mspass:
         1.  This decorator can make a function dogmatic about the type of arg0.
-            A processing function in mspass normally requires arg0 to be a 
-            seismic data type.   If the function being decorated handles 
-            arg0 propertly add `checks_arg0_type=True` to the functions 
-            kwargs list.  That will assure the error handler used by the 
+            A processing function in mspass normally requires arg0 to be a
+            seismic data type.   If the function being decorated handles
+            arg0 propertly add `checks_arg0_type=True` to the functions
+            kwargs list.  That will assure the error handler used by the
             function itself will be used instead of the generic wrapper code.
-            When False (the default) this decorator will always throw a 
+            When False (the default) this decorator will always throw a
             TypeError with a generic message if arg0 is invalid.
         2.  MsPASS data objects all use the concept of the boolean "live"
-            as a way to mark a datum as valid (dead means it is bad). 
-            MsPASS functios should normally kill a problem datum and 
-            not throw exceptions for anything but system level error 
-            like a malloc error. A properly designed function 
-            has a test for dead data immediately after verifying 
-            arg0 is valid and testing of "data.live" is a valid thing to 
-            do.  To assure that doesn't happen if checks_arg0_type is 
+            as a way to mark a datum as valid (dead means it is bad).
+            MsPASS functios should normally kill a problem datum and
+            not throw exceptions for anything but system level error
+            like a malloc error. A properly designed function
+            has a test for dead data immediately after verifying
+            arg0 is valid and testing of "data.live" is a valid thing to
+            do.  To assure that doesn't happen if checks_arg0_type is
             false and the test for a valid type yields success
-            (i.e. find data is a valid seismic object) a test for 
-            live will data will be done and the functionw will immediately 
-            return a datum marked dead.  If set True, the default, we let 
+            (i.e. find data is a valid seismic object) a test for
+            live will data will be done and the functionw will immediately
+            return a datum marked dead.  If set True, the default, we let
             the functions dead data handler do the task.
-        3.  MsPASS data object have an internal mechanism to preserve 
-            object-level history that records the sequence of algorithms 
-            applied to a piece of data to get it to it's current stage  
-            This decorator adds that functionality through three kwarg 
+        3.  MsPASS data object have an internal mechanism to preserve
+            object-level history that records the sequence of algorithms
+            applied to a piece of data to get it to it's current stage
+            This decorator adds that functionality through three kwarg
             values: `object_history`,`alg_id', and `alg_name'.  `object_history`
             is  boolean that enables (if True) or disables (False - default)
-            that mechanism.   The other two are tags.   See the User 
-            Manual for more details.  
-        4.  MsPASS data are either "atomic" (TimeSeries or Seismogram) or 
-            "ensembles" (TimeSeriesEnseble and SeismogramEnsemble).   
-            "ensembles", however, are a conainer holding one or more 
-            atomic objects.  Processing algorithms may require only atomic 
-            or ensemble objects.  For algorithms that expect atomic data, 
-            however, it is common to need to apply the same function to 
+            that mechanism.   The other two are tags.   See the User
+            Manual for more details.
+        4.  MsPASS data are either "atomic" (TimeSeries or Seismogram) or
+            "ensembles" (TimeSeriesEnseble and SeismogramEnsemble).
+            "ensembles", however, are a conainer holding one or more
+            atomic objects.  Processing algorithms may require only atomic
+            or ensemble objects.  For algorithms that expect atomic data,
+            however, it is common to need to apply the same function to
             all ensemble "members" (the set of atomic objects that define the
-            ensemble).   Some processing functions are designed to handle 
-            either but some aren't.  If a function is set up to hanlde 
-            ensembles, the `handles_ensembles` boolean should be set True. 
-            That is set True because a well designed algorithm for use with 
-            MsPASS should do that.  Set `handles_ensembles=False` if the 
-            function is set up to only handle atomic data.  In that situation 
-            the decorator will handle ensembles by setting up a loop to 
-            call the decorated function for each enemble member. 
-        5.  The boolean `inplace_return` should be set True on a function 
-            that it set up like a FORTRAN subroutine or a C void return.  
-            i.e. it doesn't return anything but alters data internally. 
-            In that situation the decorator returns arg0 that is assumed to 
+            ensemble).   Some processing functions are designed to handle
+            either but some aren't.  If a function is set up to hanlde
+            ensembles, the `handles_ensembles` boolean should be set True.
+            That is set True because a well designed algorithm for use with
+            MsPASS should do that.  Set `handles_ensembles=False` if the
+            function is set up to only handle atomic data.  In that situation
+            the decorator will handle ensembles by setting up a loop to
+            call the decorated function for each enemble member.
+        5.  The boolean `inplace_return` should be set True on a function
+            that it set up like a FORTRAN subroutine or a C void return.
+            i.e. it doesn't return anything but alters data internally.
+            In that situation the decorator returns arg0 that is assumed to
             have been altered by the function.
-        6.  Use `function_return_key` if a function doesn't return a seismic 
-            data object at all but computes something returned as a value. 
-            If used that capability allows a return value to be mapped into 
-            the Metadata container of the input data object and set with 
-            the specified key.  
-            
-    Finally, this decorator has a standardized behavior for handling 
-    ensembles that is not optional.  If the input is an ensemble it is 
-    not at all uncommon to have an algorithm kill all ensemble members.  
-    The ensemble container has a global "live" attribute that this decorator 
+        6.  Use `function_return_key` if a function doesn't return a seismic
+            data object at all but computes something returned as a value.
+            If used that capability allows a return value to be mapped into
+            the Metadata container of the input data object and set with
+            the specified key.
+
+    Finally, this decorator has a standardized behavior for handling
+    ensembles that is not optional.  If the input is an ensemble it is
+    not at all uncommon to have an algorithm kill all ensemble members.
+    The ensemble container has a global "live" attribute that this decorator
     will set False (i.e. define as dead) if all the member object are marked
     dead.
 
     :param func: target function
-    :param data: arg0 of function call being decorated.  This symbol is 
+    :param data: arg0 of function call being decorated.  This symbol is
       expected to point to an input data that is expected to be a MsPASS
       data object i.e. TimeSeries, Seismogram, Ensemble.
     :param args: extra positional arguments for decorated function
-    :param object_history:  boolean used to enable or disable 
+    :param object_history:  boolean used to enable or disable
        object level history for this function.  When False (default)
-       object-level history is not enabld for this function.  When 
+       object-level history is not enabld for this function.  When
        set True the decorator will add object history history th e
-       name of the function and the value of alg_id.  
-       Object level history is disabled by default for efficiency.  
+       name of the function and the value of alg_id.
+       Object level history is disabled by default for efficiency.
        If object_history is set True and the string passed
-       as alg_id is defined (not None which is the default) each 
+       as alg_id is defined (not None which is the default) each
        Seismogram or TimeSeries object will attempt to
-       save the history through a new_map operation.   
+       save the history through a new_map operation.
        If the history chain is empty this will silently generate
        an error posted to error log on each object.
-    :param alg_id: alg_id is a unique id to record the usage of func 
+    :param alg_id: alg_id is a unique id to record the usage of func
       while preserving the history.
     :type alg_id: str (e.g. str of an ObjectId)
-    :param alg_name: alternative name to assign the algorithm.  If not 
-      defined (set as None) the name of the decorated function is used.  
+    :param alg_name: alternative name to assign the algorithm.  If not
+      defined (set as None) the name of the decorated function is used.
     :type alg_name: :class:`str` or None (default)
     :param dryrun: True for dry-run, the algorithm is not run, but the arguments used in this wrapper will be checked.
       This is useful for pre-run checks of a large job to validate a workflow. Errors generate exceptions
@@ -145,15 +145,15 @@ def mspass_func_wrapper(
       this decorator applies the atomic function to each ensemble member in
       a loop over membes.
     :param kwargs: extra kv arguments
-    :return: modified seismic data object.  Can be a different type than 
-       the input.   If function_return_key is used only the Metadata 
+    :return: modified seismic data object.  Can be a different type than
+       the input.   If function_return_key is used only the Metadata
        container  should be altered.
     """
     # Add an error trap for arg0 if this function doesn't do that
     if not checks_arg0_type:
         if not isinstance(
-                data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
-            ):
+            data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
+        ):
             message = "mspass_func_wrapper only accepts mspass object as data input\n"
             message += "Actual type of arg0={}".format(str(type(data)))
             raise TypeError(message)
@@ -177,8 +177,8 @@ def mspass_func_wrapper(
 
     if dryrun:
         return "OK"
-    # reverse logic a bit confusing but idea is to do nothing if 
-    # handles_dead_data is true assuming the function will handle dead 
+    # reverse logic a bit confusing but idea is to do nothing if
+    # handles_dead_data is true assuming the function will handle dead
     # data propertly
     if not handles_dead_data:
         if data.dead():
@@ -187,13 +187,13 @@ def mspass_func_wrapper(
     if isinstance(data, (Seismogram, TimeSeries)):
         run_only_once = True
     elif isinstance(data, (TimeSeriesEnsemble, SeismogramEnsemble)):
-            if handles_ensembles:
-                run_only_once = True
-            else:
-                run_only_once = False
+        if handles_ensembles:
+            run_only_once = True
+        else:
+            run_only_once = False
     else:
-        # we only get here if checks_arg0_type is True and the 
-        # type is bad - with this logic func will be called and 
+        # we only get here if checks_arg0_type is True and the
+        # type is bad - with this logic func will be called and
         # we assume it throws an exception
         run_only_once = True
     try:
@@ -235,14 +235,14 @@ def mspass_func_wrapper(
                 data.member[i] = d
                 if object_history:
                     logging_helper.info(data.member[i], alg_id, alg_name)
-                    
+
             # mark ensmeble killed by all applications of func as dead
             N_live = number_live(data)
-            if N_live<=len(data.member):
+            if N_live <= len(data.member):
                 message = "function killed all ensemble members.  Marking ensemble dead"
-                data.elog.log_error(alg_name,message,ErrorSeverity.Invalid)
+                data.elog.log_error(alg_name, message, ErrorSeverity.Invalid)
                 data.kill()
-                
+
             # Note the in place return concept does not apply to
             # ensemles - all are in place by defintion if passed through
             # this wrapper
@@ -391,8 +391,8 @@ def mspass_method_wrapper(
     can then also be used to adapt an atomic algorithm to work automatically
     with ensembles.   When using the decorator if the funtion being decorated
     works only on atomic data set the boolean `handles_ensembles` should be
-    set as False.   True, which is the default, should be used functions that 
-    handle ensembles automatically. 
+    set as False.   True, which is the default, should be used functions that
+    handle ensembles automatically.
 
 
     :param func: target function
@@ -427,7 +427,7 @@ def mspass_method_wrapper(
        that when function_return_key is anything but None, it is assumed the
        returned object is the (usually modified) data object.
      :param handles_ensembes:  set True (default) if the function this is applied to
-       can hangle ensemble objects directly.   When False this decorator 
+       can hangle ensemble objects directly.   When False this decorator
        applies the atomic function to each ensemble member in
        a loop over members.
     :param kwargs: extra kv arguments
@@ -436,8 +436,8 @@ def mspass_method_wrapper(
     # Add an error trap for arg0 if this function doesn't do that
     if not checks_arg0_type:
         if not isinstance(
-                data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
-            ):
+            data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
+        ):
             message = "mspass_method_wrapper only accepts mspass object as data input\n"
             message += "Actual type of arg0={}".format(str(type(data)))
             raise TypeError(message)
@@ -466,8 +466,8 @@ def mspass_method_wrapper(
     if dryrun:
         return "OK"
 
-    # reverse logic a bit confusing but idea is to do nothing if 
-    # handles_dead_data is true assuming the function will handle dead 
+    # reverse logic a bit confusing but idea is to do nothing if
+    # handles_dead_data is true assuming the function will handle dead
     # data propertly
     if not handles_dead_data:
         if data.dead():
@@ -476,13 +476,13 @@ def mspass_method_wrapper(
     if isinstance(data, (Seismogram, TimeSeries)):
         run_only_once = True
     elif isinstance(data, (TimeSeriesEnsemble, SeismogramEnsemble)):
-            if handles_ensembles:
-                run_only_once = True
-            else:
-                run_only_once = False
+        if handles_ensembles:
+            run_only_once = True
+        else:
+            run_only_once = False
     else:
-        # we only get here if checks_arg0_type is True and the 
-        # type is bad - with this logic func will be called and 
+        # we only get here if checks_arg0_type is True and the
+        # type is bad - with this logic func will be called and
         # we assume it throws an exception
         run_only_once = True
 
@@ -528,9 +528,9 @@ def mspass_method_wrapper(
 
             # mark ensmeble killed by all applications of func as dead
             N_live = number_live(data)
-            if N_live<=len(data.member):
+            if N_live <= len(data.member):
                 message = "function killed all ensemble members.  Marking ensemble dead"
-                data.elog.log_error(alg_name,message,ErrorSeverity.Invalid)
+                data.elog.log_error(alg_name, message, ErrorSeverity.Invalid)
                 data.kill()
             # Note the in place return concept does not apply to
             # ensemles - all are in place by defintion if passed through

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -288,17 +288,26 @@ def mspass_method_wrapper(
     This decorator executes the target method on the input data.  It is used
     mainly to reduce duplicate code to perserve history and error logs
     with mspass object.
+    
+    A large fraction of algorithms used in mspass are "atomic" meaning 
+    they only operator on TimeSeries and/or Seismogram objects.   In mspass
+    an "ensemble" is a container with multiple atomic objects.  This decorator 
+    can then also be used to adapt an atomic algorithm to work automatically 
+    with ensembles.   When using the decorator if the funtion being decorated
+    works only on atomic data set the boolean `handles_ensembles` should be 
+    set as False (the default).  Set it True only for functions that handle 
+    ensembles as the type of arg0.  
 
     :param func: target function
     :param selfarg:  the self pointer for the class with which this method is associated
     :param data: input data, only mspasspy data objects are accepted, i.e. TimeSeries, Seismogram, Ensemble.
     :param args: extra arguments
     :param object_history: True to preserve this processing history in the data object, False not to. object_history
-     and alg_id are intimately related and control how object level history is handled.
-     Object level history is disabled by default for efficiency.  If object_history is set True and the string passed
-     as alg_id is defined (not None which is the default) each Seismogram or TimeSeries object will attempt to
-     save the history through a new_map operation.   If the history chain is empty this will silently generate
-     an error posted to error log on each object.
+       and alg_id are intimately related and control how object level history is handled.
+       Object level history is disabled by default for efficiency.  If object_history is set True and the string passed
+       as alg_id is defined (not None which is the default) each Seismogram or TimeSeries object will attempt to
+       save the history through a new_map operation.   If the history chain is empty this will silently generate
+       an error posted to error log on each object.
     :param alg_id: alg_id is a unique id to record the usage of func while preserving the history.
     :type alg_id: :class:`bson.objectid.ObjectId`
     :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
@@ -307,19 +316,23 @@ def mspass_method_wrapper(
       This is useful for pre-run checks of a large job to validate a workflow. Errors generate exceptions
       but the function returns before attempting any calculations.
     :param inplace_return: when func is an in-place function that doesn't return anything, but you want to
-     return the origin data (for example, in map-reduce), set inplace_return as true.
+       return the origin data (for example, in map-reduce), set inplace_return as true.
     :param function_return_key:  Some functions one might want to wrap with this decorator
-     return something that is appropriate to save as Metadata.  If so, use this argument to
-     define the key used to set that field in the data that is returned.
-     This feature should normally be considered as a way to wrap an existing
-     algorithm that you do not wish to alter, but which returns something useful.
-     In principle that return can be almost anything, but we recommend this feature
-     be limited to only simple types (i.e. int, float, etc.).  The decorator makes
-     no type checks so the caller is responsible for assuring what is posted will not cause
-     downstream problems.  The default for this parameter is None, which
-     is taken to mean any return of the wrapped function will be ignored.  Note
-     that when function_return_key is anything but None, it is assumed the
-     returned object is the (usually modified) data object.
+       return something that is appropriate to save as Metadata.  If so, use this argument to
+       define the key used to set that field in the data that is returned.
+       This feature should normally be considered as a way to wrap an existing
+       algorithm that you do not wish to alter, but which returns something useful.
+       In principle that return can be almost anything, but we recommend this feature
+       be limited to only simple types (i.e. int, float, etc.).  The decorator makes
+       no type checks so the caller is responsible for assuring what is posted will not cause
+       downstream problems.  The default for this parameter is None, which
+       is taken to mean any return of the wrapped function will be ignored.  Note
+       that when function_return_key is anything but None, it is assumed the
+       returned object is the (usually modified) data object.
+     :param handles_ensembes:  set True if the function this is applied to 
+       can hangle ensemble objects directly.   When False, which is the default 
+       this decorator applies the atomic function to each ensemble member in 
+       a loop over membes.
     :param kwargs: extra kv arguments
     :return: origin data or the output of func
     """

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -8,6 +8,7 @@ from mspasspy.ccore.seismic import (
     TimeSeriesEnsemble,
     SeismogramEnsemble,
 )
+from mspasspy.util.seismic import number_live
 
 # from mspasspy.global_history.manager import GlobalHistoryManager
 from mspasspy.util import logging_helper
@@ -24,45 +25,107 @@ def mspass_func_wrapper(
     dryrun=False,
     inplace_return=False,
     function_return_key=None,
-    handles_ensembles=False,
+    handles_ensembles=True,
+    checks_arg0_type=False,
+    handles_dead_data=True,
     **kwargs,
 ):
-    """
+    """ 
     Decorator wrapper to adapt a simple function to the mspass parallel processing framework.
 
-    This function serves as a decorator wrapper, which is widely used in mspasspy library. It executes the target
-    function on input data. Data are restricted to be mspasspy objects. It also preserves the processing history and
-    error logs into the mspasspy objects. By wrapping your function using this decorator, you can save some workload.
-    Runtime error won't be raised in order to be efficient in map-reduce operations. MspassError with a severity Fatal
-    will be raised, others won't be raised.
-
-    A large fraction of algorithms used in mspass are "atomic" meaning
-    they only operator on TimeSeries and/or Seismogram objects.   In mspass
-    an "ensemble" is a container with multiple atomic objects.  This decorator
-    can then also be used to adapt an atomic algorithm to work automatically
-    with ensembles.   When using the decorator if the funtion being decorated
-    works only on atomic data set the boolean `handles_ensembles` should be
-    set as False (the default).  Set it True only for functions that handle
-    ensembles as the type of arg0.
+    This decorator can be used to adapt a processing function to the 
+    mspass framework.  It can be used to handle the following nonstandard 
+    functionality that would not appear in a function outside of mspass:
+        1.  This decorator can make a function dogmatic about the type of arg0.
+            A processing function in mspass normally requires arg0 to be a 
+            seismic data type.   If the function being decorated handles 
+            arg0 propertly add `checks_arg0_type=True` to the functions 
+            kwargs list.  That will assure the error handler used by the 
+            function itself will be used instead of the generic wrapper code.
+            When False (the default) this decorator will always throw a 
+            TypeError with a generic message if arg0 is invalid.
+        2.  MsPASS data objects all use the concept of the boolean "live"
+            as a way to mark a datum as valid (dead means it is bad). 
+            MsPASS functios should normally kill a problem datum and 
+            not throw exceptions for anything but system level error 
+            like a malloc error. A properly designed function 
+            has a test for dead data immediately after verifying 
+            arg0 is valid and testing of "data.live" is a valid thing to 
+            do.  To assure that doesn't happen if checks_arg0_type is 
+            false and the test for a valid type yields success
+            (i.e. find data is a valid seismic object) a test for 
+            live will data will be done and the functionw will immediately 
+            return a datum marked dead.  If set True, the default, we let 
+            the functions dead data handler do the task.
+        3.  MsPASS data object have an internal mechanism to preserve 
+            object-level history that records the sequence of algorithms 
+            applied to a piece of data to get it to it's current stage  
+            This decorator adds that functionality through three kwarg 
+            values: `object_history`,`alg_id', and `alg_name'.  `object_history`
+            is  boolean that enables (if True) or disables (False - default)
+            that mechanism.   The other two are tags.   See the User 
+            Manual for more details.  
+        4.  MsPASS data are either "atomic" (TimeSeries or Seismogram) or 
+            "ensembles" (TimeSeriesEnseble and SeismogramEnsemble).   
+            "ensembles", however, are a conainer holding one or more 
+            atomic objects.  Processing algorithms may require only atomic 
+            or ensemble objects.  For algorithms that expect atomic data, 
+            however, it is common to need to apply the same function to 
+            all ensemble "members" (the set of atomic objects that define the
+            ensemble).   Some processing functions are designed to handle 
+            either but some aren't.  If a function is set up to hanlde 
+            ensembles, the `handles_ensembles` boolean should be set True. 
+            That is set True because a well designed algorithm for use with 
+            MsPASS should do that.  Set `handles_ensembles=False` if the 
+            function is set up to only handle atomic data.  In that situation 
+            the decorator will handle ensembles by setting up a loop to 
+            call the decorated function for each enemble member. 
+        5.  The boolean `inplace_return` should be set True on a function 
+            that it set up like a FORTRAN subroutine or a C void return.  
+            i.e. it doesn't return anything but alters data internally. 
+            In that situation the decorator returns arg0 that is assumed to 
+            have been altered by the function.
+        6.  Use `function_return_key` if a function doesn't return a seismic 
+            data object at all but computes something returned as a value. 
+            If used that capability allows a return value to be mapped into 
+            the Metadata container of the input data object and set with 
+            the specified key.  
+            
+    Finally, this decorator has a standardized behavior for handling 
+    ensembles that is not optional.  If the input is an ensemble it is 
+    not at all uncommon to have an algorithm kill all ensemble members.  
+    The ensemble container has a global "live" attribute that this decorator 
+    will set False (i.e. define as dead) if all the member object are marked
+    dead.
 
     :param func: target function
-    :param data: input data, only mspasspy data objects are accepted, i.e. TimeSeries, Seismogram, Ensemble.
-    :param args: extra arguments
-    :param object_history: True to preserve this processing history in the data object, False not to. object_history
-     and alg_id are intimately related and control how object level history is handled.
-     Object level history is disabled by default for efficiency.  If object_history is set True and the string passed
-     as alg_id is defined (not None which is the default) each Seismogram or TimeSeries object will attempt to
-     save the history through a new_map operation.   If the history chain is empty this will silently generate
-     an error posted to error log on each object.
-    :param alg_id: alg_id is a unique id to record the usage of func while preserving the history.
-    :type alg_id: :class:`bson.objectid.ObjectId`
-    :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
-    :type alg_name: :class:`str`
+    :param data: arg0 of function call being decorated.  This symbol is 
+      expected to point to an input data that is expected to be a MsPASS
+      data object i.e. TimeSeries, Seismogram, Ensemble.
+    :param args: extra positional arguments for decorated function
+    :param object_history:  boolean used to enable or disable 
+       object level history for this function.  When False (default)
+       object-level history is not enabld for this function.  When 
+       set True the decorator will add object history history th e
+       name of the function and the value of alg_id.  
+       Object level history is disabled by default for efficiency.  
+       If object_history is set True and the string passed
+       as alg_id is defined (not None which is the default) each 
+       Seismogram or TimeSeries object will attempt to
+       save the history through a new_map operation.   
+       If the history chain is empty this will silently generate
+       an error posted to error log on each object.
+    :param alg_id: alg_id is a unique id to record the usage of func 
+      while preserving the history.
+    :type alg_id: str (e.g. str of an ObjectId)
+    :param alg_name: alternative name to assign the algorithm.  If not 
+      defined (set as None) the name of the decorated function is used.  
+    :type alg_name: :class:`str` or None (default)
     :param dryrun: True for dry-run, the algorithm is not run, but the arguments used in this wrapper will be checked.
       This is useful for pre-run checks of a large job to validate a workflow. Errors generate exceptions
       but the function returns before attempting any calculations.
     :param inplace_return: when func is an in-place function that doesn't return anything, but you want to
-     return the origin data (for example, in map-reduce), set inplace_return as true.
+       return the origin data (for example, in map-reduce), set inplace_return as true.
     :param function_return_key:  Some functions one might want to wrap with this decorator
        return something that is appropriate to save as Metadata.  If so, use this argument to
        define the key used to set that field in the data that is returned.
@@ -82,13 +145,19 @@ def mspass_func_wrapper(
       this decorator applies the atomic function to each ensemble member in
       a loop over membes.
     :param kwargs: extra kv arguments
-    :return: origin data or the output of func
+    :return: modified seismic data object.  Can be a different type than 
+       the input.   If function_return_key is used only the Metadata 
+       container  should be altered.
     """
-    if not isinstance(
-        data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
-    ):
-        raise TypeError("mspass_func_wrapper only accepts mspass object as data input")
-
+    # Add an error trap for arg0 if this function doesn't do that
+    if not checks_arg0_type:
+        if not isinstance(
+                data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
+            ):
+            raise TypeError("mspass_func_wrapper only accepts mspass object as data input")
+        else:
+            if data.dead():
+                return data
     if function_return_key and isinstance(
         data, (TimeSeriesEnsemble, SeismogramEnsemble)
     ):
@@ -106,14 +175,25 @@ def mspass_func_wrapper(
 
     if dryrun:
         return "OK"
+    # reverse logic a bit confusing but idea is to do nothing if 
+    # handles_dead_data is true assuming the function will handle dead 
+    # data propertly
+    if not handles_dead_data:
+        if data.dead():
+            return data
 
-    if is_input_dead(data):
-        return data
-
-    if isinstance(data, (Seismogram, TimeSeries)) or handles_ensembles:
+    if isinstance(data, (Seismogram, TimeSeries)):
         run_only_once = True
+    elif isinstance(data, (TimeSeriesEnsemble, SeismogramEnsemble)):
+            if handles_ensembles:
+                run_only_once = True
+            else:
+                run_only_once = False
     else:
-        run_only_once = False
+        # we only get here if checks_arg0_type is True and the 
+        # type is bad - with this logic func will be called and 
+        # we assume it throws an exception
+        run_only_once = True
     try:
         if run_only_once:
             res = func(data, *args, **kwargs)
@@ -153,6 +233,14 @@ def mspass_func_wrapper(
                 data.member[i] = d
                 if object_history:
                     logging_helper.info(data.member[i], alg_id, alg_name)
+                    
+            # mark ensmeble killed by all applications of func as dead
+            N_live = number_live(data)
+            if N_live<=len(data.member):
+                message = "function killed all ensemble members.  Marking ensemble dead"
+                data.elog.log_error(alg_name,message,ErrorSeverity.Invalid)
+                data.kill()
+                
             # Note the in place return concept does not apply to
             # ensemles - all are in place by defintion if passed through
             # this wrapper
@@ -280,7 +368,9 @@ def mspass_method_wrapper(
     dryrun=False,
     inplace_return=False,
     function_return_key=None,
-    handles_ensembles=False,
+    handles_ensembles=True,
+    checks_arg0_type=False,
+    handles_dead_data=True,
     **kwargs,
 ):
     """
@@ -299,8 +389,9 @@ def mspass_method_wrapper(
     can then also be used to adapt an atomic algorithm to work automatically
     with ensembles.   When using the decorator if the funtion being decorated
     works only on atomic data set the boolean `handles_ensembles` should be
-    set as False (the default).  Set it True only for functions that handle
-    ensembles as the type of arg0.
+    set as False.   True, which is the default, should be used functions that 
+    handle ensembles automatically. 
+
 
     :param func: target function
     :param selfarg:  the self pointer for the class with which this method is associated
@@ -333,17 +424,22 @@ def mspass_method_wrapper(
        is taken to mean any return of the wrapped function will be ignored.  Note
        that when function_return_key is anything but None, it is assumed the
        returned object is the (usually modified) data object.
-     :param handles_ensembes:  set True if the function this is applied to
-       can hangle ensemble objects directly.   When False, which is the default
-       this decorator applies the atomic function to each ensemble member in
-       a loop over membes.
+     :param handles_ensembes:  set True (default) if the function this is applied to
+       can hangle ensemble objects directly.   When False this decorator 
+       applies the atomic function to each ensemble member in
+       a loop over members.
     :param kwargs: extra kv arguments
     :return: origin data or the output of func
     """
-    if not isinstance(
-        data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
-    ):
-        raise TypeError("mspass_func_wrapper only accepts mspass object as data input")
+    # Add an error trap for arg0 if this function doesn't do that
+    if not checks_arg0_type:
+        if not isinstance(
+                data, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
+            ):
+            raise TypeError("mspass_method_wrapper only accepts mspass object as data input")
+        else:
+            if data.dead():
+                return data
 
     # if not defined
     if not alg_name:
@@ -366,13 +462,25 @@ def mspass_method_wrapper(
     if dryrun:
         return "OK"
 
-    if is_input_dead(data):
-        return data
+    # reverse logic a bit confusing but idea is to do nothing if 
+    # handles_dead_data is true assuming the function will handle dead 
+    # data propertly
+    if not handles_dead_data:
+        if data.dead():
+            return data
 
-    if isinstance(data, (Seismogram, TimeSeries)) or handles_ensembles:
+    if isinstance(data, (Seismogram, TimeSeries)):
         run_only_once = True
+    elif isinstance(data, (TimeSeriesEnsemble, SeismogramEnsemble)):
+            if handles_ensembles:
+                run_only_once = True
+            else:
+                run_only_once = False
     else:
-        run_only_once = False
+        # we only get here if checks_arg0_type is True and the 
+        # type is bad - with this logic func will be called and 
+        # we assume it throws an exception
+        run_only_once = True
 
     try:
         if run_only_once:
@@ -413,6 +521,13 @@ def mspass_method_wrapper(
                 data.member[i] = d
                 if object_history:
                     logging_helper.info(data.member[i], alg_id, alg_name)
+
+            # mark ensmeble killed by all applications of func as dead
+            N_live = number_live(data)
+            if N_live<=len(data.member):
+                message = "function killed all ensemble members.  Marking ensemble dead"
+                data.elog.log_error(alg_name,message,ErrorSeverity.Invalid)
+                data.kill()
             # Note the in place return concept does not apply to
             # ensemles - all are in place by defintion if passed through
             # this wrapper

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -314,9 +314,9 @@ def mspass_func_wrapper_multi(
     if not isinstance(
         data2, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
     ):
-        message = "mspass_func_wrapper_multi only accepts mspass object as data input\n"
-        message += "Actual type of arg0={}".format(str(type(data2)))
-        raise TypeError(message)
+        raise TypeError(
+            "mspass_func_wrapper_multi only accepts mspass object as data input"
+        )
 
     if not alg_name:
         alg_name = func.__name__

--- a/python/tests/algorithms/decon_data_generators.py
+++ b/python/tests/algorithms/decon_data_generators.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module is a companion to a jupyter notebook tutorial documenting 
+the receiver function deconvolution algorithms in MsPASS.   It has a 
+string of frozen properties designed just for this tutorial so it is 
+best left in this location and used only by the tutorial or students of 
+the tutorial interested in what is under the hood.  
+
+The entire purpose of this module is to generate a set of synthetic 
+waveforms that can be used to demonstrate deconvolution methods.
+
+Created on Wed Dec 23 10:29:26 2020
+
+@author: Gary L Pavlis
+"""
+import numpy as np
+from scipy import signal
+from numpy.random import randn
+
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    TimeSeries,
+    TimeSeriesEnsemble,
+    TimeReferenceType,
+    DoubleVector,
+)
+from mspasspy.ccore.algorithms.basic import TimeWindow
+from mspasspy.algorithms.basic import ExtractComponent
+
+
+def make_impulse_vector(lag, imp, n=500):
+    """
+    Computes a (sparse) vector of impulse functions at a specified set of
+    lags.   Used for generating fake data for a number of contexts.
+
+    :param lag: is a list of lag values (int in samples) parallel with imp
+    :param imp: is a list of values (amplitudes) for each lag.  Algorithm is
+       simply to insert imp value at specified lag.
+    :param n: length of output vector returned.
+    :return: numpy vector of doubles of length n.  zero where lag,imp not defined.
+    """
+    if len(lag) != len(imp):
+        raise RuntimeError(
+            "make_impulse_vector:  lag and imp vectors must be equal length"
+        )
+    d = np.ndarray(n)
+    for i in range(n):
+        d[i] = 0.0
+    for i in range(len(lag)):
+        if (lag[i] < 0) | (lag[i] >= n):
+            raise RuntimeError("make_impulse_vector:  lag out of range")
+        d[lag[i]] = imp[i]
+    return d
+
+
+def addnoise(d, nscale=1.0, padlength=1024, npoles=3, corners=[0.1, 1.0]):
+    """
+    Helper function to add noise to ndarray d.  The approach is a
+    little weird that we shift the data to the right by padlength
+    adding filtered random data to the front if the signal.
+    The code later sets t0 correctly based on padlength - ok
+    for a test program but do not recycle me.
+
+    :param d: data to which noise is to be added and padded
+    :param scale:  noise scale for gaussian normal noise
+    :param padlength:   data padded on front by this many sample of noise
+    """
+    nd = len(d)
+    n = nd + padlength
+    dnoise = nscale * randn(n)
+    sos = signal.butter(npoles, corners, btype="bandpass", output="sos", fs=20.0)
+    result = signal.sosfilt(sos, dnoise)
+    for i in range(nd):
+        result[i + padlength] += d[i]
+    return result
+
+
+def make_wavelet_noise_data(
+    nscale=0.1, ns=2048, padlength=512, dt=0.05, npoles=3, corners=[0.08, 0.8]
+):
+    wn = TimeSeries(ns)
+    wn.t0 = 0.0
+    wn.dt = dt
+    wn.tref = TimeReferenceType.Relative
+    wn.live = True
+    nd = ns + 2 * padlength
+    y = nscale * randn(nd)
+    sos = signal.butter(npoles, corners, btype="bandpass", output="sos", fs=1.0 / dt)
+    y = signal.sosfilt(sos, y)
+    for i in range(ns):
+        wn.data[i] = y[i + padlength]
+    return wn
+
+
+def make_simulation_wavelet(
+    n=100,
+    dt=0.05,
+    t0=-1.0,
+    imp=(20.0, -15.0, 4.0, -1.0),
+    lag=(20, 24, 35, 45),
+    npoles=3,
+    corners=[2.0, 6.0],
+):
+    dvec = make_impulse_vector(lag, imp, n)
+    fsampling = int(1.0 / dt)
+    sos = signal.butter(npoles, corners, btype="bandpass", output="sos", fs=fsampling)
+    f = signal.sosfilt(sos, dvec)
+    wavelet = TimeSeries(n)
+    wavelet.set_t0(t0)
+    wavelet.set_dt(dt)
+    # This isn't necessary at the moment because relative is the default
+    # wavelet.set_tref(TimeReferenceType.Relative)
+    wavelet.set_npts(n)
+    wavelet.set_live()
+    for i in range(n):
+        wavelet.data[i] = f[i]
+    return wavelet
+
+
+def make_impulse_data(n=1024, dt=0.05, t0=-5.0):
+    # Compute lag for spike at time=0
+    lag0 = int(-t0 / dt)
+    z = make_impulse_vector([lag0], [150.0], n)
+    rf_lags = (lag0, lag0 + 50, lag0 + 60, lag0 + 150, lag0 + 180)
+    amps1 = (10.0, 20.0, -60.0, -3.0, 2.0)
+    amps2 = (-15.0, 30.0, 10.0, -20.0, 15.0)
+    ns = make_impulse_vector(rf_lags, amps1, n)
+    ew = make_impulse_vector(rf_lags, amps2, n)
+    d = Seismogram(n)
+    d.set_t0(t0)
+    d.set_dt(dt)
+    d.set_live()
+    d.tref = TimeReferenceType.Relative
+    for i in range(n):
+        d.data[0, i] = ew[i]
+        d.data[1, i] = ns[i]
+        d.data[2, i] = z[i]
+    return d
+
+
+def convolve_wavelet(d, w):
+    """
+    Convolves wavelet w with 3C data stored in Seismogram object d
+    to create simulated data d*w.   Returns a copy of d with the data
+    matrix replaced by the convolved data.
+    """
+    dsim = Seismogram(d)
+    # compute the output length for full convolution
+    # for numpy convolve function
+    n = d.npts + w.npts - 1
+    dsim.set_npts(n)
+    # for full convolution the start time needs to be adjusted to
+    # this value
+    dsim.t0 = d.t0 + w.t0
+    for k in range(3):
+        work = ExtractComponent(d, k)
+        convout = np.convolve(work.data, w.data)
+        dsim.data[k, :] = DoubleVector(convout)
+    return dsim
+
+
+def addnoise(d, nscale=1.0, padlength=1024, npoles=3, corners=[0.1, 1.0]):
+    """
+    Helper function to add noise to Seismogram d.  The approach is a
+    little weird in that we shift the data to the right by padlength
+    adding filtered random data to the front of the signal.
+    The padding is compensated by changes to t0 to preserve relative time
+    0.0.  The purpose of this is to allow adding colored noise to
+    a simulated 3C seismogram.
+
+    :param d: Seismogram data to which noise is to be added and padded
+    :param nscale:  noise scale for gaussian normal noise
+    :param padlength:   data padded on front by this many sample of noise
+    :param npoles: number of poles for butterworth filter
+    :param corners:  2 component array with corner frequencies for butterworth bandpass.
+    """
+    nd = d.npts
+    n = nd + padlength
+    result = Seismogram(d)
+    result.set_npts(n)
+    newt0 = d.t0 - d.dt * padlength
+    result.set_t0(newt0)
+    # at the time this code was written we had a hole in the ccore
+    # api wherein operator+ and operator+= were not defined. Hence in this
+    # loop we stack the noise and signal inline.
+    for k in range(3):
+        dnoise = nscale * randn(n)
+        sos = signal.butter(npoles, corners, btype="bandpass", output="sos", fs=20.0)
+        nfilt = signal.sosfilt(sos, dnoise)
+        for i in range(n):
+            result.data[k, i] = nfilt[i]
+        for i in range(nd):
+            t = d.time(i)
+            ii = result.sample_number(t)
+            # We don't test range here because we know we won't
+            # go outside bounds because of the logic of this function
+            result.data[k, ii] += d.data[k, i]
+    return result

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -358,10 +358,9 @@ def test_CNRRFDecon_error_handlers():
     sw = TimeWindow(-5.0, 30.0)
     # first arg type and validity checkers
     # this is what the function would throw
-    # with pytest.raises(TypeError, match="illegal type="):   
-    # mspass_func_decorator catches the same error and requires this 
-    with pytest.raises(TypeError, 
-                match="CNRRFDecon:  illegal type="):
+    # with pytest.raises(TypeError, match="illegal type="):
+    # mspass_func_decorator catches the same error and requires this
+    with pytest.raises(TypeError, match="CNRRFDecon:  illegal type="):
         d_decon = CNRRFDecon("foo", engine, signal_window=sw, noise_window=nw)
 
     d = Seismogram(d0wn)
@@ -556,9 +555,10 @@ def test_CNRArrayDecon_error_handlers():
     w = Seismogram(s0)
     # this is what the function would throw
     # with pytest.raises(TypeError, match="Illegal type for arg0"):
-    # mspass_func_decorator catches the same error and requires this 
-    with pytest.raises(TypeError, 
-                match="mspass_func_wrapper only accepts mspass object"):
+    # mspass_func_decorator catches the same error and requires this
+    with pytest.raises(
+        TypeError, match="mspass_func_wrapper only accepts mspass object"
+    ):
         e_d = CNRArrayDecon("foo", w, engine, noise_window=nw, signal_window=sw)
 
     with pytest.raises(TypeError, match="Illegal type for required arg1"):

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -272,7 +272,7 @@ def test_CNRRFDecon():
     d = Seismogram(d0wn)
     # use default pf file for this and all tests in this file
     pf = pfread("./data/pf/CNRDeconEngine.pf")
-    #pf = pfread("/geode2/home/u070/pavlis/Quartz/src/mspass/data/pf/CNRDeconEngine.pf")
+    # pf = pfread("/geode2/home/u070/pavlis/Quartz/src/mspass/data/pf/CNRDeconEngine.pf")
     engine = CNRDeconEngine(pf)
     nw = TimeWindow(-45.0, -5.0)
     sw = TimeWindow(-5.0, 30.0)
@@ -292,23 +292,23 @@ def test_CNRRFDecon():
     verify_decon_output(d_decon, engine, rfwavelet)
     # verify pickle of engine works -important for parallel processng
     # as dask and spark will pickle engine in map/reduce operators
-    #d = Seismogram(d0wn)
-    #rfwavelet - TimeSeries(rfwavelet0)
-    #dumpstring = pickle.dumps(engine)
-    #engine_cpy = pickle.loads(dumpstring)
-    #d_decon2, aout, iout = CNRRFDecon(
+    # d = Seismogram(d0wn)
+    # rfwavelet - TimeSeries(rfwavelet0)
+    # dumpstring = pickle.dumps(engine)
+    # engine_cpy = pickle.loads(dumpstring)
+    # d_decon2, aout, iout = CNRRFDecon(
     #    d,
     #    engine_cpy,
     #    signal_window=sw,
     #    noise_window=nw,
     #    return_wavelet=True,
     #    use_3C_noise=True,
-    #)
-    #assert d_decon2.live
-    #assert aout.live
-    #assert iout.live
-    #assert d_decon2.npts == d_decon.npts
-    #assert np.isclose(d_decon.data, d_decon2.data).all()
+    # )
+    # assert d_decon2.live
+    # assert aout.live
+    # assert iout.live
+    # assert d_decon2.npts == d_decon.npts
+    # assert np.isclose(d_decon.data, d_decon2.data).all()
 
     # verify_decon_output(d_decon, engine, rfwavelet)
     # repeat with 1c noise estimate option and return wavelet off

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -361,7 +361,7 @@ def test_CNRRFDecon_error_handlers():
     # with pytest.raises(TypeError, match="illegal type="):   
     # mspass_func_decorator catches the same error and requires this 
     with pytest.raises(TypeError, 
-                match="mspass_func_wrapper only accepts mspass object"):
+                match="CNRRFDecon:  illegal type="):
         d_decon = CNRRFDecon("foo", engine, signal_window=sw, noise_window=nw)
 
     d = Seismogram(d0wn)

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -357,7 +357,11 @@ def test_CNRRFDecon_error_handlers():
     nw = TimeWindow(-45.0, -5.0)
     sw = TimeWindow(-5.0, 30.0)
     # first arg type and validity checkers
-    with pytest.raises(TypeError, match="illegal type="):
+    # this is what the function would throw
+    # with pytest.raises(TypeError, match="illegal type="):   
+    # mspass_func_decorator catches the same error and requires this 
+    with pytest.raises(TypeError, 
+                match="mspass_func_wrapper only accepts mspass object"):
         d_decon = CNRRFDecon("foo", engine, signal_window=sw, noise_window=nw)
 
     d = Seismogram(d0wn)
@@ -550,7 +554,11 @@ def test_CNRArrayDecon_error_handlers():
     # first test handlers for argument errors
     e = SeismogramEnsemble(e0)
     w = Seismogram(s0)
-    with pytest.raises(TypeError, match="Illegal type for arg0"):
+    # this is what the function would throw
+    # with pytest.raises(TypeError, match="Illegal type for arg0"):
+    # mspass_func_decorator catches the same error and requires this 
+    with pytest.raises(TypeError, 
+                match="mspass_func_wrapper only accepts mspass object"):
         e_d = CNRArrayDecon("foo", w, engine, noise_window=nw, signal_window=sw)
 
     with pytest.raises(TypeError, match="Illegal type for required arg1"):

--- a/python/tests/algorithms/test_MCXcorStacking.py
+++ b/python/tests/algorithms/test_MCXcorStacking.py
@@ -47,7 +47,7 @@ def load_test_data():
     """
     filename = "MCXcorStacking.testdata"
     # for testing use this
-    # dir = "../data"
+    #dir = "../data"
     # with pytest use this
     dir = "./python/tests/data"
     path = dir + "/" + filename
@@ -73,7 +73,7 @@ def load_TAtestdata():
     """
     filename = "MCXcor_testdata.pickle"
     # for testing use this
-    # dir = "../data"
+    #dir = "../data"
     # with pytest use this
     dir = "./python/tests/data"
     path = dir + "/" + filename
@@ -621,7 +621,7 @@ def test_MCXcorPrepP():
     # first check dogmatic type tests
     e = TimeSeriesEnsemble(e0)
     with pytest.raises(TypeError, match="MCXcorPrepP:  Illegal type="):
-        [eo, beam] = MCXcorPrepP("foo", nw)
+        [eo, beam] = MCXcorPrepP("foo", nw, checks_arg0_type=True)
     with pytest.raises(TypeError, match="MCXcorPrepP:  Illegal type="):
         [eo, beam] = MCXcorPrepP(e, "foo")
     # test handling of dead ensemble

--- a/python/tests/algorithms/test_MCXcorStacking.py
+++ b/python/tests/algorithms/test_MCXcorStacking.py
@@ -47,7 +47,7 @@ def load_test_data():
     """
     filename = "MCXcorStacking.testdata"
     # for testing use this
-    #dir = "../data"
+    # dir = "../data"
     # with pytest use this
     dir = "./python/tests/data"
     path = dir + "/" + filename
@@ -73,7 +73,7 @@ def load_TAtestdata():
     """
     filename = "MCXcor_testdata.pickle"
     # for testing use this
-    #dir = "../data"
+    # dir = "../data"
     # with pytest use this
     dir = "./python/tests/data"
     path = dir + "/" + filename

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -169,7 +169,7 @@ def test_RFdecon_error_handlers():
     # which algorithm we used doesn't matter here - use defaults
     engine = RFdeconProcessor()
     # first a simple type test of arg0
-    with pytest.raises(TypeError, match="only accepts mspass object"):
+    with pytest.raises(TypeError, match="RFdecon:  arg0 is of type="):
         foo = RFdecon("badarg0")
     # test handling dead datum
     d = Seismogram(seis0)

--- a/python/tests/algorithms/test_basic.py
+++ b/python/tests/algorithms/test_basic.py
@@ -25,7 +25,7 @@ from mspasspy.algorithms.basic import (
 # module to test
 sys.path.append("python/tests")
 
-from helper import get_live_seismogram, get_live_timeseries, get_sin_timeseries
+from helper import get_live_timeseries
 
 
 def is_identity(tm):
@@ -428,6 +428,7 @@ def test_transform_to_RTZ():
     seis["seaz"] = seaz
     for i in range(nmembers):
         e.member.append(Seismogram(seis))
+    e.set_live()
     # ensemble is 3 copies of the same data this test used above
     # has seaz set
     eout = transform_to_RTZ(e)
@@ -563,14 +564,15 @@ def test_transform_to_LQT():
     # atomic version tests what is needed for arg method and
     # is not recommended for ensembles anyway
     nmembers = 3
-    e = SeismogramEnsemble(3)
+    e = SeismogramEnsemble(nmembers)
     az = 90.0 - phi
     seaz = az + 180.0
     seis = Seismogram(seis0)
     seis["seaz"] = seaz
     seis["ema"] = theta
-    for i in range(3):
+    for i in range(nmembers):
         e.member.append(Seismogram(seis))
+    e.set_live()
     # ensemble is 3 copies of the same data this test used above
     # has seaz set
     eout = transform_to_LQT(e)

--- a/python/tests/algorithms/test_resample.py
+++ b/python/tests/algorithms/test_resample.py
@@ -1,3 +1,5 @@
+import sys
+sys.path.append("python/tests")
 import numpy as np
 from helper import (
     get_live_seismogram,

--- a/python/tests/algorithms/test_resample.py
+++ b/python/tests/algorithms/test_resample.py
@@ -1,4 +1,5 @@
 import sys
+
 sys.path.append("python/tests")
 import numpy as np
 from helper import (

--- a/python/tests/algorithms/test_taper.py
+++ b/python/tests/algorithms/test_taper.py
@@ -15,10 +15,8 @@ from mspasspy.ccore.algorithms.basic import (
     _TopMute,
 )
 
-from helper import get_live_seismogram, get_live_timeseries, get_sin_timeseries
-
-# module to test
 sys.path.append("python/tests")
+from helper import get_live_seismogram, get_live_timeseries, get_sin_timeseries
 
 
 def test_linearTaper():

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -800,5 +800,8 @@ def test_TopMute():
     failmute.apply(ts2)
     assert not ts2.live
 
-    with pytest.raises(MsPASSError, match="must be a TimeSeries or Seismogram"):
+    with pytest.raises(TypeError,match="TopMute.apply:  usage error."):
         failmute.apply([1, 2, 3])
+        
+        
+test_TopMute()

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -800,8 +800,8 @@ def test_TopMute():
     failmute.apply(ts2)
     assert not ts2.live
 
-    with pytest.raises(TypeError,match="TopMute.apply:  usage error."):
+    with pytest.raises(TypeError, match="TopMute.apply:  usage error."):
         failmute.apply([1, 2, 3])
-        
-        
+
+
 test_TopMute()

--- a/python/tests/util/test_decorators.py
+++ b/python/tests/util/test_decorators.py
@@ -17,7 +17,7 @@ from mspasspy.global_history.manager import GlobalHistoryManager
 # source tree so we need to add this to path to see the helper module
 # used only for testing
 sys.path.append("python/tests")
-# sys.path.append("python/mspasspy/util/")
+
 
 from mspasspy.util.decorators import (
     mspass_func_wrapper,
@@ -115,6 +115,26 @@ def dummy_numeric_function(
     data["foobar"] = 1.0
     return data
 
+@mspass_func_wrapper
+def check_arg0_tester(
+    data,
+    *args,
+    checks_arg0_type=True,
+    handle_ensemble=True,
+    **kwargs,
+):
+    """
+    Test function used to validate behavior of the check_arg0_type
+    feature.  Raises a ValueError typical of processing functions 
+    when data is not a valid type.
+    """
+    if isinstance(data,TimeSeries):
+        data["foo"] = "bar"
+        return data
+    else:
+        raise TypeError("test function arg0 is an invalid type")
+    
+        
 
 def test_mspass_func_wrapper():
     with pytest.raises(TypeError) as err:
@@ -195,7 +215,51 @@ def test_mspass_func_wrapper():
     assert not data.live
     data = dummy_func(seis, inplace_return=True)
     assert not data.live
+    
+    # check behavir of checks_arg0_type with handles_ensembles
+    d = get_live_timeseries()
+    # should work in this case
+    d = check_arg0_tester(d)
+    assert "foo" in d
+    # this should have a message from the actuall function
+    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+        d = check_arg0_tester("notvaliddata", checks_arg0_type=True)
+    # this should return the decorator error
+    with pytest.raises(TypeError,match="mspass_func_wrapper only accepts mspass object"):
+        d = check_arg0_tester("notvaliddata", checks_arg0_type=False)
 
+    # test selective typte behavior with different settings of 
+    # handles ensemble.  Notice check_arg0_tester internally only accepts 
+    # TimeSeries.   When check_arg0_type s False and handles_ensemble is 
+    # True it should process an ensemble.  Otherwise it should throw a
+    # ValueError exception
+    e = get_live_timeseries_ensemble(3)
+    assert e.live
+    e = check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
+    for d in e.member:
+        assert d["foo"]=="bar"
+    e = get_live_timeseries_ensemble(3)
+    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+        e = check_arg0_tester(e,checks_arg0_type=True, handles_ensembles=True)
+    # this would be a mistake in usage for this test function but is the 
+    # behavio the decoraor should have - returns the functions message not 
+    # the decorator message.  Note using seismogram because the 
+    # function only takes TimeSeries - this will work for a TimeSeriesEnsemble
+    # and not throw an exceptoin
+    e = get_live_seismogram_ensemble(3)
+    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+        e = check_arg0_tester(e, checks_arg0_type=False, handles_ensembles=False)
+    # True-True not testable directly - would fail referencing "member" 
+    # attibute in decorator - an incorrect usage not worth testing
+    
+    # check handling of an algorithm killing all data
+    e = get_live_timeseries_ensemble(3)
+    for i in range(3):
+        e.member[i].kill()
+    assert e.live
+    e = check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
+    assert e.dead()
+    assert e.elog.size() == 1
 
 @timeseries_as_trace
 def dummy_func_timeseries_as_trace(d, any=None):
@@ -327,6 +391,8 @@ class dummy_class_method_wrapper:
         inplace_return=False,
         function_return_key=None,
         handles_ensembles=False,
+        checks_arg0_type=False,
+        handles_dead_data=False,
         **kwargs,
     ):
         return "Finish"
@@ -343,6 +409,8 @@ class dummy_class_method_wrapper:
         inplace_return=False,
         function_return_key=None,
         handles_ensembles=False,
+        checks_arg0_type=False,
+        handles_dead_data=False,
         **kwargs,
     ):
         """
@@ -350,31 +418,37 @@ class dummy_class_method_wrapper:
         """
         data["foobar"] = 1.0
         return data
+    
+    @mspass_method_wrapper
+    def check_arg0_tester(
+        self,
+        data,
+        *args,
+        checks_arg0_type=True,
+        handle_ensemble=True,
+        **kwargs,
+    ):
+        """
+        Test function used to validate behavior of the check_arg0_type
+        feature.  Raises a ValueError typical of processing functions 
+        when data is not a valid type.
+        """
+        if isinstance(data,TimeSeries):
+            data["foo"] = "bar"
+            return data
+        else:
+            raise TypeError("test function arg0 is an invalid type")
 
 
 def test_mspass_method_wrapper():
     dummy_instance = dummy_class_method_wrapper()
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError,match="mspass_method_wrapper only accepts") as err:
         dummy_instance.dummy_func_method_wrapper(1)
-    assert (
-        str(err.value) == "mspass_func_wrapper only accepts mspass object as data input"
-    )
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError,match="object_history was true but alg_id not defined") as err:
         seis = get_live_seismogram()
         dummy_instance.dummy_func_method_wrapper(seis, object_history=True)
-    assert (
-        str(err.value)
-        == "<class 'test_decorators.dummy_class_method_wrapper'>: object_history was true but alg_id not defined"
-    )
 
-    with pytest.raises(ValueError) as err:
-        seis = get_live_seismogram()
-        dummy_instance.dummy_func_method_wrapper(seis, object_history=True)
-    assert (
-        str(err.value)
-        == "<class 'test_decorators.dummy_class_method_wrapper'>: object_history was true but alg_id not defined"
-    )
     # added Feb 2025 to test new error handler for ValueError exception
     # do not allow function_return_key option with ensemble
     with pytest.raises(ValueError, match="Usage error:"):
@@ -389,10 +463,7 @@ def test_mspass_method_wrapper():
     dummy_instance.dummy_func_method_wrapper(seis, object_history=True, alg_id="0")
     assert seis.number_of_stages() == 1
     assert len(seis.get_nodes()) == 1
-    assert (
-        seis.current_nodedata().algorithm
-        == "<class 'test_decorators.dummy_class_method_wrapper'>"
-    )
+    assert "dummy_class_method_wrapper" in seis.current_nodedata().algorithm
     assert seis.current_nodedata().algid == "0"
 
     # inplace return
@@ -413,22 +484,24 @@ def test_mspass_method_wrapper():
     assert isinstance(data, Seismogram)
     errs = seis.elog.get_error_log()
     assert len(errs) == 2
-    assert errs[-1].algorithm == "<class 'test_decorators.dummy_class_method_wrapper'>"
+    assert "dummy_class_method_wrapper" in errs[1].algorithm
     assert (
-        errs[-1].message
+        errs[1].message
         == "Inconsistent arguments; inplace_return was set False and function_return_key was not None.\nAssuming inplace_return == True is correct"
     )
-    assert errs[-2].algorithm == "<class 'test_decorators.dummy_class_method_wrapper'>"
+    assert "dummy_class_method_wrapper" in errs[0].algorithm
     assert (
-        errs[-2].message
+        errs[0].message
         == "Illegal type received for function_return_key argument=<class 'dict'>\nReturn value not saved in Metadata"
     )
 
     # Test immediate return
     seis.kill()
     data = dummy_instance.dummy_func_method_wrapper(seis)
-    assert not data.live
+    assert data.dead()
 
+    # test dryrun feature
+    seis.set_live()
     assert "OK" == dummy_instance.dummy_func_method_wrapper(seis, dryrun=True)
 
     # tests for new ensemble handling features Feb 2025
@@ -447,7 +520,46 @@ def test_mspass_method_wrapper():
     for d in e.member:
         assert "foobar" not in d
     assert e["foobar"] == 1.0
+    
+    # check behavir of checks_arg0_type with handles_ensembles
+    d = get_live_timeseries()
+    # should work in this case
+    d = dummy_instance.check_arg0_tester(d)
+    assert "foo" in d
+    # this should have a message from the actuall function
+    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+        d = dummy_instance.check_arg0_tester("notvaliddata", checks_arg0_type=True)
+    # this should return the decorator error
+    with pytest.raises(TypeError,match="mspass_method_wrapper only accepts mspass object"):
+        d = dummy_instance.check_arg0_tester("notvaliddata", checks_arg0_type=False)
 
+    # test selective typte behavior with different settings of 
+    # handles ensemble.  Notice check_arg0_tester internally only accepts 
+    # TimeSeries.   When check_arg0_type s False and handles_ensemble is 
+    # True it should process an ensemble.  Otherwise it should throw a
+    # ValueError exception
+    e = get_live_timeseries_ensemble(3)
+    assert e.live
+    e = dummy_instance.check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
+    for d in e.member:
+        assert d["foo"]=="bar"
+    e = get_live_timeseries_ensemble(3)
+    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+        e = dummy_instance.check_arg0_tester(e,checks_arg0_type=True, handles_ensembles=True)
+    # simulate case of mismatched member type but valid seismic data type 
+    # here we get the method's exception message
+    e = get_live_seismogram_ensemble(3)
+    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+        e = dummy_instance.check_arg0_tester(e, checks_arg0_type=False, handles_ensembles=False)
+
+    # check handling of an algorithm killing all data
+    e = get_live_timeseries_ensemble(3)
+    for i in range(3):
+        e.member[i].kill()
+    assert e.live
+    e = dummy_instance.check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
+    assert e.dead()
+    assert e.elog.size() == 1
 
 @mspass_func_wrapper
 @timeseries_as_trace
@@ -687,3 +799,4 @@ def test_copy_helpers():
 
 if __name__ == "__main__":
     test_copy_helpers()
+

--- a/python/tests/util/test_decorators.py
+++ b/python/tests/util/test_decorators.py
@@ -13,11 +13,11 @@ from mspasspy.ccore.utility import MsPASSError, ErrorSeverity
 from mspasspy.global_history.manager import GlobalHistoryManager
 
 
-# pytest in mspass is always run from the top level director of the 
+# pytest in mspass is always run from the top level director of the
 # source tree so we need to add this to path to see the helper module
 # used only for testing
 sys.path.append("python/tests")
-#sys.path.append("python/mspasspy/util/")
+# sys.path.append("python/mspasspy/util/")
 
 from mspasspy.util.decorators import (
     mspass_func_wrapper,
@@ -94,25 +94,27 @@ def dummy_func(
 ):
     return "dummy"
 
+
 @mspass_func_wrapper
 def dummy_numeric_function(
-        data,
-        *args,
-        object_history=False,
-        alg_id=None,
-        dryrun=False,
-        inplace_return=False,
-        function_return_key=None,
-        handles_ensembles=False,
-        **kwargs,
-    ):
+    data,
+    *args,
+    object_history=False,
+    alg_id=None,
+    dryrun=False,
+    inplace_return=False,
+    function_return_key=None,
+    handles_ensembles=False,
+    **kwargs,
+):
     """
-    Use this dummy function if the test has to actually do something 
-    rational to the data - dummy_func will return invalid types that 
+    Use this dummy function if the test has to actually do something
+    rational to the data - dummy_func will return invalid types that
     would confuse tests on ensembles.
     """
     data["foobar"] = 1.0
     return data
+
 
 def test_mspass_func_wrapper():
     with pytest.raises(TypeError) as err:
@@ -127,12 +129,11 @@ def test_mspass_func_wrapper():
     assert (
         str(err.value) == "dummy_func: object_history was true but alg_id not defined"
     )
-    # added Feb 2025 to test new error handler for ValueError exception 
+    # added Feb 2025 to test new error handler for ValueError exception
     # do not allow function_return_key option with ensembles
-    with pytest.raises(ValueError,match="Usage error:"):
+    with pytest.raises(ValueError, match="Usage error:"):
         e = get_live_timeseries_ensemble(3)
-        dummy_numeric_function(e,function_return_key="foobar")
-                      
+        dummy_numeric_function(e, function_return_key="foobar")
 
     assert "OK" == dummy_func(seis, dryrun=True)
 
@@ -172,23 +173,21 @@ def test_mspass_func_wrapper():
         == "Illegal type received for function_return_key argument=<class 'dict'>\nReturn value not saved in Metadata"
     )
     # tests for new ensemble handling features Feb 2025
-    # note we use a TimeSeriesEnsemble but a SeismogramEnsemble would behave 
+    # note we use a TimeSeriesEnsemble but a SeismogramEnsemble would behave
     # the same for the current api - careful if there is divergence
-    e = get_live_timeseries_ensemble(3) 
+    e = get_live_timeseries_ensemble(3)
     e = dummy_numeric_function(e, handles_ensembles=False)
     # in this case all the members need to be tested
     for d in e.member:
         assert d["foobar"] == 1.0
     assert "foobar" not in e
     # with handles_ensembles_false reverse the tests above
-    e = get_live_timeseries_ensemble(3) 
+    e = get_live_timeseries_ensemble(3)
     e = dummy_numeric_function(e, handles_ensembles=True)
     # in this case all the members need to be tested
     for d in e.member:
         assert "foobar" not in d
     assert e["foobar"] == 1.0
-    
-    
 
     # dead object will return immediately
     seis.kill()
@@ -331,20 +330,21 @@ class dummy_class_method_wrapper:
         **kwargs,
     ):
         return "Finish"
+
     @mspass_method_wrapper
     def dummy_numeric_method(
-            self,
-            data,
-            *args,
-            object_history=False,
-            alg_id=None,
-            alg_name=None,
-            dryrun=False,
-            inplace_return=False,
-            function_return_key=None,
-            handles_ensembles=False,
-            **kwargs,
-        ):
+        self,
+        data,
+        *args,
+        object_history=False,
+        alg_id=None,
+        alg_name=None,
+        dryrun=False,
+        inplace_return=False,
+        function_return_key=None,
+        handles_ensembles=False,
+        **kwargs,
+    ):
         """
         Used for testing handling of ensembles with handles_ensemble option.
         """
@@ -375,11 +375,11 @@ def test_mspass_method_wrapper():
         str(err.value)
         == "<class 'test_decorators.dummy_class_method_wrapper'>: object_history was true but alg_id not defined"
     )
-    # added Feb 2025 to test new error handler for ValueError exception 
+    # added Feb 2025 to test new error handler for ValueError exception
     # do not allow function_return_key option with ensemble
-    with pytest.raises(ValueError,match="Usage error:"):
+    with pytest.raises(ValueError, match="Usage error:"):
         e = get_live_timeseries_ensemble(3)
-        dummy_instance.dummy_numeric_method(e,function_return_key="foobar")
+        dummy_instance.dummy_numeric_method(e, function_return_key="foobar")
 
     # Default behavior
     assert "Finish" == dummy_instance.dummy_func_method_wrapper(seis)
@@ -430,18 +430,18 @@ def test_mspass_method_wrapper():
     assert not data.live
 
     assert "OK" == dummy_instance.dummy_func_method_wrapper(seis, dryrun=True)
-    
+
     # tests for new ensemble handling features Feb 2025
-    # note we use a TimeSeriesEnsemble but a SeismogramEnsemble would behave 
+    # note we use a TimeSeriesEnsemble but a SeismogramEnsemble would behave
     # the same for the current api - careful if there is divergence
-    e = get_live_timeseries_ensemble(3) 
+    e = get_live_timeseries_ensemble(3)
     e = dummy_instance.dummy_numeric_method(e, handles_ensembles=False)
     # in this case all the members need to be tested
     for d in e.member:
         assert d["foobar"] == 1.0
     assert "foobar" not in e
     # with handles_ensembles_false reverse the tests above
-    e = get_live_timeseries_ensemble(3) 
+    e = get_live_timeseries_ensemble(3)
     e = dummy_instance.dummy_numeric_method(e, handles_ensembles=True)
     # in this case all the members need to be tested
     for d in e.member:
@@ -461,7 +461,7 @@ def dummy_func_2(
     alg_id=None,
     dryrun=False,
     inplace_return=True,
-    handles_ensembles=True,   # needed or mspass_func_wrapper will throw an exception
+    handles_ensembles=True,  # needed or mspass_func_wrapper will throw an exception
     **kwargs,
 ):
     if isinstance(data, obspy.Trace):

--- a/python/tests/util/test_decorators.py
+++ b/python/tests/util/test_decorators.py
@@ -139,9 +139,7 @@ def check_arg0_tester(
 def test_mspass_func_wrapper():
     with pytest.raises(TypeError) as err:
         dummy_func(1)
-    assert (
-        str(err.value) == "mspass_func_wrapper only accepts mspass object as data input"
-    )
+    assert "mspass_func_wrapper only accepts mspass object" in str(err.value)
 
     with pytest.raises(ValueError) as err:
         seis = get_live_seismogram()
@@ -588,9 +586,7 @@ def test_all_decorators():
     # test mspass_func_wrapper
     with pytest.raises(TypeError) as err:
         dummy_func_2(1)
-    assert (
-        str(err.value) == "mspass_func_wrapper only accepts mspass object as data input"
-    )
+    assert "mspass_func_wrapper only accepts mspass object" in str(err.value)
 
     with pytest.raises(ValueError) as err:
         seis = get_live_seismogram()
@@ -654,10 +650,7 @@ def dummy_func_multi(
 def test_mspass_func_wrapper_multi():
     with pytest.raises(TypeError) as err:
         dummy_func_multi(1, 2)
-    assert (
-        str(err.value)
-        == "mspass_func_wrapper_multi only accepts mspass object as data input"
-    )
+    assert "mspass_func_wrapper_multi only accepts mspass object" in str(err.value)
 
     with pytest.raises(ValueError) as err:
         seis1 = get_live_seismogram()

--- a/python/tests/util/test_decorators.py
+++ b/python/tests/util/test_decorators.py
@@ -115,6 +115,7 @@ def dummy_numeric_function(
     data["foobar"] = 1.0
     return data
 
+
 @mspass_func_wrapper
 def check_arg0_tester(
     data,
@@ -125,16 +126,15 @@ def check_arg0_tester(
 ):
     """
     Test function used to validate behavior of the check_arg0_type
-    feature.  Raises a ValueError typical of processing functions 
+    feature.  Raises a ValueError typical of processing functions
     when data is not a valid type.
     """
-    if isinstance(data,TimeSeries):
+    if isinstance(data, TimeSeries):
         data["foo"] = "bar"
         return data
     else:
         raise TypeError("test function arg0 is an invalid type")
-    
-        
+
 
 def test_mspass_func_wrapper():
     with pytest.raises(TypeError) as err:
@@ -213,43 +213,45 @@ def test_mspass_func_wrapper():
     assert not data.live
     data = dummy_func(seis, inplace_return=True)
     assert not data.live
-    
+
     # check behavir of checks_arg0_type with handles_ensembles
     d = get_live_timeseries()
     # should work in this case
     d = check_arg0_tester(d)
     assert "foo" in d
     # this should have a message from the actuall function
-    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
         d = check_arg0_tester("notvaliddata", checks_arg0_type=True)
     # this should return the decorator error
-    with pytest.raises(TypeError,match="mspass_func_wrapper only accepts mspass object"):
+    with pytest.raises(
+        TypeError, match="mspass_func_wrapper only accepts mspass object"
+    ):
         d = check_arg0_tester("notvaliddata", checks_arg0_type=False)
 
-    # test selective typte behavior with different settings of 
-    # handles ensemble.  Notice check_arg0_tester internally only accepts 
-    # TimeSeries.   When check_arg0_type s False and handles_ensemble is 
+    # test selective typte behavior with different settings of
+    # handles ensemble.  Notice check_arg0_tester internally only accepts
+    # TimeSeries.   When check_arg0_type s False and handles_ensemble is
     # True it should process an ensemble.  Otherwise it should throw a
     # ValueError exception
     e = get_live_timeseries_ensemble(3)
     assert e.live
     e = check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
     for d in e.member:
-        assert d["foo"]=="bar"
+        assert d["foo"] == "bar"
     e = get_live_timeseries_ensemble(3)
-    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
-        e = check_arg0_tester(e,checks_arg0_type=True, handles_ensembles=True)
-    # this would be a mistake in usage for this test function but is the 
-    # behavio the decoraor should have - returns the functions message not 
-    # the decorator message.  Note using seismogram because the 
+    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
+        e = check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=True)
+    # this would be a mistake in usage for this test function but is the
+    # behavio the decoraor should have - returns the functions message not
+    # the decorator message.  Note using seismogram because the
     # function only takes TimeSeries - this will work for a TimeSeriesEnsemble
     # and not throw an exceptoin
     e = get_live_seismogram_ensemble(3)
-    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
         e = check_arg0_tester(e, checks_arg0_type=False, handles_ensembles=False)
-    # True-True not testable directly - would fail referencing "member" 
+    # True-True not testable directly - would fail referencing "member"
     # attibute in decorator - an incorrect usage not worth testing
-    
+
     # check handling of an algorithm killing all data
     e = get_live_timeseries_ensemble(3)
     for i in range(3):
@@ -258,6 +260,7 @@ def test_mspass_func_wrapper():
     e = check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
     assert e.dead()
     assert e.elog.size() == 1
+
 
 @timeseries_as_trace
 def dummy_func_timeseries_as_trace(d, any=None):
@@ -416,7 +419,7 @@ class dummy_class_method_wrapper:
         """
         data["foobar"] = 1.0
         return data
-    
+
     @mspass_method_wrapper
     def check_arg0_tester(
         self,
@@ -428,10 +431,10 @@ class dummy_class_method_wrapper:
     ):
         """
         Test function used to validate behavior of the check_arg0_type
-        feature.  Raises a ValueError typical of processing functions 
+        feature.  Raises a ValueError typical of processing functions
         when data is not a valid type.
         """
-        if isinstance(data,TimeSeries):
+        if isinstance(data, TimeSeries):
             data["foo"] = "bar"
             return data
         else:
@@ -440,10 +443,12 @@ class dummy_class_method_wrapper:
 
 def test_mspass_method_wrapper():
     dummy_instance = dummy_class_method_wrapper()
-    with pytest.raises(TypeError,match="mspass_method_wrapper only accepts") as err:
+    with pytest.raises(TypeError, match="mspass_method_wrapper only accepts") as err:
         dummy_instance.dummy_func_method_wrapper(1)
 
-    with pytest.raises(ValueError,match="object_history was true but alg_id not defined") as err:
+    with pytest.raises(
+        ValueError, match="object_history was true but alg_id not defined"
+    ) as err:
         seis = get_live_seismogram()
         dummy_instance.dummy_func_method_wrapper(seis, object_history=True)
 
@@ -518,46 +523,57 @@ def test_mspass_method_wrapper():
     for d in e.member:
         assert "foobar" not in d
     assert e["foobar"] == 1.0
-    
+
     # check behavir of checks_arg0_type with handles_ensembles
     d = get_live_timeseries()
     # should work in this case
     d = dummy_instance.check_arg0_tester(d)
     assert "foo" in d
     # this should have a message from the actuall function
-    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
+    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
         d = dummy_instance.check_arg0_tester("notvaliddata", checks_arg0_type=True)
     # this should return the decorator error
-    with pytest.raises(TypeError,match="mspass_method_wrapper only accepts mspass object"):
+    with pytest.raises(
+        TypeError, match="mspass_method_wrapper only accepts mspass object"
+    ):
         d = dummy_instance.check_arg0_tester("notvaliddata", checks_arg0_type=False)
 
-    # test selective typte behavior with different settings of 
-    # handles ensemble.  Notice check_arg0_tester internally only accepts 
-    # TimeSeries.   When check_arg0_type s False and handles_ensemble is 
+    # test selective typte behavior with different settings of
+    # handles ensemble.  Notice check_arg0_tester internally only accepts
+    # TimeSeries.   When check_arg0_type s False and handles_ensemble is
     # True it should process an ensemble.  Otherwise it should throw a
     # ValueError exception
     e = get_live_timeseries_ensemble(3)
     assert e.live
-    e = dummy_instance.check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
+    e = dummy_instance.check_arg0_tester(
+        e, checks_arg0_type=True, handles_ensembles=False
+    )
     for d in e.member:
-        assert d["foo"]=="bar"
+        assert d["foo"] == "bar"
     e = get_live_timeseries_ensemble(3)
-    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
-        e = dummy_instance.check_arg0_tester(e,checks_arg0_type=True, handles_ensembles=True)
-    # simulate case of mismatched member type but valid seismic data type 
+    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
+        e = dummy_instance.check_arg0_tester(
+            e, checks_arg0_type=True, handles_ensembles=True
+        )
+    # simulate case of mismatched member type but valid seismic data type
     # here we get the method's exception message
     e = get_live_seismogram_ensemble(3)
-    with pytest.raises(TypeError,match="test function arg0 is an invalid type"):
-        e = dummy_instance.check_arg0_tester(e, checks_arg0_type=False, handles_ensembles=False)
+    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
+        e = dummy_instance.check_arg0_tester(
+            e, checks_arg0_type=False, handles_ensembles=False
+        )
 
     # check handling of an algorithm killing all data
     e = get_live_timeseries_ensemble(3)
     for i in range(3):
         e.member[i].kill()
     assert e.live
-    e = dummy_instance.check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
+    e = dummy_instance.check_arg0_tester(
+        e, checks_arg0_type=True, handles_ensembles=False
+    )
     assert e.dead()
     assert e.elog.size() == 1
+
 
 @mspass_func_wrapper
 @timeseries_as_trace
@@ -792,4 +808,3 @@ def test_copy_helpers():
 
 if __name__ == "__main__":
     test_copy_helpers()
-


### PR DESCRIPTION
This implements a change to the mspass decorators to make it easier to adapt an algorithm that works only on atomic data to ensembles.  It basically automates adding a loop over ensemble members.   It implements ideas documented in discussion item #616.  

The change required small changes to most of the code in mspasspy.algorithms to add a kwarg switch to tell the decorator to enable the ensemble loop.

This initial push is virtually guaranteed to fail the pytest run here on github.   I did not run pytest on all the algorithms and the odds are high I made a mistake or one of the test make an assumption that is invalid with the decorators enabled.   Also there will be a gap in the tests to verify the ensemble functionality works for algorithms not previously working that way.  The coverage gizmo probably won't detect that since it is a decorator feature but that may be appropriate.  