### PR TITLE
fixes for annotate_arrival_time

### DIFF
--- a/python/mspasspy/algorithms/ml/arrival.py
+++ b/python/mspasspy/algorithms/ml/arrival.py
@@ -5,7 +5,6 @@ import seisbench.models as sbm
 from seisbench.models.base import WaveformModel
 from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
 from mspasspy.ccore.algorithms.basic import TimeWindow
-from mspasspy.algorithms.window import WindowData
 from obspy import UTCDateTime
 
 
@@ -93,10 +92,15 @@ def annotate_arrival_time(
     pred_st = model.annotate(windowed_stream)
 
     # Step 1: Access the probability data
+    trace = None
     for tr in pred_st:
         if tr.stats.channel == "PhaseNet_P":
             trace = tr
             break
+    if trace is None:
+        timeseries["p_wave_picks"] = {}
+        logging.warning("Model annotation output does not contain a PhaseNet_P trace.")
+        return
     data = trace.data
 
     # Step 2: Find all the index with probability value greater than the threshold
@@ -104,6 +108,10 @@ def annotate_arrival_time(
 
     # Step 3: Calculate the corresponding time in utc timestamp
     timestamps = trace.times("timestamp")[indices]
+    if time_window:
+        in_window = (timestamps >= time_window.start) & (timestamps <= time_window.end)
+        timestamps = timestamps[in_window]
+        indices = indices[in_window]
 
     # Step 4: Create a dictionary with timestamps as keys and probability values as values
     p_wave_picks = {ts: data[i] for ts, i in zip(timestamps, indices)}

--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -309,6 +309,8 @@ def sliding_window_pipeline(
                 print(
                     "This setting makes sense only if you are running on a cluster service being used by multiple applications"
                 )
+        else:
+            swsize = sliding_window_size
     else:
 
         message = "{}: Illegal value for arg2.  Must be an instance of dask.distributed.Client".format(

--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -309,8 +309,6 @@ def sliding_window_pipeline(
                 print(
                     "This setting makes sense only if you are running on a cluster service being used by multiple applications"
                 )
-        else:
-            swsize = sliding_window_size
     else:
 
         message = "{}: Illegal value for arg2.  Must be an instance of dask.distributed.Client".format(

--- a/python/tests/algorithms/ml/test_arrival.py
+++ b/python/tests/algorithms/ml/test_arrival.py
@@ -7,7 +7,7 @@ import seisbench.models as sbm
 from mspasspy.algorithms.ml.arrival import annotate_arrival_time
 from mspasspy.ccore.algorithms.basic import TimeWindow
 from mspasspy.util.converter import Trace2TimeSeries
-from obspy import Stream, UTCDateTime, read
+from obspy import Stream, Trace, UTCDateTime, read
 from obspy.clients.fdsn import Client
 
 sys.path.append("python/tests")
@@ -104,6 +104,52 @@ def test_annotate_arrival_time_window():
 
     # Compare the sets
     assert mspass_set == seis_set
+
+
+class _BoundaryPredictionModel:
+    channel = "PhaseNet_P"
+
+    def annotate(self, stream):
+        tr = Trace(np.ones(stream[0].stats.npts))
+        tr.stats.starttime = stream[0].stats.starttime
+        tr.stats.delta = stream[0].stats.delta
+        tr.stats.channel = self.channel
+        return Stream([tr])
+
+
+def test_annotate_arrival_time_filters_trimmed_boundary_samples():
+    trace = Trace(np.zeros(10))
+    trace.stats.starttime = UTCDateTime(0)
+    trace.stats.delta = 1.0
+    timeseries = Trace2TimeSeries(trace)
+
+    window_start = 0.4
+    window_end = 3.6
+    annotate_arrival_time(
+        timeseries,
+        threshold=0,
+        time_window=TimeWindow(window_start, window_end),
+        model=_BoundaryPredictionModel(),
+    )
+
+    picks = timeseries["p_wave_picks"]
+    assert set(picks.keys()) == {1.0, 2.0, 3.0}
+    assert all(window_start <= pick_time <= window_end for pick_time in picks)
+
+
+class _NoPPhasePredictionModel(_BoundaryPredictionModel):
+    channel = "PhaseNet_S"
+
+
+def test_annotate_arrival_time_handles_missing_p_trace():
+    trace = Trace(np.zeros(10))
+    trace.stats.starttime = UTCDateTime(0)
+    trace.stats.delta = 1.0
+    timeseries = Trace2TimeSeries(trace)
+
+    annotate_arrival_time(timeseries, threshold=0, model=_NoPPhasePredictionModel())
+
+    assert timeseries["p_wave_picks"] == {}
 
 
 def test_annotate_arrival_time_for_mseed():


### PR DESCRIPTION
## Description
Updated `annotate_arrival_time` to filter predicted pick timestamps after conversion, ensuring `p_wave_picks` never includes samples outside the requested TimeWindow even when ObsPy trim keeps nearest boundary samples.

Also added graceful handling for model outputs without PhaseNet_P: the function now stores an empty pick dictionary, logs a warning, and returns. 

## Test
Added regression tests for both boundary-window filtering and missing P-trace behavior.