### PR TITLE
bug fix for normalize and a couple other functions 

### DIFF
--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -578,6 +578,7 @@ def WindowData(
     log_recoverable_errors=True,
     overwrite_members=False,
     retain_dead_members=True,
+    *args,
     object_history=False,
     alg_name="WindowData",
     alg_id=None,
@@ -585,6 +586,7 @@ def WindowData(
     handles_ensembles=True,
     checks_arg0_type=True,
     handles_dead_data=True,
+    **kwargs,
 ):
     """
     Apply a window operation to cut out data within a specified time range
@@ -831,6 +833,7 @@ def WindowData_autopad(
     stime,
     etime,
     pad_fraction_cutoff=0.05,
+    *args,
     object_history=False,
     alg_name="WindowData_autopad",
     alg_id=None,
@@ -838,6 +841,7 @@ def WindowData_autopad(
     handles_ensembles=False,
     checks_arg0_type=True,
     handles_dead_data=False,
+    **kwargs,
 ):
     """
     Windows an atomic data object with automatic padding if the
@@ -1194,9 +1198,9 @@ class TopMute:
     def apply(
         self,
         d,
-        object_history=False,
         instance=None,
         *args,
+        object_history=False,
         checks_arg0_type=True,
         handles_ensembles=False,
         handles_dead_data=True,

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -1198,7 +1198,6 @@ class TopMute:
     def apply(
         self,
         d,
-        instance=None,
         *args,
         object_history=False,
         checks_arg0_type=True,
@@ -1218,11 +1217,6 @@ class TopMute:
         :object_history:  It set true the function will add define this
           step as an map operation to preserve object level history.
           (default is False)
-        :param instance:   string defining the "instance" of this algorithm.
-          This parameter is needed only if object_history is set True.  It
-          is used to define which instance of this algrithm is being applied.
-          (In the C++ api this is what is called the algorithm id).  I can
-          come from the global history manager or be set manually.
         """
         if not isinstance(d, TimeSeries) and not isinstance(d, Seismogram):
             message = "TopMute.apply:  usage error.  Input data must be a TimeSeries or Seismogram object"
@@ -1240,31 +1234,4 @@ class TopMute:
             d.kill()
         else:
             self.processor.apply(d)
-            if object_history:
-                if instance == None:
-                    d.elog(
-                        "TopMute.apply",
-                        "Undefined instance argument - cannot save history data",
-                        ErrorSeverity.Complaint,
-                    )
-                elif d.is_empty():
-                    d.elog(
-                        "TopMute.apply",
-                        "Error log is empty.  Cannot be extended without a top level entry",
-                        ErrorSeverity.Complaint,
-                    )
-                else:
-                    if isinstance(d, Seismogram):
-                        d.new_map(
-                            "TopMute",
-                            instance,
-                            AtomicType.SEISMOGRAM,
-                            ProcessingStatus.VOLATILE,
-                        )
-                    else:
-                        d.new_map(
-                            "TopMute",
-                            instance,
-                            AtomicType.TIMESERIES,
-                            ProcessingStatus.VOLATILE,
-                        )
+        return d

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3269,12 +3269,12 @@ class ArrivalMatcher(DataFrameCacheMatcher):
 def normalize(
     mspass_object,
     matcher,
-    kill_on_failure=True,
     *args,
-    handles_ensembles=False,
+    kill_on_failure=True,
+    handles_ensembles=True,
     checks_arg0_type=False,
     handles_dead_data=True,
-    **kwargs,
+    **kwargs
 ):
     """
     Generic function to do in line normalization with dask/spark map operator.

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3270,9 +3270,11 @@ def normalize(
     mspass_object,
     matcher,
     kill_on_failure=True,
+    *args,
     handles_ensembles=False,
     checks_arg0_type=False,
     handles_dead_data=True,
+    **kwargs,
 ):
     """
     Generic function to do in line normalization with dask/spark map operator.

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -731,13 +731,13 @@ def test_WindowData_autopad():
         assert se.data[k, npts + 1] == 0.0
 
     # test handling of ensembles via the mspass_func_decorator
-    # note the function itself only handles atomic data 
+    # note the function itself only handles atomic data
     # Test only TimeSeriesEnsemble
     ens = TimeSeriesEnsemble(2)
     for i in range(2):
         ens.member.append(ts)
     ens.set_live()
-    ens = WindowData_autopad(ens,ts.time(10),ts.time(50))
+    ens = WindowData_autopad(ens, ts.time(10), ts.time(50))
     for i in range(2):
         assert ens.member[i].live
 

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -454,11 +454,9 @@ def test_windowdata_exceptions():
     with pytest.raises(ValueError, match="illegal option"):
         d = WindowData(ts, 2, 3, short_segment_handling="notvalid")
     ts = TimeSeries(ts0)
-    # note this message actually comes from the decorator
-    # the error handler in WindowData to handle this can't be
-    # reached with the decorator enable.  Caution of the decorator
-    # changes this could break
-    with pytest.raises(TypeError, match="only accepts mspass object as data input"):
+    # WindowData handles both atomic and ensemble data \
+    # this exception is handled by the function itself, no the decorators
+    with pytest.raises(TypeError, match="Illegal type for arg0="):
         d = WindowData(0.0, 2.0, 3.0)
 
     # We don't test explicit kill mode.  That is default and assume
@@ -732,16 +730,16 @@ def test_WindowData_autopad():
         assert se.data[k, 0] == 0.0
         assert se.data[k, npts + 1] == 0.0
 
-    # test error handling for this function - not made a separate function
-    # as it isn't that complex
-    d_foo = TimeSeriesEnsemble(2)
-    d_foo.member.append(ts)
-    d_foo.set_live()
-    with pytest.raises(
-        TypeError, match="arg0 must be either a TimeSeries or Seismogram object"
-    ):
-        # need to send TimeSeriesEnsemble to bypass type check of function decorator
-        ts = WindowData_autopad(d_foo, se.time(10), se.time(50))
+    # test handling of ensembles via the mspass_func_decorator
+    # note the function itself only handles atomic data 
+    # Test only TimeSeriesEnsemble
+    ens = TimeSeriesEnsemble(2)
+    for i in range(2):
+        ens.member.append(ts)
+    ens.set_live()
+    ens = WindowData_autopad(ens,ts.time(10),ts.time(50))
+    for i in range(2):
+        assert ens.member[i].live
 
     # only test this for TimeSeries - no reason to think it would behave differently for Seismogram
     ts = TimeSeries(ts0)


### PR DESCRIPTION
This branch fixes three things:
1.   The normalize function does not currently use the mspass_func_decorator and will not work correctly with ensembles. 
2.   I fixed a couple of other mistakes in algorithms with functions that do are not handling *args and **kwargs correctly with the mspass_func_decorator.  It is VERY IMPORTANT to realize this fix is dependent that pull request #632 is a dead branch.   There I found the use of *args and **kwargs with these decorators is different from the stock way they are handled.  See the comments there for details.   I found additional evidence that #632 is the wrong approach as a fix here (next item) revealed exactly what happens when the #632 approach is used.
3. WindoData functions need to be corrected for use with mspass_func_decorartor.   I had to also fix the test which revealed why the use of *args and **kwargs is as used here.   If used in the #632 approach the decorator intercepted exceptions incorrectly because the decorator was configured incorrectly.   That is why this fix has some changes to the tests for the window module.

I ran pytest functions on all the functions I changed so if this doesn't pass it will be mysterious.   Well, at this moment we have some kind of error in master that is breaking any branch forked from the current master so I expect that will be present here to.  If that is the only failure I urge you, @wangyinz, to merge this branch as it contains some important fixes.