### PR TITLE
normalize and database bug fixes

### DIFF
--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3269,12 +3269,10 @@ class ArrivalMatcher(DataFrameCacheMatcher):
 def normalize(
     mspass_object,
     matcher,
-    *args,
     kill_on_failure=True,
     handles_ensembles=False,
     checks_arg0_type=False,
     handles_dead_data=True,
-    **kwargs,
 ):
     """
     Generic function to do in line normalization with dask/spark map operator.

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3270,9 +3270,11 @@ def normalize(
     mspass_object,
     matcher,
     kill_on_failure=True,
+    *args,
     handles_ensembles=False,
     checks_arg0_type=False,
     handles_dead_data=True,
+    **kwargs,
 ):
     """
     Generic function to do in line normalization with dask/spark map operator.

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3269,8 +3269,8 @@ class ArrivalMatcher(DataFrameCacheMatcher):
 def normalize(
     mspass_object,
     matcher,
-    kill_on_failure=True,
     *args,
+    kill_on_failure=True,
     handles_ensembles=False,
     checks_arg0_type=False,
     handles_dead_data=True,

--- a/python/tests/db/test_normalize.py
+++ b/python/tests/db/test_normalize.py
@@ -1,10 +1,3 @@
-# TODO based on Aug 15, 2022 group meeting
-"""
-1.  Add decorator for mspass history to normalize function - DONE
-2.  Change api to have find return a None on failure instead of an empty list
-3.  Biggest change is to consider how to do a pandas implementation.  That will
-best be done in a discussio page on github before commiting the revisions
-"""
 from mspasspy.db.normalize import (
     normalize,
     EqualityDBMatcher,


### PR DESCRIPTION
This branch contains a bug fix for two problems:
1.   I found the normalize function (in normalize module) did not work with ensembles because of a mistake I had made in application of the decorator extensions made recently.   
2. Issue #629 

In this initial push I haven't revised the test to check either of these fixes.  For 1 I'm not sure it is necessary as the only thing adding such a test would do was duplicate tests of the decorator and validate normalize does indeed work with ensembles correctly.  2 is more problematic as I am not sure how to do a test to check the error handlers I added.   The new handlers are there to handle corrupted or completely invalid data files.   I think just trying to read a junk file with content not matching the format would work, but I'm unsure how to do that.  I'm going to push this to see what happens and ask for help from the group.