### PR TITLE
Mock arrival ci local data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,7 +213,7 @@ RUN python -c "import site; print(site.getsitepackages()[0])" > site_packages_pa
 	rm site_packages_path.txt
 
 # install Dask JupyterLab extension
-RUN pip install dask-labextension && docker-clean
+RUN pip install dask-labextension==7.0.0 && docker-clean
 
 ENV PATH="${SPARK_HOME}/bin:${SPARK_HOME}/sbin:${PATH}"
 

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -219,7 +219,7 @@ RUN python -c "import site; print(site.getsitepackages()[0])" > site_packages_pa
 	rm site_packages_path.txt
 
 # install Dask JupyterLab extension
-RUN pip install dask-labextension && docker-clean
+RUN pip install dask-labextension==7.0.0 && docker-clean
 
 ENV PATH="${SPARK_HOME}/bin:${SPARK_HOME}/sbin:${PATH}"
 

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -6017,7 +6017,7 @@ class Database(pymongo.database.Database):
           :param collection:  MongoDB collection name to be used to save the
           (often subsetted) tuples of filename as documents in this collection.
         :param separator: The delimiter used for seperating fields,
-          the default is r"\s+", which is the regular expression of "one or more
+          the default is r"\\s+", which is the regular expression of "one or more
           spaces".
               For csv file, its value should be set to ','.
               This parameter will be passed into pandas.read_csv or dask.dataframe.read_csv.

--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -636,7 +636,7 @@ def Textfile2Dataframe(
       table object that is to be processed (internally we use pandas or
       dask dataframes)
     :param separator: The delimiter used for seperating fields,
-      the default is r"\s+", which is the regular expression of "one or more
+      the default is r"\\s+", which is the regular expression of "one or more
       spaces".
       For csv file, its value should be set to ','.
       This parameter will be passed into pandas.read_csv or dask.dataframe.read_csv.

--- a/python/mspasspy/util/seismic.py
+++ b/python/mspasspy/util/seismic.py
@@ -84,14 +84,14 @@ def has_live_data(ensemble) -> bool:
         if has_live_data(ensemble):
             ensemble.set_live()
     ```
-    Note this function will throw a ValueError exception if ensemble is
+    Note this function will throw a TypeError exception if ensemble is
     anything but a TimeSeriesEnsemble or SeismogramEnsemble.
 
     :param ensemble:   input ensemble to be scanned
     """
     if not isinstance(ensemble, (TimeSeriesEnsemble, SeismogramEnsemble)):
         message = "has_live_data:  arg0 must be a TimeSeriesEnsemble or SeismogramEnsemble object\n"
-        message += "Actual type={}".type(ensemble)
+        message += "Actual type={}".format(type(ensemble))
         raise TypeError(message)
     for d in ensemble.member:
         if d.live:
@@ -272,7 +272,7 @@ def sort_ensemble(ensemble, key, nullvalue=0.0, ascending=True, drop_dead=True):
     alg = "sort_ensemble"
     if not isinstance(ensemble, (TimeSeriesEnsemble, SeismogramEnsemble)):
         message = "arg0 must be a TimeSeriesEnsemble or SeismogramEnsemble object\n"
-        message += "Actual type={}".type(ensemble)
+        message += "Actual type={}".format(type(ensemble))
         raise MsPASSError(alg, message, ErrorSeverity.Fatal)
     vallist = list()
     indexlist = list()
@@ -290,14 +290,14 @@ def sort_ensemble(ensemble, key, nullvalue=0.0, ascending=True, drop_dead=True):
     dfdict = {key: vallist, "member_number": indexlist}
     df = pd.DataFrame(dfdict)
     del dfdict
-    df.sort_values(key, ascending=ascending)
+    df = df.sort_values(key, ascending=ascending)
     N = len(df)
     if isinstance(ensemble, TimeSeriesEnsemble):
         ensout = TimeSeriesEnsemble(Metadata(ensemble), N)
     else:
         ensout = SeismogramEnsemble(Metadata(ensemble), N)
     for index, row in df.iterrows():
-        i = row["member_number"].astype(int)
+        i = int(row["member_number"])
         ensout.member.append(ensemble.member[i])
     if N > 0:
         ensout.set_live()

--- a/python/mspasspy/util/seismic.py
+++ b/python/mspasspy/util/seismic.py
@@ -73,9 +73,9 @@ def has_live_data(ensemble) -> bool:
     Check if an ensemble has any live data and return True if it does.
 
     This function simply scans the member vector of ensemble and returns
-    True the first time if finds a datum marked live.   That is much
-    faster with large ensembles than an alternative os using `number_live`
-    and using the result to set an ensemble  live or dead.   The normal
+    True the first time it finds a datum marked live. That is much
+    faster with large ensembles than an alternative to using `number_live`
+    and using the result to set an ensemble live or dead. The normal
     use of this function is to call it after accumulating a set of atomic
     data into an ensemble.  An empty ensemble container is always marked
     dead until explicitly set live.   Hence, after adding data to such
@@ -87,7 +87,7 @@ def has_live_data(ensemble) -> bool:
     Note this function will throw a ValueError exception if ensemble is
     anything but a TimeSeriesEnsemble or SeismogramEnsemble.
 
-    :param enemble:   input ensemble to be scanned
+    :param ensemble:   input ensemble to be scanned
     """
     if not isinstance(ensemble, (TimeSeriesEnsemble, SeismogramEnsemble)):
         message = "has_live_data:  arg0 must be a TimeSeriesEnsemble or SeismogramEnsemble object\n"

--- a/python/tests/algorithms/ml/test_arrival.py
+++ b/python/tests/algorithms/ml/test_arrival.py
@@ -18,7 +18,20 @@ from helper import get_live_timeseries
 class _LocalPhaseNetModel:
     channel = "PhaseNet_P"
     probabilities = np.array(
-        [0.0, 0.03, 0.12, 0.31, 0.62, 0.92, 0.48, 0.77, 0.08, 0.23, 0.55, 0.99]
+        [
+            0.0,
+            0.03,
+            0.12,
+            0.31,
+            0.62,
+            0.92,
+            0.48,
+            0.77,
+            0.08,
+            0.23,
+            0.55,
+            0.99,
+        ]
     )
 
     def annotate(self, stream):
@@ -102,7 +115,10 @@ def test_annotate_arrival_time_window():
     window_start = UTCDateTime(2009, 4, 6, 1, 30).timestamp
     window_end = window_start + 1000
     annotate_arrival_time(
-        timeseries, threshold=0, time_window=TimeWindow(window_start, window_end), model=pn_model
+        timeseries,
+        threshold=0,
+        time_window=TimeWindow(window_start, window_end),
+        model=pn_model,
     )
     mspass_picks = timeseries["p_wave_picks"]
 
@@ -184,7 +200,10 @@ def test_annotate_arrival_time_for_mseed():
     window_start = UTCDateTime(2011, 3, 11, 6, 35).timestamp
     window_end = window_start + 1200  # 20 minutes
     annotate_arrival_time(
-        timeseries, 0.1, time_window=TimeWindow(window_start, window_end), model=pn_model
+        timeseries,
+        0.1,
+        time_window=TimeWindow(window_start, window_end),
+        model=pn_model,
     )
     mspass_picks = timeseries["p_wave_picks"]
 

--- a/python/tests/algorithms/ml/test_arrival.py
+++ b/python/tests/algorithms/ml/test_arrival.py
@@ -8,7 +8,9 @@ try:
     import seisbench.models  # noqa: F401
 except ImportError:
     seisbench = types.ModuleType("seisbench")
+    seisbench.__path__ = []
     models = types.ModuleType("seisbench.models")
+    models.__path__ = []
     base = types.ModuleType("seisbench.models.base")
 
     class WaveformModel:
@@ -20,6 +22,7 @@ except ImportError:
             raise RuntimeError("PhaseNet should be injected in these tests")
 
     models.PhaseNet = _PhaseNet
+    models.base = base
     base.WaveformModel = WaveformModel
     seisbench.models = models
     sys.modules["seisbench"] = seisbench

--- a/python/tests/algorithms/ml/test_arrival.py
+++ b/python/tests/algorithms/ml/test_arrival.py
@@ -4,21 +4,38 @@ import sys
 import os
 import pytest
 
-seisbench = pytest.importorskip("seisbench")
-sbm = pytest.importorskip("seisbench.models")
+pytest.importorskip("seisbench.models")
 from mspasspy.algorithms.ml.arrival import annotate_arrival_time
 from mspasspy.ccore.algorithms.basic import TimeWindow
 from mspasspy.util.converter import Trace2TimeSeries
 from obspy import Stream, Trace, UTCDateTime, read
-from obspy.clients.fdsn import Client
 
 sys.path.append("python/tests")
 
 from helper import get_live_timeseries
 
-seisbench.use_backup_repository()
 
-pn_model = sbm.PhaseNet.from_pretrained("stead")
+class _LocalPhaseNetModel:
+    channel = "PhaseNet_P"
+    probabilities = np.array(
+        [0.0, 0.03, 0.12, 0.31, 0.62, 0.92, 0.48, 0.77, 0.08, 0.23, 0.55, 0.99]
+    )
+
+    def annotate(self, stream):
+        source = stream[0]
+        tr = Trace(self.probabilities.copy())
+        tr.stats.starttime = source.stats.starttime
+        tr.stats.channel = self.channel
+        if tr.stats.npts > 1:
+            source_duration = float(source.stats.endtime - source.stats.starttime)
+            fallback_duration = float(source.stats.delta) * (tr.stats.npts - 1)
+            tr.stats.delta = max(source_duration, fallback_duration) / (tr.stats.npts - 1)
+        else:
+            tr.stats.delta = source.stats.delta
+        return Stream([tr])
+
+
+pn_model = _LocalPhaseNetModel()
 
 
 def test_annotate_arrival_time():
@@ -31,7 +48,7 @@ def test_annotate_arrival_time():
 
     # picks from mspass
     timeseries = Trace2TimeSeries(stream[0])
-    annotate_arrival_time(timeseries, 0)
+    annotate_arrival_time(timeseries, 0, model=pn_model)
     mspass_picks = timeseries["p_wave_picks"]  # should be a dictionary
     # assert that for each pick, the value is a float number that is between 0 and 1
     assert all(0 <= value <= 1 for value in mspass_picks.values())
@@ -59,7 +76,7 @@ def test_annotate_arrival_time_threshold():
 
     # picks from mspass
     timeseries = Trace2TimeSeries(stream[0])
-    annotate_arrival_time(timeseries, 0.5)
+    annotate_arrival_time(timeseries, 0.5, model=pn_model)
     mspass_picks = timeseries["p_wave_picks"]
     assert all(value >= 0.5 for value in mspass_picks.values())
     # picks from seisbench
@@ -85,7 +102,7 @@ def test_annotate_arrival_time_window():
     window_start = UTCDateTime(2009, 4, 6, 1, 30).timestamp
     window_end = window_start + 1000
     annotate_arrival_time(
-        timeseries, threshold=0, time_window=TimeWindow(window_start, window_end)
+        timeseries, threshold=0, time_window=TimeWindow(window_start, window_end), model=pn_model
     )
     mspass_picks = timeseries["p_wave_picks"]
 
@@ -167,7 +184,7 @@ def test_annotate_arrival_time_for_mseed():
     window_start = UTCDateTime(2011, 3, 11, 6, 35).timestamp
     window_end = window_start + 1200  # 20 minutes
     annotate_arrival_time(
-        timeseries, 0.1, time_window=TimeWindow(window_start, window_end)
+        timeseries, 0.1, time_window=TimeWindow(window_start, window_end), model=pn_model
     )
     mspass_picks = timeseries["p_wave_picks"]
 
@@ -207,16 +224,9 @@ def get_mseed_trace_for_test():
 
 
 def get_trace_for_test():
-    client = Client("INGV")
-    t = UTCDateTime(2009, 4, 6, 1, 30)
-    return client.get_waveforms(
-        network="MN",
-        station="AQU",
-        location="*",
-        channel="HH?",
-        starttime=t,
-        endtime=t + 3600,
-    )
+    trace = get_mseed_trace_for_test().copy()
+    trace.stats.starttime = UTCDateTime(2009, 4, 6, 1, 30)
+    return Stream([trace])
 
 
 if __name__ == "__main__":

--- a/python/tests/algorithms/ml/test_arrival.py
+++ b/python/tests/algorithms/ml/test_arrival.py
@@ -1,18 +1,34 @@
 import numpy as np
 import sys
+import types
 
 import os
-import pytest
 
-pytest.importorskip("seisbench.models")
+try:
+    import seisbench.models  # noqa: F401
+except ImportError:
+    seisbench = types.ModuleType("seisbench")
+    models = types.ModuleType("seisbench.models")
+    base = types.ModuleType("seisbench.models.base")
+
+    class WaveformModel:
+        pass
+
+    class _PhaseNet:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise RuntimeError("PhaseNet should be injected in these tests")
+
+    models.PhaseNet = _PhaseNet
+    base.WaveformModel = WaveformModel
+    seisbench.models = models
+    sys.modules["seisbench"] = seisbench
+    sys.modules["seisbench.models"] = models
+    sys.modules["seisbench.models.base"] = base
 from mspasspy.algorithms.ml.arrival import annotate_arrival_time
 from mspasspy.ccore.algorithms.basic import TimeWindow
 from mspasspy.util.converter import Trace2TimeSeries
 from obspy import Stream, Trace, UTCDateTime, read
-
-sys.path.append("python/tests")
-
-from helper import get_live_timeseries
 
 
 class _LocalPhaseNetModel:

--- a/python/tests/algorithms/ml/test_arrival.py
+++ b/python/tests/algorithms/ml/test_arrival.py
@@ -42,7 +42,8 @@ class _LocalPhaseNetModel:
         if tr.stats.npts > 1:
             source_duration = float(source.stats.endtime - source.stats.starttime)
             fallback_duration = float(source.stats.delta) * (tr.stats.npts - 1)
-            tr.stats.delta = max(source_duration, fallback_duration) / (tr.stats.npts - 1)
+            prediction_duration = max(source_duration, fallback_duration)
+            tr.stats.delta = prediction_duration / (tr.stats.npts - 1)
         else:
             tr.stats.delta = source.stats.delta
         return Stream([tr])

--- a/python/tests/algorithms/test_decon_algorithm_validation.py
+++ b/python/tests/algorithms/test_decon_algorithm_validation.py
@@ -517,7 +517,9 @@ def _slice_matrix_to_window(matrix, src_t0, dt, out_t0, out_npts):
     return result
 
 
-def _plot_rf_overlay(plot_dir, filename, title, results, truth, t0, dt):
+def _plot_rf_overlay(
+    plot_dir, filename, title, results, truth, t0, dt, failed_methods=None
+):
     if plot_dir is None:
         return
     plt = _import_matplotlib_pyplot()
@@ -562,6 +564,17 @@ def _plot_rf_overlay(plot_dir, filename, title, results, truth, t0, dt):
         axis.axvline(0.0, color="0.5", linestyle="--", linewidth=0.8)
         axis.set_ylabel(component_names[component])
         axis.grid(True, color="0.85", linewidth=0.6)
+    failed_methods = failed_methods or []
+    for name in failed_methods:
+        axes[0].plot(
+            [],
+            [],
+            color="0.45",
+            linestyle=":",
+            linewidth=1.2,
+            label=f"{name} (failed)",
+        )
+
     axes[-1].set_xlabel("Lag time relative to direct P sample (s)")
     axes[0].legend(loc="upper right", ncol=3, fontsize="small")
     fig.suptitle(title + " (method traces are vertically offset)")
@@ -596,7 +609,9 @@ def _plot_complex_colored_results(plot_dir, results, truth, wavelet):
     plt.close(fig)
 
 
-def _plot_stress_results(plot_dir, results, truth, wavelet, t0, dt, prefix):
+def _plot_stress_results(
+    plot_dir, results, truth, wavelet, t0, dt, prefix, failed_methods=None
+):
     if plot_dir is None:
         return
     _plot_rf_overlay(
@@ -607,6 +622,7 @@ def _plot_stress_results(plot_dir, results, truth, wavelet, t0, dt, prefix):
         truth,
         t0,
         dt,
+        failed_methods=failed_methods,
     )
 
 
@@ -622,7 +638,9 @@ def _plot_gid_mode_results(plot_dir, engine_name, results, truth, t0, dt):
     )
 
 
-def _plot_gid_sparse_results(plot_dir, engine_name, results, truth, t0, dt, suffix):
+def _plot_gid_sparse_results(
+    plot_dir, engine_name, results, truth, t0, dt, suffix, failed_methods=None
+):
     _plot_rf_overlay(
         plot_dir,
         f"{engine_name}_{suffix}_sparse_results.png",
@@ -631,6 +649,7 @@ def _plot_gid_sparse_results(plot_dir, engine_name, results, truth, t0, dt, suff
         truth,
         t0,
         dt,
+        failed_methods=failed_methods,
     )
 
 
@@ -1225,6 +1244,7 @@ def test_gid_methods_recover_stress_spike_signs_for_all_inverse_modes(
         plot_dt = rf.dt
 
     plot_truth = truth
+    skipped_plot_modes = []
     if decon_validation_plot_dir is not None and decon_validation_noise_scale != 0.01:
         plot_data, plot_truth, _ = _make_stress_colored_validation_data(
             noise_scale=decon_validation_noise_scale,
@@ -1232,6 +1252,7 @@ def test_gid_methods_recover_stress_spike_signs_for_all_inverse_modes(
         )
         plot_results = {}
         plot_sparse_results = {}
+        skipped_plot_modes = []
         plot_t0 = None
         plot_dt = None
         for mode in modes:
@@ -1248,6 +1269,8 @@ def test_gid_methods_recover_stress_spike_signs_for_all_inverse_modes(
                 plot_sparse_results[mode] = np.asarray(engine.sparse_output().data)
                 plot_t0 = rf.t0
                 plot_dt = rf.dt
+            else:
+                skipped_plot_modes.append(mode)
 
     _plot_stress_results(
         decon_validation_plot_dir,
@@ -1257,6 +1280,7 @@ def test_gid_methods_recover_stress_spike_signs_for_all_inverse_modes(
         plot_t0,
         plot_dt,
         f"{engine_class.__name__}_noise_{decon_validation_noise_scale:g}",
+        failed_methods=skipped_plot_modes,
     )
     _plot_gid_sparse_results(
         decon_validation_plot_dir,
@@ -1266,6 +1290,7 @@ def test_gid_methods_recover_stress_spike_signs_for_all_inverse_modes(
         plot_t0,
         plot_dt,
         f"noise_{decon_validation_noise_scale:g}_stress",
+        failed_methods=skipped_plot_modes,
     )
 
 

--- a/python/tests/algorithms/test_decon_algorithm_validation.py
+++ b/python/tests/algorithms/test_decon_algorithm_validation.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import warnings
+
 import numpy as np
 import pytest
 from scipy import signal
@@ -52,6 +54,38 @@ STRESS_SPIKES = {
     10.4: (-14.0, 19.0, 0.0),
     10.95: (13.0, -18.0, 0.0),
 }
+
+
+def _import_matplotlib_pyplot():
+    try:
+        from pyparsing.exceptions import PyparsingDeprecationWarning
+    except ImportError:
+        warning_category = Warning
+    else:
+        warning_category = PyparsingDeprecationWarning
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=warning_category,
+            module=r"matplotlib\._fontconfig_pattern",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=warning_category,
+            module=r"matplotlib\._mathtext",
+        )
+        try:
+            import matplotlib
+
+            matplotlib.use("Agg", force=True)
+            import matplotlib.pyplot as plt
+        except ImportError as err:
+            pytest.fail(
+                "--decon-validation-plots requires matplotlib; install it to write "
+                f"validation plots ({err})"
+            )
+    return plt
 
 
 def _make_validation_data(noise_level=0.0):
@@ -486,16 +520,7 @@ def _slice_matrix_to_window(matrix, src_t0, dt, out_t0, out_npts):
 def _plot_rf_overlay(plot_dir, filename, title, results, truth, t0, dt):
     if plot_dir is None:
         return
-    try:
-        import matplotlib
-
-        matplotlib.use("Agg", force=True)
-        import matplotlib.pyplot as plt
-    except ImportError as err:
-        pytest.fail(
-            "--decon-validation-plots requires matplotlib; install it to write "
-            f"validation plots ({err})"
-        )
+    plt = _import_matplotlib_pyplot()
 
     npts = min(matrix.shape[1] for matrix in results.values())
     t = t0 + np.arange(npts) * dt
@@ -548,17 +573,6 @@ def _plot_rf_overlay(plot_dir, filename, title, results, truth, t0, dt):
 def _plot_complex_colored_results(plot_dir, results, truth, wavelet):
     if plot_dir is None:
         return
-    try:
-        import matplotlib
-
-        matplotlib.use("Agg", force=True)
-        import matplotlib.pyplot as plt
-    except ImportError as err:
-        pytest.fail(
-            "--decon-validation-plots requires matplotlib; install it to write "
-            f"validation plots ({err})"
-        )
-
     _plot_rf_overlay(
         plot_dir,
         "complex_colored_scalar_methods.png",
@@ -569,6 +583,7 @@ def _plot_complex_colored_results(plot_dir, results, truth, wavelet):
         truth.dt,
     )
 
+    plt = _import_matplotlib_pyplot()
     tw = wavelet.t0 + np.arange(wavelet.npts) * wavelet.dt
     fig, axis = plt.subplots(1, 1, figsize=(10, 3))
     axis.plot(tw, np.asarray(wavelet.data), color="black", linewidth=1.2)

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -333,6 +333,9 @@ class TestDatabase:
             response.read.side_effect = [pickle.load(handle)]
         return response
 
+    def mock_urlopen_failure(*args):
+        raise OSError("mocked download failure")
+
     def test_read_data_from_url(self):
         with patch("urllib.request.urlopen", new=self.mock_urlopen):
             url = "http://service.iris.edu/fdsnws/dataselect/1/query?net=IU&sta=ANMO&loc=00&cha=BH?&start=2010-02-27T06:30:00.000&end=2010-02-27T06:35:00.000"
@@ -344,8 +347,9 @@ class TestDatabase:
 
         # test invalid url
         bad_url = "http://service.iris.edu/fdsnws/dataselect/1/query?net=IU&sta=ANMO&loc=00&cha=DUMMY&start=2010-02-27T06:30:00.000&end=2010-02-27T06:35:00.000"
-        with pytest.raises(MsPASSError, match="Error while downloading"):
-            self.db._read_data_from_url(tmp_ts, bad_url)
+        with patch("urllib.request.urlopen", new=self.mock_urlopen_failure):
+            with pytest.raises(MsPASSError, match="Error while downloading"):
+                self.db._read_data_from_url(tmp_ts, bad_url)
 
     def test_mspass_type_helper(self):
         schema = self.metadata_def.Seismogram

--- a/python/tests/util/test_seismic.py
+++ b/python/tests/util/test_seismic.py
@@ -5,8 +5,10 @@ from mspasspy.util.seismic import (
     has_live_data,
     ensemble_time_range,
     regularize_sampling,
+    sort_ensemble,
 )
 from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble, Seismogram
+from mspasspy.ccore.utility import MsPASSError
 import numpy as np
 
 
@@ -66,6 +68,31 @@ def test_has_live_data():
     for i in range(len(e.member)):
         e.member[i].kill()
     assert not has_live_data(e)
+
+    with pytest.raises(TypeError, match="arg0 must be a TimeSeriesEnsemble"):
+        has_live_data(d)
+
+
+def test_sort_ensemble_rejects_non_ensemble():
+    with pytest.raises(MsPASSError) as err:
+        sort_ensemble(TimeSeries(), "sta")
+    assert "arg0 must be a TimeSeriesEnsemble" in err.value.args[1]
+
+
+def test_sort_ensemble_returns_timeseries_ensemble():
+    ensemble = TimeSeriesEnsemble(2)
+    for sta in ["B", "A"]:
+        datum = TimeSeries()
+        datum.set_live()
+        datum["sta"] = sta
+        ensemble.member.append(datum)
+
+    sorted_ensemble = sort_ensemble(ensemble, "sta")
+
+    assert isinstance(sorted_ensemble, TimeSeriesEnsemble)
+    assert sorted_ensemble.live
+    assert len(sorted_ensemble.member) == 2
+    assert [datum["sta"] for datum in sorted_ensemble.member] == ["A", "B"]
 
 
 def test_regularize_sampling():


### PR DESCRIPTION
This pull request focuses on improving test reliability, code clarity, and documentation accuracy. The main changes include making the machine learning arrival time tests independent of external dependencies, enhancing plotting robustness in deconvolution validation tests, and correcting typos in docstrings and parameter names.

**Testing improvements:**

* [`python/tests/algorithms/ml/test_arrival.py`](diffhunk://#diff-fb1771def88af2874a1bebc9fa42f98e176b7812ca4323c55c0b27ab06040b4dR3-R68): Refactored tests to mock the `seisbench` dependency and model, removing the need for network access or external packages. The tests now use a local mock model, and all calls to `annotate_arrival_time` explicitly inject this model. Also, replaced live waveform fetching with a static test trace to ensure test stability. [[1]](diffhunk://#diff-fb1771def88af2874a1bebc9fa42f98e176b7812ca4323c55c0b27ab06040b4dR3-R68) [[2]](diffhunk://#diff-fb1771def88af2874a1bebc9fa42f98e176b7812ca4323c55c0b27ab06040b4dL34-R81) [[3]](diffhunk://#diff-fb1771def88af2874a1bebc9fa42f98e176b7812ca4323c55c0b27ab06040b4dL62-R109) [[4]](diffhunk://#diff-fb1771def88af2874a1bebc9fa42f98e176b7812ca4323c55c0b27ab06040b4dL88-R138) [[5]](diffhunk://#diff-fb1771def88af2874a1bebc9fa42f98e176b7812ca4323c55c0b27ab06040b4dL170-R223) [[6]](diffhunk://#diff-fb1771def88af2874a1bebc9fa42f98e176b7812ca4323c55c0b27ab06040b4dL210-R265)

* [`python/tests/db/test_database.py`](diffhunk://#diff-5ee7a80f28cebf6fc3e0dbb57eb29e99ca1da218446e51746310efcc05cb4a94R336-R338): Added a mock function to simulate URL download failures and updated the test to verify proper error handling for failed downloads. [[1]](diffhunk://#diff-5ee7a80f28cebf6fc3e0dbb57eb29e99ca1da218446e51746310efcc05cb4a94R336-R338) [[2]](diffhunk://#diff-5ee7a80f28cebf6fc3e0dbb57eb29e99ca1da218446e51746310efcc05cb4a94R350)

**Plotting and visualization robustness:**

* [`python/tests/algorithms/test_decon_algorithm_validation.py`](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R4-R5): Centralized matplotlib import and warning suppression logic to a helper function, improving maintainability and suppressing deprecation warnings. Enhanced plotting functions to indicate failed methods in legends and propagate this information through overlays. [[1]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R4-R5) [[2]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R59-R90) [[3]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351L486-R525) [[4]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R567-R577) [[5]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351L551-L561) [[6]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R599) [[7]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351L584-R614) [[8]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351L610-R643) [[9]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R652) [[10]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R1247-R1255) [[11]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R1272-R1273) [[12]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R1283) [[13]](diffhunk://#diff-435bd21f71dd46076cd508b4b4a771be5dbf0c295d39a554e71eab61d3785351R1293)

**Documentation and code clarity:**

* [`python/mspasspy/util/seismic.py`](diffhunk://#diff-4751eb81c4eecbac66b6868361aab053319d7f585369d6a711d8dd506a6010bfL76-R77): Fixed typos in docstrings and corrected a parameter name from `enemble` to `ensemble` for clarity. [[1]](diffhunk://#diff-4751eb81c4eecbac66b6868361aab053319d7f585369d6a711d8dd506a6010bfL76-R77) [[2]](diffhunk://#diff-4751eb81c4eecbac66b6868361aab053319d7f585369d6a711d8dd506a6010bfL90-R90)
* `python/mspasspy/db/database.py`, `python/mspasspy/util/converter.py`: Escaped backslashes in docstring regular expressions for correct rendering. [[1]](diffhunk://#diff-4df9c28c033b772f3718f3d6678bdfb91328d7a9c491933fd863327f809f6027L6020-R6020) [[2]](diffhunk://#diff-e564dc11c574cbd95e0727d5e6d251dcc9fcc9160f1a096b1a1a3d43a125689fL639-R639)