### PR TITLE
Add Exception fallback to mspass decorator wrappers

### DIFF
--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -155,7 +155,8 @@ def mspass_func_wrapper(
     :param kwargs: extra kv arguments
     :return: modified seismic data object.  Can be a different type than
        the input.   If function_return_key is used only the Metadata
-       container  should be altered.
+       container  should be altered.  On RuntimeError, MsPASSError (non-Fatal),
+       or generic Exception, arg0 is logged, killed, and returned.
     """
     # Add an error trap for arg0 if this function doesn't do that
     if not checks_arg0_type:
@@ -269,11 +270,14 @@ def mspass_func_wrapper(
             # ensemles - all are in place by defintion if passed through
             # this wrapper
             return data
+    # On failure log arg0, kill it, and return it so callers never see implicit None.
+    # Fatal MsPASSError is re-raised and does not use this handler.
     except RuntimeError as err:
         if isinstance(data, (Seismogram, TimeSeries)):
             data.elog.log_error(alg_name, str(err), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data, alg_name, err, ErrorSeverity.Invalid)
+        data.kill()
         return data
     except MsPASSError as ex:
         if ex.severity == ErrorSeverity.Fatal:
@@ -282,6 +286,7 @@ def mspass_func_wrapper(
             data.elog.log_error(alg_name, ex.message, ex.severity)
         else:
             logging_helper.ensemble_error(data, alg_name, ex.message, ex.severity)
+        data.kill()
         return data
     except Exception as exc:
         if not isinstance(data, _MSPASS_WRAPPER_DATA_TYPES):
@@ -290,6 +295,7 @@ def mspass_func_wrapper(
             data.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data, alg_name, exc, ErrorSeverity.Invalid)
+        data.kill()
         return data
 
 
@@ -328,7 +334,8 @@ def mspass_func_wrapper_multi(
       This is useful for pre-run checks of a large job to validate a workflow. Errors generate exceptions
       but the function returns before attempting any calculations.
     :param kwargs: extra kv arguments
-    :return: the output of func
+    :return: the output of func.  On RuntimeError, MsPASSError (non-Fatal), or
+      generic Exception, both inputs are logged, killed, and data1 is returned.
     """
     if not isinstance(
         data1, (Seismogram, TimeSeries, SeismogramEnsemble, TimeSeriesEnsemble)
@@ -362,6 +369,8 @@ def mspass_func_wrapper_multi(
             logging_helper.info(data1, alg_id, alg_name)
             logging_helper.info(data2, alg_id, alg_name)
         return res
+    # On failure log each input, kill both, and return data1 so callers never see implicit None.
+    # Fatal MsPASSError is re-raised and does not use this handler.
     except RuntimeError as err:
         if isinstance(data1, (Seismogram, TimeSeries)):
             data1.elog.log_error(alg_name, str(err), ErrorSeverity.Invalid)
@@ -371,6 +380,9 @@ def mspass_func_wrapper_multi(
             data2.elog.log_error(alg_name, str(err), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data2, alg_name, err, ErrorSeverity.Invalid)
+        data1.kill()
+        data2.kill()
+        return data1
     except MsPASSError as ex:
         if ex.severity == ErrorSeverity.Fatal:
             raise
@@ -382,6 +394,9 @@ def mspass_func_wrapper_multi(
             data2.elog.log_error(alg_name, ex.message, ex.severity)
         else:
             logging_helper.ensemble_error(data2, alg_name, ex.message, ex.severity)
+        data1.kill()
+        data2.kill()
+        return data1
     except Exception as exc:
         if not isinstance(data1, _MSPASS_WRAPPER_DATA_TYPES) or not isinstance(
             data2, _MSPASS_WRAPPER_DATA_TYPES
@@ -395,6 +410,9 @@ def mspass_func_wrapper_multi(
             data2.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data2, alg_name, exc, ErrorSeverity.Invalid)
+        data1.kill()
+        data2.kill()
+        return data1
 
 
 @decorator
@@ -470,7 +488,8 @@ def mspass_method_wrapper(
        applies the atomic function to each ensemble member in
        a loop over members.
     :param kwargs: extra kv arguments
-    :return: origin data or the output of func
+    :return: origin data or the output of func.  On RuntimeError, MsPASSError
+       (non-Fatal), or generic Exception, arg0 is logged, killed, and returned.
     """
     # Add an error trap for arg0 if this function doesn't do that
     if not checks_arg0_type:
@@ -576,11 +595,14 @@ def mspass_method_wrapper(
             # ensembles - all are in place by defintion if passed through
             # this wrapper
             return data
+    # On failure log arg0, kill it, and return it so callers never see implicit None.
+    # Fatal MsPASSError is re-raised and does not use this handler.
     except RuntimeError as err:
         if isinstance(data, (Seismogram, TimeSeries)):
             data.elog.log_error(alg_name, str(err), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data, alg_name, err, ErrorSeverity.Invalid)
+        data.kill()
         return data
     except MsPASSError as ex:
         if ex.severity == ErrorSeverity.Fatal:
@@ -589,6 +611,7 @@ def mspass_method_wrapper(
             data.elog.log_error(alg_name, ex.message, ex.severity)
         else:
             logging_helper.ensemble_error(data, alg_name, ex.message, ex.severity)
+        data.kill()
         return data
     except Exception as exc:
         if not isinstance(data, _MSPASS_WRAPPER_DATA_TYPES):
@@ -597,6 +620,7 @@ def mspass_method_wrapper(
             data.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data, alg_name, exc, ErrorSeverity.Invalid)
+        data.kill()
         return data
 
 
@@ -946,7 +970,9 @@ def mspass_reduce_func_wrapper(
       This is useful for pre-run checks of a large job to validate a workflow. Errors generate exceptions
       but the function returns before attempting any calculations.
     :param kwargs: extra kv arguments
-    :return: the output of func
+    :return: the output of func.  On RuntimeError, logged MsPASSError
+      (Informational or Debug), or generic Exception, both inputs are killed
+      and data1 is returned; other MsPASSError severities are re-raised.
     """
     if not alg_name:
         alg_name = func.__name__
@@ -970,6 +996,8 @@ def mspass_reduce_func_wrapper(
         if object_history:
             logging_helper.reduce(data1, data2, alg_id, alg_name)
         return res
+    # On failure log both inputs, kill both, and return data1 so callers never see implicit None.
+    # mspass_reduce_func_wrapper MsPASSError: only Informational/Debug are logged here; others re-raise.
     except RuntimeError as err:
         if isinstance(data1, (Seismogram, TimeSeries)):
             data1.elog.log_error(alg_name, str(err), ErrorSeverity.Invalid)
@@ -977,6 +1005,9 @@ def mspass_reduce_func_wrapper(
         else:
             logging_helper.ensemble_error(data1, alg_name, err, ErrorSeverity.Invalid)
             logging_helper.ensemble_error(data2, alg_name, err, ErrorSeverity.Invalid)
+        data1.kill()
+        data2.kill()
+        return data1
     except MsPASSError as ex:
         if (
             ex.severity != ErrorSeverity.Informational
@@ -989,6 +1020,9 @@ def mspass_reduce_func_wrapper(
         else:
             logging_helper.ensemble_error(data1, alg_name, ex.message, ex.severity)
             logging_helper.ensemble_error(data2, alg_name, ex.message, ex.severity)
+        data1.kill()
+        data2.kill()
+        return data1
     except Exception as exc:
         if not isinstance(data1, _MSPASS_WRAPPER_DATA_TYPES) or not isinstance(
             data2, _MSPASS_WRAPPER_DATA_TYPES
@@ -1000,6 +1034,9 @@ def mspass_reduce_func_wrapper(
         else:
             logging_helper.ensemble_error(data1, alg_name, exc, ErrorSeverity.Invalid)
             logging_helper.ensemble_error(data2, alg_name, exc, ErrorSeverity.Invalid)
+        data1.kill()
+        data2.kill()
+        return data1
 
 
 # @decorator

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -13,7 +13,7 @@ from mspasspy.util.seismic import number_live
 # from mspasspy.global_history.manager import GlobalHistoryManager
 from mspasspy.util import logging_helper
 
-# Arg0/arg1/arg2 passed to wrapper try blocks must be one of these to use elog/ensemble_error. 
+# Arg0/arg1/arg2 passed to wrapper try blocks must be one of these to use elog/ensemble_error.
 _MSPASS_WRAPPER_DATA_TYPES = (
     Seismogram,
     TimeSeries,
@@ -1045,4 +1045,4 @@ def mspass_reduce_func_wrapper(
 #             alg_id = ObjectId()
 #         global_history.logging(alg_id, alg_name, parameters)
 
-#     return func(*args, **kwargs) 
+#     return func(*args, **kwargs)

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -13,7 +13,7 @@ from mspasspy.util.seismic import number_live
 # from mspasspy.global_history.manager import GlobalHistoryManager
 from mspasspy.util import logging_helper
 
-# Arg0/arg1/arg2 passed to wrapper try blocks must be one of these to use elog/ensemble_error.
+# Arg0/arg1/arg2 passed to wrapper try blocks must be one of these to use elog/ensemble_error. 
 _MSPASS_WRAPPER_DATA_TYPES = (
     Seismogram,
     TimeSeries,
@@ -1045,4 +1045,4 @@ def mspass_reduce_func_wrapper(
 #             alg_id = ObjectId()
 #         global_history.logging(alg_id, alg_name, parameters)
 
-#     return func(*args, **kwargs)
+#     return func(*args, **kwargs) 

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -274,9 +274,7 @@ def mspass_func_wrapper(
             data.elog.log_error(alg_name, str(err), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data, alg_name, err, ErrorSeverity.Invalid)
-        # some unexpected error happen, if inplace_return is true, we may want to return the original data
-        if inplace_return:
-            return data
+        return data
     except MsPASSError as ex:
         if ex.severity == ErrorSeverity.Fatal:
             raise
@@ -284,9 +282,7 @@ def mspass_func_wrapper(
             data.elog.log_error(alg_name, ex.message, ex.severity)
         else:
             logging_helper.ensemble_error(data, alg_name, ex.message, ex.severity)
-        # some unexpected error happen, if inplace_return is true, we may want to return the original data
-        if inplace_return:
-            return data
+        return data
     except Exception as exc:
         if not isinstance(data, _MSPASS_WRAPPER_DATA_TYPES):
             raise exc
@@ -294,8 +290,7 @@ def mspass_func_wrapper(
             data.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data, alg_name, exc, ErrorSeverity.Invalid)
-        if inplace_return:
-            return data
+        return data
 
 
 @decorator
@@ -586,9 +581,7 @@ def mspass_method_wrapper(
             data.elog.log_error(alg_name, str(err), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data, alg_name, err, ErrorSeverity.Invalid)
-        # some unexpected error happen, if inplace_return is true, we may want to return the original data
-        if inplace_return:
-            return data
+        return data
     except MsPASSError as ex:
         if ex.severity == ErrorSeverity.Fatal:
             raise
@@ -596,9 +589,7 @@ def mspass_method_wrapper(
             data.elog.log_error(alg_name, ex.message, ex.severity)
         else:
             logging_helper.ensemble_error(data, alg_name, ex.message, ex.severity)
-        # some unexpected error happen, if inplace_return is true, we may want to return the original data
-        if inplace_return:
-            return data
+        return data
     except Exception as exc:
         if not isinstance(data, _MSPASS_WRAPPER_DATA_TYPES):
             raise exc
@@ -606,8 +597,7 @@ def mspass_method_wrapper(
             data.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
         else:
             logging_helper.ensemble_error(data, alg_name, exc, ErrorSeverity.Invalid)
-        if inplace_return:
-            return data
+        return data
 
 
 def is_input_dead(*args, **kwargs):

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -279,6 +279,13 @@ def mspass_func_wrapper(
         # some unexpected error happen, if inplace_return is true, we may want to return the original data
         if inplace_return:
             return data
+    except Exception as exc:
+        if isinstance(data, (Seismogram, TimeSeries)):
+            data.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
+        else:
+            logging_helper.ensemble_error(data, alg_name, exc, ErrorSeverity.Invalid)
+        if inplace_return:
+            return data
 
 
 @decorator
@@ -370,6 +377,15 @@ def mspass_func_wrapper_multi(
             data2.elog.log_error(alg_name, ex.message, ex.severity)
         else:
             logging_helper.ensemble_error(data2, alg_name, ex.message, ex.severity)
+    except Exception as exc:
+        if isinstance(data1, (Seismogram, TimeSeries)):
+            data1.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
+        else:
+            logging_helper.ensemble_error(data1, alg_name, exc, ErrorSeverity.Invalid)
+        if isinstance(data2, (Seismogram, TimeSeries)):
+            data2.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
+        else:
+            logging_helper.ensemble_error(data2, alg_name, exc, ErrorSeverity.Invalid)
 
 
 @decorator
@@ -567,6 +583,13 @@ def mspass_method_wrapper(
         else:
             logging_helper.ensemble_error(data, alg_name, ex.message, ex.severity)
         # some unexpected error happen, if inplace_return is true, we may want to return the original data
+        if inplace_return:
+            return data
+    except Exception as exc:
+        if isinstance(data, (Seismogram, TimeSeries)):
+            data.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
+        else:
+            logging_helper.ensemble_error(data, alg_name, exc, ErrorSeverity.Invalid)
         if inplace_return:
             return data
 
@@ -960,6 +983,13 @@ def mspass_reduce_func_wrapper(
         else:
             logging_helper.ensemble_error(data1, alg_name, ex.message, ex.severity)
             logging_helper.ensemble_error(data2, alg_name, ex.message, ex.severity)
+    except Exception as exc:
+        if isinstance(data1, (Seismogram, TimeSeries)):
+            data1.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
+            data2.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
+        else:
+            logging_helper.ensemble_error(data1, alg_name, exc, ErrorSeverity.Invalid)
+            logging_helper.ensemble_error(data2, alg_name, exc, ErrorSeverity.Invalid)
 
 
 # @decorator

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -13,6 +13,14 @@ from mspasspy.util.seismic import number_live
 # from mspasspy.global_history.manager import GlobalHistoryManager
 from mspasspy.util import logging_helper
 
+# Arg0/arg1/arg2 passed to wrapper try blocks must be one of these to use elog/ensemble_error.
+_MSPASS_WRAPPER_DATA_TYPES = (
+    Seismogram,
+    TimeSeries,
+    TimeSeriesEnsemble,
+    SeismogramEnsemble,
+)
+
 
 @decorator
 def mspass_func_wrapper(
@@ -280,6 +288,8 @@ def mspass_func_wrapper(
         if inplace_return:
             return data
     except Exception as exc:
+        if not isinstance(data, _MSPASS_WRAPPER_DATA_TYPES):
+            raise exc
         if isinstance(data, (Seismogram, TimeSeries)):
             data.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
         else:
@@ -378,6 +388,10 @@ def mspass_func_wrapper_multi(
         else:
             logging_helper.ensemble_error(data2, alg_name, ex.message, ex.severity)
     except Exception as exc:
+        if not isinstance(data1, _MSPASS_WRAPPER_DATA_TYPES) or not isinstance(
+            data2, _MSPASS_WRAPPER_DATA_TYPES
+        ):
+            raise exc
         if isinstance(data1, (Seismogram, TimeSeries)):
             data1.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
         else:
@@ -586,6 +600,8 @@ def mspass_method_wrapper(
         if inplace_return:
             return data
     except Exception as exc:
+        if not isinstance(data, _MSPASS_WRAPPER_DATA_TYPES):
+            raise exc
         if isinstance(data, (Seismogram, TimeSeries)):
             data.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
         else:
@@ -984,6 +1000,10 @@ def mspass_reduce_func_wrapper(
             logging_helper.ensemble_error(data1, alg_name, ex.message, ex.severity)
             logging_helper.ensemble_error(data2, alg_name, ex.message, ex.severity)
     except Exception as exc:
+        if not isinstance(data1, _MSPASS_WRAPPER_DATA_TYPES) or not isinstance(
+            data2, _MSPASS_WRAPPER_DATA_TYPES
+        ):
+            raise exc
         if isinstance(data1, (Seismogram, TimeSeries)):
             data1.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)
             data2.elog.log_error(alg_name, str(exc), ErrorSeverity.Invalid)

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -565,8 +565,10 @@ def test_CNRArrayDecon_error_handlers():
     ):
         e_d = CNRArrayDecon("foo", w, engine, noise_window=nw, signal_window=sw)
 
-    with pytest.raises(TypeError, match="Illegal type for required arg1"):
-        e_d = CNRArrayDecon(e, "foo", engine, noise_window=nw, signal_window=sw)
+    CNRArrayDecon(e, "foo", engine, noise_window=nw, signal_window=sw)
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "illegal type" in errs[-1].message.lower()
 
     with pytest.raises(ValueError, match="Illegal argument combination"):
         e_d = CNRArrayDecon(e, w, engine)

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -368,18 +368,20 @@ def test_CNRRFDecon_error_handlers():
         d_decon = CNRRFDecon("foo", engine, signal_window=sw, noise_window=nw)
 
     d = Seismogram(d0wn)
-    with pytest.raises(TypeError, match="Must be an instance of a CNRDeconEngine"):
-        d_decon = CNRRFDecon(d, "foo", signal_window=sw, noise_window=nw)
+    CNRRFDecon(d, "foo", signal_window=sw, noise_window=nw)
+    assert d.elog.size() >= 1
+    assert "must be an instance" in d.elog.get_error_log()[-1].message.lower()
 
     d = Seismogram(d0wn)
-    with pytest.raises(ValueError, match="Illegal value received"):
-        d_decon = CNRRFDecon(
-            d,
-            engine,
-            component=20,
-            signal_window=sw,
-            noise_window=nw,
-        )
+    CNRRFDecon(
+        d,
+        engine,
+        component=20,
+        signal_window=sw,
+        noise_window=nw,
+    )
+    assert d.elog.size() >= 1
+    assert "illegal value" in d.elog.get_error_log()[-1].message.lower()
     # verify handling of dead datum
     d = Seismogram(d0wn)
     d.kill()
@@ -570,8 +572,12 @@ def test_CNRArrayDecon_error_handlers():
     assert len(errs) >= 1
     assert "illegal type" in errs[-1].message.lower()
 
-    with pytest.raises(ValueError, match="Illegal argument combination"):
-        e_d = CNRArrayDecon(e, w, engine)
+    e = SeismogramEnsemble(e0)
+    w = Seismogram(s0)
+    CNRArrayDecon(e, w, engine)
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "illegal argument combination" in errs[-1].message.lower()
 
     # verify handlling of dead input
     e = SeismogramEnsemble(e0)

--- a/python/tests/algorithms/test_MCXcorStacking.py
+++ b/python/tests/algorithms/test_MCXcorStacking.py
@@ -317,30 +317,27 @@ def test_align_and_stack_error_handlers():
             "badtype",
             e.member[0],
         )
-    with pytest.raises(TypeError, match="illegal type for arg1"):
-        [eo, beam] = align_and_stack(
-            e,
-            "badtype",
-        )
-    with pytest.raises(ValueError, match="Invalid value for robust_stack_method="):
-        [eo, beam] = align_and_stack(
-            e,
-            e.member[0],
-            robust_stack_method="notvalid",
-        )
+    e = TimeSeriesEnsemble(e0)
+    align_and_stack(e, "badtype")
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "illegal type for arg1" in errs[-1].message.lower()
+    e = TimeSeriesEnsemble(e0)
+    align_and_stack(e, e.member[0], robust_stack_method="notvalid")
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "invalid value for robust_stack_method" in errs[-1].message.lower()
     # test handlers for setting correlation window
-    with pytest.raises(TypeError, match="Illegal type for correlation_window="):
-        [eo, beam] = align_and_stack(
-            e,
-            e.member[0],
-            correlation_window="badarg",
-        )
-    with pytest.raises(TypeError, match="Illegal type="):
-        [eo, beam] = align_and_stack(
-            e,
-            e.member[0],
-            correlation_window_keys="badarg",
-        )
+    e = TimeSeriesEnsemble(e0)
+    align_and_stack(e, e.member[0], correlation_window="badarg")
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "illegal type for correlation_window" in errs[-1].message.lower()
+    e = TimeSeriesEnsemble(e0)
+    align_and_stack(e, e.member[0], correlation_window_keys="badarg")
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "illegal type" in errs[-1].message.lower()
     # these handlers log errors but don't throw exceptions - test them differently
     e = TimeSeriesEnsemble(e0)
     w = TimeSeries(e.member[0])
@@ -376,18 +373,16 @@ def test_align_and_stack_error_handlers():
     assert eo.live
     assert eo.elog.size() == 0
     # test handlers for setting robust window
-    with pytest.raises(ValueError, match="Illegal type for robust_stack_window"):
-        [eo, beam] = align_and_stack(
-            e,
-            e.member[0],
-            robust_stack_window="badarg",
-        )
-    with pytest.raises(ValueError, match="Illegal type="):
-        [eo, beam] = align_and_stack(
-            e,
-            e.member[0],
-            robust_stack_window_keys="badarg",
-        )
+    e = TimeSeriesEnsemble(e0)
+    align_and_stack(e, e.member[0], robust_stack_window="badarg")
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "illegal type for robust_stack_window" in errs[-1].message.lower()
+    e = TimeSeriesEnsemble(e0)
+    align_and_stack(e, e.member[0], robust_stack_window_keys="badarg")
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "illegal type" in errs[-1].message.lower()
     # these handlers log errors but don't throw exceptions - test them differently
     # as above but for section setting robust window
     e = TimeSeriesEnsemble(e0)
@@ -623,8 +618,11 @@ def test_MCXcorPrepP():
     e = TimeSeriesEnsemble(e0)
     with pytest.raises(TypeError, match="MCXcorPrepP:  Illegal type="):
         [eo, beam] = MCXcorPrepP("foo", nw, checks_arg0_type=True)
-    with pytest.raises(TypeError, match="MCXcorPrepP:  Illegal type="):
-        [eo, beam] = MCXcorPrepP(e, "foo")
+    e = TimeSeriesEnsemble(e0)
+    MCXcorPrepP(e, "foo")
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "illegal type" in errs[-1].message.lower()
     # test handling of dead ensemble
     e.kill()
     [eo, beam] = MCXcorPrepP(e, nw, station_collection="site")

--- a/python/tests/algorithms/test_MCXcorStacking.py
+++ b/python/tests/algorithms/test_MCXcorStacking.py
@@ -623,7 +623,8 @@ def test_MCXcorPrepP():
     errs = e.member[0].elog.get_error_log()
     assert len(errs) >= 1
     assert "illegal type" in errs[-1].message.lower()
-    # test handling of dead ensemble
+    # test handling of dead ensemble (fresh ensemble; prior call returns None)
+    e = TimeSeriesEnsemble(e0)
     e.kill()
     [eo, beam] = MCXcorPrepP(e, nw, station_collection="site")
     assert eo.dead()
@@ -657,18 +658,17 @@ def test_MCXcorPrepP():
     assert eo.member[ibad].dead()
 
     # test handling of frequency bandwidth override with arguments
-    # low_f_corner and high_f_corner
+    # low_f_corner and high_f_corner (errors posted to elog by wrapper)
     e = TimeSeriesEnsemble(e0)
-    with pytest.raises(
-        ValueError, match="low_f_corner value is greater than high_f_corner value"
-    ):
-        [eo, beam] = MCXcorPrepP(
-            e, nw, station_collection="site", low_f_corner=10.0, high_f_corner=0.1
-        )
-    with pytest.raises(
-        ValueError, match="If you specify one you must specify the other"
-    ):
-        [eo, beam] = MCXcorPrepP(e, nw, station_collection="site", low_f_corner=0.1)
+    MCXcorPrepP(e, nw, station_collection="site", low_f_corner=10.0, high_f_corner=0.1)
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "greater than" in errs[-1].message.lower()
+    e = TimeSeriesEnsemble(e0)
+    MCXcorPrepP(e, nw, station_collection="site", low_f_corner=0.1)
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "specify" in errs[-1].message.lower() or "other" in errs[-1].message.lower()
 
 
 #    from mspasspy.graphics import SeismicPlotter

--- a/python/tests/algorithms/test_basic.py
+++ b/python/tests/algorithms/test_basic.py
@@ -412,11 +412,12 @@ def test_free_surface_transform():
     sout = free_surface_transformation(seis)
     assert sout.dead()
     assert sout.elog.size() == 1
-    # invalid arg0 should throw an exception
+    # invalid arg0: logged to elog (mspass_func_wrapper catches generic exceptions)
     x = TimeSeries()
     x.set_live()
-    with pytest.raises(TypeError, match="received invalid type"):
-        sout = free_surface_transformation(x)
+    sout = free_surface_transformation(x)
+    assert sout.elog.size() >= 1
+    assert "received invalid type" in sout.elog.get_error_log()[-1].message.lower()
 
 
 def test_transform_to_RTZ():
@@ -509,11 +510,12 @@ def test_transform_to_RTZ():
     assert sout.elog.size() == 1
     assert sout.dead()
 
-    # invalid data throws an exception
+    # invalid data: TypeError is logged on arg0 (inplace_return default False)
     x = TimeSeries()
     x.set_live()
-    with pytest.raises(TypeError, match="received invalid type"):
-        sout = transform_to_RTZ(x)
+    transform_to_RTZ(x)
+    assert x.elog.size() >= 1
+    assert "received invalid type" in x.elog.get_error_log()[-1].message.lower()
 
 
 def test_transform_to_LQT():
@@ -656,8 +658,9 @@ def test_transform_to_LQT():
     assert sout.elog.size() == 1
     assert sout.dead()
 
-    # invalid data throws an exception
+    # invalid data: TypeError is logged on arg0 (inplace_return default False)
     x = TimeSeries()
     x.set_live()
-    with pytest.raises(TypeError, match="received invalid type"):
-        sout = transform_to_LQT(x)
+    transform_to_LQT(x)
+    assert x.elog.size() >= 1
+    assert "received invalid type" in x.elog.get_error_log()[-1].message.lower()

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -479,11 +479,11 @@ def test_windowdata_exceptions():
     ts_ens0.member[0].t0 += offset_m0
     se_ens0.member[0].t0 += offset_m0
 
-    # First test argument mistake handler.  i.e. these cases throw
-    # exceptions instead of posting elog messages
+    # First test argument mistake handler: ValueError is logged on arg0
     ts = TimeSeries(ts0)
-    with pytest.raises(ValueError, match="illegal option"):
-        d = WindowData(ts, 2, 3, short_segment_handling="notvalid")
+    WindowData(ts, 2, 3, short_segment_handling="notvalid")
+    assert ts.elog.size() >= 1
+    assert "illegal option" in ts.elog.get_error_log()[-1].message.lower()
     ts = TimeSeries(ts0)
     # WindowData handles both atomic and ensemble data \
     # this exception is handled by the function itself, no the decorators

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -115,9 +115,10 @@ def test_reduce_stack():
 def test_reduce_stack_exception():
     tse1 = get_live_timeseries_ensemble(2)
     tse2 = get_live_timeseries_ensemble(3)
-    with pytest.raises(IndexError) as err:
-        stack(tse1, tse2)
-    assert str(err.value) == "data1 and data2 have different sizes of member"
+    stack(tse1, tse2)
+    errs = tse1.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "different sizes of member" in errs[-1].message
 
     # fixme cxx is not throwing error
     # ts1 = get_live_timeseries()

--- a/python/tests/util/test_decorators.py
+++ b/python/tests/util/test_decorators.py
@@ -135,6 +135,20 @@ def check_arg0_tester(
         raise TypeError("test function arg0 is an invalid type")
 
 
+@mspass_func_wrapper
+def raises_generic_exception(
+    data,
+    *args,
+    object_history=False,
+    alg_id=None,
+    dryrun=False,
+    inplace_return=False,
+    function_return_key=None,
+    **kwargs,
+):
+    raise ValueError("deliberate test exception")
+
+
 def test_mspass_func_wrapper():
     with pytest.raises(TypeError) as err:
         dummy_func(1)
@@ -263,6 +277,13 @@ def test_mspass_func_wrapper():
     e = check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=False)
     assert e.dead()
     assert e.elog.size() == 1
+
+    # Exception path must return arg0 when inplace_return is False (not None).
+    ts_exc = get_live_timeseries()
+    out_exc = raises_generic_exception(ts_exc, inplace_return=False)
+    assert out_exc is ts_exc
+    assert out_exc.live is True
+    assert len(ts_exc.elog.get_error_log()) >= 1
 
 
 @timeseries_as_trace
@@ -443,6 +464,24 @@ class dummy_class_method_wrapper:
         else:
             raise TypeError("test function arg0 is an invalid type")
 
+    @mspass_method_wrapper
+    def raises_method_exception(
+        self,
+        data,
+        *args,
+        object_history=False,
+        alg_id=None,
+        alg_name=None,
+        dryrun=False,
+        inplace_return=False,
+        function_return_key=None,
+        handles_ensembles=False,
+        checks_arg0_type=False,
+        handles_dead_data=False,
+        **kwargs,
+    ):
+        raise ValueError("deliberate test exception")
+
 
 def test_mspass_method_wrapper():
     dummy_instance = dummy_class_method_wrapper()
@@ -576,6 +615,11 @@ def test_mspass_method_wrapper():
     )
     assert e.dead()
     assert e.elog.size() == 1
+
+    seis_exc = get_live_seismogram()
+    out_m = dummy_instance.raises_method_exception(seis_exc, inplace_return=False)
+    assert out_m is seis_exc
+    assert len(seis_exc.elog.get_error_log()) >= 1
 
 
 @mspass_func_wrapper

--- a/python/tests/util/test_decorators.py
+++ b/python/tests/util/test_decorators.py
@@ -238,8 +238,10 @@ def test_mspass_func_wrapper():
     for d in e.member:
         assert d["foo"] == "bar"
     e = get_live_timeseries_ensemble(3)
-    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
-        e = check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=True)
+    check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=True)
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "invalid type" in errs[-1].message.lower()
     # this would be a mistake in usage for this test function but is the
     # behavio the decoraor should have - returns the functions message not
     # the decorator message.  Note using seismogram because the
@@ -550,10 +552,10 @@ def test_mspass_method_wrapper():
     for d in e.member:
         assert d["foo"] == "bar"
     e = get_live_timeseries_ensemble(3)
-    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
-        e = dummy_instance.check_arg0_tester(
-            e, checks_arg0_type=True, handles_ensembles=True
-        )
+    dummy_instance.check_arg0_tester(e, checks_arg0_type=True, handles_ensembles=True)
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "invalid type" in errs[-1].message.lower()
     # simulate case of mismatched member type but valid seismic data type
     # here we get the method's exception message
     e = get_live_seismogram_ensemble(3)

--- a/python/tests/util/test_decorators.py
+++ b/python/tests/util/test_decorators.py
@@ -248,8 +248,10 @@ def test_mspass_func_wrapper():
     # function only takes TimeSeries - this will work for a TimeSeriesEnsemble
     # and not throw an exceptoin
     e = get_live_seismogram_ensemble(3)
-    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
-        e = check_arg0_tester(e, checks_arg0_type=False, handles_ensembles=False)
+    check_arg0_tester(e, checks_arg0_type=False, handles_ensembles=False)
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "invalid type" in errs[-1].message.lower()
     # True-True not testable directly - would fail referencing "member"
     # attibute in decorator - an incorrect usage not worth testing
 
@@ -559,10 +561,10 @@ def test_mspass_method_wrapper():
     # simulate case of mismatched member type but valid seismic data type
     # here we get the method's exception message
     e = get_live_seismogram_ensemble(3)
-    with pytest.raises(TypeError, match="test function arg0 is an invalid type"):
-        e = dummy_instance.check_arg0_tester(
-            e, checks_arg0_type=False, handles_ensembles=False
-        )
+    dummy_instance.check_arg0_tester(e, checks_arg0_type=False, handles_ensembles=False)
+    errs = e.member[0].elog.get_error_log()
+    assert len(errs) >= 1
+    assert "invalid type" in errs[-1].message.lower()
 
     # check handling of an algorithm killing all data
     e = get_live_timeseries_ensemble(3)

--- a/python/tests/util/test_decorators.py
+++ b/python/tests/util/test_decorators.py
@@ -136,7 +136,7 @@ def check_arg0_tester(
 
 
 @mspass_func_wrapper
-def raises_generic_exception(
+def dummy_func_raises_valueerror(
     data,
     *args,
     object_history=False,
@@ -147,6 +147,34 @@ def raises_generic_exception(
     **kwargs,
 ):
     raise ValueError("deliberate test exception")
+
+
+@mspass_func_wrapper
+def dummy_func_raises_runtimeerror(
+    data,
+    *args,
+    object_history=False,
+    alg_id=None,
+    dryrun=False,
+    inplace_return=False,
+    function_return_key=None,
+    **kwargs,
+):
+    raise RuntimeError("runtime wrapper test")
+
+
+@mspass_func_wrapper
+def dummy_func_raises_mspass_invalid(
+    data,
+    *args,
+    object_history=False,
+    alg_id=None,
+    dryrun=False,
+    inplace_return=False,
+    function_return_key=None,
+    **kwargs,
+):
+    raise MsPASSError("mspass invalid wrapper", ErrorSeverity.Invalid)
 
 
 def test_mspass_func_wrapper():
@@ -280,10 +308,22 @@ def test_mspass_func_wrapper():
 
     # Exception path must return arg0 when inplace_return is False (not None).
     ts_exc = get_live_timeseries()
-    out_exc = raises_generic_exception(ts_exc, inplace_return=False)
+    out_exc = dummy_func_raises_valueerror(ts_exc, inplace_return=False)
     assert out_exc is ts_exc
-    assert out_exc.live is True
+    assert out_exc.live is False
     assert len(ts_exc.elog.get_error_log()) >= 1
+
+    ts_rt = get_live_timeseries()
+    out_rt = dummy_func_raises_runtimeerror(ts_rt, inplace_return=False)
+    assert out_rt is ts_rt
+    assert out_rt.live is False
+    assert len(ts_rt.elog.get_error_log()) >= 1
+
+    ts_ms = get_live_timeseries()
+    out_ms = dummy_func_raises_mspass_invalid(ts_ms, inplace_return=False)
+    assert out_ms is ts_ms
+    assert out_ms.live is False
+    assert len(ts_ms.elog.get_error_log()) >= 1
 
 
 @timeseries_as_trace
@@ -465,7 +505,7 @@ class dummy_class_method_wrapper:
             raise TypeError("test function arg0 is an invalid type")
 
     @mspass_method_wrapper
-    def raises_method_exception(
+    def dummy_method_raises_valueerror(
         self,
         data,
         *args,
@@ -617,8 +657,11 @@ def test_mspass_method_wrapper():
     assert e.elog.size() == 1
 
     seis_exc = get_live_seismogram()
-    out_m = dummy_instance.raises_method_exception(seis_exc, inplace_return=False)
+    out_m = dummy_instance.dummy_method_raises_valueerror(
+        seis_exc, inplace_return=False
+    )
     assert out_m is seis_exc
+    assert seis_exc.live is False
     assert len(seis_exc.elog.get_error_log()) >= 1
 
 
@@ -710,6 +753,34 @@ def dummy_func_multi(
     return None
 
 
+@mspass_func_wrapper_multi
+def dummy_multi_runtime(
+    data1, data2, *args, object_history=False, alg_id=None, dryrun=False, **kwargs
+):
+    raise RuntimeError("multi runtime test")
+
+
+@mspass_func_wrapper_multi
+def dummy_multi_mspass_invalid(
+    data1, data2, *args, object_history=False, alg_id=None, dryrun=False, **kwargs
+):
+    raise MsPASSError("multi invalid", ErrorSeverity.Invalid)
+
+
+@mspass_func_wrapper_multi
+def dummy_multi_mspass_fatal(
+    data1, data2, *args, object_history=False, alg_id=None, dryrun=False, **kwargs
+):
+    raise MsPASSError("multi fatal", ErrorSeverity.Fatal)
+
+
+@mspass_func_wrapper_multi
+def dummy_multi_valueerror(
+    data1, data2, *args, object_history=False, alg_id=None, dryrun=False, **kwargs
+):
+    raise ValueError("multi generic test")
+
+
 def test_mspass_func_wrapper_multi():
     with pytest.raises(TypeError) as err:
         dummy_func_multi(1, 2)
@@ -740,6 +811,48 @@ def test_mspass_func_wrapper_multi():
     for i in range(3):
         assert seis_e.member[i].number_of_stages() == 1
 
+    # mspass_func_wrapper_multi error paths: log, kill both, return data1 (Fatal MsPASSError re-raises).
+    sa = get_live_seismogram()
+    sb = get_live_seismogram()
+    ret = dummy_multi_runtime(sa, sb)
+    assert ret is sa
+    assert not sa.live
+    assert not sb.live
+    assert len(sa.elog.get_error_log()) >= 1
+    assert len(sb.elog.get_error_log()) >= 1
+
+    sa = get_live_seismogram()
+    sb = get_live_seismogram()
+    ret = dummy_multi_mspass_invalid(sa, sb)
+    assert ret is sa
+    assert not sa.live
+    assert not sb.live
+    assert len(sa.elog.get_error_log()) >= 1
+    assert len(sb.elog.get_error_log()) >= 1
+
+    sa = get_live_seismogram()
+    sb = get_live_seismogram()
+    with pytest.raises(MsPASSError, match="multi fatal"):
+        dummy_multi_mspass_fatal(sa, sb)
+
+    sa = get_live_seismogram()
+    sb = get_live_seismogram()
+    ret = dummy_multi_valueerror(sa, sb)
+    assert ret is sa
+    assert not sa.live
+    assert not sb.live
+    assert len(sa.elog.get_error_log()) >= 1
+    assert len(sb.elog.get_error_log()) >= 1
+
+    sa = get_live_seismogram()
+    ens = get_live_seismogram_ensemble(2)
+    ret = dummy_multi_runtime(sa, ens)
+    assert ret is sa
+    assert not sa.live
+    assert not ens.live
+    assert len(sa.elog.get_error_log()) >= 1
+    assert len(ens.member[0].elog.get_error_log()) >= 1
+
     # dead object will return immediately
     seis1.kill()
     seis2.kill()
@@ -766,6 +879,13 @@ def dummy_reduce_func_mspasserror(
     data1, data2, *args, object_history=False, alg_id=None, dryrun=False, **kwargs
 ):
     raise MsPASSError("test", ErrorSeverity.Fatal)
+
+
+@mspass_reduce_func_wrapper
+def dummy_reduce_valueerror(
+    data1, data2, *args, object_history=False, alg_id=None, dryrun=False, **kwargs
+):
+    raise ValueError("reduce generic")
 
 
 def test_mspass_reduce_func_wrapper():
@@ -803,9 +923,21 @@ def test_mspass_reduce_func_wrapper():
     ts1 = get_live_timeseries()
     ts2 = get_live_timeseries()
     assert len(ts1.elog.get_error_log()) == 0
-    dummy_reduce_func_runtime(ts1, ts2, object_history=True, alg_id="3")
+    ret = dummy_reduce_func_runtime(ts1, ts2, object_history=True, alg_id="3")
+    assert ret is ts1
+    assert not ts1.live
+    assert not ts2.live
     assert len(ts1.elog.get_error_log()) == 1
     assert len(ts2.elog.get_error_log()) == 1
+
+    ts1 = get_live_timeseries()
+    ts2 = get_live_timeseries()
+    ret = dummy_reduce_valueerror(ts1, ts2, object_history=True, alg_id="3")
+    assert ret is ts1
+    assert not ts1.live
+    assert not ts2.live
+    assert len(ts1.elog.get_error_log()) >= 1
+    assert len(ts2.elog.get_error_log()) >= 1
 
     ts1 = get_live_timeseries()
     ts2 = get_live_timeseries()


### PR DESCRIPTION
## Summary
Hardens MsPASS decorator error handling so parallel/map-style callers always get a **MsPASS data object back** (with errors in `elog` and the datum marked **dead** where appropriate), instead of Python’s implicit **`None`**—which was causing downstream `AttributeError` (e.g. on `.live`).
## Changes
### `mspass_func_wrapper` / `mspass_method_wrapper`
- **`RuntimeError`**, **`MsPASSError`** (non-`Fatal`), and **`Exception`** (when `data` is a known wrapper type): after logging to `elog` / `ensemble_error`, call **`data.kill()`** and **`return data`**.
- **`MsPASSError`** with **`Fatal`** severity: still **re-raised** (no kill/return on that path).
- **`Exception`** when `data` is **not** a supported MsPASS type: **re-raise** unchanged.
### `mspass_func_wrapper_multi`
- Same pattern for both inputs: log per atomic/ensemble branch, then **`data1.kill()`**, **`data2.kill()`**, **`return data1`** for **`RuntimeError`**, non-`Fatal` **`MsPASSError`**, and handled **`Exception`**.
- **`Fatal` `MsPASSError`**: still **re-raised**.
### `mspass_reduce_func_wrapper`
- Keeps the existing **`MsPASSError`** rule: only **`Informational`** / **`Debug`** are logged in the wrapper; other severities **re-raise**.
- For **`RuntimeError`**, logged **`MsPASSError`**, and handled **`Exception`**: after logging, **`data1.kill()`**, **`data2.kill()`**, **`return data1`**.
### Tests (`python/tests/util/test_decorators.py`)
- New **`dummy_*`** helpers and assertions to cover the above branches (including dual-arg, ensemble companion, `Fatal` vs non-`Fatal`, and reduce **`Exception`**).
- Existing ensemble **`check_arg0_tester`** expectations updated where the decorator now **logs** instead of propagating **`TypeError`**.
