### PR TITLE
Add group-sparse and adaptive GID penalties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ docs/source/mspass_schema/*.csv
 misc
 .coverage*
 build/
+python/mspasspy/ccore/
 python/mspasspy/data/
 python/mspasspy.egg-info/
 dask-worker-space/
 dist/
+/tmp/

--- a/cxx/include/mspass/algorithms/deconvolution/FrequencyDomainGIDDecon.h
+++ b/cxx/include/mspass/algorithms/deconvolution/FrequencyDomainGIDDecon.h
@@ -23,8 +23,9 @@ namespace mspass::algorithms::deconvolution {
 This engine shares the sparse GID iteration semantics of TimeDomainGIDDecon
 but applies the candidate inverse operator in the frequency domain.  Processing
 requires both a loaded signal window and residual-domain noise window.  External
-PowerSpectrum noise is only an ns_gid inverse-operator regularization estimate;
-it does not replace load(d, dwin, nwin) or loadnoise(d, nwin).
+PowerSpectrum noise is accepted by ns_gid and group_sparse because both use
+NS-GID inverse-operator regularization; it does not replace load(d, dwin, nwin)
+or loadnoise(d, nwin).
 */
 class FrequencyDomainGIDDecon : public ScalarDecon {
 public:
@@ -148,6 +149,8 @@ private:
   double group_sparse_active_threshold_used;
   double group_sparse_objective_initial, group_sparse_objective_final;
   double group_sparse_fractional_improvement_final;
+  double group_sparse_debiased_objective_final;
+  double group_sparse_debiased_fractional_improvement_final;
   int group_sparse_max_iterations, group_sparse_iterations;
   int group_sparse_active_groups;
   bool group_sparse_converged;

--- a/cxx/include/mspass/algorithms/deconvolution/FrequencyDomainGIDDecon.h
+++ b/cxx/include/mspass/algorithms/deconvolution/FrequencyDomainGIDDecon.h
@@ -140,6 +140,17 @@ private:
   double adaptive_penalty_noise_amplitude;
   double adaptive_penalty_memory_linf;
   double adaptive_penalty_memory_l2;
+  double group_sparse_lambda, group_sparse_lambda_scale;
+  double group_sparse_lambda_used, group_sparse_tolerance;
+  double group_sparse_active_threshold, group_sparse_active_threshold_scale;
+  double group_sparse_active_threshold_quantile;
+  double group_sparse_active_threshold_quantile_value;
+  double group_sparse_active_threshold_used;
+  double group_sparse_objective_initial, group_sparse_objective_final;
+  double group_sparse_fractional_improvement_final;
+  int group_sparse_max_iterations, group_sparse_iterations;
+  int group_sparse_active_groups;
+  bool group_sparse_converged;
 
   void initialize_inverse_operator();
   void invalidate_processing_state();

--- a/cxx/include/mspass/algorithms/deconvolution/GIDDeconUtil.h
+++ b/cxx/include/mspass/algorithms/deconvolution/GIDDeconUtil.h
@@ -35,8 +35,14 @@ IterDeconType ParseGIDDeconType(const mspass::utility::Metadata &md,
 std::string GIDDeconTypeName(const IterDeconType type);
 double GetDoubleDefault(const mspass::utility::Metadata &md,
                         const std::string &key, const double default_value);
+double GetDoubleRequired(const mspass::utility::Metadata &md,
+                         const std::string &key);
 int GetIntDefault(const mspass::utility::Metadata &md, const std::string &key,
                   const int default_value);
+int GetIntRequired(const mspass::utility::Metadata &md,
+                   const std::string &key);
+long GetLongRequired(const mspass::utility::Metadata &md,
+                     const std::string &key);
 bool GetBoolDefault(const mspass::utility::Metadata &md,
                     const std::string &key, const bool default_value);
 void ValidateProbability(const double p, const std::string &key,

--- a/cxx/include/mspass/algorithms/deconvolution/GIDDeconUtil.h
+++ b/cxx/include/mspass/algorithms/deconvolution/GIDDeconUtil.h
@@ -55,6 +55,9 @@ void PutPrefixedMetadata(mspass::utility::Metadata &target,
 std::string AntelopePfToText(const mspass::utility::AntelopePf &pf,
                              const int indent = 0);
 std::vector<double> ThreeCAmplitudes(const mspass::utility::dmatrix &d);
+double GroupSparseObjective(const mspass::seismic::CoreSeismogram &residual,
+                            const std::list<ThreeCSpike> &spikes,
+                            const double lambda);
 void ValidateGIDLeafWindow(const mspass::utility::AntelopePf &mdleaf,
                            const mspass::algorithms::TimeWindow &fftwin,
                            const std::string &leaf_name,

--- a/cxx/include/mspass/algorithms/deconvolution/GIDDeconUtil.h
+++ b/cxx/include/mspass/algorithms/deconvolution/GIDDeconUtil.h
@@ -13,6 +13,23 @@
 #include <vector>
 
 namespace mspass::algorithms::deconvolution {
+struct GroupSparseDeconResult {
+  std::list<ThreeCSpike> spikes;
+  mspass::seismic::CoreSeismogram residual;
+  int iterations = 0;
+  int active_groups = 0;
+  bool converged = false;
+  double lambda = 0.0;
+  double active_threshold_floor = 0.0;
+  double active_threshold_scale = 1.0;
+  double active_threshold_quantile = 0.0;
+  double active_threshold_quantile_value = 0.0;
+  double active_threshold_used = 0.0;
+  double objective_initial = 0.0;
+  double objective_final = 0.0;
+  double fractional_improvement_final = 0.0;
+};
+
 IterDeconType ParseGIDDeconType(const mspass::utility::Metadata &md,
                                 const std::string &caller);
 double GetDoubleDefault(const mspass::utility::Metadata &md,
@@ -94,5 +111,11 @@ void RefitSpikeAmplitudes(std::list<ThreeCSpike> &spikes,
                           const std::vector<double> &actual_o_fir,
                           const int actual_o_0,
                           const double ridge_beta = 1.0e-10);
+GroupSparseDeconResult SolveGroupSparseDecon(
+    const mspass::seismic::CoreSeismogram &target,
+    const std::vector<double> &actual_o_fir, const int actual_o_0,
+    const double lambda, const int max_iterations, const double tolerance,
+    const double active_threshold, const double active_threshold_scale,
+    const double active_threshold_quantile, const std::string &caller);
 } // namespace mspass::algorithms::deconvolution
 #endif

--- a/cxx/include/mspass/algorithms/deconvolution/GIDDeconUtil.h
+++ b/cxx/include/mspass/algorithms/deconvolution/GIDDeconUtil.h
@@ -32,6 +32,7 @@ struct GroupSparseDeconResult {
 
 IterDeconType ParseGIDDeconType(const mspass::utility::Metadata &md,
                                 const std::string &caller);
+std::string GIDDeconTypeName(const IterDeconType type);
 double GetDoubleDefault(const mspass::utility::Metadata &md,
                         const std::string &key, const double default_value);
 int GetIntDefault(const mspass::utility::Metadata &md, const std::string &key,

--- a/cxx/include/mspass/algorithms/deconvolution/ThreeCSpike.h
+++ b/cxx/include/mspass/algorithms/deconvolution/ThreeCSpike.h
@@ -3,7 +3,14 @@
 #include "mspass/utility/dmatrix.h"
 
 namespace mspass::algorithms::deconvolution {
-enum IterDeconType { WATER_LEVEL, LEAST_SQ, MULTI_TAPER, CNR, NS_GID };
+enum IterDeconType {
+  WATER_LEVEL,
+  LEAST_SQ,
+  MULTI_TAPER,
+  CNR,
+  NS_GID,
+  GROUP_SPARSE
+};
 
 class ThreeCSpike {
 public:
@@ -15,6 +22,8 @@ public:
   double amp;
   /*! Construct a spike from the vector sample at column k. */
   ThreeCSpike(mspass::utility::dmatrix &d, int k);
+  /*! Construct a spike from explicit three-component amplitudes. */
+  ThreeCSpike(int k, const double u0, const double u1, const double u2);
   /*! Copy constructor. */
   ThreeCSpike(const ThreeCSpike &parent);
   /*! Assignment operator required for STL containers. */

--- a/cxx/include/mspass/algorithms/deconvolution/TimeDomainGIDDecon.h
+++ b/cxx/include/mspass/algorithms/deconvolution/TimeDomainGIDDecon.h
@@ -36,9 +36,10 @@ uses the configured receiver-function compatibility behavior.
 
 External TimeSeries noise can supply both the inverse-operator noise estimate
 and, when no windowed residual noise has been loaded, the residual-domain
-stopping threshold.  External PowerSpectrum noise is only an inverse-operator
-regularization estimate for ns_gid; callers must still load residual-domain
-noise with load(d, dwin, nwin) or loadnoise(d, nwin) before process().
+stopping threshold.  External PowerSpectrum noise is accepted by ns_gid and
+group_sparse because both use NS-GID inverse-operator regularization; callers
+must still load residual-domain noise with load(d, dwin, nwin) or
+loadnoise(d, nwin) before process().
 */
 
 class TimeDomainGIDDecon : public ScalarDecon {
@@ -259,6 +260,8 @@ private:
   double group_sparse_active_threshold_used;
   double group_sparse_objective_initial, group_sparse_objective_final;
   double group_sparse_fractional_improvement_final;
+  double group_sparse_debiased_objective_final;
+  double group_sparse_debiased_fractional_improvement_final;
   int group_sparse_max_iterations, group_sparse_iterations;
   int group_sparse_active_groups;
   bool group_sparse_converged;

--- a/cxx/include/mspass/algorithms/deconvolution/TimeDomainGIDDecon.h
+++ b/cxx/include/mspass/algorithms/deconvolution/TimeDomainGIDDecon.h
@@ -251,6 +251,17 @@ private:
   double adaptive_penalty_noise_amplitude;
   double adaptive_penalty_memory_linf;
   double adaptive_penalty_memory_l2;
+  double group_sparse_lambda, group_sparse_lambda_scale;
+  double group_sparse_lambda_used, group_sparse_tolerance;
+  double group_sparse_active_threshold, group_sparse_active_threshold_scale;
+  double group_sparse_active_threshold_quantile;
+  double group_sparse_active_threshold_quantile_value;
+  double group_sparse_active_threshold_used;
+  double group_sparse_objective_initial, group_sparse_objective_final;
+  double group_sparse_fractional_improvement_final;
+  int group_sparse_max_iterations, group_sparse_iterations;
+  int group_sparse_active_groups;
+  bool group_sparse_converged;
 
 };
 } // namespace mspass::algorithms::deconvolution

--- a/cxx/include/mspass/utility/Metadata.h
+++ b/cxx/include/mspass/utility/Metadata.h
@@ -10,6 +10,7 @@
 #include <pybind11/pybind11.h>
 #include <set>
 #include <sstream>
+#include <string>
 #include <typeinfo>
 
 namespace mspass {
@@ -44,7 +45,7 @@ public:
     when the type of the return does not match the type requested. */
   MetadataGetError(const char *boostmessage, const std::string key,
                    const char *Texpected, const char *Tactual) {
-    ss << "Error in Metadata get method.   Type mismatch in attem to get "
+    ss << "Error in Metadata get method.   Type mismatch in attempt to get "
        << "data with key=" << key << std::endl
        << "boost::any bad_any_cast wrote this message:  " << std::endl
        << boostmessage << std::endl;
@@ -52,6 +53,24 @@ public:
     ss << "Trying to convert to data of type=" << name_e << std::endl;
     std::string name_a(boost::core::demangle(Tactual));
     ss << "Actual entry has type=" << name_a << std::endl;
+    message = ss.str();
+    badness = ErrorSeverity::Suspect;
+  };
+  /*! \brief Constructor called when compatible scalar conversion fails.
+
+    This form is used by typed getter wrappers that accept compatible
+    scalar types (for example, integer metadata for a double request), but
+    still need to reject semantic mismatches such as a fractional value for
+    an integer request. */
+  MetadataGetError(const std::string key, const char *Texpected,
+                   const char *Tactual, const std::string detail) {
+    ss << "Error in Metadata get method. Type mismatch in attempt to get "
+       << "data with key=" << key << std::endl;
+    std::string name_e(boost::core::demangle(Texpected));
+    ss << "Trying to convert to data of type=" << name_e << std::endl;
+    std::string name_a(boost::core::demangle(Tactual));
+    ss << "Actual entry has type=" << name_a << std::endl;
+    ss << detail << std::endl;
     message = ss.str();
     badness = ErrorSeverity::Suspect;
   };
@@ -128,22 +147,7 @@ other attributes.
   type mismatch.
   \param key keyword associated with requested metadata member.
   **/
-  double get_double(const std::string key) const override {
-    try {
-      double val;
-      val = get<double>(key);
-      return val;
-    } catch (MetadataGetError &merr) {
-      /* Try a float if that failed */
-      try {
-        float fval;
-        fval = get<float>(key);
-        return fval;
-      } catch (MetadataGetError &merr) {
-        throw merr;
-      }
-    }
-  };
+  double get_double(const std::string key) const override;
   /*!
   Get an integer from the Metadata object.
 
@@ -151,21 +155,7 @@ other attributes.
   type mismatch.
   \param key keyword associated with requested metadata member.
   **/
-  int get_int(const std::string key) const override {
-    try {
-      int val;
-      val = get<int>(key);
-      return val;
-    } catch (MetadataGetError &merr) {
-      try {
-        long lval;
-        lval = get<long>(key);
-        return static_cast<int>(lval);
-      } catch (MetadataGetError &merr) {
-        throw merr;
-      }
-    }
-  };
+  int get_int(const std::string key) const override;
   /*!
   Get a long integer from the Metadata object.
 
@@ -173,21 +163,7 @@ other attributes.
   type mismatch.
   \param key keyword associated with requested metadata member.
   **/
-  long get_long(const std::string key) const {
-    try {
-      long val;
-      val = get<long>(key);
-      return val;
-    } catch (MetadataGetError &merr) {
-      try {
-        int ival;
-        ival = get<int>(key);
-        return static_cast<long>(ival);
-      } catch (MetadataGetError &merr) {
-        throw merr;
-      }
-    }
-  };
+  long get_long(const std::string key) const;
   /*!
   Get a string from the Metadata object.
 
@@ -211,20 +187,12 @@ other attributes.
   /*!
   Get a  boolean parameter from the Metadata object.
 
-  This method never throws an exception assuming that if the
-  requested parameter is not found it is false.
+  \exception MetadataGetError if requested parameter is not found or there is a
+  type mismatch.
 
   \param key keyword associated with requested metadata member.
   **/
-  bool get_bool(const std::string key) const override {
-    try {
-      bool val;
-      val = get<bool>(key);
-      return val;
-    } catch (...) {
-      throw;
-    };
-  };
+  bool get_bool(const std::string key) const override;
   /*! Generic get interface.
 
   This is a generic interface most useful for template procedures
@@ -458,6 +426,11 @@ template <typename T> T Metadata::get(const std::string key) const {
   };
   return result;
 }
+template <> double Metadata::get<double>(const std::string key) const;
+template <> int Metadata::get<int>(const std::string key) const;
+template <> long Metadata::get<long>(const std::string key) const;
+template <> bool Metadata::get<bool>(const std::string key) const;
+template <> float Metadata::get<float>(const std::string key) const;
 /*! Return a pretty name from a boost any object.
  *
  * We use a boost::any object as a container to hold any generic object.

--- a/cxx/python/utility/boost_any_converter_py.h
+++ b/cxx/python/utility/boost_any_converter_py.h
@@ -27,8 +27,15 @@ namespace pybind11 { namespace detail {
     static std::map<std::type_index, std::function<handle(boost::any const&)>> toPythonMap;
     static std::map<std::type_index, std::function<handle(boost::any const&)>> createToPythonMap() {
       std::map<std::type_index, std::function<handle(boost::any const&)>> m;
+      m[typeid(short)]       = [](boost::any const& x) { return py::cast(boost::any_cast<short>(x)).release();};
+      m[typeid(unsigned short)] = [](boost::any const& x) { return py::cast(boost::any_cast<unsigned short>(x)).release();};
       m[typeid(long)]        = [](boost::any const& x) { return py::cast(boost::any_cast<long>(x)).release();};
+      m[typeid(unsigned long)] = [](boost::any const& x) { return py::cast(boost::any_cast<unsigned long>(x)).release();};
       m[typeid(int)]         = [](boost::any const& x) { return py::cast(boost::any_cast<int>(x)).release();};
+      m[typeid(unsigned int)] = [](boost::any const& x) { return py::cast(boost::any_cast<unsigned int>(x)).release();};
+      m[typeid(long long)]   = [](boost::any const& x) { return py::cast(boost::any_cast<long long>(x)).release();};
+      m[typeid(unsigned long long)] = [](boost::any const& x) { return py::cast(boost::any_cast<unsigned long long>(x)).release();};
+      m[typeid(float)]       = [](boost::any const& x) { return py::cast(boost::any_cast<float>(x)).release();};
       m[typeid(double)]      = [](boost::any const& x) { return py::cast(boost::any_cast<double>(x)).release();};
       m[typeid(bool)]        = [](boost::any const& x) { return py::cast(boost::any_cast<bool>(x)).release();};
       m[typeid(std::string)] = [](boost::any const& x) { return py::cast(boost::any_cast<std::string>(x)).release();};

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -24,6 +24,50 @@ namespace py=pybind11;
 using namespace std;
 using namespace mspass::utility;
 
+namespace {
+bool is_expected_python_conversion_error(py::error_already_set &err) {
+  return err.matches(PyExc_TypeError) || err.matches(PyExc_ValueError) ||
+         err.matches(PyExc_OverflowError);
+}
+
+void put_metadata_py_value(Metadata &md, const std::string &key,
+                           py::object value) {
+  py::object original_value = value;
+  if (!(py::isinstance<py::float_>(value) ||
+        py::isinstance<py::bool_>(value) ||
+        py::isinstance<py::int_>(value) ||
+        py::isinstance<py::bytes>(value) ||
+        py::isinstance<py::str>(value))) {
+    py::object numpy_generic = py::module_::import("numpy").attr("generic");
+    if (py::isinstance(value, numpy_generic))
+      value = value.attr("item")();
+  }
+
+  if(py::isinstance<py::float_>(value))
+    md.put(key, (value.cast<double>()));
+  else if(py::isinstance<py::bool_>(value))
+    md.put(key, (value.cast<bool>()));
+  else if(py::isinstance<py::int_>(value)) {
+    try {
+      md.put(key, (value.cast<long>()));
+    } catch (const py::cast_error &) {
+      md.put_object(key, original_value);
+    } catch (py::error_already_set &err) {
+      if (!is_expected_python_conversion_error(err))
+        throw;
+      PyErr_Clear();
+      md.put_object(key, original_value);
+    }
+  }
+  else if(py::isinstance<py::bytes>(value))
+    md.put_object(key, value);
+  else if(py::isinstance<py::str>(value))
+    md.put(key, std::string(py::str(value)));
+  else
+    md.put_object(key, value);
+}
+} // namespace
+
 /* This is what the pybind11 documentation calls a trampoline class for
 needed to handle virtual function in the abstract base class BasicMetadata. */
 class PyBasicMetadata : public BasicMetadata {
@@ -256,18 +300,9 @@ PYBIND11_MODULE(utility, m) {
     .def(py::init([](py::dict d) {
       auto md = new Metadata();
       for(auto i : d) {
-        if(py::isinstance<py::float_>(i.second))
-          md->put(std::string(py::str(i.first)), (i.second.cast<double>()));
-        else if(py::isinstance<py::bool_>(i.second))
-          md->put(std::string(py::str(i.first)), (i.second.cast<bool>()));
-        else if(py::isinstance<py::int_>(i.second))
-          md->put(std::string(py::str(i.first)), (i.second.cast<long>()));
-        else if(py::isinstance<py::bytes>(i.second))
-          md->put_object(std::string(py::str(i.first)), py::reinterpret_borrow<py::object>(i.second));
-        else if(py::isinstance<py::str>(i.second))
-          md->put(std::string(py::str(i.first)), std::string(py::str(i.second)));
-        else
-          md->put_object(std::string(py::str(i.first)), py::reinterpret_borrow<py::object>(i.second));
+        put_metadata_py_value(
+            *md, std::string(py::str(i.first)),
+            py::reinterpret_borrow<py::object>(i.second));
       }
       md->clear_modified();
       return md;
@@ -279,18 +314,7 @@ PYBIND11_MODULE(utility, m) {
     .def("get",&Metadata::get_any,"Return the value indexed by a specified key")
     .def("__getitem__",&Metadata::get_any,"Return the value indexed by a specified key")
     .def("put", [](Metadata& md, const py::bytes k, const py::object v) {
-      if(py::isinstance<py::float_>(v))
-        md.put(std::string(py::str(k.attr("__str__")())), (v.cast<double>()));
-      else if(py::isinstance<py::bool_>(v))
-        md.put(std::string(py::str(k.attr("__str__")())), (v.cast<bool>()));
-      else if(py::isinstance<py::int_>(v))
-        md.put(std::string(py::str(k.attr("__str__")())), (v.cast<long>()));
-      else if(py::isinstance<py::bytes>(v))
-        md.put_object(std::string(py::str(k.attr("__str__")())), v);
-      else if(py::isinstance<py::str>(v))
-        md.put(std::string(py::str(k.attr("__str__")())), std::string(py::str(v)));
-      else
-        md.put_object(std::string(py::str(k.attr("__str__")())), v);
+      put_metadata_py_value(md, std::string(py::str(k.attr("__str__")())), v);
     })
     .def("put",py::overload_cast<const std::string,const double>(&BasicMetadata::put))
     .def("put",py::overload_cast<const std::string,const bool>(&BasicMetadata::put))
@@ -299,20 +323,11 @@ PYBIND11_MODULE(utility, m) {
         md.put_object(k, py::reinterpret_borrow<py::object>(v));
     })
     .def("put",py::overload_cast<const std::string,const std::string>(&BasicMetadata::put))
-    .def("put",py::overload_cast<const std::string,const py::object>(&Metadata::put_object))
+    .def("put",[](Metadata& md, const std::string k, const py::object v) {
+        put_metadata_py_value(md, k, v);
+    })
     .def("__setitem__", [](Metadata& md, const py::bytes k, const py::object v) {
-      if(py::isinstance<py::float_>(v))
-        md.put(std::string(py::str(k.attr("__str__")())), (v.cast<double>()));
-      else if(py::isinstance<py::bool_>(v))
-        md.put(std::string(py::str(k.attr("__str__")())), (v.cast<bool>()));
-      else if(py::isinstance<py::int_>(v))
-        md.put(std::string(py::str(k.attr("__str__")())), (v.cast<long>()));
-      else if(py::isinstance<py::bytes>(v))
-        md.put_object(std::string(py::str(k.attr("__str__")())), v);
-      else if(py::isinstance<py::str>(v))
-        md.put(std::string(py::str(k.attr("__str__")())), std::string(py::str(v)));
-      else
-        md.put_object(std::string(py::str(k.attr("__str__")())), v);
+      put_metadata_py_value(md, std::string(py::str(k.attr("__str__")())), v);
     })
     .def("__setitem__",py::overload_cast<const std::string,const double>(&BasicMetadata::put))
     .def("__setitem__",py::overload_cast<const std::string,const bool>(&BasicMetadata::put))
@@ -321,7 +336,9 @@ PYBIND11_MODULE(utility, m) {
         md.put_object(k, py::reinterpret_borrow<py::object>(v));
     })
     .def("__setitem__",py::overload_cast<const std::string,const std::string>(&BasicMetadata::put))
-    .def("__setitem__",py::overload_cast<const std::string,const py::object>(&Metadata::put_object))
+    .def("__setitem__",[](Metadata& md, const std::string k, const py::object v) {
+        put_metadata_py_value(md, k, v);
+    })
     .def("put_double",&Metadata::put_double,"Interface class for doubles")
     .def("put_bool",&Metadata::put_bool,"Interface class for boolean")
     .def("put_string",&Metadata::put_string,"Interface class for strings")
@@ -381,6 +398,22 @@ PYBIND11_MODULE(utility, m) {
           key = key + ": False, ";
         else if (index->second.type() == typeid(long))
           key = key + ": " + std::to_string(boost::any_cast<long>(index->second)) + ", ";
+        else if (index->second.type() == typeid(int))
+          key = key + ": " + std::to_string(boost::any_cast<int>(index->second)) + ", ";
+        else if (index->second.type() == typeid(short))
+          key = key + ": " + std::to_string(boost::any_cast<short>(index->second)) + ", ";
+        else if (index->second.type() == typeid(unsigned short))
+          key = key + ": " + std::to_string(boost::any_cast<unsigned short>(index->second)) + ", ";
+        else if (index->second.type() == typeid(unsigned int))
+          key = key + ": " + std::to_string(boost::any_cast<unsigned int>(index->second)) + ", ";
+        else if (index->second.type() == typeid(unsigned long))
+          key = key + ": " + std::to_string(boost::any_cast<unsigned long>(index->second)) + ", ";
+        else if (index->second.type() == typeid(long long))
+          key = key + ": " + std::to_string(boost::any_cast<long long>(index->second)) + ", ";
+        else if (index->second.type() == typeid(unsigned long long))
+          key = key + ": " + std::to_string(boost::any_cast<unsigned long long>(index->second)) + ", ";
+        else if (index->second.type() == typeid(float))
+          key = key + ": " + std::to_string(boost::any_cast<float>(index->second)) + ", ";
         /* The py::repr function will get the double/single
          * quotes right based on the content of the string */
         else
@@ -433,6 +466,8 @@ PYBIND11_MODULE(utility, m) {
     .def_readwrite("tag",&Metadata_typedef::tag,"Name key for this metadata")
     .def_readwrite("mdt",&Metadata_typedef::mdt,"Type of any value associated with this key")
   ;
+  m.def("copy_selected_metadata",&copy_selected_metadata,
+        "Copy selected values from one Metadata container to another using a MetadataList schema");
 
   /* We need this definition to bind dmatrix to a numpy array as described
   in this section of pybind11 documentation:\

--- a/cxx/src/lib/algorithms/deconvolution/CNR3CDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/CNR3CDecon.cc
@@ -1,9 +1,11 @@
 #include "mspass/algorithms/deconvolution/CNR3CDecon.h"
 #include "mspass/algorithms/algorithms.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/seismic/Seismogram.h"
 #include "mspass/seismic/TimeSeries.h"
 #include "mspass/utility/MsPASSError.h"
 #include <algorithm>
+#include <sstream>
 #include <string.h> //needed for memcpy
 
 /* This enum is file scope to intentionally exclude it from python wrappers.
@@ -22,6 +24,21 @@ using namespace mspass::seismic;
 using namespace mspass::utility;
 using namespace mspass::algorithms;
 using namespace mspass::algorithms::amplitudes;
+
+namespace {
+double parse_vector_taper_value(const string &text,
+                                const string &table_name) {
+  istringstream ss(text);
+  double val;
+  ss >> val;
+  if (!ss || !(ss >> ws).eof())
+    throw MsPASSError("CNR3CDecon::read_parameters: invalid numeric value "
+                      "in " +
+                          table_name + ": " + text,
+                      ErrorSeverity::Fatal);
+  return val;
+}
+} // namespace
 
 CNR3CDecon::CNR3CDecon()
     : FFTDeconOperator(), signalengine(), waveletengine(), dnoise_engine(),
@@ -73,7 +90,7 @@ void CNR3CDecon::read_parameters(const AntelopePf &pf) {
                             stmp,
                         ErrorSeverity::Fatal);
     }
-    this->damp = pf.get_double("damping_factor");
+    this->damp = GetDoubleRequired(pf, "damping_factor");
     if (this->damp <= 0.0) {
       throw MsPASSError("CNR3CDecon::read_parameters: damping_factor must be "
                         "positive for stable regularized deconvolution",
@@ -81,18 +98,20 @@ void CNR3CDecon::read_parameters(const AntelopePf &pf) {
     }
     /* Note this paramter is used for both the damping method and the
     generalized_water_level */
-    this->noise_floor = pf.get_double("noise_floor");
-    this->snr_regularization_floor = pf.get_double("snr_regularization_floor");
-    this->snr_bandwidth = pf.get_double("snr_for_bandwidth_estimator");
-    this->operator_dt = pf.get_double("target_sample_interval");
+    this->noise_floor = GetDoubleRequired(pf, "noise_floor");
+    this->snr_regularization_floor =
+        GetDoubleRequired(pf, "snr_regularization_floor");
+    this->snr_bandwidth =
+        GetDoubleRequired(pf, "snr_for_bandwidth_estimator");
+    this->operator_dt = GetDoubleRequired(pf, "target_sample_interval");
     if (this->operator_dt <= 0.0)
       throw MsPASSError("CNR3CDecon::read_parameters: "
                         "target_sample_interval must be positive",
                         ErrorSeverity::Fatal);
-    this->fhs = pf.get_double("high_frequency_search_start");
+    this->fhs = GetDoubleRequired(pf, "high_frequency_search_start");
     double ts, te;
-    ts = pf.get_double("deconvolution_data_window_start");
-    te = pf.get_double("deconvolution_data_window_end");
+    ts = GetDoubleRequired(pf, "deconvolution_data_window_start");
+    te = GetDoubleRequired(pf, "deconvolution_data_window_end");
     this->processing_window = TimeWindow(ts, te);
     ValidateWindowDuration(this->processing_window,
                            "deconvolution_data_window",
@@ -109,7 +128,7 @@ void CNR3CDecon::read_parameters(const AntelopePf &pf) {
      * ShapingWavelet constructor and FFTDeconOperator api constraints created
      * by use in other classes in this directory that also use these */
     int nfftneeded = nextPowerOf2(minwinsize);
-    int nfftpf = pf.get<int>("operator_nfft");
+    int nfftpf = GetIntRequired(pf, "operator_nfft");
     if (nfftneeded != nfftpf) {
       FFTDeconOperator::change_size(nfftneeded);
       AntelopePf pfcopy(pf);
@@ -127,14 +146,14 @@ void CNR3CDecon::read_parameters(const AntelopePf &pf) {
           ErrorSeverity::Invalid);
     }
     FFTDeconOperator::change_size(nextPowerOf2(minwinsize));
-    ts = pf.get_double("noise_window_start");
-    te = pf.get_double("noise_window_end");
+    ts = GetDoubleRequired(pf, "noise_window_start");
+    te = GetDoubleRequired(pf, "noise_window_end");
     this->noise_window = TimeWindow(ts, te);
     ValidateWindowDuration(this->noise_window, "noise_window",
                            "CNR3CDecon::read_parameters");
     int noise_winlength = round((te - ts) / operator_dt) + 1;
-    double tbp = pf.get_double("time_bandwidth_product");
-    long ntapers = pf.get_long("number_tapers");
+    double tbp = GetDoubleRequired(pf, "time_bandwidth_product");
+    long ntapers = GetLongRequired(pf, "number_tapers");
     this->dnoise_engine = MTPowerSpectrumEngine(noise_winlength, tbp, ntapers);
     /* Default wavelet noise window to data window length - adjusted dynamically
     if changed*/
@@ -147,37 +166,38 @@ void CNR3CDecon::read_parameters(const AntelopePf &pf) {
     sval = pf.get_string("taper_type");
     /* New parameter added for dynamic bandwidth adjustment feature implemented
     december 2020 */
-    decon_bandwidth_cutoff = pf.get_double("decon_bandwidth_cutoff");
+    decon_bandwidth_cutoff =
+        GetDoubleRequired(pf, "decon_bandwidth_cutoff");
     if (sval == "linear") {
       double f0, f1, t1, t0;
       AntelopePf pfb = pf.get_branch("LinearTaper");
       AntelopePf pfbranch = pfb.get_branch("wavelet_taper");
-      f0 = pfbranch.get_double("front0");
-      f1 = pfbranch.get_double("front1");
-      t1 = pfbranch.get_double("tail1");
-      t0 = pfbranch.get_double("tail0");
+      f0 = GetDoubleRequired(pfbranch, "front0");
+      f1 = GetDoubleRequired(pfbranch, "front1");
+      t1 = GetDoubleRequired(pfbranch, "tail1");
+      t0 = GetDoubleRequired(pfbranch, "tail0");
       wavelet_taper = shared_ptr<LinearTaper>(new LinearTaper(f0, f1, t1, t0));
       pfbranch = pfb.get_branch("data_taper");
-      f0 = pfbranch.get_double("front0");
-      f1 = pfbranch.get_double("front1");
-      t1 = pfbranch.get_double("tail1");
-      t0 = pfbranch.get_double("tail0");
+      f0 = GetDoubleRequired(pfbranch, "front0");
+      f1 = GetDoubleRequired(pfbranch, "front1");
+      t1 = GetDoubleRequired(pfbranch, "tail1");
+      t0 = GetDoubleRequired(pfbranch, "tail0");
       data_taper = shared_ptr<LinearTaper>(new LinearTaper(f0, f1, t1, t0));
       taper_data = true;
     } else if (sval == "cosine") {
       double f0, f1, t1, t0;
       AntelopePf pfb = pf.get_branch("CosineTaper");
       AntelopePf pfbranch = pfb.get_branch("wavelet_taper");
-      f0 = pfbranch.get_double("front0");
-      f1 = pfbranch.get_double("front1");
-      t1 = pfbranch.get_double("tail1");
-      t0 = pfbranch.get_double("tail0");
+      f0 = GetDoubleRequired(pfbranch, "front0");
+      f1 = GetDoubleRequired(pfbranch, "front1");
+      t1 = GetDoubleRequired(pfbranch, "tail1");
+      t0 = GetDoubleRequired(pfbranch, "tail0");
       wavelet_taper = shared_ptr<CosineTaper>(new CosineTaper(f0, f1, t1, t0));
       pfbranch = pfb.get_branch("data_taper");
-      f0 = pfbranch.get_double("front0");
-      f1 = pfbranch.get_double("front1");
-      t1 = pfbranch.get_double("tail1");
-      t0 = pfbranch.get_double("tail0");
+      f0 = GetDoubleRequired(pfbranch, "front0");
+      f1 = GetDoubleRequired(pfbranch, "front1");
+      t1 = GetDoubleRequired(pfbranch, "tail1");
+      t0 = GetDoubleRequired(pfbranch, "tail0");
       data_taper = shared_ptr<CosineTaper>(new CosineTaper(f0, f1, t1, t0));
       taper_data = true;
     } else if (sval == "vector") {
@@ -188,9 +208,8 @@ void CNR3CDecon::read_parameters(const AntelopePf &pf) {
       tdataread.reserve(tdl.size());
       list<string>::iterator tptr;
       for (tptr = tdl.begin(); tptr != tdl.end(); ++tptr) {
-        double val;
-        sscanf(tptr->c_str(), "%lf", &val);
-        tdataread.push_back(val);
+        tdataread.push_back(
+            parse_vector_taper_value(*tptr, "wavelet_taper_vector"));
       }
       wavelet_taper = shared_ptr<VectorTaper>(new VectorTaper(tdataread));
       tdataread.clear();
@@ -198,9 +217,8 @@ void CNR3CDecon::read_parameters(const AntelopePf &pf) {
       tdl = pfbranch.get_tbl("data_taper_vector");
       tdataread.reserve(tdl.size());
       for (tptr = tdl.begin(); tptr != tdl.end(); ++tptr) {
-        double val;
-        sscanf(tptr->c_str(), "%lf", &val);
-        tdataread.push_back(val);
+        tdataread.push_back(
+            parse_vector_taper_value(*tptr, "data_taper_vector"));
       }
       data_taper = shared_ptr<VectorTaper>(new VectorTaper(tdataread));
       taper_data = true;

--- a/cxx/src/lib/algorithms/deconvolution/CNRDeconEngine.cc
+++ b/cxx/src/lib/algorithms/deconvolution/CNRDeconEngine.cc
@@ -1,6 +1,7 @@
 #include "mspass/algorithms/deconvolution/CNRDeconEngine.h"
 #include "mspass/algorithms/algorithms.h"
 #include "mspass/algorithms/amplitudes.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/utility/MsPASSError.h"
 #include <sstream>
 #include <string>
@@ -42,7 +43,7 @@ CNRDeconEngine::CNRDeconEngine(const AntelopePf &pf)
                             stmp,
                         ErrorSeverity::Fatal);
     }
-    this->damp = pf.get_double("damping_factor");
+    this->damp = GetDoubleRequired(pf, "damping_factor");
     if (this->damp <= 0.0) {
       throw MsPASSError("CNRDeconEngine(constructor): damping_factor must be "
                         "positive for stable regularized deconvolution",
@@ -50,10 +51,11 @@ CNRDeconEngine::CNRDeconEngine(const AntelopePf &pf)
     }
     /* Note this paramter is used for both the damping method and the
     generalized_water_level */
-    this->noise_floor = pf.get_double("noise_floor");
-    this->snr_regularization_floor = pf.get_double("snr_regularization_floor");
-    this->band_snr_floor = pf.get_double("snr_data_bandwidth_floor");
-    this->operator_dt = pf.get_double("target_sample_interval");
+    this->noise_floor = GetDoubleRequired(pf, "noise_floor");
+    this->snr_regularization_floor =
+        GetDoubleRequired(pf, "snr_regularization_floor");
+    this->band_snr_floor = GetDoubleRequired(pf, "snr_data_bandwidth_floor");
+    this->operator_dt = GetDoubleRequired(pf, "target_sample_interval");
     if (this->operator_dt <= 0.0)
       throw MsPASSError("CNRDeconEngine(constructor): "
                         "target_sample_interval must be positive",
@@ -63,8 +65,8 @@ CNRDeconEngine::CNRDeconEngine(const AntelopePf &pf)
     instead of number of samples as it is less error prone to a user than
     requiring them to compute the number from the sample interval. */
     double ts, te;
-    ts = pf.get_double("deconvolution_data_window_start");
-    te = pf.get_double("deconvolution_data_window_end");
+    ts = GetDoubleRequired(pf, "deconvolution_data_window_start");
+    te = GetDoubleRequired(pf, "deconvolution_data_window_end");
     ValidateWindowDuration(TimeWindow(ts, te), "deconvolution_data_window",
                            "CNRDeconEngine(constructor)");
     this->winlength = round((te - ts) / this->operator_dt) + 1;
@@ -104,8 +106,8 @@ CNRDeconEngine::CNRDeconEngine(const AntelopePf &pf)
       /* These MUST be consistent with FFTDeconOperator pf constructor
       names.   */
       int npoles_lo, npoles_hi;
-      npoles_lo = pf.get_int("npoles_lo");
-      npoles_hi = pf.get_int("npoles_hi");
+      npoles_lo = GetIntRequired(pf, "npoles_lo");
+      npoles_hi = GetIntRequired(pf, "npoles_hi");
       if (npoles_hi != npoles_lo) {
         stringstream ss;
         ss << "CNRDeconEngine(Metadata constructor):  "
@@ -122,13 +124,13 @@ CNRDeconEngine::CNRDeconEngine(const AntelopePf &pf)
     }
     /* As with signal we use this for initializing the noise engine
     rather than the number of points, which is all the engine cares about. */
-    ts = pf.get_double("noise_window_start");
-    te = pf.get_double("noise_window_end");
+    ts = GetDoubleRequired(pf, "noise_window_start");
+    te = GetDoubleRequired(pf, "noise_window_end");
     ValidateWindowDuration(TimeWindow(ts, te), "noise_window",
                            "CNRDeconEngine(constructor)");
     int noise_winlength = round((te - ts) / operator_dt) + 1;
-    double tbp = pf.get_double("time_bandwidth_product");
-    long ntapers = pf.get_long("number_tapers");
+    double tbp = GetDoubleRequired(pf, "time_bandwidth_product");
+    long ntapers = GetLongRequired(pf, "number_tapers");
     this->noise_engine = MTPowerSpectrumEngine(
         noise_winlength, tbp, ntapers, noise_winlength, this->operator_dt);
     this->signal_engine = MTPowerSpectrumEngine(
@@ -172,23 +174,23 @@ void CNRDeconEngine::changeparameter(const Metadata &md) {
                             stmp,
                         ErrorSeverity::Fatal);
     }
-    this->damp = md.get_double("damping_factor");
+    this->damp = GetDoubleRequired(md, "damping_factor");
     if (this->damp <= 0.0)
       throw MsPASSError("CNRDeconEngine::changeparameter: damping_factor must "
                         "be positive for stable regularized deconvolution",
                         ErrorSeverity::Fatal);
-    this->noise_floor = md.get_double("noise_floor");
+    this->noise_floor = GetDoubleRequired(md, "noise_floor");
     this->snr_regularization_floor =
-        md.get_double("snr_regularization_floor");
-    this->band_snr_floor = md.get_double("snr_data_bandwidth_floor");
-    this->operator_dt = md.get_double("target_sample_interval");
+        GetDoubleRequired(md, "snr_regularization_floor");
+    this->band_snr_floor = GetDoubleRequired(md, "snr_data_bandwidth_floor");
+    this->operator_dt = GetDoubleRequired(md, "target_sample_interval");
     if (this->operator_dt <= 0.0)
       throw MsPASSError("CNRDeconEngine::changeparameter: "
                         "target_sample_interval must be positive",
                         ErrorSeverity::Fatal);
 
-    double ts(md.get_double("deconvolution_data_window_start"));
-    double te(md.get_double("deconvolution_data_window_end"));
+    double ts(GetDoubleRequired(md, "deconvolution_data_window_start"));
+    double te(GetDoubleRequired(md, "deconvolution_data_window_end"));
     ValidateWindowDuration(TimeWindow(ts, te), "deconvolution_data_window",
                            "CNRDeconEngine::changeparameter");
     this->winlength = round((te - ts) / this->operator_dt) + 1;
@@ -213,8 +215,8 @@ void CNRDeconEngine::changeparameter(const Metadata &md) {
           ErrorSeverity::Fatal);
     }
     if (swname == "butterworth") {
-      int npoles_lo(md.get_int("npoles_lo"));
-      int npoles_hi(md.get_int("npoles_hi"));
+      int npoles_lo(GetIntRequired(md, "npoles_lo"));
+      int npoles_hi(GetIntRequired(md, "npoles_hi"));
       if (npoles_hi != npoles_lo) {
         stringstream ss;
         ss << "CNRDeconEngine::changeparameter: Butterworth filter high and "
@@ -227,13 +229,13 @@ void CNRDeconEngine::changeparameter(const Metadata &md) {
       this->shaping_wavelet_number_poles = npoles_lo;
     }
 
-    ts = md.get_double("noise_window_start");
-    te = md.get_double("noise_window_end");
+    ts = GetDoubleRequired(md, "noise_window_start");
+    te = GetDoubleRequired(md, "noise_window_end");
     ValidateWindowDuration(TimeWindow(ts, te), "noise_window",
                            "CNRDeconEngine::changeparameter");
     int noise_winlength = round((te - ts) / operator_dt) + 1;
-    double tbp = md.get_double("time_bandwidth_product");
-    long ntapers = md.get_long("number_tapers");
+    double tbp = GetDoubleRequired(md, "time_bandwidth_product");
+    long ntapers = GetLongRequired(md, "number_tapers");
     this->noise_engine = MTPowerSpectrumEngine(
         noise_winlength, tbp, ntapers, noise_winlength, this->operator_dt);
     this->signal_engine = MTPowerSpectrumEngine(

--- a/cxx/src/lib/algorithms/deconvolution/ComputeTaperLength.cc
+++ b/cxx/src/lib/algorithms/deconvolution/ComputeTaperLength.cc
@@ -1,5 +1,6 @@
 #include "mspass/algorithms/TimeWindow.h"
 #include "mspass/algorithms/deconvolution/FFTDeconOperator.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/utility/MsPASSError.h"
 #include "mspass/utility/Metadata.h"
 #include <cmath>
@@ -13,9 +14,9 @@ int ComputeTaperLength(const Metadata &md) {
   try {
     const string caller("ComputeTaperLength");
     double ts, te, dt;
-    ts = md.get<double>("deconvolution_data_window_start");
-    te = md.get<double>("deconvolution_data_window_end");
-    dt = md.get<double>("target_sample_interval");
+    ts = GetDoubleRequired(md, "deconvolution_data_window_start");
+    te = GetDoubleRequired(md, "deconvolution_data_window_end");
+    dt = GetDoubleRequired(md, "target_sample_interval");
     ValidateWindowDuration(TimeWindow(ts, te), "deconvolution window", caller);
     if (!std::isfinite(dt) || dt <= 0.0)
       throw MsPASSError(caller + ": target_sample_interval must be positive",

--- a/cxx/src/lib/algorithms/deconvolution/FFTDeconOperator.cc
+++ b/cxx/src/lib/algorithms/deconvolution/FFTDeconOperator.cc
@@ -1,4 +1,5 @@
 #include "mspass/algorithms/deconvolution/FFTDeconOperator.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/seismic/CoreTimeSeries.h"
 #include "mspass/utility/MsPASSError.h"
 #include <algorithm>
@@ -18,16 +19,17 @@ FFTDeconOperator::FFTDeconOperator() {
 FFTDeconOperator::FFTDeconOperator(const Metadata &md) {
   try {
     const string base_error("FFTDeconOperator Metadata constructor:  ");
-    const double ts = md.get_double("deconvolution_data_window_start");
-    const double te = md.get_double("deconvolution_data_window_end");
-    const double dt = md.get_double("target_sample_interval");
+    const double ts =
+        GetDoubleRequired(md, "deconvolution_data_window_start");
+    const double te = GetDoubleRequired(md, "deconvolution_data_window_end");
+    const double dt = GetDoubleRequired(md, "target_sample_interval");
     ValidateWindowDuration(TimeWindow(ts, te), "deconvolution_data_window",
                            base_error);
     if (!std::isfinite(dt) || dt <= 0.0)
       throw MsPASSError(base_error +
                             "target_sample_interval must be positive",
                         ErrorSeverity::Fatal);
-    int nfftpf = md.get_int("operator_nfft");
+    int nfftpf = GetIntRequired(md, "operator_nfft");
     /* We force a power of 2 algorithm for efficiency and always round up*/
     this->nfft = nextPowerOf2(nfftpf);
     /* We compute the sample shift from the window start time and dt.  This
@@ -77,16 +79,17 @@ FFTDeconOperator &FFTDeconOperator::operator=(const FFTDeconOperator &parent) {
 void FFTDeconOperator::changeparameter(const Metadata &md) {
   try {
     const string base_error("FFTDeconOperator::changeparameter:  ");
-    const double ts = md.get_double("deconvolution_data_window_start");
-    const double te = md.get_double("deconvolution_data_window_end");
-    const double dt = md.get_double("target_sample_interval");
+    const double ts =
+        GetDoubleRequired(md, "deconvolution_data_window_start");
+    const double te = GetDoubleRequired(md, "deconvolution_data_window_end");
+    const double dt = GetDoubleRequired(md, "target_sample_interval");
     ValidateWindowDuration(TimeWindow(ts, te), "deconvolution_data_window",
                            base_error);
     if (!std::isfinite(dt) || dt <= 0.0)
       throw MsPASSError(base_error +
                             "target_sample_interval must be positive",
                         ErrorSeverity::Fatal);
-    const int nfft_test = nextPowerOf2(md.get_int("operator_nfft"));
+    const int nfft_test = nextPowerOf2(GetIntRequired(md, "operator_nfft"));
     const int sample_shift_test = ComputeDeconSampleShift(md);
     if (sample_shift_test < 0)
       throw MsPASSError(base_error +
@@ -222,10 +225,10 @@ overloading in C++ */
 int ComputeFFTLength(const Metadata &md) {
   try {
     double ts, te, dt;
-    ts = md.get<double>("deconvolution_data_window_start");
-    te = md.get<double>("deconvolution_data_window_end");
+    ts = GetDoubleRequired(md, "deconvolution_data_window_start");
+    te = GetDoubleRequired(md, "deconvolution_data_window_end");
     TimeWindow w(ts, te);
-    dt = md.get<double>("target_sample_interval");
+    dt = GetDoubleRequired(md, "target_sample_interval");
     int nfft;
     nfft = ComputeFFTLength(w, dt);
     if (nfft < 2)
@@ -239,8 +242,8 @@ int ComputeFFTLength(const Metadata &md) {
   };
 }
 int ComputeDeconSampleShift(const Metadata &md) {
-  double dt_to_use = md.get_double("target_sample_interval");
-  double dwinstart = md.get_double("deconvolution_data_window_start");
+  double dt_to_use = GetDoubleRequired(md, "target_sample_interval");
+  double dwinstart = GetDoubleRequired(md, "deconvolution_data_window_start");
   if (!std::isfinite(dt_to_use) || dt_to_use <= 0.0)
     throw MsPASSError(
         "ComputeDeconSampleShift: target_sample_interval must be positive",

--- a/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
@@ -74,12 +74,13 @@ FrequencyDomainGIDDecon::FrequencyDomainGIDDecon(const AntelopePf &mdtoplevel)
     AntelopePf md = mdtoplevel.get_branch("deconvolution_operator_type");
     AntelopePf mdgid = md.get_branch("frequency_domain_gid_deconvolution");
     decon_type = ParseGIDDeconType(mdgid, "FrequencyDomainGIDDecon");
-    dwin = TimeWindow(mdgid.get<double>("full_data_window_start"),
-                      mdgid.get<double>("full_data_window_end"));
-    fftwin = TimeWindow(mdgid.get<double>("deconvolution_data_window_start"),
-                        mdgid.get<double>("deconvolution_data_window_end"));
-    nwin = TimeWindow(mdgid.get<double>("noise_window_start"),
-                      mdgid.get<double>("noise_window_end"));
+    dwin = TimeWindow(GetDoubleRequired(mdgid, "full_data_window_start"),
+                      GetDoubleRequired(mdgid, "full_data_window_end"));
+    fftwin =
+        TimeWindow(GetDoubleRequired(mdgid, "deconvolution_data_window_start"),
+                   GetDoubleRequired(mdgid, "deconvolution_data_window_end"));
+    nwin = TimeWindow(GetDoubleRequired(mdgid, "noise_window_start"),
+                      GetDoubleRequired(mdgid, "noise_window_end"));
     ValidateWindowDuration(dwin, "full_data_window", base_error);
     ValidateWindowDuration(fftwin, "deconvolution_data_window", base_error);
     ValidateWindowDuration(nwin, "noise_window", base_error);
@@ -87,22 +88,22 @@ FrequencyDomainGIDDecon::FrequencyDomainGIDDecon(const AntelopePf &mdtoplevel)
       throw MsPASSError(base_error +
                             "deconvolution window must be inside full window",
                         ErrorSeverity::Invalid);
-    noise_component = mdgid.get<int>("noise_component");
+    noise_component = GetIntRequired(mdgid, "noise_component");
     ValidateThreeComponentIndex(noise_component, "noise_component", base_error);
-    target_dt = mdgid.get<double>("target_sample_interval");
+    target_dt = GetDoubleRequired(mdgid, "target_sample_interval");
     ValidatePositive(target_dt, "target_sample_interval", base_error);
     int maxns = static_cast<int>((fftwin.end - fftwin.start) / target_dt) + 1;
     int nfft = nextPowerOf2(maxns);
     mdgid.put("operator_nfft", nfft);
     this->ScalarDecon::changeparameter(mdgid);
     this->shapingwavelet = ShapingWavelet(mdgid, nfft);
-    iter_max = mdgid.get<int>("maximum_iterations");
+    iter_max = GetIntRequired(mdgid, "maximum_iterations");
     ValidatePositiveInteger(iter_max, "maximum_iterations", base_error);
-    residual_ratio_floor = mdgid.get<double>("residual_ratio_floor");
+    residual_ratio_floor = GetDoubleRequired(mdgid, "residual_ratio_floor");
     ValidateNonnegative(residual_ratio_floor, "residual_ratio_floor",
                         base_error);
     residual_improvement_floor =
-        mdgid.get<double>("residual_fractional_improvement_floor");
+        GetDoubleRequired(mdgid, "residual_fractional_improvement_floor");
     ValidateNonnegative(residual_improvement_floor,
                         "residual_fractional_improvement_floor", base_error);
     lag_weight_penalty_function =
@@ -111,7 +112,7 @@ FrequencyDomainGIDDecon::FrequencyDomainGIDDecon(const AntelopePf &mdtoplevel)
             : "none";
     lag_weight_penalty_scale_factor =
         mdgid.is_defined("lag_weight_penalty_scale_factor")
-            ? mdgid.get<double>("lag_weight_penalty_scale_factor")
+            ? GetDoubleRequired(mdgid, "lag_weight_penalty_scale_factor")
             : 1.0;
     if (!isfinite(lag_weight_penalty_scale_factor) ||
         lag_weight_penalty_scale_factor <= 0.0 ||
@@ -121,7 +122,7 @@ FrequencyDomainGIDDecon::FrequencyDomainGIDDecon(const AntelopePf &mdtoplevel)
                         ErrorSeverity::Fatal);
     lag_weight_function_width =
         mdgid.is_defined("lag_weight_function_width")
-            ? mdgid.get<int>("lag_weight_function_width")
+            ? GetIntRequired(mdgid, "lag_weight_function_width")
             : 0;
     if (mdgid.is_defined("lag_weight_function_width"))
       ValidatePositiveInteger(lag_weight_function_width,

--- a/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
@@ -164,6 +164,12 @@ FrequencyDomainGIDDecon::FrequencyDomainGIDDecon(const AntelopePf &mdtoplevel)
       ValidateGIDLeafWindow(mdleaf, fftwin, "CNR", base_error);
       cnrprocessor = std::make_unique<CNRDeconEngine>(mdleaf);
       break;
+    case GROUP_SPARSE:
+      mdleaf = md.get_branch("ns_gid");
+      ValidateGIDLeafWindow(mdleaf, fftwin, "group sparse NS-GID inverse",
+                            base_error);
+      preprocessor = std::make_unique<NoiseStableDecon>(mdleaf);
+      break;
     case NS_GID:
     default:
       mdleaf = md.get_branch("ns_gid");
@@ -204,6 +210,33 @@ FrequencyDomainGIDDecon::FrequencyDomainGIDDecon(const AntelopePf &mdtoplevel)
     ns_ridge_beta =
         GetDoubleDefault(mdgid, "ns_gid_ridge_beta", 1.0e-10);
     ValidateNonnegative(ns_ridge_beta, "ns_gid_ridge_beta", base_error);
+    group_sparse_lambda = GetDoubleDefault(mdgid, "group_sparse_lambda", 0.0);
+    ValidateNonnegative(group_sparse_lambda, "group_sparse_lambda",
+                        base_error);
+    group_sparse_lambda_scale =
+        GetDoubleDefault(mdgid, "group_sparse_lambda_scale", 1.0);
+    ValidateNonnegative(group_sparse_lambda_scale,
+                        "group_sparse_lambda_scale", base_error);
+    group_sparse_tolerance =
+        GetDoubleDefault(mdgid, "group_sparse_tolerance", 1.0e-4);
+    ValidatePositive(group_sparse_tolerance, "group_sparse_tolerance",
+                     base_error);
+    group_sparse_max_iterations =
+        GetIntDefault(mdgid, "group_sparse_max_iterations", iter_max);
+    ValidatePositiveInteger(group_sparse_max_iterations,
+                            "group_sparse_max_iterations", base_error);
+    group_sparse_active_threshold =
+        GetDoubleDefault(mdgid, "group_sparse_active_threshold", 2.0e-2);
+    ValidateNonnegative(group_sparse_active_threshold,
+                        "group_sparse_active_threshold", base_error);
+    group_sparse_active_threshold_scale =
+        GetDoubleDefault(mdgid, "group_sparse_active_threshold_scale", 1.0);
+    ValidateNonnegative(group_sparse_active_threshold_scale,
+                        "group_sparse_active_threshold_scale", base_error);
+    group_sparse_active_threshold_quantile =
+        GetDoubleDefault(mdgid, "group_sparse_active_threshold_quantile", 0.90);
+    ValidateProbability(group_sparse_active_threshold_quantile,
+                        "group_sparse_active_threshold_quantile", base_error);
     this->invalidate_processing_state();
   } catch (...) {
     throw;
@@ -244,6 +277,15 @@ void FrequencyDomainGIDDecon::invalidate_processing_state() {
   ns_stop_reason = "not_started";
   gid_converged = false;
   gid_stop_reason = "not_started";
+  group_sparse_lambda_used = 0.0;
+  group_sparse_objective_initial = 0.0;
+  group_sparse_objective_final = 0.0;
+  group_sparse_fractional_improvement_final = 0.0;
+  group_sparse_active_threshold_quantile_value = 0.0;
+  group_sparse_active_threshold_used = 0.0;
+  group_sparse_iterations = 0;
+  group_sparse_active_groups = 0;
+  group_sparse_converged = false;
   processed = false;
 }
 
@@ -363,11 +405,12 @@ int FrequencyDomainGIDDecon::loadnoise(const CoreTimeSeries &noise_in) {
 }
 
 int FrequencyDomainGIDDecon::loadnoise(const PowerSpectrum &noise_spectrum_in) {
-  if (decon_type != NS_GID)
+  if (decon_type != NS_GID && decon_type != GROUP_SPARSE)
     throw MsPASSError("FrequencyDomainGIDDecon::loadnoise: external "
-                      "PowerSpectrum noise is only supported for ns_gid; pass "
-                      "a TimeSeries noise estimate for multi_taper or use the "
-                      "configured noise window for other GID modes",
+                      "PowerSpectrum noise is only supported for ns_gid and "
+                      "group_sparse; pass a TimeSeries noise estimate for "
+                      "multi_taper or use the configured noise window for "
+                      "other GID modes",
                       ErrorSeverity::Invalid);
   ValidatePowerSpectrumCoversDC(noise_spectrum_in,
                                 "FrequencyDomainGIDDecon::loadnoise");
@@ -463,7 +506,7 @@ void FrequencyDomainGIDDecon::initialize_inverse_operator() {
       if (mt_noise.size() > static_cast<size_t>(mtop->get_taperlen()))
         mt_noise.resize(mtop->get_taperlen());
       mtop->loadnoise(mt_noise);
-    } else if (decon_type == NS_GID) {
+    } else if (decon_type == NS_GID || decon_type == GROUP_SPARSE) {
       NoiseStableDecon *nsop = dynamic_cast<NoiseStableDecon *>(preprocessor.get());
       if (external_noise_spectrum_loaded)
         nsop->loadnoise(external_noise_spectrum);
@@ -559,7 +602,7 @@ CoreTimeSeries FrequencyDomainGIDDecon::inverse_wavelet(double t0parent) {
 }
 
 double FrequencyDomainGIDDecon::compute_ns_peak_threshold() {
-  if (decon_type != NS_GID)
+  if (decon_type != NS_GID && decon_type != GROUP_SPARSE)
     return 0.0;
   CoreSeismogram nwork(n);
   dmatrix uwork(nwork.u);
@@ -715,6 +758,60 @@ void FrequencyDomainGIDDecon::process() {
     if (resid_l2_initial <= 0.0)
       throw MsPASSError(base_error + "input data residual is zero",
                         ErrorSeverity::Invalid);
+    if (decon_type == GROUP_SPARSE) {
+      process_stage = "group-sparse regularized solve";
+      group_sparse_lambda_used = group_sparse_lambda;
+      if (group_sparse_lambda_used <= 0.0) {
+        const double lambda_base =
+            (ns_peak_threshold > 0.0) ? ns_peak_threshold
+                                      : 0.02 * resid_linf_initial;
+        group_sparse_lambda_used = group_sparse_lambda_scale * lambda_base;
+      }
+      GroupSparseDeconResult gs = SolveGroupSparseDecon(
+          d_decon, actual_o_fir, actual_o_0, group_sparse_lambda_used,
+          group_sparse_max_iterations, group_sparse_tolerance,
+          group_sparse_active_threshold, group_sparse_active_threshold_scale,
+          group_sparse_active_threshold_quantile, "FrequencyDomainGIDDecon");
+      spikes = gs.spikes;
+      iter_count = gs.iterations;
+      group_sparse_iterations = gs.iterations;
+      group_sparse_active_groups = static_cast<int>(spikes.size());
+      group_sparse_converged = gs.converged;
+      group_sparse_objective_initial = gs.objective_initial;
+      group_sparse_objective_final = gs.objective_final;
+      group_sparse_fractional_improvement_final =
+          gs.fractional_improvement_final;
+      group_sparse_active_threshold_quantile_value =
+          gs.active_threshold_quantile_value;
+      group_sparse_active_threshold_used = gs.active_threshold_used;
+      process_stage = "refit group-sparse amplitudes";
+      RefitSpikeAmplitudes(spikes, d_decon, actual_o_fir, actual_o_0,
+                           ns_ridge_beta);
+      spikes.remove_if([this](const ThreeCSpike &spk) {
+        return spk.amp <= group_sparse_active_threshold_used;
+      });
+      group_sparse_active_groups = static_cast<int>(spikes.size());
+      process_stage = "recompute group-sparse final residual";
+      r = d_decon;
+      for (auto sptr = spikes.begin(); sptr != spikes.end(); ++sptr)
+        this->update_residual_matrix(*sptr);
+      resid_l2_final = matrix_l2(r.u);
+      resid_linf_final = matrix_linf(r.u);
+      if (!lag_weights.empty()) {
+        auto lwmax = max_element(lag_weights.begin(), lag_weights.end());
+        lag_weight_linf_final = (lwmax != lag_weights.end()) ? *lwmax : 0.0;
+        lag_weight_l2_final =
+            cblas_dnrm2(lag_weights.size(), &(lag_weights[0]), 1);
+      }
+      gid_stop_reason = group_sparse_converged
+                            ? "group_sparse_converged"
+                            : "group_sparse_max_iterations";
+      gid_converged = group_sparse_converged;
+      ns_stop_reason = "not_enabled";
+      ns_converged = false;
+      processed = true;
+      return;
+    }
     vector<double> amps;
     amps.reserve(r.npts());
     process_stage = "sparse iteration";
@@ -970,6 +1067,57 @@ Metadata FrequencyDomainGIDDecon::QCMetrics() {
   md.put("gid_actual_o_fir_zero_lag_index", actual_o_0);
   md.put("gid_actual_o_fir_peak_normalized",
          processed && !actual_o_fir.empty());
+  md.put("group_sparse_enabled", decon_type == GROUP_SPARSE);
+  md.put("group_sparse_inverse_operator", string("ns_gid"));
+  md.put("group_sparse_lambda_requested", group_sparse_lambda);
+  md.put("group_sparse_lambda_scale", group_sparse_lambda_scale);
+  md.put("group_sparse_lambda_used", group_sparse_lambda_used);
+  md.put("group_sparse_tolerance", group_sparse_tolerance);
+  md.put("group_sparse_max_iterations", group_sparse_max_iterations);
+  md.put("group_sparse_iterations", group_sparse_iterations);
+  md.put("group_sparse_converged", group_sparse_converged);
+  md.put("group_sparse_active_threshold", group_sparse_active_threshold);
+  md.put("group_sparse_active_threshold_scale",
+         group_sparse_active_threshold_scale);
+  md.put("group_sparse_active_threshold_quantile",
+         group_sparse_active_threshold_quantile);
+  md.put("group_sparse_active_threshold_quantile_value",
+         group_sparse_active_threshold_quantile_value);
+  md.put("group_sparse_active_threshold_used",
+         group_sparse_active_threshold_used);
+  md.put("group_sparse_active_groups", group_sparse_active_groups);
+  md.put("group_sparse_objective_initial", group_sparse_objective_initial);
+  md.put("group_sparse_objective_final", group_sparse_objective_final);
+  md.put("group_sparse_fractional_improvement_final",
+         group_sparse_fractional_improvement_final);
+  md.put("group_sparse_noise_threshold", ns_peak_threshold);
+  if (decon_type == GROUP_SPARSE) {
+    NoiseStableDecon *nsop =
+        dynamic_cast<NoiseStableDecon *>(preprocessor.get());
+    if (nsop != nullptr) {
+      Metadata nsmd(nsop->QCMetrics());
+      md.put("group_sparse_inverse_gain_max_requested",
+             nsmd.get_double("ns_gid_gain_max_requested"));
+      md.put("group_sparse_inverse_gain_max_actual",
+             nsmd.get_double("ns_gid_gain_max_actual"));
+      md.put("group_sparse_inverse_mu_min", nsmd.get_double("ns_gid_mu_min"));
+      md.put("group_sparse_inverse_alpha", nsmd.get_double("ns_gid_alpha"));
+      md.put("group_sparse_inverse_noise_amplification",
+             nsmd.get_double("ns_gid_noise_amplification"));
+      md.put("group_sparse_inverse_effective_bandwidth_fraction",
+             nsmd.get_double("ns_gid_effective_bandwidth_fraction"));
+      md.put("group_sparse_inverse_operator_nfft",
+             nsmd.get_int("ns_gid_operator_nfft"));
+      md.put("group_sparse_inverse_use_reliability_taper",
+             nsmd.get_bool("ns_gid_use_reliability_taper"));
+      md.put("group_sparse_inverse_external_wavelet_used",
+             external_wavelet_loaded);
+      md.put("group_sparse_inverse_external_noise_used",
+             external_noise_loaded);
+      md.put("group_sparse_inverse_external_noise_spectrum_used",
+             external_noise_spectrum_loaded);
+    }
+  }
   md.put("ns_gid_enabled", decon_type == NS_GID);
   if (decon_type == NS_GID) {
     md.put("ns_gid_stop_reason", ns_stop_reason);

--- a/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
@@ -282,6 +282,8 @@ void FrequencyDomainGIDDecon::invalidate_processing_state() {
   group_sparse_objective_initial = 0.0;
   group_sparse_objective_final = 0.0;
   group_sparse_fractional_improvement_final = 0.0;
+  group_sparse_debiased_objective_final = 0.0;
+  group_sparse_debiased_fractional_improvement_final = 0.0;
   group_sparse_active_threshold_quantile_value = 0.0;
   group_sparse_active_threshold_used = 0.0;
   group_sparse_iterations = 0;
@@ -800,10 +802,11 @@ void FrequencyDomainGIDDecon::process() {
         this->update_residual_matrix(*sptr);
       resid_l2_final = matrix_l2(r.u);
       resid_linf_final = matrix_linf(r.u);
-      group_sparse_objective_final =
+      group_sparse_debiased_objective_final =
           GroupSparseObjective(r, spikes, group_sparse_lambda_used);
-      group_sparse_fractional_improvement_final =
-          (group_sparse_objective_initial - group_sparse_objective_final) /
+      group_sparse_debiased_fractional_improvement_final =
+          (group_sparse_objective_initial -
+           group_sparse_debiased_objective_final) /
           max(1.0, group_sparse_objective_initial);
       if (!lag_weights.empty()) {
         auto lwmax = max_element(lag_weights.begin(), lag_weights.end());
@@ -1036,7 +1039,8 @@ Metadata FrequencyDomainGIDDecon::QCMetrics() {
   md.put("gid_stop_reason", gid_stop_reason);
   md.put("gid_iterations", iter_count);
   md.put("gid_number_spikes", static_cast<int>(spikes.size()));
-  md.put("gid_maximum_iterations", iter_max);
+  md.put("gid_maximum_iterations",
+         (decon_type == GROUP_SPARSE) ? group_sparse_max_iterations : iter_max);
   if (decon_type != GROUP_SPARSE) {
     md.put("gid_penalty_function", lag_weight_penalty_function);
     md.put("gid_penalty_scale_factor", lag_weight_penalty_scale_factor);
@@ -1100,6 +1104,10 @@ Metadata FrequencyDomainGIDDecon::QCMetrics() {
     md.put("group_sparse_objective_final", group_sparse_objective_final);
     md.put("group_sparse_fractional_improvement_final",
            group_sparse_fractional_improvement_final);
+    md.put("group_sparse_debiased_objective_final",
+           group_sparse_debiased_objective_final);
+    md.put("group_sparse_debiased_fractional_improvement_final",
+           group_sparse_debiased_fractional_improvement_final);
     md.put("group_sparse_noise_threshold", ns_peak_threshold);
     NoiseStableDecon *nsop =
         dynamic_cast<NoiseStableDecon *>(preprocessor.get());

--- a/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
@@ -711,7 +711,7 @@ void FrequencyDomainGIDDecon::process() {
       throw MsPASSError(base_error + "valid noise window has not been loaded",
                         ErrorSeverity::Invalid);
     this->initialize_inverse_operator();
-    if (decon_type == NS_GID) {
+    if (decon_type == NS_GID || decon_type == GROUP_SPARSE) {
       process_stage = "compute NS-GID peak threshold";
       ns_peak_threshold = this->compute_ns_peak_threshold();
       adaptive_penalty_noise_amplitude =
@@ -760,6 +760,8 @@ void FrequencyDomainGIDDecon::process() {
                         ErrorSeverity::Invalid);
     if (decon_type == GROUP_SPARSE) {
       process_stage = "group-sparse regularized solve";
+      if (ns_peak_threshold <= 0.0)
+        ns_peak_threshold = this->compute_ns_peak_threshold();
       group_sparse_lambda_used = group_sparse_lambda;
       if (group_sparse_lambda_used <= 0.0) {
         const double lambda_base =
@@ -797,6 +799,11 @@ void FrequencyDomainGIDDecon::process() {
         this->update_residual_matrix(*sptr);
       resid_l2_final = matrix_l2(r.u);
       resid_linf_final = matrix_linf(r.u);
+      group_sparse_objective_final =
+          GroupSparseObjective(r, spikes, group_sparse_lambda_used);
+      group_sparse_fractional_improvement_final =
+          (group_sparse_objective_initial - group_sparse_objective_final) /
+          max(1.0, group_sparse_objective_initial);
       if (!lag_weights.empty()) {
         auto lwmax = max_element(lag_weights.begin(), lag_weights.end());
         lag_weight_linf_final = (lwmax != lag_weights.end()) ? *lwmax : 0.0;
@@ -1029,30 +1036,30 @@ Metadata FrequencyDomainGIDDecon::QCMetrics() {
   md.put("gid_iterations", iter_count);
   md.put("gid_number_spikes", static_cast<int>(spikes.size()));
   md.put("gid_maximum_iterations", iter_max);
-  md.put("gid_penalty_function", lag_weight_penalty_function);
-  md.put("gid_penalty_scale_factor", lag_weight_penalty_scale_factor);
-  md.put("gid_penalty_width", lag_weight_function_width);
-  md.put("gid_penalty_effective_width",
-         static_cast<int>(lag_weight_penalty.size()));
-  md.put("gid_adaptive_penalty_enabled",
-         GIDLagWeightPenaltyUsesAdaptiveMemory(lag_weight_penalty_function));
-  md.put("gid_penalty_noise_amplitude", adaptive_penalty_noise_amplitude);
-  md.put("gid_penalty_last_confidence",
-         adaptive_penalty_last_confidence);
-  md.put("gid_penalty_last_immediate_strength",
-         adaptive_penalty_last_immediate_strength);
-  md.put("gid_penalty_last_specificity",
-         adaptive_penalty_last_specificity);
-  md.put("gid_penalty_last_decay_factor",
-         adaptive_penalty_last_decay_factor);
-  md.put("gid_penalty_memory_Linf_final", adaptive_penalty_memory_linf);
-  md.put("gid_penalty_memory_L2_final", adaptive_penalty_memory_l2);
-  int gid_penalty_valid_lags(0);
-  for (auto w : lag_weights) {
-    if (w > 0.0)
-      ++gid_penalty_valid_lags;
+  if (decon_type != GROUP_SPARSE) {
+    md.put("gid_penalty_function", lag_weight_penalty_function);
+    md.put("gid_penalty_scale_factor", lag_weight_penalty_scale_factor);
+    md.put("gid_penalty_width", lag_weight_function_width);
+    md.put("gid_penalty_effective_width",
+           static_cast<int>(lag_weight_penalty.size()));
+    md.put("gid_adaptive_penalty_enabled",
+           GIDLagWeightPenaltyUsesAdaptiveMemory(lag_weight_penalty_function));
+    md.put("gid_penalty_noise_amplitude", adaptive_penalty_noise_amplitude);
+    md.put("gid_penalty_last_confidence", adaptive_penalty_last_confidence);
+    md.put("gid_penalty_last_immediate_strength",
+           adaptive_penalty_last_immediate_strength);
+    md.put("gid_penalty_last_specificity", adaptive_penalty_last_specificity);
+    md.put("gid_penalty_last_decay_factor",
+           adaptive_penalty_last_decay_factor);
+    md.put("gid_penalty_memory_Linf_final", adaptive_penalty_memory_linf);
+    md.put("gid_penalty_memory_L2_final", adaptive_penalty_memory_l2);
+    int gid_penalty_valid_lags(0);
+    for (auto w : lag_weights) {
+      if (w > 0.0)
+        ++gid_penalty_valid_lags;
+    }
+    md.put("gid_penalty_valid_lags", gid_penalty_valid_lags);
   }
-  md.put("gid_penalty_valid_lags", gid_penalty_valid_lags);
   md.put("gid_external_wavelet_used", external_wavelet_loaded);
   md.put("gid_external_noise_used", external_noise_loaded);
   md.put("gid_external_noise_spectrum_used",

--- a/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
@@ -1068,32 +1068,31 @@ Metadata FrequencyDomainGIDDecon::QCMetrics() {
   md.put("gid_actual_o_fir_zero_lag_index", actual_o_0);
   md.put("gid_actual_o_fir_peak_normalized",
          processed && !actual_o_fir.empty());
-  md.put("group_sparse_enabled", decon_type == GROUP_SPARSE);
-  md.put("group_sparse_inverse_operator",
-         string(decon_type == GROUP_SPARSE ? "ns_gid" : "not_enabled"));
-  md.put("group_sparse_lambda_requested", group_sparse_lambda);
-  md.put("group_sparse_lambda_scale", group_sparse_lambda_scale);
-  md.put("group_sparse_lambda_used", group_sparse_lambda_used);
-  md.put("group_sparse_tolerance", group_sparse_tolerance);
-  md.put("group_sparse_max_iterations", group_sparse_max_iterations);
-  md.put("group_sparse_iterations", group_sparse_iterations);
-  md.put("group_sparse_converged", group_sparse_converged);
-  md.put("group_sparse_active_threshold", group_sparse_active_threshold);
-  md.put("group_sparse_active_threshold_scale",
-         group_sparse_active_threshold_scale);
-  md.put("group_sparse_active_threshold_quantile",
-         group_sparse_active_threshold_quantile);
-  md.put("group_sparse_active_threshold_quantile_value",
-         group_sparse_active_threshold_quantile_value);
-  md.put("group_sparse_active_threshold_used",
-         group_sparse_active_threshold_used);
-  md.put("group_sparse_active_groups", group_sparse_active_groups);
-  md.put("group_sparse_objective_initial", group_sparse_objective_initial);
-  md.put("group_sparse_objective_final", group_sparse_objective_final);
-  md.put("group_sparse_fractional_improvement_final",
-         group_sparse_fractional_improvement_final);
-  md.put("group_sparse_noise_threshold", ns_peak_threshold);
   if (decon_type == GROUP_SPARSE) {
+    md.put("group_sparse_enabled", true);
+    md.put("group_sparse_inverse_operator", string("ns_gid"));
+    md.put("group_sparse_lambda_requested", group_sparse_lambda);
+    md.put("group_sparse_lambda_scale", group_sparse_lambda_scale);
+    md.put("group_sparse_lambda_used", group_sparse_lambda_used);
+    md.put("group_sparse_tolerance", group_sparse_tolerance);
+    md.put("group_sparse_max_iterations", group_sparse_max_iterations);
+    md.put("group_sparse_iterations", group_sparse_iterations);
+    md.put("group_sparse_converged", group_sparse_converged);
+    md.put("group_sparse_active_threshold", group_sparse_active_threshold);
+    md.put("group_sparse_active_threshold_scale",
+           group_sparse_active_threshold_scale);
+    md.put("group_sparse_active_threshold_quantile",
+           group_sparse_active_threshold_quantile);
+    md.put("group_sparse_active_threshold_quantile_value",
+           group_sparse_active_threshold_quantile_value);
+    md.put("group_sparse_active_threshold_used",
+           group_sparse_active_threshold_used);
+    md.put("group_sparse_active_groups", group_sparse_active_groups);
+    md.put("group_sparse_objective_initial", group_sparse_objective_initial);
+    md.put("group_sparse_objective_final", group_sparse_objective_final);
+    md.put("group_sparse_fractional_improvement_final",
+           group_sparse_fractional_improvement_final);
+    md.put("group_sparse_noise_threshold", ns_peak_threshold);
     NoiseStableDecon *nsop =
         dynamic_cast<NoiseStableDecon *>(preprocessor.get());
     if (nsop != nullptr) {
@@ -1120,8 +1119,8 @@ Metadata FrequencyDomainGIDDecon::QCMetrics() {
              external_noise_spectrum_loaded);
     }
   }
-  md.put("ns_gid_enabled", decon_type == NS_GID);
   if (decon_type == NS_GID) {
+    md.put("ns_gid_enabled", true);
     md.put("ns_gid_stop_reason", ns_stop_reason);
     md.put("ns_gid_converged", ns_converged);
     md.put("ns_gid_iterations", iter_count);

--- a/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
@@ -1013,6 +1013,7 @@ Metadata FrequencyDomainGIDDecon::QCMetrics() {
   Metadata md;
   PutPrefixedMetadata(md, changed_leaf_metadata, "gid_leaf_");
   md.put("decon_operator", string("FrequencyDomainGIDDecon"));
+  md.put("deconvolution_type", GIDDeconTypeName(decon_type));
   md.put("decon_processed", processed);
   md.put("decon_sample_interval", target_dt);
   md.put("decon_window_start", dwin.start);

--- a/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/FrequencyDomainGIDDecon.cc
@@ -1069,7 +1069,8 @@ Metadata FrequencyDomainGIDDecon::QCMetrics() {
   md.put("gid_actual_o_fir_peak_normalized",
          processed && !actual_o_fir.empty());
   md.put("group_sparse_enabled", decon_type == GROUP_SPARSE);
-  md.put("group_sparse_inverse_operator", string("ns_gid"));
+  md.put("group_sparse_inverse_operator",
+         string(decon_type == GROUP_SPARSE ? "ns_gid" : "not_enabled"));
   md.put("group_sparse_lambda_requested", group_sparse_lambda);
   md.put("group_sparse_lambda_scale", group_sparse_lambda_scale);
   md.put("group_sparse_lambda_used", group_sparse_lambda_used);

--- a/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
+++ b/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
@@ -29,6 +29,9 @@ IterDeconType ParseGIDDeconType(const Metadata &md, const string &caller) {
   if ((sval == "ns_gid") || (sval == "noise_stable") ||
       (sval == "noise_aware_stable"))
     return NS_GID;
+  if ((sval == "group_sparse") || (sval == "group_lasso") ||
+      (sval == "sparse_group_lasso"))
+    return GROUP_SPARSE;
   throw MsPASSError(caller + ": unknown deconvolution_type=" + sval,
                     ErrorSeverity::Fatal);
 }
@@ -244,7 +247,14 @@ void ValidateGIDLeafOperatorMetadata(const Metadata &md,
       "ns_gid_max_spikes",
       "ns_gid_refit_interval",
       "ns_gid_ridge_beta",
-      "ns_gid_external_wavelet_allowed"};
+      "ns_gid_external_wavelet_allowed",
+      "group_sparse_lambda",
+      "group_sparse_lambda_scale",
+      "group_sparse_tolerance",
+      "group_sparse_max_iterations",
+      "group_sparse_active_threshold",
+      "group_sparse_active_threshold_scale",
+      "group_sparse_active_threshold_quantile"};
   static const vector<string> noise_window_keys{"noise_window_start",
                                                 "noise_window_end"};
   for (auto const &key : gid_level_keys) {
@@ -798,5 +808,190 @@ void RefitSpikeAmplitudes(list<ThreeCSpike> &spikes,
   for (auto &spk : spikes)
     spk.amp =
         sqrt(spk.u[0] * spk.u[0] + spk.u[1] * spk.u[1] + spk.u[2] * spk.u[2]);
+}
+
+double VectorQuantile(vector<double> values, const double quantile) {
+  if (values.empty())
+    return 0.0;
+  sort(values.begin(), values.end());
+  const double q = min(1.0, max(0.0, quantile));
+  const double pos = q * static_cast<double>(values.size() - 1);
+  const int lo = static_cast<int>(floor(pos));
+  const int hi = static_cast<int>(ceil(pos));
+  if (lo == hi)
+    return values[lo];
+  const double frac = pos - static_cast<double>(lo);
+  return values[lo] * (1.0 - frac) + values[hi] * frac;
+}
+
+GroupSparseDeconResult SolveGroupSparseDecon(
+    const CoreSeismogram &target, const vector<double> &actual_o_fir,
+    const int actual_o_0, const double lambda, const int max_iterations,
+    const double tolerance, const double active_threshold,
+    const double active_threshold_scale, const double active_threshold_quantile,
+    const string &caller) {
+  if (target.dead() || target.npts() <= 0)
+    throw MsPASSError(caller + ": target data are dead or empty",
+                      ErrorSeverity::Invalid);
+  if (actual_o_fir.empty())
+    throw MsPASSError(caller + ": actual output FIR kernel is empty",
+                      ErrorSeverity::Invalid);
+  if (!isfinite(lambda) || lambda < 0.0)
+    throw MsPASSError(caller + ": group_sparse_lambda must be nonnegative",
+                      ErrorSeverity::Fatal);
+  ValidatePositiveInteger(max_iterations, "group_sparse_max_iterations",
+                          caller);
+  ValidatePositive(tolerance, "group_sparse_tolerance", caller);
+  ValidateNonnegative(active_threshold, "group_sparse_active_threshold",
+                      caller);
+  ValidateNonnegative(active_threshold_scale,
+                      "group_sparse_active_threshold_scale", caller);
+  ValidateProbability(active_threshold_quantile,
+                      "group_sparse_active_threshold_quantile", caller);
+
+  const int npts = static_cast<int>(target.npts());
+  const int ncoef = 3 * npts;
+  const auto index = [npts](const int component, const int sample) {
+    return component * npts + sample;
+  };
+
+  vector<char> valid(npts, false);
+  for (int j = 0; j < npts; ++j) {
+    const int col0 = j - actual_o_0;
+    valid[j] = (col0 >= 0) &&
+               ((col0 + static_cast<int>(actual_o_fir.size())) <= npts);
+  }
+
+  double sumabs(0.0);
+  for (auto x : actual_o_fir)
+    sumabs += fabs(x);
+  const double lipschitz = max(1.0e-12, sumabs * sumabs);
+  const double step = 1.0 / lipschitz;
+
+  vector<double> target_vec(ncoef, 0.0), x(ncoef, 0.0), xnew(ncoef, 0.0),
+      model(ncoef, 0.0), residual(ncoef, 0.0), gradient(ncoef, 0.0);
+  for (int k = 0; k < 3; ++k) {
+    for (int j = 0; j < npts; ++j)
+      target_vec[index(k, j)] = target.u(k, j);
+  }
+
+  auto build_model = [&](const vector<double> &coef) {
+    fill(model.begin(), model.end(), 0.0);
+    for (int j = 0; j < npts; ++j) {
+      if (!valid[j])
+        continue;
+      const int col0 = j - actual_o_0;
+      for (int p = 0; p < static_cast<int>(actual_o_fir.size()); ++p) {
+        const int sample = col0 + p;
+        const double h = actual_o_fir[p];
+        for (int k = 0; k < 3; ++k)
+          model[index(k, sample)] += h * coef[index(k, j)];
+      }
+    }
+    for (int i = 0; i < ncoef; ++i)
+      residual[i] = model[i] - target_vec[i];
+  };
+
+  auto objective = [&](const vector<double> &coef) {
+    double rss(0.0), penalty(0.0);
+    for (auto e : residual)
+      rss += e * e;
+    for (int j = 0; j < npts; ++j) {
+      const double nrm = sqrt(coef[index(0, j)] * coef[index(0, j)] +
+                              coef[index(1, j)] * coef[index(1, j)] +
+                              coef[index(2, j)] * coef[index(2, j)]);
+      penalty += nrm;
+    }
+    return 0.5 * rss + lambda * penalty;
+  };
+
+  GroupSparseDeconResult result;
+  result.lambda = lambda;
+  result.active_threshold_floor = active_threshold;
+  result.active_threshold_scale = active_threshold_scale;
+  result.active_threshold_quantile = active_threshold_quantile;
+  build_model(x);
+  result.objective_initial = objective(x);
+  double prev_objective = result.objective_initial;
+  for (int iter = 1; iter <= max_iterations; ++iter) {
+    fill(gradient.begin(), gradient.end(), 0.0);
+    for (int j = 0; j < npts; ++j) {
+      if (!valid[j])
+        continue;
+      const int col0 = j - actual_o_0;
+      for (int p = 0; p < static_cast<int>(actual_o_fir.size()); ++p) {
+        const int sample = col0 + p;
+        const double h = actual_o_fir[p];
+        for (int k = 0; k < 3; ++k)
+          gradient[index(k, j)] += h * residual[index(k, sample)];
+      }
+    }
+
+    const double shrink_threshold = lambda * step;
+    fill(xnew.begin(), xnew.end(), 0.0);
+    for (int j = 0; j < npts; ++j) {
+      if (!valid[j])
+        continue;
+      double z[3];
+      double znorm2(0.0);
+      for (int k = 0; k < 3; ++k) {
+        z[k] = x[index(k, j)] - step * gradient[index(k, j)];
+        znorm2 += z[k] * z[k];
+      }
+      const double znorm = sqrt(znorm2);
+      if (znorm <= shrink_threshold || znorm <= 0.0)
+        continue;
+      const double scale = 1.0 - shrink_threshold / znorm;
+      for (int k = 0; k < 3; ++k)
+        xnew[index(k, j)] = scale * z[k];
+    }
+
+    build_model(xnew);
+    const double current_objective = objective(xnew);
+    result.iterations = iter;
+    result.fractional_improvement_final =
+        (prev_objective - current_objective) / max(1.0, prev_objective);
+    x.swap(xnew);
+    if (fabs(prev_objective - current_objective) <=
+        tolerance * max(1.0, prev_objective)) {
+      result.converged = true;
+      prev_objective = current_objective;
+      break;
+    }
+    prev_objective = current_objective;
+  }
+
+  build_model(x);
+  result.objective_final = objective(x);
+  result.residual = CoreSeismogram(target);
+  for (int k = 0; k < 3; ++k) {
+    for (int j = 0; j < npts; ++j)
+      result.residual.u(k, j) = target_vec[index(k, j)] - model[index(k, j)];
+  }
+  vector<double> group_norms;
+  group_norms.reserve(npts);
+  for (int j = 0; j < npts; ++j) {
+    const double nrm = sqrt(x[index(0, j)] * x[index(0, j)] +
+                            x[index(1, j)] * x[index(1, j)] +
+                            x[index(2, j)] * x[index(2, j)]);
+    if (valid[j])
+      group_norms.push_back(nrm);
+  }
+  result.active_threshold_quantile_value =
+      VectorQuantile(group_norms, active_threshold_quantile);
+  result.active_threshold_used =
+      max(active_threshold,
+          active_threshold_scale * result.active_threshold_quantile_value);
+  for (int j = 0; j < npts; ++j) {
+    const double nrm = sqrt(x[index(0, j)] * x[index(0, j)] +
+                            x[index(1, j)] * x[index(1, j)] +
+                            x[index(2, j)] * x[index(2, j)]);
+    if (valid[j] && nrm > result.active_threshold_used) {
+      result.spikes.emplace_back(j, x[index(0, j)], x[index(1, j)],
+                                 x[index(2, j)]);
+      ++result.active_groups;
+    }
+  }
+  return result;
 }
 } // namespace mspass::algorithms::deconvolution

--- a/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
+++ b/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
@@ -4,7 +4,6 @@
 #include "misc/blas.h"
 #include <algorithm>
 #include <boost/any.hpp>
-#include <cctype>
 #include <cmath>
 #include <limits>
 #include <sstream>
@@ -18,102 +17,20 @@ using namespace mspass::seismic;
 using namespace mspass::utility;
 
 namespace {
-string metadata_type_name(const boost::any &val) { return val.type().name(); }
+string metadata_type_name(const boost::any &val) { return demangled_name(val); }
 
-MsPASSError metadata_type_error(const string &function_name, const string &key,
-                                const string &expected,
-                                const boost::any &val) {
+MsPASSError metadata_get_context_error(const string &function_name,
+                                       const string &key,
+                                       const string &expected,
+                                       const MetadataGetError &err) {
   return MsPASSError(function_name + ": Metadata key=" + key + " must be " +
-                        expected + "; actual type=" + metadata_type_name(val),
+                        expected + "; " + string(err.what()),
                     ErrorSeverity::Invalid);
 }
 
-bool any_to_double(const boost::any &val, double &result) {
-  if (val.type() == typeid(double)) {
-    result = boost::any_cast<double>(val);
-    return true;
-  }
-  if (val.type() == typeid(float)) {
-    result = static_cast<double>(boost::any_cast<float>(val));
-    return true;
-  }
-  if (val.type() == typeid(int)) {
-    result = static_cast<double>(boost::any_cast<int>(val));
-    return true;
-  }
-  if (val.type() == typeid(long)) {
-    result = static_cast<double>(boost::any_cast<long>(val));
-    return true;
-  }
-  if (val.type() == typeid(long long)) {
-    result = static_cast<double>(boost::any_cast<long long>(val));
-    return true;
-  }
-  return false;
-}
-
-bool double_is_integer_valued(const double value) {
-  return isfinite(value) && floor(value) == value;
-}
-
-bool any_to_long(const boost::any &val, long &result) {
-  if (val.type() == typeid(int)) {
-    result = static_cast<long>(boost::any_cast<int>(val));
-    return true;
-  }
-  if (val.type() == typeid(long)) {
-    result = boost::any_cast<long>(val);
-    return true;
-  }
-  if (val.type() == typeid(long long)) {
-    const long long value = boost::any_cast<long long>(val);
-    if (value < static_cast<long long>(numeric_limits<long>::min()) ||
-        value > static_cast<long long>(numeric_limits<long>::max()))
-      return false;
-    result = static_cast<long>(value);
-    return true;
-  }
-  double numeric_value(0.0);
-  if (any_to_double(val, numeric_value) &&
-      double_is_integer_valued(numeric_value) &&
-      numeric_value >= static_cast<double>(numeric_limits<long>::min()) &&
-      numeric_value <= static_cast<double>(numeric_limits<long>::max())) {
-    result = static_cast<long>(numeric_value);
-    return true;
-  }
-  return false;
-}
-
-string lower_ascii(string value) {
-  transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
-    return static_cast<char>(tolower(c));
-  });
-  return value;
-}
-
-bool any_to_bool(const boost::any &val, bool &result) {
-  if (val.type() == typeid(bool)) {
-    result = boost::any_cast<bool>(val);
-    return true;
-  }
-  long integer_value(0);
-  if (any_to_long(val, integer_value) &&
-      (integer_value == 0 || integer_value == 1)) {
-    result = (integer_value == 1);
-    return true;
-  }
-  if (val.type() == typeid(string)) {
-    const string value = lower_ascii(boost::any_cast<string>(val));
-    if (value == "true" || value == "yes" || value == "1") {
-      result = true;
-      return true;
-    }
-    if (value == "false" || value == "no" || value == "0") {
-      result = false;
-      return true;
-    }
-  }
-  return false;
+inline double three_component_norm(const double x0, const double x1,
+                                   const double x2) {
+  return sqrt(x0 * x0 + x1 * x1 + x2 * x2);
 }
 } // namespace
 
@@ -163,11 +80,14 @@ double GetDoubleDefault(const Metadata &md, const string &key,
 }
 
 double GetDoubleRequired(const Metadata &md, const string &key) {
-  boost::any val(md.get_any(key));
-  double result(0.0);
-  if (any_to_double(val, result))
-    return result;
-  throw metadata_type_error("GetDoubleRequired", key, "numeric", val);
+  try {
+    return md.get_double(key);
+  } catch (const MetadataGetError &merr) {
+    if (md.is_defined(key))
+      throw metadata_get_context_error("GetDoubleRequired", key, "numeric",
+                                       merr);
+    throw;
+  }
 }
 
 int GetIntDefault(const Metadata &md, const string &key,
@@ -178,31 +98,35 @@ int GetIntDefault(const Metadata &md, const string &key,
 }
 
 int GetIntRequired(const Metadata &md, const string &key) {
-  boost::any val(md.get_any(key));
-  long result(0);
-  if (any_to_long(val, result) &&
-      result >= static_cast<long>(numeric_limits<int>::min()) &&
-      result <= static_cast<long>(numeric_limits<int>::max()))
-    return static_cast<int>(result);
-  throw metadata_type_error("GetIntRequired", key, "integer-valued", val);
+  try {
+    return md.get_int(key);
+  } catch (const MetadataGetError &merr) {
+    if (md.is_defined(key))
+      throw metadata_get_context_error("GetIntRequired", key, "integer-valued",
+                                       merr);
+    throw;
+  }
 }
 
 long GetLongRequired(const Metadata &md, const string &key) {
-  boost::any val(md.get_any(key));
-  long result(0);
-  if (any_to_long(val, result))
-    return result;
-  throw metadata_type_error("GetLongRequired", key, "integer-valued", val);
+  try {
+    return md.get_long(key);
+  } catch (const MetadataGetError &merr) {
+    if (md.is_defined(key))
+      throw metadata_get_context_error("GetLongRequired", key,
+                                       "integer-valued", merr);
+    throw;
+  }
 }
 
 bool GetBoolDefault(const Metadata &md, const string &key,
                     const bool default_value) {
   if (md.is_defined(key)) {
-    boost::any val(md.get_any(key));
-    bool result(false);
-    if (any_to_bool(val, result))
-      return result;
-    throw metadata_type_error("GetBoolDefault", key, "boolean", val);
+    try {
+      return md.get_bool(key);
+    } catch (const MetadataGetError &merr) {
+      throw metadata_get_context_error("GetBoolDefault", key, "boolean", merr);
+    }
   }
   return default_value;
 }
@@ -259,7 +183,11 @@ void PutPrefixedMetadata(Metadata &target, const Metadata &source,
     else if (val.type() == typeid(string))
       target.put(prefixed_key, boost::any_cast<string>(val));
     else
-      continue;
+      throw MsPASSError("PutPrefixedMetadata: unsupported Metadata type for "
+                        "key=" +
+                            key + " prefixed as " + prefixed_key +
+                            "; actual type=" + metadata_type_name(val),
+                        ErrorSeverity::Invalid);
   }
 }
 
@@ -338,12 +266,10 @@ string AntelopePfToText(const AntelopePf &pf, const int indent) {
 
 vector<double> ThreeCAmplitudes(const dmatrix &d) {
   vector<double> result;
-  result.reserve(d.columns());
-  for (int i = 0; i < d.columns(); ++i) {
-    double amp2(0.0);
-    for (int k = 0; k < 3; ++k)
-      amp2 += d(k, i) * d(k, i);
-    result.push_back(sqrt(amp2));
+  const int ncols = static_cast<int>(d.columns());
+  result.reserve(ncols);
+  for (int i = 0; i < ncols; ++i) {
+    result.push_back(three_component_norm(d(0, i), d(1, i), d(2, i)));
   }
   return result;
 }
@@ -361,8 +287,7 @@ double GroupSparseObjective(const CoreSeismogram &residual,
     }
   }
   for (const auto &spk : spikes) {
-    penalty += sqrt(spk.u[0] * spk.u[0] + spk.u[1] * spk.u[1] +
-                    spk.u[2] * spk.u[2]);
+    penalty += three_component_norm(spk.u[0], spk.u[1], spk.u[2]);
   }
   return 0.5 * rss + lambda * penalty;
 }
@@ -546,12 +471,13 @@ int fwhm_radius(const vector<double> &coherence) {
 double EstimateThreeCColumnAmplitudeRMS(const CoreSeismogram &d) {
   if (d.dead() || d.npts() <= 0)
     return 0.0;
+  const int npts = static_cast<int>(d.npts());
   double sumsq(0.0);
-  for (int i = 0; i < d.npts(); ++i) {
+  for (int i = 0; i < npts; ++i) {
     for (int k = 0; k < 3; ++k)
       sumsq += d.u(k, i) * d.u(k, i);
   }
-  return sqrt(sumsq / static_cast<double>(d.npts()));
+  return sqrt(sumsq / static_cast<double>(npts));
 }
 
 vector<double> BuildGIDLagWeightPenaltyFunctionFromKernel(
@@ -972,8 +898,7 @@ void RefitSpikeAmplitudes(list<ThreeCSpike> &spikes,
       spike_ptrs[i]->u[component] = amps[i];
   }
   for (auto &spk : spikes)
-    spk.amp =
-        sqrt(spk.u[0] * spk.u[0] + spk.u[1] * spk.u[1] + spk.u[2] * spk.u[2]);
+    spk.amp = three_component_norm(spk.u[0], spk.u[1], spk.u[2]);
 }
 
 double VectorQuantile(vector<double> values, const double quantile) {
@@ -1076,9 +1001,7 @@ GroupSparseDeconResult SolveGroupSparseDecon(
     const double *c1 = c0 + npts;
     const double *c2 = c1 + npts;
     for (int j = 0; j < npts; ++j) {
-      const double nrm =
-          sqrt(c0[j] * c0[j] + c1[j] * c1[j] + c2[j] * c2[j]);
-      penalty += nrm;
+      penalty += three_component_norm(c0[j], c1[j], c2[j]);
     }
     return 0.5 * rss + lambda * penalty;
   };
@@ -1156,16 +1079,16 @@ GroupSparseDeconResult SolveGroupSparseDecon(
     prev_objective = current_objective;
   }
 
+  vector<double> xnorm(npts, 0.0);
   vector<double> group_norms;
   group_norms.reserve(npts);
   const double *x0 = x.data();
   const double *x1 = x0 + npts;
   const double *x2 = x1 + npts;
   for (int j = 0; j < npts; ++j) {
-    const double nrm =
-        sqrt(x0[j] * x0[j] + x1[j] * x1[j] + x2[j] * x2[j]);
+    xnorm[j] = three_component_norm(x0[j], x1[j], x2[j]);
     if (valid[j])
-      group_norms.push_back(nrm);
+      group_norms.push_back(xnorm[j]);
   }
   result.active_threshold_quantile_value =
       VectorQuantile(std::move(group_norms), active_threshold_quantile);
@@ -1177,9 +1100,7 @@ GroupSparseDeconResult SolveGroupSparseDecon(
   double *xa1 = xa0 + npts;
   double *xa2 = xa1 + npts;
   for (int j = 0; j < npts; ++j) {
-    const double nrm =
-        sqrt(x0[j] * x0[j] + x1[j] * x1[j] + x2[j] * x2[j]);
-    if (valid[j] && nrm > result.active_threshold_used) {
+    if (valid[j] && xnorm[j] > result.active_threshold_used) {
       result.spikes.emplace_back(j, x0[j], x1[j], x2[j]);
       xa0[j] = x0[j];
       xa1[j] = x1[j];

--- a/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
+++ b/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
@@ -996,7 +996,7 @@ GroupSparseDeconResult SolveGroupSparseDecon(
       group_norms.push_back(nrm);
   }
   result.active_threshold_quantile_value =
-      VectorQuantile(group_norms, active_threshold_quantile);
+      VectorQuantile(std::move(group_norms), active_threshold_quantile);
   result.active_threshold_used =
       max(active_threshold,
           active_threshold_scale * result.active_threshold_quantile_value);

--- a/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
+++ b/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
@@ -36,6 +36,24 @@ IterDeconType ParseGIDDeconType(const Metadata &md, const string &caller) {
                     ErrorSeverity::Fatal);
 }
 
+string GIDDeconTypeName(const IterDeconType type) {
+  switch (type) {
+  case WATER_LEVEL:
+    return "water_level";
+  case LEAST_SQ:
+    return "least_square";
+  case MULTI_TAPER:
+    return "multi_taper";
+  case CNR:
+    return "cnr";
+  case NS_GID:
+    return "ns_gid";
+  case GROUP_SPARSE:
+    return "group_sparse";
+  }
+  return "unknown";
+}
+
 double GetDoubleDefault(const Metadata &md, const string &key,
                         const double default_value) {
   if (md.is_defined(key))

--- a/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
+++ b/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
@@ -56,8 +56,20 @@ string GIDDeconTypeName(const IterDeconType type) {
 
 double GetDoubleDefault(const Metadata &md, const string &key,
                         const double default_value) {
-  if (md.is_defined(key))
-    return md.get_double(key);
+  if (md.is_defined(key)) {
+    boost::any val(md.get_any(key));
+    if (val.type() == typeid(double))
+      return boost::any_cast<double>(val);
+    if (val.type() == typeid(float))
+      return static_cast<double>(boost::any_cast<float>(val));
+    if (val.type() == typeid(int))
+      return static_cast<double>(boost::any_cast<int>(val));
+    if (val.type() == typeid(long))
+      return static_cast<double>(boost::any_cast<long>(val));
+    throw MsPASSError("GetDoubleDefault: Metadata key=" + key +
+                          " must be numeric",
+                      ErrorSeverity::Invalid);
+  }
   return default_value;
 }
 
@@ -888,9 +900,7 @@ GroupSparseDeconResult SolveGroupSparseDecon(
 
   const int npts = static_cast<int>(target.npts());
   const int ncoef = 3 * npts;
-  const auto index = [npts](const int component, const int sample) {
-    return component * npts + sample;
-  };
+  const int nf = static_cast<int>(actual_o_fir.size());
 
   vector<char> valid(npts, false);
   for (int j = 0; j < npts; ++j) {
@@ -907,22 +917,33 @@ GroupSparseDeconResult SolveGroupSparseDecon(
 
   vector<double> target_vec(ncoef, 0.0), x(ncoef, 0.0), xnew(ncoef, 0.0),
       model(ncoef, 0.0), residual(ncoef, 0.0), gradient(ncoef, 0.0);
-  for (int k = 0; k < 3; ++k) {
-    for (int j = 0; j < npts; ++j)
-      target_vec[index(k, j)] = target.u(k, j);
+  for (int j = 0; j < npts; ++j) {
+    target_vec[j] = target.u(0, j);
+    target_vec[npts + j] = target.u(1, j);
+    target_vec[2 * npts + j] = target.u(2, j);
   }
 
   auto build_model = [&](const vector<double> &coef) {
     fill(model.begin(), model.end(), 0.0);
+    const double *c0 = coef.data();
+    const double *c1 = c0 + npts;
+    const double *c2 = c1 + npts;
+    double *m0 = model.data();
+    double *m1 = m0 + npts;
+    double *m2 = m1 + npts;
     for (int j = 0; j < npts; ++j) {
       if (!valid[j])
         continue;
       const int col0 = j - actual_o_0;
-      for (int p = 0; p < static_cast<int>(actual_o_fir.size()); ++p) {
+      const double a0 = c0[j];
+      const double a1 = c1[j];
+      const double a2 = c2[j];
+      for (int p = 0; p < nf; ++p) {
         const int sample = col0 + p;
         const double h = actual_o_fir[p];
-        for (int k = 0; k < 3; ++k)
-          model[index(k, sample)] += h * coef[index(k, j)];
+        m0[sample] += h * a0;
+        m1[sample] += h * a1;
+        m2[sample] += h * a2;
       }
     }
     for (int i = 0; i < ncoef; ++i)
@@ -934,10 +955,12 @@ GroupSparseDeconResult SolveGroupSparseDecon(
     double rss(0.0), penalty(0.0);
     for (auto e : residual)
       rss += e * e;
+    const double *c0 = coef.data();
+    const double *c1 = c0 + npts;
+    const double *c2 = c1 + npts;
     for (int j = 0; j < npts; ++j) {
-      const double nrm = sqrt(coef[index(0, j)] * coef[index(0, j)] +
-                              coef[index(1, j)] * coef[index(1, j)] +
-                              coef[index(2, j)] * coef[index(2, j)]);
+      const double nrm =
+          sqrt(c0[j] * c0[j] + c1[j] * c1[j] + c2[j] * c2[j]);
       penalty += nrm;
     }
     return 0.5 * rss + lambda * penalty;
@@ -952,35 +975,54 @@ GroupSparseDeconResult SolveGroupSparseDecon(
   double prev_objective = result.objective_initial;
   for (int iter = 1; iter <= max_iterations; ++iter) {
     fill(gradient.begin(), gradient.end(), 0.0);
+    double *g0 = gradient.data();
+    double *g1 = g0 + npts;
+    double *g2 = g1 + npts;
+    const double *r0 = residual.data();
+    const double *r1 = r0 + npts;
+    const double *r2 = r1 + npts;
     for (int j = 0; j < npts; ++j) {
       if (!valid[j])
         continue;
       const int col0 = j - actual_o_0;
-      for (int p = 0; p < static_cast<int>(actual_o_fir.size()); ++p) {
+      double sum0(0.0), sum1(0.0), sum2(0.0);
+      for (int p = 0; p < nf; ++p) {
         const int sample = col0 + p;
         const double h = actual_o_fir[p];
-        for (int k = 0; k < 3; ++k)
-          gradient[index(k, j)] += h * residual[index(k, sample)];
+        sum0 += h * r0[sample];
+        sum1 += h * r1[sample];
+        sum2 += h * r2[sample];
       }
+      g0[j] = sum0;
+      g1[j] = sum1;
+      g2[j] = sum2;
     }
 
     const double shrink_threshold = lambda * step;
     fill(xnew.begin(), xnew.end(), 0.0);
+    const double *x0 = x.data();
+    const double *x1 = x0 + npts;
+    const double *x2 = x1 + npts;
+    const double *grad0 = gradient.data();
+    const double *grad1 = grad0 + npts;
+    const double *grad2 = grad1 + npts;
+    double *xn0 = xnew.data();
+    double *xn1 = xn0 + npts;
+    double *xn2 = xn1 + npts;
     for (int j = 0; j < npts; ++j) {
       if (!valid[j])
         continue;
-      double z[3];
-      double znorm2(0.0);
-      for (int k = 0; k < 3; ++k) {
-        z[k] = x[index(k, j)] - step * gradient[index(k, j)];
-        znorm2 += z[k] * z[k];
-      }
+      const double z0 = x0[j] - step * grad0[j];
+      const double z1 = x1[j] - step * grad1[j];
+      const double z2 = x2[j] - step * grad2[j];
+      const double znorm2 = z0 * z0 + z1 * z1 + z2 * z2;
       const double znorm = sqrt(znorm2);
       if (znorm <= shrink_threshold || znorm <= 0.0)
         continue;
       const double scale = 1.0 - shrink_threshold / znorm;
-      for (int k = 0; k < 3; ++k)
-        xnew[index(k, j)] = scale * z[k];
+      xn0[j] = scale * z0;
+      xn1[j] = scale * z1;
+      xn2[j] = scale * z2;
     }
 
     const double current_objective = objective(xnew);
@@ -999,10 +1041,12 @@ GroupSparseDeconResult SolveGroupSparseDecon(
 
   vector<double> group_norms;
   group_norms.reserve(npts);
+  const double *x0 = x.data();
+  const double *x1 = x0 + npts;
+  const double *x2 = x1 + npts;
   for (int j = 0; j < npts; ++j) {
-    const double nrm = sqrt(x[index(0, j)] * x[index(0, j)] +
-                            x[index(1, j)] * x[index(1, j)] +
-                            x[index(2, j)] * x[index(2, j)]);
+    const double nrm =
+        sqrt(x0[j] * x0[j] + x1[j] * x1[j] + x2[j] * x2[j]);
     if (valid[j])
       group_norms.push_back(nrm);
   }
@@ -1012,15 +1056,17 @@ GroupSparseDeconResult SolveGroupSparseDecon(
       max(active_threshold,
           active_threshold_scale * result.active_threshold_quantile_value);
   vector<double> xactive(ncoef, 0.0);
+  double *xa0 = xactive.data();
+  double *xa1 = xa0 + npts;
+  double *xa2 = xa1 + npts;
   for (int j = 0; j < npts; ++j) {
-    const double nrm = sqrt(x[index(0, j)] * x[index(0, j)] +
-                            x[index(1, j)] * x[index(1, j)] +
-                            x[index(2, j)] * x[index(2, j)]);
+    const double nrm =
+        sqrt(x0[j] * x0[j] + x1[j] * x1[j] + x2[j] * x2[j]);
     if (valid[j] && nrm > result.active_threshold_used) {
-      result.spikes.emplace_back(j, x[index(0, j)], x[index(1, j)],
-                                 x[index(2, j)]);
-      for (int k = 0; k < 3; ++k)
-        xactive[index(k, j)] = x[index(k, j)];
+      result.spikes.emplace_back(j, x0[j], x1[j], x2[j]);
+      xa0[j] = x0[j];
+      xa1[j] = x1[j];
+      xa2[j] = x2[j];
       ++result.active_groups;
     }
   }
@@ -1029,9 +1075,13 @@ GroupSparseDeconResult SolveGroupSparseDecon(
       (result.objective_initial - result.objective_final) /
       max(1.0, result.objective_initial);
   result.residual = CoreSeismogram(target);
-  for (int k = 0; k < 3; ++k) {
-    for (int j = 0; j < npts; ++j)
-      result.residual.u(k, j) = target_vec[index(k, j)] - model[index(k, j)];
+  const double *m0 = model.data();
+  const double *m1 = m0 + npts;
+  const double *m2 = m1 + npts;
+  for (int j = 0; j < npts; ++j) {
+    result.residual.u(0, j) = target_vec[j] - m0[j];
+    result.residual.u(1, j) = target_vec[npts + j] - m1[j];
+    result.residual.u(2, j) = target_vec[2 * npts + j] - m2[j];
   }
   return result;
 }

--- a/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
+++ b/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
@@ -4,6 +4,7 @@
 #include "misc/blas.h"
 #include <algorithm>
 #include <boost/any.hpp>
+#include <cctype>
 #include <cmath>
 #include <limits>
 #include <sstream>
@@ -15,6 +16,106 @@ using namespace std;
 using namespace mspass::algorithms;
 using namespace mspass::seismic;
 using namespace mspass::utility;
+
+namespace {
+string metadata_type_name(const boost::any &val) { return val.type().name(); }
+
+MsPASSError metadata_type_error(const string &function_name, const string &key,
+                                const string &expected,
+                                const boost::any &val) {
+  return MsPASSError(function_name + ": Metadata key=" + key + " must be " +
+                        expected + "; actual type=" + metadata_type_name(val),
+                    ErrorSeverity::Invalid);
+}
+
+bool any_to_double(const boost::any &val, double &result) {
+  if (val.type() == typeid(double)) {
+    result = boost::any_cast<double>(val);
+    return true;
+  }
+  if (val.type() == typeid(float)) {
+    result = static_cast<double>(boost::any_cast<float>(val));
+    return true;
+  }
+  if (val.type() == typeid(int)) {
+    result = static_cast<double>(boost::any_cast<int>(val));
+    return true;
+  }
+  if (val.type() == typeid(long)) {
+    result = static_cast<double>(boost::any_cast<long>(val));
+    return true;
+  }
+  if (val.type() == typeid(long long)) {
+    result = static_cast<double>(boost::any_cast<long long>(val));
+    return true;
+  }
+  return false;
+}
+
+bool double_is_integer_valued(const double value) {
+  return isfinite(value) && floor(value) == value;
+}
+
+bool any_to_long(const boost::any &val, long &result) {
+  if (val.type() == typeid(int)) {
+    result = static_cast<long>(boost::any_cast<int>(val));
+    return true;
+  }
+  if (val.type() == typeid(long)) {
+    result = boost::any_cast<long>(val);
+    return true;
+  }
+  if (val.type() == typeid(long long)) {
+    const long long value = boost::any_cast<long long>(val);
+    if (value < static_cast<long long>(numeric_limits<long>::min()) ||
+        value > static_cast<long long>(numeric_limits<long>::max()))
+      return false;
+    result = static_cast<long>(value);
+    return true;
+  }
+  double numeric_value(0.0);
+  if (any_to_double(val, numeric_value) &&
+      double_is_integer_valued(numeric_value) &&
+      numeric_value >= static_cast<double>(numeric_limits<long>::min()) &&
+      numeric_value <= static_cast<double>(numeric_limits<long>::max())) {
+    result = static_cast<long>(numeric_value);
+    return true;
+  }
+  return false;
+}
+
+string lower_ascii(string value) {
+  transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+    return static_cast<char>(tolower(c));
+  });
+  return value;
+}
+
+bool any_to_bool(const boost::any &val, bool &result) {
+  if (val.type() == typeid(bool)) {
+    result = boost::any_cast<bool>(val);
+    return true;
+  }
+  long integer_value(0);
+  if (any_to_long(val, integer_value) &&
+      (integer_value == 0 || integer_value == 1)) {
+    result = (integer_value == 1);
+    return true;
+  }
+  if (val.type() == typeid(string)) {
+    const string value = lower_ascii(boost::any_cast<string>(val));
+    if (value == "true" || value == "yes" || value == "1") {
+      result = true;
+      return true;
+    }
+    if (value == "false" || value == "no" || value == "0") {
+      result = false;
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace
 
 IterDeconType ParseGIDDeconType(const Metadata &md, const string &caller) {
   string sval = md.get_string("deconvolution_type");
@@ -56,34 +157,53 @@ string GIDDeconTypeName(const IterDeconType type) {
 
 double GetDoubleDefault(const Metadata &md, const string &key,
                         const double default_value) {
-  if (md.is_defined(key)) {
-    boost::any val(md.get_any(key));
-    if (val.type() == typeid(double))
-      return boost::any_cast<double>(val);
-    if (val.type() == typeid(float))
-      return static_cast<double>(boost::any_cast<float>(val));
-    if (val.type() == typeid(int))
-      return static_cast<double>(boost::any_cast<int>(val));
-    if (val.type() == typeid(long))
-      return static_cast<double>(boost::any_cast<long>(val));
-    throw MsPASSError("GetDoubleDefault: Metadata key=" + key +
-                          " must be numeric",
-                      ErrorSeverity::Invalid);
-  }
+  if (md.is_defined(key))
+    return GetDoubleRequired(md, key);
   return default_value;
+}
+
+double GetDoubleRequired(const Metadata &md, const string &key) {
+  boost::any val(md.get_any(key));
+  double result(0.0);
+  if (any_to_double(val, result))
+    return result;
+  throw metadata_type_error("GetDoubleRequired", key, "numeric", val);
 }
 
 int GetIntDefault(const Metadata &md, const string &key,
                   const int default_value) {
   if (md.is_defined(key))
-    return md.get_int(key);
+    return GetIntRequired(md, key);
   return default_value;
+}
+
+int GetIntRequired(const Metadata &md, const string &key) {
+  boost::any val(md.get_any(key));
+  long result(0);
+  if (any_to_long(val, result) &&
+      result >= static_cast<long>(numeric_limits<int>::min()) &&
+      result <= static_cast<long>(numeric_limits<int>::max()))
+    return static_cast<int>(result);
+  throw metadata_type_error("GetIntRequired", key, "integer-valued", val);
+}
+
+long GetLongRequired(const Metadata &md, const string &key) {
+  boost::any val(md.get_any(key));
+  long result(0);
+  if (any_to_long(val, result))
+    return result;
+  throw metadata_type_error("GetLongRequired", key, "integer-valued", val);
 }
 
 bool GetBoolDefault(const Metadata &md, const string &key,
                     const bool default_value) {
-  if (md.is_defined(key))
-    return md.get_bool(key);
+  if (md.is_defined(key)) {
+    boost::any val(md.get_any(key));
+    bool result(false);
+    if (any_to_bool(val, result))
+      return result;
+    throw metadata_type_error("GetBoolDefault", key, "boolean", val);
+  }
   return default_value;
 }
 
@@ -139,10 +259,7 @@ void PutPrefixedMetadata(Metadata &target, const Metadata &source,
     else if (val.type() == typeid(string))
       target.put(prefixed_key, boost::any_cast<string>(val));
     else
-      throw MsPASSError("PutPrefixedMetadata: unsupported Metadata type for "
-                            "key=" +
-                            key,
-                        ErrorSeverity::Invalid);
+      continue;
   }
 }
 
@@ -254,8 +371,8 @@ void ValidateGIDLeafWindow(const AntelopePf &mdleaf,
                            const TimeWindow &fftwin,
                            const string &leaf_name,
                            const string &base_error) {
-  const double ts = mdleaf.get<double>("deconvolution_data_window_start");
-  const double te = mdleaf.get<double>("deconvolution_data_window_end");
+  const double ts = GetDoubleRequired(mdleaf, "deconvolution_data_window_start");
+  const double te = GetDoubleRequired(mdleaf, "deconvolution_data_window_end");
   if ((ts != fftwin.start) || (te != fftwin.end)) {
     stringstream ss;
     ss << base_error << leaf_name
@@ -325,21 +442,21 @@ void ValidateGIDLeafOperatorMetadata(const Metadata &md,
     }
   }
   if (md.is_defined("deconvolution_data_window_start")) {
-    const double ts = md.get_double("deconvolution_data_window_start");
+    const double ts = GetDoubleRequired(md, "deconvolution_data_window_start");
     if (fabs(ts - fftwin.start) > 1.0e-10)
       throw MsPASSError(caller + ": leaf deconvolution_data_window_start does "
                                  "not match the GID deconvolution window",
                         ErrorSeverity::Fatal);
   }
   if (md.is_defined("deconvolution_data_window_end")) {
-    const double te = md.get_double("deconvolution_data_window_end");
+    const double te = GetDoubleRequired(md, "deconvolution_data_window_end");
     if (fabs(te - fftwin.end) > 1.0e-10)
       throw MsPASSError(caller + ": leaf deconvolution_data_window_end does "
                                  "not match the GID deconvolution window",
                         ErrorSeverity::Fatal);
   }
   if (md.is_defined("target_sample_interval")) {
-    const double dt = md.get_double("target_sample_interval");
+    const double dt = GetDoubleRequired(md, "target_sample_interval");
     if (fabs(dt - target_dt) >
         1.0e-6 * max(1.0, max(fabs(dt), fabs(target_dt))))
       throw MsPASSError(caller + ": leaf target_sample_interval does not "
@@ -347,7 +464,7 @@ void ValidateGIDLeafOperatorMetadata(const Metadata &md,
                         ErrorSeverity::Fatal);
   }
   if (md.is_defined("shaping_wavelet_dt")) {
-    const double dt = md.get_double("shaping_wavelet_dt");
+    const double dt = GetDoubleRequired(md, "shaping_wavelet_dt");
     if (fabs(dt - target_dt) >
         1.0e-6 * max(1.0, max(fabs(dt), fabs(target_dt))))
       throw MsPASSError(caller + ": leaf shaping_wavelet_dt does not match "
@@ -655,7 +772,7 @@ vector<double> BuildGIDLagWeightPenaltyFunction(const Metadata &md,
 
   const double penalty_scale =
       md.is_defined("lag_weight_penalty_scale_factor")
-          ? md.get<double>("lag_weight_penalty_scale_factor")
+          ? GetDoubleRequired(md, "lag_weight_penalty_scale_factor")
           : 1.0;
   if (!std::isfinite(penalty_scale) || penalty_scale <= 0.0 ||
       penalty_scale > 1.0)
@@ -668,7 +785,7 @@ vector<double> BuildGIDLagWeightPenaltyFunction(const Metadata &md,
                           "missing required parameter "
                           "lag_weight_function_width",
                       ErrorSeverity::Fatal);
-  int npenalty = md.get<int>("lag_weight_function_width");
+  int npenalty = GetIntRequired(md, "lag_weight_function_width");
   if (npenalty <= 0)
     throw MsPASSError(base_error + "lag_weight_function_width must be positive",
                       ErrorSeverity::Fatal);

--- a/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
+++ b/cxx/src/lib/algorithms/deconvolution/GIDDeconUtil.cc
@@ -219,6 +219,25 @@ vector<double> ThreeCAmplitudes(const dmatrix &d) {
   return result;
 }
 
+double GroupSparseObjective(const CoreSeismogram &residual,
+                            const list<ThreeCSpike> &spikes,
+                            const double lambda) {
+  double rss(0.0), penalty(0.0);
+  const int nrows = static_cast<int>(residual.u.rows());
+  const int ncols = static_cast<int>(residual.u.columns());
+  for (int k = 0; k < nrows; ++k) {
+    for (int j = 0; j < ncols; ++j) {
+      const double e = residual.u(k, j);
+      rss += e * e;
+    }
+  }
+  for (const auto &spk : spikes) {
+    penalty += sqrt(spk.u[0] * spk.u[0] + spk.u[1] * spk.u[1] +
+                    spk.u[2] * spk.u[2]);
+  }
+  return 0.5 * rss + lambda * penalty;
+}
+
 void ValidateGIDLeafWindow(const AntelopePf &mdleaf,
                            const TimeWindow &fftwin,
                            const string &leaf_name,
@@ -911,6 +930,7 @@ GroupSparseDeconResult SolveGroupSparseDecon(
   };
 
   auto objective = [&](const vector<double> &coef) {
+    build_model(coef);
     double rss(0.0), penalty(0.0);
     for (auto e : residual)
       rss += e * e;
@@ -928,7 +948,6 @@ GroupSparseDeconResult SolveGroupSparseDecon(
   result.active_threshold_floor = active_threshold;
   result.active_threshold_scale = active_threshold_scale;
   result.active_threshold_quantile = active_threshold_quantile;
-  build_model(x);
   result.objective_initial = objective(x);
   double prev_objective = result.objective_initial;
   for (int iter = 1; iter <= max_iterations; ++iter) {
@@ -964,7 +983,6 @@ GroupSparseDeconResult SolveGroupSparseDecon(
         xnew[index(k, j)] = scale * z[k];
     }
 
-    build_model(xnew);
     const double current_objective = objective(xnew);
     result.iterations = iter;
     result.fractional_improvement_final =
@@ -979,13 +997,6 @@ GroupSparseDeconResult SolveGroupSparseDecon(
     prev_objective = current_objective;
   }
 
-  build_model(x);
-  result.objective_final = objective(x);
-  result.residual = CoreSeismogram(target);
-  for (int k = 0; k < 3; ++k) {
-    for (int j = 0; j < npts; ++j)
-      result.residual.u(k, j) = target_vec[index(k, j)] - model[index(k, j)];
-  }
   vector<double> group_norms;
   group_norms.reserve(npts);
   for (int j = 0; j < npts; ++j) {
@@ -1000,6 +1011,7 @@ GroupSparseDeconResult SolveGroupSparseDecon(
   result.active_threshold_used =
       max(active_threshold,
           active_threshold_scale * result.active_threshold_quantile_value);
+  vector<double> xactive(ncoef, 0.0);
   for (int j = 0; j < npts; ++j) {
     const double nrm = sqrt(x[index(0, j)] * x[index(0, j)] +
                             x[index(1, j)] * x[index(1, j)] +
@@ -1007,8 +1019,19 @@ GroupSparseDeconResult SolveGroupSparseDecon(
     if (valid[j] && nrm > result.active_threshold_used) {
       result.spikes.emplace_back(j, x[index(0, j)], x[index(1, j)],
                                  x[index(2, j)]);
+      for (int k = 0; k < 3; ++k)
+        xactive[index(k, j)] = x[index(k, j)];
       ++result.active_groups;
     }
+  }
+  result.objective_final = objective(xactive);
+  result.fractional_improvement_final =
+      (result.objective_initial - result.objective_final) /
+      max(1.0, result.objective_initial);
+  result.residual = CoreSeismogram(target);
+  for (int k = 0; k < 3; ++k) {
+    for (int j = 0; j < npts; ++j)
+      result.residual.u(k, j) = target_vec[index(k, j)] - model[index(k, j)];
   }
   return result;
 }

--- a/cxx/src/lib/algorithms/deconvolution/LeastSquareDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/LeastSquareDecon.cc
@@ -1,5 +1,6 @@
 #include "mspass/algorithms/deconvolution/LeastSquareDecon.h"
 #include "mspass/algorithms/amplitudes.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/algorithms/deconvolution/MultiTaperXcorDecon.h"
 #include "mspass/utility/MsPASSError.h"
 namespace mspass::algorithms::deconvolution {
@@ -17,7 +18,7 @@ int LeastSquareDecon::read_metadata(const Metadata &md) {
     const string base_error("LeastSquareDecon::read_metadata method: ");
     const int nfft_from_win = ComputeFFTLength(md);
     const int new_sample_shift = ComputeDeconSampleShift(md);
-    const double new_damp = md.get_double("damping_factor");
+    const double new_damp = GetDoubleRequired(md, "damping_factor");
     if (new_damp <= 0.0) {
       throw MsPASSError(base_error +
                             "damping_factor must be positive.  A zero value "

--- a/cxx/src/lib/algorithms/deconvolution/MultiTaperSpecDivDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/MultiTaperSpecDivDecon.cc
@@ -1,5 +1,6 @@
 #include "mspass/algorithms/deconvolution/MultiTaperSpecDivDecon.h"
 #include "mspass/algorithms/amplitudes.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/algorithms/deconvolution/dpss.h"
 #include "mspass/utility/Metadata.h"
 #include "mspass/utility/MsPASSError.h"
@@ -71,19 +72,19 @@ int MultiTaperSpecDivDecon::read_metadata(const Metadata &md, bool refresh) {
       throw MsPASSError(base_error +
                             "computed sample_shift exceeds length of fft",
                         ErrorSeverity::Fatal);
-    damp = md.get_double("damping_factor");
+    damp = GetDoubleRequired(md, "damping_factor");
     if (damp <= 0.0) {
       throw MsPASSError(base_error +
                             "damping_factor must be positive to regularize "
                             "multitaper spectral division.",
                         ErrorSeverity::Fatal);
     }
-    nw = md.get_double("time_bandwidth_product");
+    nw = GetDoubleRequired(md, "time_bandwidth_product");
     /* Wang originally had this as nw*2-2 but Park and Levin say
     the maximum is nw*2-1 which we use here.  P&L papers all use mw=2.5
     with K(seql here) of 3 */
     // seql=md.get_int("lower_dpss");
-    nseq = md.get_int("number_tapers");
+    nseq = GetIntRequired(md, "number_tapers");
     int nseqtest = static_cast<int>(2.0 * nw);
     if (nseq > nseqtest || (nseq < 1)) {
       throw MsPASSError(base_error +

--- a/cxx/src/lib/algorithms/deconvolution/MultiTaperXcorDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/MultiTaperXcorDecon.cc
@@ -1,5 +1,6 @@
 #include "mspass/algorithms/deconvolution/MultiTaperXcorDecon.h"
 #include "mspass/algorithms/amplitudes.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/algorithms/deconvolution/common_multitaper.h"
 #include "mspass/algorithms/deconvolution/dpss.h"
 #include "mspass/seismic/CoreTimeSeries.h"
@@ -70,19 +71,19 @@ int MultiTaperXcorDecon::read_metadata(const Metadata &md, bool refresh) {
       throw MsPASSError(base_error +
                             "computed sample_shift exceeds length of fft",
                         ErrorSeverity::Fatal);
-    damp = md.get_double("damping_factor");
+    damp = GetDoubleRequired(md, "damping_factor");
     if (damp <= 0.0) {
       throw MsPASSError(base_error +
                             "damping_factor must be positive to regularize "
                             "multitaper spectral division.",
                         ErrorSeverity::Fatal);
     }
-    nw = md.get_double("time_bandwidth_product");
+    nw = GetDoubleRequired(md, "time_bandwidth_product");
     /* Wang originally had this as nw*2-2 but Park and Levin say
     the maximum is nw*2-1 which we use here.  P&L papers all use mw=2.5
     with K(seql here) of 3 */
     // seql=md.get_int("lower_dpss");
-    nseq = md.get_int("number_tapers");
+    nseq = GetIntRequired(md, "number_tapers");
     int nseqtest = static_cast<int>(2.0 * nw);
     if (nseq > nseqtest || (nseq < 1)) {
       throw MsPASSError(base_error +

--- a/cxx/src/lib/algorithms/deconvolution/NoiseStableDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/NoiseStableDecon.cc
@@ -1,5 +1,6 @@
 #include "mspass/algorithms/deconvolution/NoiseStableDecon.h"
 #include "mspass/algorithms/amplitudes.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/utility/MsPASSError.h"
 #include <algorithm>
 #include <cmath>
@@ -14,13 +15,13 @@ namespace {
 double get_double_default(const Metadata &md, const string &key,
                           const double default_value) {
   if (md.is_defined(key))
-    return md.get_double(key);
+    return GetDoubleRequired(md, key);
   return default_value;
 }
 bool get_bool_default(const Metadata &md, const string &key,
                       const bool default_value) {
   if (md.is_defined(key))
-    return md.get_bool(key);
+    return GetBoolDefault(md, key, default_value);
   return default_value;
 }
 double folded_frequency(const int k, const int nfft, const double dt) {

--- a/cxx/src/lib/algorithms/deconvolution/ScalarDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/ScalarDecon.cc
@@ -1,4 +1,5 @@
 #include "mspass/algorithms/deconvolution/ScalarDecon.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 namespace mspass::algorithms::deconvolution {
 using namespace std;
 using namespace mspass::utility;
@@ -7,7 +8,7 @@ ScalarDecon::ScalarDecon(const Metadata &md) : shapingwavelet(md) {
   try {
     /* This has to be defined or the shapingwavlet constructor will
      * fail in the current implementation */
-    int nfft = md.get_int("operator_nfft");
+    int nfft = GetIntRequired(md, "operator_nfft");
     wavelet.reserve(nfft);
     data.reserve(nfft);
     result.reserve(nfft);

--- a/cxx/src/lib/algorithms/deconvolution/ShapingWavelet.cc
+++ b/cxx/src/lib/algorithms/deconvolution/ShapingWavelet.cc
@@ -3,6 +3,7 @@
 #include "mspass/algorithms/Butterworth.h"
 #include "mspass/algorithms/amplitudes.h"
 #include "mspass/algorithms/deconvolution/FFTDeconOperator.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/algorithms/deconvolution/wavelet.h"
 #include "mspass/seismic/CoreTimeSeries.h"
 #include "mspass/utility/MsPASSError.h"
@@ -26,7 +27,7 @@ ShapingWavelet::ShapingWavelet(const Metadata &md, int nfftin) {
       this->nfft = nfftin;
     else {
       try {
-        nfft = md.get_int("operator_nfft");
+        nfft = GetIntRequired(md, "operator_nfft");
       } catch (MetadataGetError &mderr) {
         throw MsPASSError(base_error +
                               "Called constructor with nfft=0 but parameter "
@@ -43,10 +44,10 @@ ShapingWavelet::ShapingWavelet(const Metadata &md, int nfftin) {
     workspace = gsl_fft_complex_workspace_alloc(nfft);
     string wavelettype = md.get_string("shaping_wavelet_type");
     wavelet_name = wavelettype;
-    dt = md.get_double("shaping_wavelet_dt");
+    dt = GetDoubleRequired(md, "shaping_wavelet_dt");
     double *r;
     if (wavelettype == "gaussian") {
-      float fpeak = md.get_double("shaping_wavelet_frequency");
+      float fpeak = GetDoubleRequired(md, "shaping_wavelet_frequency");
       // construct wavelet and fft
       r = gaussian(fpeak, (float)dt, nfft);
       w = ComplexArray(nfft, r);
@@ -58,7 +59,8 @@ ShapingWavelet::ShapingWavelet(const Metadata &md, int nfftin) {
     them in this class because these forms are needed by the family of
     scalar deconvolution algorithms */
     else if (wavelettype == "ricker") {
-      float fpeak = (float)md.get_double("shaping_wavelet_frequency");
+      float fpeak =
+          static_cast<float>(GetDoubleRequired(md, "shaping_wavelet_frequency"));
       // construct wavelet and fft
       r = rickerwavelet(fpeak, (float)dt, nfft);
       // DEBUG
@@ -69,11 +71,11 @@ ShapingWavelet::ShapingWavelet(const Metadata &md, int nfftin) {
       delete[] r;
     } else if (wavelettype == "butterworth") {
       double f3db_lo, f3db_hi;
-      f3db_lo = md.get_double("f3db_lo");
-      f3db_hi = md.get_double("f3db_hi");
+      f3db_lo = GetDoubleRequired(md, "f3db_lo");
+      f3db_hi = GetDoubleRequired(md, "f3db_hi");
       int npoles_lo, npoles_hi;
-      npoles_lo = md.get_int("npoles_lo");
-      npoles_hi = md.get_int("npoles_hi");
+      npoles_lo = GetIntRequired(md, "npoles_lo");
+      npoles_hi = GetIntRequired(md, "npoles_hi");
       Butterworth bwf(true, true, true, npoles_lo, f3db_lo, npoles_hi, f3db_hi,
                       this->dt);
       w = bwf.transfer_function(this->nfft);
@@ -106,8 +108,9 @@ ShapingWavelet::ShapingWavelet(const Metadata &md, int nfftin) {
     }
     */
     else if ((wavelettype == "slepian") || (wavelettype == "Slepian")) {
-      double tbp = md.get_double("time_bandwidth_product");
-      double target_pulse_width = md.get_double("target_pulse_width");
+      double tbp = GetDoubleRequired(md, "time_bandwidth_product");
+      double target_pulse_width =
+          GetDoubleRequired(md, "target_pulse_width");
       /* Sanity check on pulse width */
       if (target_pulse_width > (nfft / 4) || (target_pulse_width < tbp)) {
         stringstream ss;

--- a/cxx/src/lib/algorithms/deconvolution/ThreeCSpike.cc
+++ b/cxx/src/lib/algorithms/deconvolution/ThreeCSpike.cc
@@ -17,6 +17,14 @@ ThreeCSpike::ThreeCSpike(dmatrix &d, int k) {
     throw;
   };
 }
+ThreeCSpike::ThreeCSpike(int k, const double u0, const double u1,
+                         const double u2) {
+  col = k;
+  u[0] = u0;
+  u[1] = u1;
+  u[2] = u2;
+  amp = sqrt(u0 * u0 + u1 * u1 + u2 * u2);
+}
 ThreeCSpike::ThreeCSpike(const ThreeCSpike &parent) {
   col = parent.col;
   amp = parent.amp;

--- a/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
@@ -148,6 +148,12 @@ TimeDomainGIDDecon::TimeDomainGIDDecon(const AntelopePf &mdtoplevel)
       ValidateGIDLeafWindow(mdleaf, fftwin, "CNR", base_error);
       cnrprocessor = std::make_unique<CNRDeconEngine>(mdleaf);
       break;
+    case GROUP_SPARSE:
+      mdleaf = md.get_branch("ns_gid");
+      ValidateGIDLeafWindow(mdleaf, fftwin, "group sparse NS-GID inverse",
+                            base_error);
+      preprocessor = std::make_unique<NoiseStableDecon>(mdleaf);
+      break;
     case NS_GID:
     default:
       mdleaf = md.get_branch("ns_gid");
@@ -200,6 +206,32 @@ TimeDomainGIDDecon::TimeDomainGIDDecon(const AntelopePf &mdtoplevel)
     ValidateNonnegative(ns_ridge_beta, "ns_gid_ridge_beta", base_error);
     external_wavelet_allowed = GetBoolDefault(
         mdgiter, "ns_gid_external_wavelet_allowed", true);
+    group_sparse_lambda = GetDoubleDefault(mdgiter, "group_sparse_lambda", 0.0);
+    ValidateNonnegative(group_sparse_lambda, "group_sparse_lambda", base_error);
+    group_sparse_lambda_scale =
+        GetDoubleDefault(mdgiter, "group_sparse_lambda_scale", 1.0);
+    ValidateNonnegative(group_sparse_lambda_scale,
+                        "group_sparse_lambda_scale", base_error);
+    group_sparse_tolerance =
+        GetDoubleDefault(mdgiter, "group_sparse_tolerance", 1.0e-4);
+    ValidatePositive(group_sparse_tolerance, "group_sparse_tolerance",
+                     base_error);
+    group_sparse_max_iterations =
+        GetIntDefault(mdgiter, "group_sparse_max_iterations", iter_max);
+    ValidatePositiveInteger(group_sparse_max_iterations,
+                            "group_sparse_max_iterations", base_error);
+    group_sparse_active_threshold =
+        GetDoubleDefault(mdgiter, "group_sparse_active_threshold", 2.0e-2);
+    ValidateNonnegative(group_sparse_active_threshold,
+                        "group_sparse_active_threshold", base_error);
+    group_sparse_active_threshold_scale =
+        GetDoubleDefault(mdgiter, "group_sparse_active_threshold_scale", 1.0);
+    ValidateNonnegative(group_sparse_active_threshold_scale,
+                        "group_sparse_active_threshold_scale", base_error);
+    group_sparse_active_threshold_quantile = GetDoubleDefault(
+        mdgiter, "group_sparse_active_threshold_quantile", 0.90);
+    ValidateProbability(group_sparse_active_threshold_quantile,
+                        "group_sparse_active_threshold_quantile", base_error);
     this->invalidate_processing_state();
   } catch (...) {
     throw;
@@ -241,6 +273,15 @@ void TimeDomainGIDDecon::invalidate_processing_state() {
   ns_stop_reason = "not_started";
   gid_converged = false;
   gid_stop_reason = "not_started";
+  group_sparse_lambda_used = 0.0;
+  group_sparse_objective_initial = 0.0;
+  group_sparse_objective_final = 0.0;
+  group_sparse_fractional_improvement_final = 0.0;
+  group_sparse_active_threshold_quantile_value = 0.0;
+  group_sparse_active_threshold_used = 0.0;
+  group_sparse_iterations = 0;
+  group_sparse_active_groups = 0;
+  group_sparse_converged = false;
   processed = false;
 }
 
@@ -387,7 +428,7 @@ int TimeDomainGIDDecon::loadnoise(const CoreSeismogram &draw,
     if (n.dead() || n.npts() <= 0)
       return 1;
     nnwin = n.npts();
-    if (decon_type == NS_GID) {
+    if (decon_type == NS_GID || decon_type == GROUP_SPARSE) {
       ns_noise_components.clear();
       ns_noise_components.reserve(3);
       for (int k = 0; k < 3; ++k) {
@@ -468,11 +509,11 @@ int TimeDomainGIDDecon::loadnoise(const CoreTimeSeries &noise_in) {
   return this->loadnoise(ts);
 }
 int TimeDomainGIDDecon::loadnoise(const PowerSpectrum &noise_spectrum_in) {
-  if (decon_type != NS_GID)
+  if (decon_type != NS_GID && decon_type != GROUP_SPARSE)
     throw MsPASSError("TimeDomainGIDDecon::loadnoise: external PowerSpectrum "
-                      "noise is only supported for ns_gid; pass a TimeSeries "
-                      "noise estimate for multi_taper or use the configured "
-                      "noise window for other GID modes",
+                      "noise is only supported for ns_gid and group_sparse; "
+                      "pass a TimeSeries noise estimate for multi_taper or "
+                      "use the configured noise window for other GID modes",
                       ErrorSeverity::Invalid);
   ValidatePowerSpectrumCoversDC(noise_spectrum_in,
                                 "TimeDomainGIDDecon::loadnoise");
@@ -768,7 +809,7 @@ void TimeDomainGIDDecon::process() {
         cblas_dcopy(copysize, dwork.u.get_address(k, 0), 3,
                     uwork.get_address(k, 0), 3);
     } else {
-      if (decon_type == NS_GID) {
+      if (decon_type == NS_GID || decon_type == GROUP_SPARSE) {
         process_stage = "NS-GID load inverse-operator noise";
         NoiseStableDecon *nsop = dynamic_cast<NoiseStableDecon *>(preprocessor.get());
         if (external_noise_spectrum_loaded)
@@ -818,7 +859,7 @@ void TimeDomainGIDDecon::process() {
     to map the noise window into the inverse domain; NS-GID uses a separate
     noise-aware threshold and skips that extra inverse construction. */
     CoreTimeSeries winv;
-    if (decon_type != NS_GID) {
+    if (decon_type != NS_GID && decon_type != GROUP_SPARSE) {
       process_stage = "compute inverse wavelet";
       if (decon_type == CNR)
         winv = cnrprocessor->inverse_wavelet(current_wavelet, d_decon.t0());
@@ -889,7 +930,7 @@ void TimeDomainGIDDecon::process() {
          << "Window size must be larger than two times FIR filter size" << endl;
       throw MsPASSError(ss.str(), ErrorSeverity::Invalid);
     }
-    if (decon_type == NS_GID) {
+    if (decon_type == NS_GID || decon_type == GROUP_SPARSE) {
       process_stage = "NS-GID estimate inverse-filtered noise threshold";
       int ns_noise_npts(0);
       if (!ns_noise_components.empty()) {
@@ -1009,6 +1050,59 @@ void TimeDomainGIDDecon::process() {
     gid_stop_reason = "running";
     gid_converged = false;
     ns_last_peak_significance = 0.0;
+    if (decon_type == GROUP_SPARSE) {
+      process_stage = "group-sparse regularized solve";
+      group_sparse_lambda_used = group_sparse_lambda;
+      if (group_sparse_lambda_used <= 0.0) {
+        const double lambda_base =
+            (ns_peak_threshold > 0.0) ? ns_peak_threshold
+                                      : 0.02 * resid_linf_initial;
+        group_sparse_lambda_used = group_sparse_lambda_scale * lambda_base;
+      }
+      GroupSparseDeconResult gs = SolveGroupSparseDecon(
+          d_decon, actual_o_fir, actual_o_0, group_sparse_lambda_used,
+          group_sparse_max_iterations, group_sparse_tolerance,
+          group_sparse_active_threshold, group_sparse_active_threshold_scale,
+          group_sparse_active_threshold_quantile, "TimeDomainGIDDecon");
+      spikes = gs.spikes;
+      iter_count = gs.iterations;
+      group_sparse_iterations = gs.iterations;
+      group_sparse_active_groups = static_cast<int>(spikes.size());
+      group_sparse_converged = gs.converged;
+      group_sparse_objective_initial = gs.objective_initial;
+      group_sparse_objective_final = gs.objective_final;
+      group_sparse_fractional_improvement_final =
+          gs.fractional_improvement_final;
+      group_sparse_active_threshold_quantile_value =
+          gs.active_threshold_quantile_value;
+      group_sparse_active_threshold_used = gs.active_threshold_used;
+      process_stage = "refit group-sparse amplitudes";
+      RefitSpikeAmplitudes(spikes, d_decon, actual_o_fir, actual_o_0,
+                           ns_ridge_beta);
+      spikes.remove_if([this](const ThreeCSpike &spk) {
+        return spk.amp <= group_sparse_active_threshold_used;
+      });
+      group_sparse_active_groups = static_cast<int>(spikes.size());
+      process_stage = "recompute group-sparse final residual";
+      r = d_decon;
+      for (auto sptr = spikes.begin(); sptr != spikes.end(); ++sptr)
+        this->update_residual_matrix(*sptr);
+      resid_linf_prev = Linf(r.u);
+      resid_l2_prev = L2(r.u);
+      if (!lag_weights.empty()) {
+        auto lwmax = max_element(lag_weights.begin(), lag_weights.end());
+        lw_linf_prev = (lwmax != lag_weights.end()) ? *lwmax : 0.0;
+        lw_l2_prev = cblas_dnrm2(lag_weights.size(), &(lag_weights[0]), 1);
+      }
+      gid_stop_reason = group_sparse_converged
+                            ? "group_sparse_converged"
+                            : "group_sparse_max_iterations";
+      gid_converged = group_sparse_converged;
+      ns_stop_reason = "not_enabled";
+      ns_converged = false;
+      processed = true;
+      return;
+    }
     do {
       process_stage = "sparse iteration";
       /* Compute the vector of amplitudes and find the maximum */
@@ -1321,6 +1415,57 @@ Metadata TimeDomainGIDDecon::QCMetrics() {
   md.put("gid_actual_o_fir_zero_lag_index", actual_o_0);
   md.put("gid_actual_o_fir_peak_normalized",
          processed && !actual_o_fir.empty());
+  md.put("group_sparse_enabled", decon_type == GROUP_SPARSE);
+  md.put("group_sparse_inverse_operator", string("ns_gid"));
+  md.put("group_sparse_lambda_requested", group_sparse_lambda);
+  md.put("group_sparse_lambda_scale", group_sparse_lambda_scale);
+  md.put("group_sparse_lambda_used", group_sparse_lambda_used);
+  md.put("group_sparse_tolerance", group_sparse_tolerance);
+  md.put("group_sparse_max_iterations", group_sparse_max_iterations);
+  md.put("group_sparse_iterations", group_sparse_iterations);
+  md.put("group_sparse_converged", group_sparse_converged);
+  md.put("group_sparse_active_threshold", group_sparse_active_threshold);
+  md.put("group_sparse_active_threshold_scale",
+         group_sparse_active_threshold_scale);
+  md.put("group_sparse_active_threshold_quantile",
+         group_sparse_active_threshold_quantile);
+  md.put("group_sparse_active_threshold_quantile_value",
+         group_sparse_active_threshold_quantile_value);
+  md.put("group_sparse_active_threshold_used",
+         group_sparse_active_threshold_used);
+  md.put("group_sparse_active_groups", group_sparse_active_groups);
+  md.put("group_sparse_objective_initial", group_sparse_objective_initial);
+  md.put("group_sparse_objective_final", group_sparse_objective_final);
+  md.put("group_sparse_fractional_improvement_final",
+         group_sparse_fractional_improvement_final);
+  md.put("group_sparse_noise_threshold", ns_peak_threshold);
+  if (decon_type == GROUP_SPARSE) {
+    NoiseStableDecon *nsop =
+        dynamic_cast<NoiseStableDecon *>(preprocessor.get());
+    if (nsop != nullptr) {
+      Metadata nsmd(nsop->QCMetrics());
+      md.put("group_sparse_inverse_gain_max_requested",
+             nsmd.get_double("ns_gid_gain_max_requested"));
+      md.put("group_sparse_inverse_gain_max_actual",
+             nsmd.get_double("ns_gid_gain_max_actual"));
+      md.put("group_sparse_inverse_mu_min", nsmd.get_double("ns_gid_mu_min"));
+      md.put("group_sparse_inverse_alpha", nsmd.get_double("ns_gid_alpha"));
+      md.put("group_sparse_inverse_noise_amplification",
+             nsmd.get_double("ns_gid_noise_amplification"));
+      md.put("group_sparse_inverse_effective_bandwidth_fraction",
+             nsmd.get_double("ns_gid_effective_bandwidth_fraction"));
+      md.put("group_sparse_inverse_operator_nfft",
+             nsmd.get_int("ns_gid_operator_nfft"));
+      md.put("group_sparse_inverse_use_reliability_taper",
+             nsmd.get_bool("ns_gid_use_reliability_taper"));
+      md.put("group_sparse_inverse_external_wavelet_used",
+             external_wavelet_loaded);
+      md.put("group_sparse_inverse_external_noise_used",
+             external_noise_loaded);
+      md.put("group_sparse_inverse_external_noise_spectrum_used",
+             external_noise_spectrum_loaded);
+    }
+  }
   md.put("ns_gid_enabled", decon_type == NS_GID);
   if (decon_type == NS_GID) {
     md.put("ns_gid_stop_reason", ns_stop_reason);

--- a/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
@@ -1362,6 +1362,7 @@ Metadata TimeDomainGIDDecon::QCMetrics() {
   Metadata md;
   PutPrefixedMetadata(md, changed_leaf_metadata, "gid_leaf_");
   md.put("decon_operator", string("TimeDomainGIDDecon"));
+  md.put("deconvolution_type", GIDDeconTypeName(decon_type));
   md.put("decon_processed", processed);
   md.put("decon_sample_interval", target_dt);
   md.put("decon_window_start", dwin.start);

--- a/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
@@ -61,14 +61,14 @@ TimeDomainGIDDecon::TimeDomainGIDDecon(const AntelopePf &mdtoplevel)
     IterDeconType dct = ParseGIDDeconType(mdgiter, "TimeDomainGIDDecon");
     this->decon_type = dct;
     double ts, te;
-    ts = mdgiter.get<double>("full_data_window_start");
-    te = mdgiter.get<double>("full_data_window_end");
+    ts = GetDoubleRequired(mdgiter, "full_data_window_start");
+    te = GetDoubleRequired(mdgiter, "full_data_window_end");
     dwin = TimeWindow(ts, te);
-    ts = mdgiter.get<double>("deconvolution_data_window_start");
-    te = mdgiter.get<double>("deconvolution_data_window_end");
+    ts = GetDoubleRequired(mdgiter, "deconvolution_data_window_start");
+    te = GetDoubleRequired(mdgiter, "deconvolution_data_window_end");
     fftwin = TimeWindow(ts, te);
-    ts = mdgiter.get<double>("noise_window_start");
-    te = mdgiter.get<double>("noise_window_end");
+    ts = GetDoubleRequired(mdgiter, "noise_window_start");
+    te = GetDoubleRequired(mdgiter, "noise_window_end");
     nwin = TimeWindow(ts, te);
     ValidateWindowDuration(dwin, "full_data_window", base_error);
     ValidateWindowDuration(fftwin, "deconvolution_data_window", base_error);
@@ -85,9 +85,9 @@ TimeDomainGIDDecon::TimeDomainGIDDecon(const AntelopePf &mdtoplevel)
          << fftwin.end << endl;
       throw MsPASSError(ss.str(), ErrorSeverity::Invalid);
     }
-    noise_component = mdgiter.get<int>("noise_component");
+    noise_component = GetIntRequired(mdgiter, "noise_component");
     ValidateThreeComponentIndex(noise_component, "noise_component", base_error);
-    target_dt = mdgiter.get<double>("target_sample_interval");
+    target_dt = GetDoubleRequired(mdgiter, "target_sample_interval");
     ValidatePositive(target_dt, "target_sample_interval", base_error);
     int maxns = static_cast<int>((fftwin.end - fftwin.start) / target_dt);
     ++maxns; // Add one - points not intervals
@@ -166,17 +166,18 @@ TimeDomainGIDDecon::TimeDomainGIDDecon(const AntelopePf &mdtoplevel)
     make changes easier to implement. */
     this->construct_weight_penalty_function(mdgiter);
     /* Set convergence parameters from md keys */
-    iter_max = mdgiter.get<int>("maximum_iterations");
+    iter_max = GetIntRequired(mdgiter, "maximum_iterations");
     ValidatePositiveInteger(iter_max, "maximum_iterations", base_error);
-    lw_linf_floor = mdgiter.get<double>("lag_weight_Linf_floor");
+    lw_linf_floor = GetDoubleRequired(mdgiter, "lag_weight_Linf_floor");
     ValidateNonnegative(lw_linf_floor, "lag_weight_Linf_floor", base_error);
-    lw_l2_floor = mdgiter.get<double>("lag_weight_rms_floor");
+    lw_l2_floor = GetDoubleRequired(mdgiter, "lag_weight_rms_floor");
     ValidateNonnegative(lw_l2_floor, "lag_weight_rms_floor", base_error);
     resid_linf_prob =
-        mdgiter.get<double>("residual_noise_rms_probability_floor");
+        GetDoubleRequired(mdgiter, "residual_noise_rms_probability_floor");
     ValidateProbability(resid_linf_prob, "residual_noise_rms_probability_floor",
                         base_error);
-    resid_l2_tol = mdgiter.get<double>("residual_fractional_improvement_floor");
+    resid_l2_tol =
+        GetDoubleRequired(mdgiter, "residual_fractional_improvement_floor");
     ValidateNonnegative(resid_l2_tol,
                         "residual_fractional_improvement_floor", base_error);
     ns_peak_sigma_threshold =
@@ -334,7 +335,7 @@ void TimeDomainGIDDecon::construct_weight_penalty_function(const Metadata &md) {
             : "none";
     lag_weight_penalty_scale_factor =
         md.is_defined("lag_weight_penalty_scale_factor")
-            ? md.get<double>("lag_weight_penalty_scale_factor")
+            ? GetDoubleRequired(md, "lag_weight_penalty_scale_factor")
             : 1.0;
     if (!isfinite(lag_weight_penalty_scale_factor) ||
         lag_weight_penalty_scale_factor <= 0.0 ||
@@ -344,7 +345,7 @@ void TimeDomainGIDDecon::construct_weight_penalty_function(const Metadata &md) {
                         ErrorSeverity::Fatal);
     lag_weight_function_width =
         md.is_defined("lag_weight_function_width")
-            ? md.get<int>("lag_weight_function_width")
+            ? GetIntRequired(md, "lag_weight_function_width")
             : 0;
     if (md.is_defined("lag_weight_function_width"))
       ValidatePositiveInteger(

--- a/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
@@ -1417,7 +1417,8 @@ Metadata TimeDomainGIDDecon::QCMetrics() {
   md.put("gid_actual_o_fir_peak_normalized",
          processed && !actual_o_fir.empty());
   md.put("group_sparse_enabled", decon_type == GROUP_SPARSE);
-  md.put("group_sparse_inverse_operator", string("ns_gid"));
+  md.put("group_sparse_inverse_operator",
+         string(decon_type == GROUP_SPARSE ? "ns_gid" : "not_enabled"));
   md.put("group_sparse_lambda_requested", group_sparse_lambda);
   md.put("group_sparse_lambda_scale", group_sparse_lambda_scale);
   md.put("group_sparse_lambda_used", group_sparse_lambda_used);

--- a/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
@@ -278,6 +278,8 @@ void TimeDomainGIDDecon::invalidate_processing_state() {
   group_sparse_objective_initial = 0.0;
   group_sparse_objective_final = 0.0;
   group_sparse_fractional_improvement_final = 0.0;
+  group_sparse_debiased_objective_final = 0.0;
+  group_sparse_debiased_fractional_improvement_final = 0.0;
   group_sparse_active_threshold_quantile_value = 0.0;
   group_sparse_active_threshold_used = 0.0;
   group_sparse_iterations = 0;
@@ -1090,10 +1092,11 @@ void TimeDomainGIDDecon::process() {
         this->update_residual_matrix(*sptr);
       resid_linf_prev = Linf(r.u);
       resid_l2_prev = L2(r.u);
-      group_sparse_objective_final =
+      group_sparse_debiased_objective_final =
           GroupSparseObjective(r, spikes, group_sparse_lambda_used);
-      group_sparse_fractional_improvement_final =
-          (group_sparse_objective_initial - group_sparse_objective_final) /
+      group_sparse_debiased_fractional_improvement_final =
+          (group_sparse_objective_initial -
+           group_sparse_debiased_objective_final) /
           max(1.0, group_sparse_objective_initial);
       if (!lag_weights.empty()) {
         auto lwmax = max_element(lag_weights.begin(), lag_weights.end());
@@ -1383,7 +1386,8 @@ Metadata TimeDomainGIDDecon::QCMetrics() {
   md.put("gid_stop_reason", gid_stop_reason);
   md.put("gid_iterations", iter_count);
   md.put("gid_number_spikes", static_cast<int>(spikes.size()));
-  md.put("gid_maximum_iterations", iter_max);
+  md.put("gid_maximum_iterations",
+         (decon_type == GROUP_SPARSE) ? group_sparse_max_iterations : iter_max);
   if (decon_type != GROUP_SPARSE) {
     md.put("gid_penalty_function", lag_weight_penalty_function);
     md.put("gid_penalty_scale_factor", lag_weight_penalty_scale_factor);
@@ -1446,6 +1450,10 @@ Metadata TimeDomainGIDDecon::QCMetrics() {
     md.put("group_sparse_objective_final", group_sparse_objective_final);
     md.put("group_sparse_fractional_improvement_final",
            group_sparse_fractional_improvement_final);
+    md.put("group_sparse_debiased_objective_final",
+           group_sparse_debiased_objective_final);
+    md.put("group_sparse_debiased_fractional_improvement_final",
+           group_sparse_debiased_fractional_improvement_final);
     md.put("group_sparse_noise_threshold", ns_peak_threshold);
     NoiseStableDecon *nsop =
         dynamic_cast<NoiseStableDecon *>(preprocessor.get());

--- a/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
@@ -1416,32 +1416,31 @@ Metadata TimeDomainGIDDecon::QCMetrics() {
   md.put("gid_actual_o_fir_zero_lag_index", actual_o_0);
   md.put("gid_actual_o_fir_peak_normalized",
          processed && !actual_o_fir.empty());
-  md.put("group_sparse_enabled", decon_type == GROUP_SPARSE);
-  md.put("group_sparse_inverse_operator",
-         string(decon_type == GROUP_SPARSE ? "ns_gid" : "not_enabled"));
-  md.put("group_sparse_lambda_requested", group_sparse_lambda);
-  md.put("group_sparse_lambda_scale", group_sparse_lambda_scale);
-  md.put("group_sparse_lambda_used", group_sparse_lambda_used);
-  md.put("group_sparse_tolerance", group_sparse_tolerance);
-  md.put("group_sparse_max_iterations", group_sparse_max_iterations);
-  md.put("group_sparse_iterations", group_sparse_iterations);
-  md.put("group_sparse_converged", group_sparse_converged);
-  md.put("group_sparse_active_threshold", group_sparse_active_threshold);
-  md.put("group_sparse_active_threshold_scale",
-         group_sparse_active_threshold_scale);
-  md.put("group_sparse_active_threshold_quantile",
-         group_sparse_active_threshold_quantile);
-  md.put("group_sparse_active_threshold_quantile_value",
-         group_sparse_active_threshold_quantile_value);
-  md.put("group_sparse_active_threshold_used",
-         group_sparse_active_threshold_used);
-  md.put("group_sparse_active_groups", group_sparse_active_groups);
-  md.put("group_sparse_objective_initial", group_sparse_objective_initial);
-  md.put("group_sparse_objective_final", group_sparse_objective_final);
-  md.put("group_sparse_fractional_improvement_final",
-         group_sparse_fractional_improvement_final);
-  md.put("group_sparse_noise_threshold", ns_peak_threshold);
   if (decon_type == GROUP_SPARSE) {
+    md.put("group_sparse_enabled", true);
+    md.put("group_sparse_inverse_operator", string("ns_gid"));
+    md.put("group_sparse_lambda_requested", group_sparse_lambda);
+    md.put("group_sparse_lambda_scale", group_sparse_lambda_scale);
+    md.put("group_sparse_lambda_used", group_sparse_lambda_used);
+    md.put("group_sparse_tolerance", group_sparse_tolerance);
+    md.put("group_sparse_max_iterations", group_sparse_max_iterations);
+    md.put("group_sparse_iterations", group_sparse_iterations);
+    md.put("group_sparse_converged", group_sparse_converged);
+    md.put("group_sparse_active_threshold", group_sparse_active_threshold);
+    md.put("group_sparse_active_threshold_scale",
+           group_sparse_active_threshold_scale);
+    md.put("group_sparse_active_threshold_quantile",
+           group_sparse_active_threshold_quantile);
+    md.put("group_sparse_active_threshold_quantile_value",
+           group_sparse_active_threshold_quantile_value);
+    md.put("group_sparse_active_threshold_used",
+           group_sparse_active_threshold_used);
+    md.put("group_sparse_active_groups", group_sparse_active_groups);
+    md.put("group_sparse_objective_initial", group_sparse_objective_initial);
+    md.put("group_sparse_objective_final", group_sparse_objective_final);
+    md.put("group_sparse_fractional_improvement_final",
+           group_sparse_fractional_improvement_final);
+    md.put("group_sparse_noise_threshold", ns_peak_threshold);
     NoiseStableDecon *nsop =
         dynamic_cast<NoiseStableDecon *>(preprocessor.get());
     if (nsop != nullptr) {
@@ -1468,8 +1467,8 @@ Metadata TimeDomainGIDDecon::QCMetrics() {
              external_noise_spectrum_loaded);
     }
   }
-  md.put("ns_gid_enabled", decon_type == NS_GID);
   if (decon_type == NS_GID) {
+    md.put("ns_gid_enabled", true);
     md.put("ns_gid_stop_reason", ns_stop_reason);
     md.put("ns_gid_converged", ns_converged);
     md.put("ns_gid_iterations", iter_count);

--- a/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/TimeDomainGIDDecon.cc
@@ -1089,6 +1089,11 @@ void TimeDomainGIDDecon::process() {
         this->update_residual_matrix(*sptr);
       resid_linf_prev = Linf(r.u);
       resid_l2_prev = L2(r.u);
+      group_sparse_objective_final =
+          GroupSparseObjective(r, spikes, group_sparse_lambda_used);
+      group_sparse_fractional_improvement_final =
+          (group_sparse_objective_initial - group_sparse_objective_final) /
+          max(1.0, group_sparse_objective_initial);
       if (!lag_weights.empty()) {
         auto lwmax = max_element(lag_weights.begin(), lag_weights.end());
         lw_linf_prev = (lwmax != lag_weights.end()) ? *lwmax : 0.0;
@@ -1378,29 +1383,29 @@ Metadata TimeDomainGIDDecon::QCMetrics() {
   md.put("gid_iterations", iter_count);
   md.put("gid_number_spikes", static_cast<int>(spikes.size()));
   md.put("gid_maximum_iterations", iter_max);
-  md.put("gid_penalty_function", lag_weight_penalty_function);
-  md.put("gid_penalty_scale_factor", lag_weight_penalty_scale_factor);
-  md.put("gid_penalty_width", lag_weight_function_width);
-  md.put("gid_penalty_effective_width", nwtf);
-  md.put("gid_adaptive_penalty_enabled",
-         GIDLagWeightPenaltyUsesAdaptiveMemory(lag_weight_penalty_function));
-  md.put("gid_penalty_noise_amplitude", adaptive_penalty_noise_amplitude);
-  md.put("gid_penalty_last_confidence",
-         adaptive_penalty_last_confidence);
-  md.put("gid_penalty_last_immediate_strength",
-         adaptive_penalty_last_immediate_strength);
-  md.put("gid_penalty_last_specificity",
-         adaptive_penalty_last_specificity);
-  md.put("gid_penalty_last_decay_factor",
-         adaptive_penalty_last_decay_factor);
-  md.put("gid_penalty_memory_Linf_final", adaptive_penalty_memory_linf);
-  md.put("gid_penalty_memory_L2_final", adaptive_penalty_memory_l2);
-  int gid_penalty_valid_lags(0);
-  for (auto w : lag_weights) {
-    if (w > 0.0)
-      ++gid_penalty_valid_lags;
+  if (decon_type != GROUP_SPARSE) {
+    md.put("gid_penalty_function", lag_weight_penalty_function);
+    md.put("gid_penalty_scale_factor", lag_weight_penalty_scale_factor);
+    md.put("gid_penalty_width", lag_weight_function_width);
+    md.put("gid_penalty_effective_width", nwtf);
+    md.put("gid_adaptive_penalty_enabled",
+           GIDLagWeightPenaltyUsesAdaptiveMemory(lag_weight_penalty_function));
+    md.put("gid_penalty_noise_amplitude", adaptive_penalty_noise_amplitude);
+    md.put("gid_penalty_last_confidence", adaptive_penalty_last_confidence);
+    md.put("gid_penalty_last_immediate_strength",
+           adaptive_penalty_last_immediate_strength);
+    md.put("gid_penalty_last_specificity", adaptive_penalty_last_specificity);
+    md.put("gid_penalty_last_decay_factor",
+           adaptive_penalty_last_decay_factor);
+    md.put("gid_penalty_memory_Linf_final", adaptive_penalty_memory_linf);
+    md.put("gid_penalty_memory_L2_final", adaptive_penalty_memory_l2);
+    int gid_penalty_valid_lags(0);
+    for (auto w : lag_weights) {
+      if (w > 0.0)
+        ++gid_penalty_valid_lags;
+    }
+    md.put("gid_penalty_valid_lags", gid_penalty_valid_lags);
   }
-  md.put("gid_penalty_valid_lags", gid_penalty_valid_lags);
   md.put("gid_external_wavelet_used", external_wavelet_loaded);
   md.put("gid_external_noise_used", external_noise_loaded);
   md.put("gid_external_noise_spectrum_used",

--- a/cxx/src/lib/algorithms/deconvolution/TimeDomainLeastSquareDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/TimeDomainLeastSquareDecon.cc
@@ -1,6 +1,7 @@
 #include "mspass/algorithms/deconvolution/TimeDomainLeastSquareDecon.h"
 #include "gsl/gsl_cblas.h"
 #include "mspass/algorithms/amplitudes.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include "mspass/utility/MsPASSError.h"
 #include <cmath>
 #include <sstream>
@@ -87,18 +88,20 @@ TimeDomainLeastSquareDecon::TimeDomainLeastSquareDecon(
 void TimeDomainLeastSquareDecon::read_metadata(const Metadata &md) {
   const string base_error("TimeDomainLeastSquareDecon::read_metadata:  ");
   try {
-    damp = md.get_double("damping_factor");
+    damp = GetDoubleRequired(md, "damping_factor");
     if (damp <= 0.0)
       throw MsPASSError(base_error +
                             "damping_factor must be positive for stable "
                         "time-domain least-squares deconvolution",
                         ErrorSeverity::Fatal);
-    dt = md.get_double("target_sample_interval");
+    dt = GetDoubleRequired(md, "target_sample_interval");
     if (dt <= 0.0)
       throw MsPASSError(base_error + "target_sample_interval must be positive",
                         ErrorSeverity::Fatal);
-    const double dwinstart = md.get_double("deconvolution_data_window_start");
-    const double dwinend = md.get_double("deconvolution_data_window_end");
+    const double dwinstart =
+        GetDoubleRequired(md, "deconvolution_data_window_start");
+    const double dwinend =
+        GetDoubleRequired(md, "deconvolution_data_window_end");
     if (dwinend <= dwinstart)
       throw MsPASSError(base_error +
                             "deconvolution_data_window_end must be greater "
@@ -111,15 +114,16 @@ void TimeDomainLeastSquareDecon::read_metadata(const Metadata &md) {
                             "positive for this lag convention",
                         ErrorSeverity::Fatal);
     if (md.is_defined("model_length")) {
-      output_length = md.get_int("model_length");
+      output_length = GetIntRequired(md, "model_length");
       if (output_length <= 0)
         throw MsPASSError(base_error + "model_length must be positive",
                           ErrorSeverity::Fatal);
     } else {
       output_length = 0;
     }
-    int shaping_nfft(md.is_defined("operator_nfft") ? md.get_int("operator_nfft")
-                                                    : 0);
+    int shaping_nfft(
+        md.is_defined("operator_nfft") ? GetIntRequired(md, "operator_nfft")
+                                       : 0);
     if (shaping_nfft <= 0)
       shaping_nfft = 1;
     shapingwavelet = ShapingWavelet(md, shaping_nfft);

--- a/cxx/src/lib/algorithms/deconvolution/WaterLevelDecon.cc
+++ b/cxx/src/lib/algorithms/deconvolution/WaterLevelDecon.cc
@@ -1,5 +1,6 @@
 #include "mspass/algorithms/deconvolution/WaterLevelDecon.h"
 #include "mspass/algorithms/amplitudes.h"
+#include "mspass/algorithms/deconvolution/GIDDeconUtil.h"
 #include <cfloat> // Needed for DBL_EPSILON
 namespace mspass::algorithms::deconvolution {
 using namespace std;
@@ -16,7 +17,7 @@ int WaterLevelDecon::read_metadata(const Metadata &md) {
     const string base_error("WaterLevelDecon::read_metadata method: ");
     const int nfft_from_win = ComputeFFTLength(md);
     const int new_sample_shift = ComputeDeconSampleShift(md);
-    const double new_wlv = md.get_double("water_level");
+    const double new_wlv = GetDoubleRequired(md, "water_level");
     if (new_wlv <= 0.0) {
       throw MsPASSError(base_error +
                             "water_level must be positive.  A zero value is "

--- a/cxx/src/lib/utility/Metadata.cc
+++ b/cxx/src/lib/utility/Metadata.cc
@@ -59,6 +59,18 @@ bool pyobject_to_double(const py::object &obj, double &result) {
   }
 }
 
+bool double_is_integer_valued(const double value) {
+  return isfinite(value) && floor(value) == value;
+}
+
+bool double_fits_long(const double value) {
+  if (!double_is_integer_valued(value))
+    return false;
+  const long double wide_value = static_cast<long double>(value);
+  return wide_value >= static_cast<long double>(numeric_limits<long>::min()) &&
+         wide_value <= static_cast<long double>(numeric_limits<long>::max());
+}
+
 bool pyobject_to_long(const py::object &obj, long &result) {
   py::gil_scoped_acquire gil;
   if (pyobject_is_bool_like(obj))
@@ -98,10 +110,8 @@ bool pyobject_to_long(const py::object &obj, long &result) {
 
   if ((has_dtype_kind && kind == "f") || py::isinstance<py::float_>(obj)) {
     double numeric_value(0.0);
-    if (pyobject_to_double(obj, numeric_value) && isfinite(numeric_value) &&
-        floor(numeric_value) == numeric_value &&
-        numeric_value >= static_cast<double>(numeric_limits<long>::min()) &&
-        numeric_value < static_cast<double>(numeric_limits<long>::max())) {
+    if (pyobject_to_double(obj, numeric_value) &&
+        double_fits_long(numeric_value)) {
       result = static_cast<long>(numeric_value);
       return true;
     }
@@ -174,10 +184,6 @@ bool any_to_double(const boost::any &val, double &result) {
   return false;
 }
 
-bool double_is_integer_valued(const double value) {
-  return isfinite(value) && floor(value) == value;
-}
-
 bool any_to_long(const boost::any &val, long &result) {
   if (val.type() == typeid(short)) {
     result = static_cast<long>(boost::any_cast<short>(val));
@@ -224,10 +230,7 @@ bool any_to_long(const boost::any &val, long &result) {
   if (val.type() == typeid(py::object))
     return pyobject_to_long(boost::any_cast<py::object>(val), result);
   double numeric_value(0.0);
-  if (any_to_double(val, numeric_value) &&
-      double_is_integer_valued(numeric_value) &&
-      numeric_value >= static_cast<double>(numeric_limits<long>::min()) &&
-      numeric_value < static_cast<double>(numeric_limits<long>::max())) {
+  if (any_to_double(val, numeric_value) && double_fits_long(numeric_value)) {
     result = static_cast<long>(numeric_value);
     return true;
   }

--- a/cxx/src/lib/utility/Metadata.cc
+++ b/cxx/src/lib/utility/Metadata.cc
@@ -1,11 +1,287 @@
 #include "mspass/utility/Metadata.h"
 #include "misc/base64.h"
 #include "mspass/utility/MsPASSError.h"
+#include <algorithm>
 #include <boost/core/demangle.hpp>
+#include <cctype>
+#include <cmath>
 #include <iomanip>
+#include <limits>
 #include <pybind11/stl.h>
 namespace mspass::utility {
 using namespace std;
+
+namespace {
+namespace py = pybind11;
+
+bool is_expected_python_probe_error(py::error_already_set &err) {
+  return err.matches(PyExc_AttributeError) || err.matches(PyExc_TypeError) ||
+         err.matches(PyExc_ValueError) || err.matches(PyExc_OverflowError);
+}
+
+bool pyobject_dtype_kind(const py::object &obj, string &kind) {
+  if (!py::hasattr(obj, "dtype"))
+    return false;
+  try {
+    kind = py::str(obj.attr("dtype").attr("kind"));
+    return true;
+  } catch (py::error_already_set &err) {
+    if (is_expected_python_probe_error(err)) {
+      PyErr_Clear();
+      return false;
+    }
+    throw;
+  }
+}
+
+bool pyobject_is_bool_like(const py::object &obj) {
+  if (py::isinstance<py::bool_>(obj))
+    return true;
+  string kind;
+  return pyobject_dtype_kind(obj, kind) && kind == "b";
+}
+
+bool pyobject_to_double(const py::object &obj, double &result) {
+  py::gil_scoped_acquire gil;
+  if (pyobject_is_bool_like(obj))
+    return false;
+  try {
+    result = obj.cast<double>();
+    return true;
+  } catch (py::cast_error &) {
+    return false;
+  } catch (py::error_already_set &err) {
+    if (is_expected_python_probe_error(err)) {
+      PyErr_Clear();
+      return false;
+    }
+    throw;
+  }
+}
+
+bool pyobject_to_long(const py::object &obj, long &result) {
+  py::gil_scoped_acquire gil;
+  if (pyobject_is_bool_like(obj))
+    return false;
+
+  string kind;
+  const bool has_dtype_kind = pyobject_dtype_kind(obj, kind);
+  if (has_dtype_kind && (kind == "i" || kind == "u")) {
+    try {
+      result = obj.cast<long>();
+      return true;
+    } catch (py::cast_error &) {
+      return false;
+    } catch (py::error_already_set &err) {
+      if (is_expected_python_probe_error(err)) {
+        PyErr_Clear();
+        return false;
+      }
+      throw;
+    }
+  }
+
+  if (py::isinstance<py::int_>(obj)) {
+    try {
+      result = obj.cast<long>();
+      return true;
+    } catch (py::cast_error &) {
+      return false;
+    } catch (py::error_already_set &err) {
+      if (is_expected_python_probe_error(err)) {
+        PyErr_Clear();
+        return false;
+      }
+      throw;
+    }
+  }
+
+  if ((has_dtype_kind && kind == "f") || py::isinstance<py::float_>(obj)) {
+    double numeric_value(0.0);
+    if (pyobject_to_double(obj, numeric_value) && isfinite(numeric_value) &&
+        floor(numeric_value) == numeric_value &&
+        numeric_value >= static_cast<double>(numeric_limits<long>::min()) &&
+        numeric_value < static_cast<double>(numeric_limits<long>::max())) {
+      result = static_cast<long>(numeric_value);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool pyobject_to_bool(const py::object &obj, bool &result) {
+  py::gil_scoped_acquire gil;
+  if (pyobject_is_bool_like(obj)) {
+    try {
+      result = obj.cast<bool>();
+      return true;
+    } catch (py::cast_error &) {
+      return false;
+    } catch (py::error_already_set &err) {
+      if (is_expected_python_probe_error(err)) {
+        PyErr_Clear();
+        return false;
+      }
+      throw;
+    }
+  }
+  return false;
+}
+
+bool any_to_double(const boost::any &val, double &result) {
+  if (val.type() == typeid(double)) {
+    result = boost::any_cast<double>(val);
+    return true;
+  }
+  if (val.type() == typeid(float)) {
+    result = static_cast<double>(boost::any_cast<float>(val));
+    return true;
+  }
+  if (val.type() == typeid(short)) {
+    result = static_cast<double>(boost::any_cast<short>(val));
+    return true;
+  }
+  if (val.type() == typeid(unsigned short)) {
+    result = static_cast<double>(boost::any_cast<unsigned short>(val));
+    return true;
+  }
+  if (val.type() == typeid(int)) {
+    result = static_cast<double>(boost::any_cast<int>(val));
+    return true;
+  }
+  if (val.type() == typeid(unsigned int)) {
+    result = static_cast<double>(boost::any_cast<unsigned int>(val));
+    return true;
+  }
+  if (val.type() == typeid(long)) {
+    result = static_cast<double>(boost::any_cast<long>(val));
+    return true;
+  }
+  if (val.type() == typeid(unsigned long)) {
+    result = static_cast<double>(boost::any_cast<unsigned long>(val));
+    return true;
+  }
+  if (val.type() == typeid(long long)) {
+    result = static_cast<double>(boost::any_cast<long long>(val));
+    return true;
+  }
+  if (val.type() == typeid(unsigned long long)) {
+    result = static_cast<double>(boost::any_cast<unsigned long long>(val));
+    return true;
+  }
+  if (val.type() == typeid(py::object))
+    return pyobject_to_double(boost::any_cast<py::object>(val), result);
+  return false;
+}
+
+bool double_is_integer_valued(const double value) {
+  return isfinite(value) && floor(value) == value;
+}
+
+bool any_to_long(const boost::any &val, long &result) {
+  if (val.type() == typeid(short)) {
+    result = static_cast<long>(boost::any_cast<short>(val));
+    return true;
+  }
+  if (val.type() == typeid(unsigned short)) {
+    result = static_cast<long>(boost::any_cast<unsigned short>(val));
+    return true;
+  }
+  if (val.type() == typeid(int)) {
+    result = static_cast<long>(boost::any_cast<int>(val));
+    return true;
+  }
+  if (val.type() == typeid(unsigned int)) {
+    result = static_cast<long>(boost::any_cast<unsigned int>(val));
+    return true;
+  }
+  if (val.type() == typeid(long)) {
+    result = boost::any_cast<long>(val);
+    return true;
+  }
+  if (val.type() == typeid(unsigned long)) {
+    const unsigned long value = boost::any_cast<unsigned long>(val);
+    if (value > static_cast<unsigned long>(numeric_limits<long>::max()))
+      return false;
+    result = static_cast<long>(value);
+    return true;
+  }
+  if (val.type() == typeid(long long)) {
+    const long long value = boost::any_cast<long long>(val);
+    if (value < static_cast<long long>(numeric_limits<long>::min()) ||
+        value > static_cast<long long>(numeric_limits<long>::max()))
+      return false;
+    result = static_cast<long>(value);
+    return true;
+  }
+  if (val.type() == typeid(unsigned long long)) {
+    const unsigned long long value = boost::any_cast<unsigned long long>(val);
+    if (value > static_cast<unsigned long long>(numeric_limits<long>::max()))
+      return false;
+    result = static_cast<long>(value);
+    return true;
+  }
+  if (val.type() == typeid(py::object))
+    return pyobject_to_long(boost::any_cast<py::object>(val), result);
+  double numeric_value(0.0);
+  if (any_to_double(val, numeric_value) &&
+      double_is_integer_valued(numeric_value) &&
+      numeric_value >= static_cast<double>(numeric_limits<long>::min()) &&
+      numeric_value < static_cast<double>(numeric_limits<long>::max())) {
+    result = static_cast<long>(numeric_value);
+    return true;
+  }
+  return false;
+}
+
+string lower_ascii(string value) {
+  transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+    return static_cast<char>(tolower(c));
+  });
+  return value;
+}
+
+string trim_ascii(string value) {
+  const auto first =
+      find_if_not(value.begin(), value.end(),
+                  [](unsigned char c) { return isspace(c); });
+  const auto last =
+      find_if_not(value.rbegin(), value.rend(),
+                  [](unsigned char c) { return isspace(c); })
+          .base();
+  if (first >= last)
+    return string();
+  return string(first, last);
+}
+
+bool any_to_bool(const boost::any &val, bool &result) {
+  if (val.type() == typeid(bool)) {
+    result = boost::any_cast<bool>(val);
+    return true;
+  }
+  if (val.type() == typeid(py::object) &&
+      pyobject_to_bool(boost::any_cast<py::object>(val), result))
+    return true;
+  long integer_value(0);
+  if (any_to_long(val, integer_value) &&
+      (integer_value == 0 || integer_value == 1)) {
+    result = (integer_value == 1);
+    return true;
+  }
+  if (val.type() == typeid(string)) {
+    const string value = lower_ascii(trim_ascii(boost::any_cast<string>(val)));
+    if (value == "true" || value == "yes" || value == "1") {
+      result = true;
+      return true;
+    }
+    if (value == "false" || value == "no" || value == "0") {
+      result = false;
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace
 
 Metadata::Metadata(ifstream &ifs, const string form) {
   try {
@@ -69,6 +345,92 @@ bool Metadata::is_defined(const string key) const noexcept {
     return false;
   }
 }
+
+double Metadata::get_double(const string key) const {
+  map<string, boost::any>::const_iterator iptr;
+  iptr = md.find(key);
+  if (iptr == md.end())
+    throw MetadataGetError(key, typeid(double).name());
+  double val(0.0);
+  if (any_to_double(iptr->second, val))
+    return val;
+  throw MetadataGetError(key, typeid(double).name(), iptr->second.type().name(),
+                         "Metadata value is not numeric");
+}
+
+int Metadata::get_int(const string key) const {
+  map<string, boost::any>::const_iterator iptr;
+  iptr = md.find(key);
+  if (iptr == md.end())
+    throw MetadataGetError(key, typeid(int).name());
+  long val(0);
+  if (any_to_long(iptr->second, val) &&
+      val >= static_cast<long>(numeric_limits<int>::min()) &&
+      val <= static_cast<long>(numeric_limits<int>::max()))
+    return static_cast<int>(val);
+  throw MetadataGetError(
+      key, typeid(int).name(), iptr->second.type().name(),
+      "Metadata value is not integer-valued or is outside int range");
+}
+
+long Metadata::get_long(const string key) const {
+  map<string, boost::any>::const_iterator iptr;
+  iptr = md.find(key);
+  if (iptr == md.end())
+    throw MetadataGetError(key, typeid(long).name());
+  long val(0);
+  if (any_to_long(iptr->second, val))
+    return val;
+  throw MetadataGetError(
+      key, typeid(long).name(), iptr->second.type().name(),
+      "Metadata value is not integer-valued or is outside long range");
+}
+
+bool Metadata::get_bool(const string key) const {
+  map<string, boost::any>::const_iterator iptr;
+  iptr = md.find(key);
+  if (iptr == md.end())
+    throw MetadataGetError(key, typeid(bool).name());
+  bool val(false);
+  if (any_to_bool(iptr->second, val))
+    return val;
+  throw MetadataGetError(key, typeid(bool).name(), iptr->second.type().name(),
+                         "Metadata value is not boolean");
+}
+
+template <> double Metadata::get<double>(const string key) const {
+  return this->get_double(key);
+}
+
+template <> int Metadata::get<int>(const string key) const {
+  return this->get_int(key);
+}
+
+template <> long Metadata::get<long>(const string key) const {
+  return this->get_long(key);
+}
+
+template <> bool Metadata::get<bool>(const string key) const {
+  return this->get_bool(key);
+}
+
+template <> float Metadata::get<float>(const string key) const {
+  map<string, boost::any>::const_iterator iptr;
+  iptr = md.find(key);
+  if (iptr == md.end())
+    throw MetadataGetError(key, typeid(float).name());
+  if (iptr->second.type() == typeid(float))
+    return boost::any_cast<float>(iptr->second);
+  double val(0.0);
+  if (any_to_double(iptr->second, val) && isfinite(val) &&
+      val >= -static_cast<double>(numeric_limits<float>::max()) &&
+      val <= static_cast<double>(numeric_limits<float>::max()))
+    return static_cast<float>(val);
+  throw MetadataGetError(
+      key, typeid(float).name(), iptr->second.type().name(),
+      "Metadata value is not numeric or is outside float range");
+}
+
 void Metadata::append_chain(const std::string key, const std::string val,
                             const std::string separator) {
   if (this->is_defined(key)) {

--- a/cxx/src/lib/utility/metadata_helpers.cc
+++ b/cxx/src/lib/utility/metadata_helpers.cc
@@ -50,10 +50,9 @@ MetadataList get_mdlist(const AntelopePf &m, const string tag) {
 int copy_selected_metadata(const Metadata &mdin, Metadata &mdout,
                            const MetadataList &mdlist) {
   MetadataList::const_iterator mdti;
-  int count;
+  int copied_count(0);
 
-  for (mdti = mdlist.begin(), count = 0; mdti != mdlist.end();
-       ++mdti, ++count) {
+  for (mdti = mdlist.begin(); mdti != mdlist.end(); ++mdti) {
     MDtype mdtest;
     float f;
     double r;
@@ -69,35 +68,35 @@ int copy_selected_metadata(const Metadata &mdin, Metadata &mdout,
       case MDtype::Real32:
         f = mdin.get<float>(mdti->tag);
         mdout.put(mdti->tag, f);
-        ++count;
+        ++copied_count;
         break;
       case MDtype::Double:
       case MDtype::Real64:
         r = mdin.get<double>(mdti->tag);
         mdout.put(mdti->tag, r);
-        ++count;
+        ++copied_count;
         break;
       case MDtype::Integer:
       case MDtype::Int32:
         ii = mdin.get<int>(mdti->tag);
         mdout.put(mdti->tag, ii);
-        ++count;
+        ++copied_count;
         break;
       case MDtype::Long:
       case MDtype::Int64:
         iv = mdin.get<long>(mdti->tag);
         mdout.put(mdti->tag, iv);
-        ++count;
+        ++copied_count;
         break;
       case MDtype::String:
         s = mdin.get<string>(mdti->tag);
         mdout.put(mdti->tag, s);
-        ++count;
+        ++copied_count;
         break;
       case MDtype::Boolean:
         b = mdin.get<bool>(mdti->tag);
         mdout.put(mdti->tag, b);
-        ++count;
+        ++copied_count;
         break;
       case MDtype::Invalid:
         // silently skip values marked as invalid
@@ -115,6 +114,6 @@ int copy_selected_metadata(const Metadata &mdin, Metadata &mdout,
       throw;
     }
   }
-  return count;
+  return copied_count;
 }
 } // namespace mspass::utility

--- a/data/pf/FrequencyDomainGIDDecon.pf
+++ b/data/pf/FrequencyDomainGIDDecon.pf
@@ -2,7 +2,7 @@
 
 deconvolution_operator_type &Arr{
     frequency_domain_gid_deconvolution &Arr{
-        deconvolution_type least_square
+        deconvolution_type ns_gid
         target_sample_interval 0.05
         full_data_window_start -8.0
         full_data_window_end 20.0

--- a/data/pf/FrequencyDomainGIDDecon.pf
+++ b/data/pf/FrequencyDomainGIDDecon.pf
@@ -23,6 +23,11 @@ deconvolution_operator_type &Arr{
         ns_gid_refit_interval 5
         ns_gid_ridge_beta 1.0e-10
         ns_gid_external_wavelet_allowed true
+
+        # The group_sparse_* parameters are used only when
+        # deconvolution_type is group_sparse.  group_sparse_lambda 0.0 means
+        # use the automatic noise-scaled lambda.  active-threshold parameters
+        # control the sparse support exported after the regularized solve.
         group_sparse_lambda 0.0
         group_sparse_lambda_scale 1.0
         group_sparse_tolerance 1.0e-4

--- a/data/pf/FrequencyDomainGIDDecon.pf
+++ b/data/pf/FrequencyDomainGIDDecon.pf
@@ -23,6 +23,13 @@ deconvolution_operator_type &Arr{
         ns_gid_refit_interval 5
         ns_gid_ridge_beta 1.0e-10
         ns_gid_external_wavelet_allowed true
+        group_sparse_lambda 0.0
+        group_sparse_lambda_scale 1.0
+        group_sparse_tolerance 1.0e-4
+        group_sparse_max_iterations 200
+        group_sparse_active_threshold 0.02
+        group_sparse_active_threshold_scale 1.0
+        group_sparse_active_threshold_quantile 0.90
 
         # adaptive_memory derives its applied footprint from the resolution
         # kernel.  lag_weight_function_width is used by fixed-width penalties

--- a/data/pf/TimeDomainGIDDecon.pf
+++ b/data/pf/TimeDomainGIDDecon.pf
@@ -30,6 +30,13 @@ deconvolution_operator_type &Arr{
         ns_gid_refit_interval 5
         ns_gid_ridge_beta 1.0e-10
         ns_gid_external_wavelet_allowed true
+        group_sparse_lambda 0.0
+        group_sparse_lambda_scale 1.0
+        group_sparse_tolerance 1.0e-4
+        group_sparse_max_iterations 200
+        group_sparse_active_threshold 0.02
+        group_sparse_active_threshold_scale 1.0
+        group_sparse_active_threshold_quantile 0.90
 
         # adaptive_memory derives its applied footprint from the resolution
         # kernel.  lag_weight_function_width is used by fixed-width penalties

--- a/data/pf/TimeDomainGIDDecon.pf
+++ b/data/pf/TimeDomainGIDDecon.pf
@@ -30,6 +30,11 @@ deconvolution_operator_type &Arr{
         ns_gid_refit_interval 5
         ns_gid_ridge_beta 1.0e-10
         ns_gid_external_wavelet_allowed true
+
+        # The group_sparse_* parameters are used only when
+        # deconvolution_type is group_sparse.  group_sparse_lambda 0.0 means
+        # use the automatic noise-scaled lambda.  active-threshold parameters
+        # control the sparse support exported after the regularized solve.
         group_sparse_lambda 0.0
         group_sparse_lambda_scale 1.0
         group_sparse_tolerance 1.0e-4

--- a/data/pf/TimeDomainGIDDecon.pf
+++ b/data/pf/TimeDomainGIDDecon.pf
@@ -7,7 +7,7 @@
 
 deconvolution_operator_type &Arr{
     time_domain_gid_deconvolution &Arr{
-        deconvolution_type least_square
+        deconvolution_type ns_gid
         target_sample_interval 0.05
         full_data_window_start -8.0
         full_data_window_end 20.0

--- a/docs/source/user_manual/deconvolution.rst
+++ b/docs/source/user_manual/deconvolution.rst
@@ -210,11 +210,12 @@ The word "noise" has several meanings:
     Noise used by iterative methods to decide whether another sparse spike is
     significant and when iteration should stop.
 
-For ``ns_gid``, an external ``TimeSeries`` noise estimate can be used for both
-inverse-operator regularization and, when loaded as residual noise,
-residual-domain stopping.  An external ``PowerSpectrum`` can regularize only
-the inverse operator; a residual-domain noise window is still needed for sparse
-iteration stopping.
+For ``ns_gid`` and ``group_sparse``, an external ``TimeSeries`` noise estimate
+can be used for inverse-operator regularization and, when loaded as residual
+noise, residual-domain stopping or support decisions.  An external
+``PowerSpectrum`` can regularize only the NS-GID inverse operator; a
+residual-domain noise window or time-domain noise estimate is still needed for
+sparse iteration stopping or group-sparse support decisions.
 
 Choosing an operator
 --------------------
@@ -331,6 +332,11 @@ For lower-level workflows that use the GID engines directly, use
        deconvolution_type="least_square",
    )
 
+``make_gid_engine`` returns the lower-level C++ GID engine object.  Pass that
+object to ``TimeDomainGIDRFDecon`` or ``FrequencyDomainGIDRFDecon``; pass an
+``RFdeconProcessor`` object to the high-level ``RFdecon(..., engine=...)``
+interface.
+
 These settings are separate layers.  The ``deconvolution_type`` method layer and
 its alias ``gid_mode`` choose the GID inverse or solver mode, such as ``ns_gid``,
 ``least_square``, or ``group_sparse``.  ``lag_weight_penalty_function`` and its
@@ -340,6 +346,11 @@ such as ``group_sparse_active_threshold``,
 ``group_sparse_active_threshold_scale``, and
 ``group_sparse_active_threshold_quantile``, are applied after the group-sparse
 solve to decide which lag groups remain in the sparse output.
+
+The modes above are the recommended user-facing choices.  Legacy and advanced
+inverse modes are still accepted where supported, including ``water_level``,
+``multi_taper``, ``cnr``/``cnr3c``, the ``noise_stable`` alias for ``ns_gid``,
+and the ``group_lasso``/``sparse_group_lasso`` aliases for ``group_sparse``.
 
 Scalar inverse operators
 ------------------------
@@ -484,7 +495,9 @@ wavelets can be supplied through the GID ``loadwavelet`` APIs or wrapper
 inverse regularization and residual-domain stopping when loaded as residual
 noise.  External ``PowerSpectrum`` noise only regularizes the inverse operator;
 a residual-domain noise window is still needed for spike significance and
-stopping.
+stopping.  In ``group_sparse`` mode, that inverse regularization can also
+change the automatically selected ``group_sparse_lambda`` because the automatic
+lambda uses the NS-GID inverse-filtered noise threshold when it is available.
 
 Convergence and stopping
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -908,9 +921,11 @@ QC and interpretation
 ``group_sparse_active_threshold_quantile_value``,
 ``group_sparse_active_threshold_used``, and
 ``group_sparse_active_groups``.  It also records ``group_sparse_iterations``
-and ``group_sparse_converged`` for the proximal solve.  These fields let
-downstream QC distinguish the regularized solve from the support-reporting
-layer.
+and ``group_sparse_converged`` for the proximal solve, plus
+``group_sparse_debiased_objective_final`` and
+``group_sparse_debiased_fractional_improvement_final`` for the amplitude refit
+on the selected support.  These fields let downstream QC distinguish the
+regularized solve from the support-reporting and debiased-amplitude layers.
 
 These are not optional display fields.  They are part of the QC subdocument
 that should be saved with the deconvolved datum and used by downstream
@@ -1082,9 +1097,13 @@ Useful first-pass fields are:
 ``group_sparse_active_threshold_used``, ``group_sparse_active_groups``,
 ``group_sparse_objective_initial``, and ``group_sparse_objective_final``
     Summarize the regularized group-sparse solve and the exported sparse
-    support decision.  ``group_sparse_objective_final`` is recomputed after
-    thresholding and amplitude refit, so it describes the exported sparse
-    receiver function.  These fields are present only for
+    support decision.  ``group_sparse_objective_final`` is the solver's final
+    regularized objective after thresholding the proximal solution.  The
+    amplitude refit is reported separately as
+    ``group_sparse_debiased_objective_final`` and
+    ``group_sparse_debiased_fractional_improvement_final`` because it is the
+    same regularized objective evaluated after the debiased amplitude update on
+    the selected support.  These fields are present only for
     ``deconvolution_type group_sparse``.
 
 ``ns_gid_gain_max_actual``, ``ns_gid_noise_amplification``, and

--- a/docs/source/user_manual/deconvolution.rst
+++ b/docs/source/user_manual/deconvolution.rst
@@ -15,7 +15,7 @@ source spectra contain notches and real data contain noise, so MsPASS uses
 regularized inverse filters or sparse iterative methods rather than direct
 spectral division.
 
-Most users should read this page in three passes:
+Most users should read this page in four passes:
 
 1. Skim `Essential terms`_ so the method descriptions use familiar words.
 2. Read `Wrappers and engines`_, `Common conventions`_, and

--- a/docs/source/user_manual/deconvolution.rst
+++ b/docs/source/user_manual/deconvolution.rst
@@ -1073,14 +1073,18 @@ Useful first-pass fields are:
 
 ``gid_penalty_function``, ``gid_penalty_effective_width``,
 ``lag_weight_L2_final``, and the ``gid_penalty_*`` adaptive-memory fields
-    Explain how the lag-weight penalty affected candidate selection.
+    Explain how the lag-weight penalty affected candidate selection.  These
+    fields are present for greedy GID modes, not for
+    ``deconvolution_type group_sparse``.
 
 ``group_sparse_enabled``, ``group_sparse_converged``,
 ``group_sparse_iterations``, ``group_sparse_lambda_used``,
 ``group_sparse_active_threshold_used``, ``group_sparse_active_groups``,
 ``group_sparse_objective_initial``, and ``group_sparse_objective_final``
     Summarize the regularized group-sparse solve and the exported sparse
-    support decision.  These fields are present only for
+    support decision.  ``group_sparse_objective_final`` is recomputed after
+    thresholding and amplitude refit, so it describes the exported sparse
+    receiver function.  These fields are present only for
     ``deconvolution_type group_sparse``.
 
 ``ns_gid_gain_max_actual``, ``ns_gid_noise_amplification``, and

--- a/docs/source/user_manual/deconvolution.rst
+++ b/docs/source/user_manual/deconvolution.rst
@@ -240,10 +240,12 @@ with the failure mode you need to control:
    * - Want shared sparse support across components
      - ``deconvolution_type group_sparse``
 
-The distributed GID parameter files currently keep
-``deconvolution_type least_square`` for backward compatibility.  For noisy
-production GID, use ``deconvolution_type ns_gid`` unless validation on your data
-supports another inverse mode.
+The distributed GID parameter files use ``deconvolution_type ns_gid`` with the
+``adaptive_memory`` lag penalty.  Validation sweeps selected that combination
+because it is more resistant to noise-driven false picks than the legacy
+``least_square`` inverse.  Use ``group_sparse`` when a shared-support sparse
+prior matches the problem, and reserve ``least_square`` for explicit legacy
+comparisons or diagnostics.
 
 Scalar inverse operators
 ------------------------
@@ -466,10 +468,12 @@ The easiest way to choose a penalty is by failure mode:
    * - Resolution-footprint studies
      - ``resolution_kernel`` or ``shaping_wavelet``
 
-The shipped GID parameter files set ``lag_weight_penalty_function
-adaptive_memory`` and ``lag_weight_penalty_scale_factor=0.35``.  The default
-``deconvolution_type`` remains ``least_square`` for backward compatibility.
-Treat this as a conservative noisy-data setting, not a universal optimum.
+The shipped GID parameter files set ``deconvolution_type ns_gid``,
+``lag_weight_penalty_function adaptive_memory``, and
+``lag_weight_penalty_scale_factor=0.35``.  Validation sweeps across moderate and
+large noise levels selected this as the default because the legacy
+``least_square`` inverse can generate noise-driven false picks even with the
+same lag penalty.  Treat it as a robust starting point, not a universal optimum.
 
 How the greedy penalty enters GID
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/user_manual/deconvolution.rst
+++ b/docs/source/user_manual/deconvolution.rst
@@ -912,6 +912,15 @@ and ``group_sparse_converged`` for the proximal solve.  These fields let
 downstream QC distinguish the regularized solve from the support-reporting
 layer.
 
+These are not optional display fields.  They are part of the QC subdocument
+that should be saved with the deconvolved datum and used by downstream
+screening jobs to reject unstable or poorly constrained receiver functions.
+When ``deconvolution_type group_sparse`` is active, the group-sparse fields
+describe the solve that produced the output.  When another GID method is
+active, the ``group_sparse_*`` fields are absent.  The QC document is not a
+fixed table; method-specific keys are recorded only when that method or
+internal method component actually ran.
+
 ``group_sparse_active_groups`` is a count of retained coefficient groups, not a
 resolved geologic arrival count.  Validation plots and tests use separate
 detection metrics for arrival-level comparisons.
@@ -1071,7 +1080,8 @@ Useful first-pass fields are:
 ``group_sparse_active_threshold_used``, ``group_sparse_active_groups``,
 ``group_sparse_objective_initial``, and ``group_sparse_objective_final``
     Summarize the regularized group-sparse solve and the exported sparse
-    support decision.
+    support decision.  These fields are present only for
+    ``deconvolution_type group_sparse``.
 
 ``ns_gid_gain_max_actual``, ``ns_gid_noise_amplification``, and
 ``ns_gid_effective_bandwidth_fraction``
@@ -1081,7 +1091,8 @@ Useful first-pass fields are:
 ``group_sparse_inverse_noise_amplification``, and
 ``group_sparse_inverse_effective_bandwidth_fraction``
     Help audit the NS-GID inverse branch used internally by
-    ``deconvolution_type group_sparse``.
+    ``deconvolution_type group_sparse``.  These fields are absent for other
+    GID modes.
 
 Implementation and compatibility notes
 --------------------------------------

--- a/docs/source/user_manual/deconvolution.rst
+++ b/docs/source/user_manual/deconvolution.rst
@@ -1,424 +1,483 @@
 Deconvolution Operators
 =======================
 
-This page summarizes the mathematical conventions used by the receiver
-function deconvolution operators in MsPASS.  The defaults are intended for
-seismic time series and solve linear convolution problems.  Circular
-convolution is used only internally as an FFT implementation detail after
-zero padding, or in explicitly diagnostic quantities.
-
-Common convention
------------------
-
-The deconvolution operators model a signal as
+This page describes the receiver-function deconvolution operators available in
+MsPASS.  Deconvolution estimates an Earth response from an observed component
+and an estimated source wavelet.  In simplified form,
 
 .. math::
 
    d(t) = s(t) * m(t) + n(t),
 
-where ``d`` is the observed component, ``s`` is the source or vertical
-component wavelet, ``m`` is the receiver-function estimate, and ``n`` is
-noise.  For discrete data, the implementation treats this as a linear
-convolution problem.  FFT-based scalar operators pad the working arrays
-before transforming, then extract the requested lag window from the padded
-linear-convolution result.  The default result is therefore not the wrapped
-output of a circular convolution.  For a requested output window of ``N``
-samples, scalar FFT operators use an FFT length of at least ``2*N - 1``,
-rounded up to the next power of two.  That is the linear
-convolution/correlation length for the loaded source and data windows and
-avoids the unnecessary computation and diagnostic spectral over-sampling of a
-larger guard buffer.
+where ``d`` is the observed target component, ``s`` is the source or reference
+wavelet, ``m`` is the receiver-function estimate, and ``n`` is noise.  Real
+source spectra contain notches and real data contain noise, so MsPASS uses
+regularized inverse filters or sparse iterative methods rather than direct
+spectral division.
 
-The receiver-function output window is controlled by the operator parameter
-file, normally through ``deconvolution_data_window_start`` and
-``deconvolution_data_window_end``.  The zero-lag convention is the sample of
-the output window whose time is 0.0 relative to the source-wavelet reference
-time.  If an operator reports ``actual_output`` or ``inverse_wavelet``, that
-diagnostic object may be the full padded operator response; use the returned
-receiver function for the cropped seismic result.
+Most users should read this page in three passes:
 
-Terminology
------------
+1. Skim `Essential terms`_ so the method descriptions use familiar words.
+2. Read `Wrappers and engines`_, `Common conventions`_, and
+   `Choosing an operator`_ to understand the processing workflow.
+3. Read the method section for the operator you plan to use.
+4. Use `Validation and QC workflow`_ to inspect plots and saved metadata.
 
-This page follows the terminology of Wang & Pavlis (2016) for generalized
-iterative deconvolution:
-
-``sparse impulse response``
-    The finite spike series :math:`\hat{i}(t)` selected by the iterative loop.
-    In code this is returned by ``sparse_output``.
-
-``output shaping wavelet``
-    The wavelet :math:`w_s(t)` convolved with :math:`\hat{i}(t)` to form the
-    finite-duration receiver-function representation
-    :math:`\hat{m}_{id}(t)=w_s(t)*\hat{i}(t)`.  In code the preferred method
-    name is ``output_shaping_wavelet``.  The older method name
-    ``ideal_output`` is retained only as a legacy alias.
-
-``actual output`` or ``resolution kernel``
-    The inverse operator applied to the estimated source wavelet,
-    :math:`\hat{R}(\omega)=\hat{s}^{-g}(\omega)\hat{s}(\omega)`.  This is the
-    paper's actual output of the inverse filter and is returned by
-    ``actual_output`` or the alias ``resolution_kernel``.
-
-``inverse operator``
-    The operator :math:`\hat{s}^{-g}` used to transform the residual into the
-    GID detection function.  It is not the output shaping wavelet.
-
-Wrapper Data Handling
----------------------
-
-The low-level scalar C++ operators load raw vectors and do not carry absolute
-time windows.  ``RFdeconProcessor`` and ``RFdecon`` own scalar data handling:
-they extract the configured deconvolution, wavelet, and noise windows before
-calling the scalar engines.  If a configured window is not present in the
-input datum, the wrapper returns a killed datum and does not attach a QC
-subdocument.
-
-``CNRRFDecon`` and ``CNRArrayDecon`` have a stricter explicit contract.  A
-caller must either provide both ``signal_window`` and ``noise_window`` or
-provide a precomputed ``PowerSpectrum`` noise estimate.  If a signal window is
-provided it is applied to the output data.  If an external wavelet is provided,
-that wavelet is used for all components; otherwise the configured component of
-the signal window is used as the source wavelet.
-
-The GID wrappers share a common convention.  If ``signal_window`` is omitted,
-the input datum's full time range is used as the analysis/output window.  If
-``noise_window`` is omitted, the engine's configured parameter-file noise
-window is used.  The analysis window must contain the configured
-deconvolution/inverse-operator window; otherwise the wrapper returns a killed
-datum instead of processing a partial window.
-
-Noise Semantics
+Essential terms
 ---------------
 
-The word "noise" appears in several deconvolution APIs, but it does not always
-mean the same mathematical object.  Keeping these roles separate is important
-when building reusable processors for Dask or Spark jobs:
+``target component`` or ``target trace``
+    The observed component being deconvolved.
+
+``source wavelet`` or ``reference wavelet``
+    The estimated source pulse used to build an inverse operator.  In many
+    receiver-function workflows this is the vertical component, the P component
+    aligned with the incoming P-wave direction, or an externally prepared stack.
+
+``signal_window``
+    The target interval to analyze and usually return.
+
+``noise_window``
+    A time interval used to estimate noise for inverse stabilization or
+    iterative stopping.
+
+``TimeSeries`` and ``PowerSpectrum``
+    MsPASS data objects used by some deconvolution APIs.  A ``TimeSeries``
+    stores a sampled time-domain signal.  A ``PowerSpectrum`` stores a
+    frequency-domain power estimate, commonly used as a reusable noise
+    spectrum.
+
+``deconvolution window`` or ``receiver-function lag window``
+    The output lag interval configured by parameters such as
+    ``deconvolution_data_window_start`` and
+    ``deconvolution_data_window_end``.  For the GID wrappers, the
+    ``signal_window`` must contain this lag window.
+
+``receiver function``
+    The estimated Earth response.  Scalar inverse operators return a
+    regularized receiver-function trace directly.  GID operators first estimate
+    a sparse impulse response and then shape it into a receiver-function trace.
+
+``inverse operator``
+    The regularized operator applied to data or residuals.  In GID it is used
+    to form a detection function for choosing candidate spikes.  It is not the
+    output shaping wavelet.
+
+``generalized iterative deconvolution`` or ``GID``
+    A three-component sparse deconvolution family based on Wang and Pavlis
+    (2016).  This page uses ``greedy GID`` for the classic one-spike-at-a-time
+    iteration and ``group_sparse`` for the regularized solver that estimates
+    all lags together.
+
+``NS-GID``
+    Noise-stable GID.  It is selected with ``deconvolution_type ns_gid`` and
+    changes the inverse operator used inside GID.
+
+``sparse impulse response``
+    The finite spike series selected by GID.  In code this is returned by
+    ``sparse_output``.
+
+``shaped receiver function``
+    The sparse impulse response convolved with the output shaping wavelet.  This
+    is the finite-bandwidth receiver function returned by ``getresult`` for GID.
+
+``output shaping wavelet``
+    The wavelet convolved with the sparse impulse response to form the shaped
+    receiver function.  In code the preferred method name is
+    ``output_shaping_wavelet``.  The older name ``ideal_output`` is retained
+    only as a legacy alias.
+
+``actual output`` or ``resolution kernel``
+    The inverse operator applied to the estimated source wavelet.  It describes
+    the resolution of the inverse filter and is returned by ``actual_output``
+    or ``resolution_kernel``.
+
+``inverse_wavelet``
+    A diagnostic representation of the inverse filter itself.  It can be longer
+    than the returned receiver-function lag window because FFT-based operators
+    work on padded arrays internally.
+
+``sparse support``
+    The lag samples retained as nonzero arrivals in the sparse impulse
+    response.  A ``lag group`` is the three-component coefficient vector at one
+    lag sample.
+
+``support threshold``
+    A cutoff used after a sparse solve to decide which lag groups are retained
+    in ``sparse_output`` and in the final refit model.
+
+``lag-weight penalty``
+    A greedy-GID mechanism that downweights candidate lags after a spike has
+    already been accepted.  It changes future candidate selection; it is not an
+    amplitude shrinkage penalty.
+
+``group-sparse regularization``
+    A separate GID mode selected with ``deconvolution_type group_sparse``.  It
+    estimates the full sparse impulse response with a grouped sparsity penalty
+    instead of using the greedy GID spike picker.
+
+``QC metadata``
+    Quality-control metadata stored by wrappers and engines.  These scalar
+    fields record processing status, convergence, residual norms, penalty
+    settings, support thresholds, and inverse-stability diagnostics.
+
+``CNR``
+    Colored-noise-ratio deconvolution.
+
+``SNR``
+    Signal-to-noise ratio.
+
+Wrappers and engines
+--------------------
+
+MsPASS separates data handling from numerical deconvolution.
+
+``RFdeconProcessor`` and ``RFdecon``
+    General receiver-function wrappers.  They operate on MsPASS data objects,
+    read parameter files, extract wavelet, data, and noise windows, call the
+    selected engine, and save QC metadata in a subdocument.  Conventional scalar
+    methods are applied component by component.  Generalized iterative
+    deconvolution methods operate on the full three-component seismogram because
+    their spike selection is vector-valued.  If a required window is absent, the
+    wrapper returns a killed datum and does not attach the QC subdocument.
+
+``CNRRFDecon`` and ``CNRArrayDecon``
+    Wrappers for colored-noise-ratio deconvolution.  A caller must provide both
+    ``signal_window`` and ``noise_window`` or provide a precomputed
+    ``PowerSpectrum`` noise estimate.  If an external wavelet is supplied, it
+    is used for all components; otherwise the configured component of the
+    signal window is used as the source wavelet.
+
+``TimeDomainGIDRFDecon`` and ``FrequencyDomainGIDRFDecon``
+    Direct wrappers around the GID engines.  If ``signal_window`` is omitted,
+    the full input time range is used as the interval to analyze and return.  If
+    ``noise_window`` is omitted, the engine's parameter-file noise window is
+    used.  The analysis interval must contain the configured receiver-function
+    lag window.
+
+The lower-level C++ engines do the numerical work.  They are useful for tests,
+diagnostics, and specialized processing tools, but they expect the caller to
+load the correct data, wavelet, and noise estimates.
+
+Common conventions
+------------------
+
+MsPASS treats receiver-function deconvolution as a linear convolution problem.
+FFT-based operators use zero padding internally, but the returned receiver
+function is the requested linear lag window, not a wrapped circular-convolution
+result.  For a requested scalar FFT output window of ``N`` samples, the working
+FFT length is at least ``2*N - 1`` samples, rounded up to the next power of two.
+
+The receiver-function output window is normally configured with
+``deconvolution_data_window_start`` and ``deconvolution_data_window_end``.  Zero
+lag is the sample whose time is 0.0 relative to the source-wavelet reference
+time.  Diagnostic objects can describe the full padded inverse-operator
+response: ``actual_output`` or ``resolution_kernel`` is the inverse operator
+applied to the source wavelet, while ``inverse_wavelet`` is the inverse filter
+itself.  The returned receiver function is the cropped seismic result.
+
+Windows and noise
+-----------------
+
+Three window concepts appear throughout the deconvolution APIs:
+
+``signal_window``
+    The target time interval to analyze and normally the output interval to
+    return.
+
+``wavelet`` or ``wavelet window``
+    The source estimate used to build the inverse operator.  In receiver
+    function workflows this is commonly the vertical or P component, or an
+    external stacked source estimate.
+
+``noise_window``
+    A time interval or spectrum used to stabilize the inverse or to decide when
+    an iterative method should stop.
+
+The word "noise" has several meanings:
 
 ``source/wavelet noise``
     Noise used to stabilize the inverse operator denominator.  Multitaper,
     CNR, and NS-GID use this information to avoid excessive inverse gain in
-    weak or noisy source-wavelet bands.  This noise controls the inverse
-    operator, not the target trace itself.
+    weak or noisy source-wavelet bands.
 
 ``target/data noise``
-    Noise already present in the component being deconvolved.  Any inverse
-    filter can amplify this noise.  Stable scalar operators reduce that
-    amplification indirectly by regularizing the source-wavelet inverse, but
-    they do not explicitly separate every target-trace noise component.
+    Noise already present in the component being deconvolved.  Stable inverse
+    operators reduce amplification of this noise indirectly by regularizing the
+    source-wavelet inverse.
 
 ``residual-domain noise``
     Noise used by iterative methods to decide whether another sparse spike is
-    significant and when iteration should stop.  In GID/NS-GID this is a
-    stopping and candidate-acceptance quantity.  It is conceptually separate
-    from the frequency-domain noise spectrum used to build the inverse
-    operator.
+    significant and when iteration should stop.
 
-For NS-GID, an external ``TimeSeries`` noise estimate can serve both as the
-inverse-operator noise estimate and, when explicitly loaded as residual noise,
-the residual-domain stopping estimate.  An external ``PowerSpectrum`` noise
-estimate can only regularize the inverse operator; a residual-domain noise
-window is still required for spike significance and residual-noise stopping.
+For ``ns_gid``, an external ``TimeSeries`` noise estimate can be used for both
+inverse-operator regularization and, when loaded as residual noise,
+residual-domain stopping.  An external ``PowerSpectrum`` can regularize only
+the inverse operator; a residual-domain noise window is still needed for sparse
+iteration stopping.
+
+Choosing an operator
+--------------------
+
+No deconvolution operator is best for every receiver-function problem.  Start
+with the failure mode you need to control:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Goal or data condition
+     - Recommended starting point
+   * - Simple scalar receiver functions with moderate noise
+     - ``LeastSquareDecon`` or ``WaterLevelDecon`` through ``RFdecon``
+   * - Source spectrum is noisy or has strong notches
+     - ``NoiseStableDecon`` for scalar tests, or ``ns_gid`` for GID
+   * - Need colored-noise regularization on three components
+     - ``CNRDeconEngine`` through ``CNRRFDecon`` or ``CNRArrayDecon``
+   * - Need sparse three-component arrivals and per-spike diagnostics
+     - ``TimeDomainGIDDecon`` or ``FrequencyDomainGIDDecon``
+   * - Noisy GID repeatedly picks the same strong arrival
+     - ``deconvolution_type ns_gid`` with ``adaptive_memory`` lag penalty
+   * - Want shared sparse support across components
+     - ``deconvolution_type group_sparse``
+
+The distributed GID parameter files currently keep
+``deconvolution_type least_square`` for backward compatibility.  For noisy
+production GID, use ``deconvolution_type ns_gid`` unless validation on your data
+supports another inverse mode.
 
 Scalar inverse operators
 ------------------------
 
-Scalar operators load one source wavelet and one data trace at a time.  They
-return a regularized inverse-filter receiver-function trace, not a sparse
-impulse response.  The scalar parameter files default to
-``shaping_wavelet_type none``.  Scalar operators can still apply an optional
-legacy target-pulse filter if a shaping wavelet is configured, but that is a
-post-deconvolution display/bandlimiting filter and is not the GID shaping
-wavelet used to represent sparse spikes.
+Scalar operators load one source wavelet and one target trace.  They return a
+regularized inverse-filter receiver function, not a sparse impulse response.
+Their default parameter files do not apply a GID-style output shaping wavelet
+(``shaping_wavelet_type none``).  If an older scalar parameter file configures
+an output filter, treat it as a legacy display or bandlimiting filter.
 
 ``LeastSquareDecon``
-    Frequency-domain damped least-squares deconvolution.  The inverse
-    operator has the form
+    Frequency-domain damped least-squares deconvolution.  The inverse operator
+    has the form
 
     .. math::
 
        S_g^{-1}(\omega) =
        \frac{\overline{S(\omega)}}{|S(\omega)|^2 + \mu},
 
-    where ``mu`` is the damping term.  Smaller damping improves resolution
-    for clean data but amplifies noise and spectral notches.  Larger damping
-    produces a smoother, more stable estimate.  In the implementation
-    ``mu`` is ``(rms(S) * damping_factor)^2`` in the normal-equation
-    denominator.  The data and wavelet are zero padded to the linear
-    convolution length before the FFT, ``winv`` stores the stabilized inverse,
-    and ``getresult`` returns the cropped lag window of
-    ``S_g^{-1}(omega) D(omega)`` unless an optional scalar output filter is
-    configured.
+    where ``mu`` is the damping term.  Smaller damping improves resolution for
+    clean data but amplifies noise and spectral notches.  Larger damping
+    produces a smoother, more stable estimate.
 
 ``WaterLevelDecon``
     Frequency-domain deconvolution with a water-level floor on the source
-    power spectrum.  The water level protects the result from division by
-    near-zero spectral amplitudes.  The implementation raises
-    ``|S(omega)|`` to at least ``water_level * rms(S)`` before division and
-    extracts the linear lag window.  Raising the floor improves stability at
-    the cost of reduced resolution.
+    spectrum.  Raising the water level improves stability but reduces
+    resolution.
 
 ``MultiTaperPowerXcor`` and ``MultiTaperPowerSpecDiv``
-    Multitaper frequency-domain operators.  Both use DPSS tapers to stabilize
-    spectral estimates, but the final receiver-function estimate is produced
-    by applying the inverse operator to the untapered, zero-padded data
-    window.  This avoids biasing delayed converted phases by the taper value
-    at their arrival time.
+    Multitaper frequency-domain operators that use discrete prolate spheroidal
+    sequence (DPSS) tapers to stabilize source-power estimates.  The final
+    receiver-function estimate is formed with the untapered data window so
+    delayed converted phases are not weighted by the taper value at their
+    arrival time.  In receiver-function workflows, the noise vector should
+    normally describe the source/wavelet component, not the radial or
+    transverse target component.
 
     These MsPASS operators are not paper-faithful Park and Levin (2000)
-    multitaper correlation estimators.  Park and Levin use tapered data/source
-    cross spectra in both numerator and denominator.  The current operators
-    instead use the untapered wavelet phase and untapered data spectrum in the
-    final inverse, while DPSS spectra stabilize the source-power denominator:
-
-    .. math::
-
-       G(f) = \frac{\overline{W_0(f)}}{\operatorname{Den}_{mt}(f)},\quad
-       RF(f)=G(f)D_0(f),\quad AO(f)=G(f)W_0(f).
-
-    In RF workflows the multitaper noise vector should normally come from the
-    source/wavelet component, commonly the vertical or P component or the
-    uncertainty estimate of an external stacked wavelet, not from the radial or
-    transverse target component being deconvolved.
-
-    ``MultiTaperPowerXcor`` uses the mean multitaper source power plus a
-    damped mean multitaper noise power as ``Den_mt``.
-    ``MultiTaperPowerSpecDiv`` is the multitaper power-stabilized
-    spectral-division variant: it regularizes each tapered source power by the
-    corresponding noise power and a small relative floor, combines those
-    powers, and then forms the same untapered-phase inverse.  The two methods
-    should be close on clean data; large differences normally indicate
-    instability or a configuration problem.  Both return a linear-convolution
-    lag window.  The C++/pybind classes are still registered as
-    ``MultiTaperXcorDecon`` and ``MultiTaperSpecDivDecon`` for ABI and pickle
-    compatibility; ``MultiTaperPowerXcorDecon`` and
-    ``MultiTaperPowerSpecDivDecon`` are Python module aliases to those classes,
-    not distinct runtime types.  The old RF processor algorithm names
-    ``MultiTaperXcor`` and ``MultiTaperSpecDiv`` remain available as
-    deprecated compatibility aliases for the power-stabilized operators.
-    ``MultiTaperSpecDivDecon`` still exposes legacy ``all_inverse_wavelets``,
-    ``all_rfestimates``, and ``all_actual_outputs`` methods, but in the current
-    implementation those compatibility methods normally contain one combined
-    multitaper estimate rather than one independent product per taper.
-
-    .. warning::
-
-       This is a migration point.  New code should use the explicit
-       ``MultiTaperPowerXcor`` and ``MultiTaperPowerSpecDiv`` RF algorithm
-       names.  ``damping_factor`` is now interpreted in the power-domain
-       denominator, and parameter files
-       tuned against older tapered-numerator behavior should be retuned and
-       revalidated.  Values should not be assumed numerically equivalent to the
-       historical Park-Levin-style implementation.
+    multitaper correlation estimators.  They use DPSS spectra to stabilize the
+    source-power denominator, but apply the final inverse operator to the
+    untapered wavelet phase and untapered data spectrum.
 
 ``NoiseStableDecon``
-    Noise-aware stable scalar inverse used by the ``ns_gid`` GID mode and also
-    exposed as a standalone scalar operator for validation.  It applies one
-    inverse operator,
+    Noise-aware scalar inverse used by ``ns_gid`` and exposed as a standalone
+    validation operator.  It applies gain limits and frequency-dependent
+    regularization from the source/noise estimate:
 
     .. math::
 
-       G(f)=B(f)\frac{\overline{S(f)}}{|S(f)|^2+\mu(f)},
+       G(f)=B(f)\frac{\overline{S(f)}}{|S(f)|^2+\mu(f)}.
 
-    directly to the data spectrum and returns the finite-bandwidth inverse
-    result.  It does not run spike picking, does not expose a sparse output,
-    and does not apply the GID output shaping wavelet.  ``mu(f)`` is the
-    maximum of a relative minimum floor scaled by peak ``|S|^2``, a
-    noise-spectrum damping term, and a term required to enforce
-    ``|G(f)| <= ns_gid_gain_max``.  An optional SNR reliability taper can
-    reduce or zero low-SNR bands before inverse filtering.
+    The operator does not pick sparse spikes and does not apply the GID output
+    shaping wavelet.
 
 ``TimeDomainLeastSquareDecon``
-    Time-domain least-squares deconvolution.  This operator builds the
-    Toeplitz linear-convolution matrix for the requested output lag window
-    and solves the regularized normal equations with a stable linear solver.
-    It does not build a circular convolution matrix.  The damping parameter
-    controls the same resolution/noise trade-off as the frequency-domain
-    least-squares operator.  The implementation forms ``S^T S`` and
-    ``S^T d`` directly from the cropped linear convolution operator, adds
-    ``damping_factor * max(diag(S^T S))`` to the diagonal, and solves with
-    LAPACK Cholesky.  If Cholesky fails, it falls back to LAPACK LU and raises
-    an error if the regularized system is still singular.  No explicit matrix
-    inverse is constructed.  ``getresult`` returns the solved Toeplitz model by
-    default.  If a scalar output filter is explicitly configured it is applied
-    after solving, but this is not part of the least-squares inverse itself.
+    Time-domain least-squares deconvolution.  This operator builds a linear
+    convolution system for the requested lag window and solves the regularized
+    normal equations.  It does not build a circular convolution matrix.
 
-Three-component and iterative operators
----------------------------------------
+Three-component CNR operators
+-----------------------------
 
-``CNRDeconEngine`` and ``CNR3CDecon``
-    Three-component correlation-noise-ratio receiver-function deconvolution.
-    These operators estimate a noise spectrum from a configured noise window
-    and regularize the source spectrum as a function of colored noise level
-    and SNR.  ``colored_noise_damping`` adds a frequency-dependent damping term
-    to the normal-equation denominator.  ``generalized_water_level`` raises
-    low-SNR source amplitudes before division.  Both produce scalar
-    finite-bandwidth component traces after the configured output shaping
-    wavelet is applied.  ``CNRDeconEngine`` is the current engine used by the
-    Python wrappers and GID inverse mode.  ``CNR3CDecon`` is the older 3C
-    prototype kept for compatibility.
+``CNRDeconEngine`` and ``CNR3CDecon`` implement colored-noise-ratio
+receiver-function deconvolution.  They estimate or load a noise spectrum and
+regularize the source spectrum as a function of colored noise level and SNR.
+``colored_noise_damping`` adds a frequency-dependent damping term to the
+normal-equation denominator.  ``generalized_water_level`` raises low-SNR source
+amplitudes before division.
 
-``TimeDomainGIDDecon`` and ``FrequencyDomainGIDDecon``
-    Generalized iterative deconvolution following Wang and Pavlis (2016).
-    The method maintains a sparse impulse response during iteration.  At each
-    step it computes a detection function
+``CNRDeconEngine`` is the current engine used by the Python wrappers and by the
+CNR inverse mode inside GID.  ``CNR3CDecon`` is the older three-component
+prototype kept for compatibility.
 
-    .. math::
+Generalized iterative deconvolution (GID)
+-----------------------------------------
 
-       a(t) = s_g^{-1}(t) * r(t),
+``TimeDomainGIDDecon`` and ``FrequencyDomainGIDDecon`` estimate a sparse
+three-component impulse response.  Accepted spikes are convolved with the
+configured output shaping wavelet to produce the shaped receiver function
+returned by ``getresult``.  The raw sparse impulse response is available
+through ``sparse_output`` for diagnostics and validation.
 
-    where ``r`` is the current residual and ``s_g^{-1}`` is a configurable
-    inverse operator.  Supported inverse modes include damped least squares,
-    water level, multitaper, and the three-component CNR inverse where
-    available.  The represented receiver function is the sparse impulse
-    response convolved with the output shaping wavelet; the raw sparse impulse
-    response is not the finite-bandwidth receiver function.
+Greedy GID workflow
+~~~~~~~~~~~~~~~~~~~
 
-    The GID engines maintain residuals in the original data domain.  The
-    inverse operator is used only to form the detection function for candidate
-    spike selection.  Residual subtraction uses a compact copy of the inverse
-    operator's actual output/resolution kernel.  That internal residual-update
-    kernel is trimmed, may be shortened to a small window around zero lag, and
-    is peak-normalized before use.  By contrast, public ``actual_output()``
-    returns the underlying inverse operator's full resolution kernel.  QC fields
-    ``gid_actual_o_fir_npts``, ``gid_actual_o_fir_zero_lag_index``, and
-    ``gid_actual_o_fir_peak_normalized`` describe the compact internal kernel.
-    Optional joint refitting of accepted spike amplitudes solves a small dense
-    system with LAPACK Cholesky and LU fallback.  The sparse impulse response is
-    exposed by ``sparse_output``.
+Greedy GID is the classic one-spike-at-a-time sparse method.  At each
+iteration the engine applies a configured inverse operator to the current
+residual to form a detection function,
 
-    Candidate spike selection can be biased by a lag-weight penalty function.
-    The penalty is configured with ``lag_weight_penalty_function`` (``none``,
-    ``boxcar``, ``cosine_taper``, ``shaping_wavelet``,
-    ``resolution_kernel``, or ``adaptive_memory``),
-    ``lag_weight_penalty_scale_factor``, and ``lag_weight_function_width``.
-    After a spike is accepted, the selected lag
-    neighborhood is multiplied by that penalty, which suppresses repeated picks
-    of the same large arrival and encourages later iterations to search for
-    weaker arrivals.  ``boxcar`` and ``cosine_taper`` use the configured fixed
-    width.  ``shaping_wavelet`` and ``resolution_kernel`` derive their applied
-    width from a kernel autocorrelation and preserve the configured width only
-    as QC context.  ``adaptive_memory`` also derives its applied width from the
-    resolution kernel, but uses a finite memory cost whose strength and
-    retention depend on spike amplitude relative to noise and on the fraction
-    of valid lags covered by the kernel footprint.  ``QCMetrics`` reports
-    ``lag_weight_Linf_final`` and
-    ``lag_weight_L2_final`` and both engines expose the full final weight curve
-    with ``lag_weight_vector()`` for diagnostic plotting.  The metadata fields
-    ``gid_penalty_scale_factor`` and ``gid_penalty_width`` preserve configured
-    values, while ``gid_penalty_effective_width`` records the helper kernel
-    length actually applied (for example, ``none`` is a one-sample no-op
-    kernel).  Adaptive-memory QC also includes
-    ``gid_adaptive_penalty_enabled``, ``gid_penalty_noise_amplitude``,
-    ``gid_penalty_last_confidence``,
-    ``gid_penalty_last_immediate_strength``,
-    ``gid_penalty_last_specificity``, ``gid_penalty_last_decay_factor``,
-    ``gid_penalty_memory_Linf_final``, ``gid_penalty_memory_L2_final``, and
-    ``gid_penalty_valid_lags``.  The Python wrappers store scalar QC fields
-    in their QC metadata subdocuments, so they are saved with normal database
-    records.
+.. math::
 
-    The six helper modes map directly to the final lag-weight plots produced
-    by the validation tests.  The theoretical interpretation and recommended
-    default are summarized in `Lag-weight penalty framework`_.
+   a(t) = g(t) * r(t),
 
-    The time- and frequency-domain GID engines now use the same iteration-cap
-    behavior.  Reaching ``maximum_iterations`` stops the iteration, returns the
-    best accepted sparse model after the final amplitude refit, and records
-    ``gid_stop_reason="max_iterations"`` with ``gid_converged=false``.  Other
-    common QC fields include ``decon_operator``, ``decon_processed``,
-    ``gid_iterations``, ``gid_number_spikes``, ``gid_penalty_function``,
-    ``gid_penalty_scale_factor``, ``gid_penalty_width``, and
-    ``gid_penalty_effective_width``.
+where ``r`` is the current residual and ``g`` is the configured inverse
+operator for the selected GID mode.  The largest acceptable three-component
+detection-function peak becomes a candidate spike.  The engine subtracts that
+candidate's predicted contribution from the data-domain residual and keeps the
+spike only if the residual decreases.
 
-    Both GID Python wrappers use the same window convention.  If
-    ``signal_window`` is omitted, the input datum's full time range is used as
-    the analysis/output window.  If ``noise_window`` is omitted, the engine's
-    configured parameter-file noise window is used.  The analysis window must
-    contain the configured deconvolution/inverse-operator window; otherwise
-    the wrappers return a killed datum instead of processing a partial window.
-    Internally, the loaded noise window is transformed into the same domain as
-    the sparse iteration before legacy residual-noise stopping thresholds are
-    evaluated.
+The inverse operator is therefore used to choose candidate spike locations and
+amplitudes.  It is not the final receiver-function representation.  The
+reported GID receiver function is the sparse impulse response convolved with
+the output shaping wavelet.
 
-    For ``ns_gid``, externally supplied noise and the configured noise window
-    serve different roles.  External TimeSeries noise passed to ``loadnoise`` or
-    the Python wrappers is used by the stable inverse operator to estimate
-    frequency-dependent regularization and gain limits.  When a windowed noise
-    segment has already been loaded, that window remains the residual-domain
-    noise estimate for spike significance and residual-noise stopping.  External
-    PowerSpectrum noise is only an inverse-operator regularization estimate; a
-    direct engine call sequence such as ``loadnoise(power_spectrum); load(d,
-    dwin); process()`` is incomplete because no residual-domain noise window has
-    been loaded.  Use ``load(d, dwin, nwin)`` or ``loadnoise(d, nwin)`` as well.
+Time-domain and frequency-domain engines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Direct ``TimeDomainGIDDecon`` and ``FrequencyDomainGIDDecon`` engine
-    objects are pickleable for distributed wrapper use.  Their pickle state
-    preserves the parameter-file configuration, successful leaf-operator
-    changes made through ``changeparameter()``, and any externally loaded
-    wavelet, TimeSeries noise, or PowerSpectrum noise.  It does not preserve
-    loaded seismograms, processed receiver functions, residuals, sparse spike
-    trains, or runtime QC state; a restored engine is a reusable configured
-    operator, not a copy of the last processed datum.
+The two GID engines implement the same sparse model with different internal
+machinery.  The time-domain engine performs the iterative residual update in
+the time domain.  The frequency-domain engine builds inverse and resolution
+quantities with frequency-domain operations.  Both engines update residuals
+with a compact, peak-normalized residual-update kernel derived from the inverse
+operator's actual output.  The public ``actual_output()`` method returns the
+full inverse-operator resolution diagnostic, not the compact residual-update
+kernel.
 
-    For Dask or Spark jobs, build and configure the reusable deconvolution
-    processor on the driver, then scatter or close over that configured object.
-    Avoid loading per-datum scalar data into an ``RFdeconProcessor`` before
-    scattering it, because scalar compatibility mode intentionally preserves
-    cached input vectors for post-processing diagnostics.  For GID processors,
-    externally loaded reusable wavelets/noise are synchronized into the C++
-    engine before serialization and are not duplicated as separate Python
-    arrays in the pickle payload.
+The ``multi_taper`` inverse mode is still a frequency-domain inverse operator,
+even when selected inside ``TimeDomainGIDDecon``.  In that case "time domain"
+describes the sparse iteration and residual update, not the spectral method
+used by the inverse operator.
 
-    The ``multi_taper`` inverse mode in both GID engines currently uses
-    ``MultiTaperXcorDecon`` as the core C++ inverse operator, with the
-    power-stabilized untapered-phase semantics described above.  In
-    ``TimeDomainGIDDecon`` the term "time domain" describes the iterative
-    residual subtraction and sparse-spike update.  The multitaper inverse
-    operator itself is still estimated in the frequency domain.
+``NS-GID`` inverse mode
+~~~~~~~~~~~~~~~~~~~~~~~
 
-    The iterative operators expose separate convergence controls for
-    fractional residual improvement and normalized residual energy.  The
-    residual-energy threshold is a noise-level stopping rule: increasing it
-    suppresses noise-generated spikes, while decreasing it can recover weak
-    arrivals at the risk of fitting noise.
+``NS-GID`` is selected with ``deconvolution_type ns_gid`` in either GID engine.
+It is a noise-stable inverse mode used inside the GID iteration, not a separate
+preprocessing workflow.  The inverse operator is
+
+.. math::
+
+   G(f) = B(f)\frac{\overline{S(f)}}{|S(f)|^2 + \mu(f)},
+
+where ``S`` is the source wavelet spectrum, ``B`` is the optional band-limiting
+or reliability taper, and ``mu(f)`` is a frequency-dependent damping term.  The
+damping combines a relative spectral floor, noise-spectrum information, and an
+explicit maximum-gain constraint controlled by ``ns_gid_gain_max``.
+
+Use ``ns_gid`` when noisy or spectrally weak source wavelets make greedy GID
+with a less noise-stable inverse pick noise-generated spikes.  External
+wavelets can be supplied through the GID ``loadwavelet`` APIs or wrapper
+``external_wavelet`` argument.  External ``TimeSeries`` noise can support both
+inverse regularization and residual-domain stopping when loaded as residual
+noise.  External ``PowerSpectrum`` noise only regularizes the inverse operator;
+a residual-domain noise window is still needed for spike significance and
+stopping.
+
+Convergence and stopping
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+GID stops when the configured iteration limit is reached or when a stopping
+test says another spike is not useful.  Common stopping tests include small
+fractional residual improvement, residual energy reaching a noise floor, no
+acceptable candidate lag, a lag-weight penalty exhausting valid candidates, and,
+when ``ns_gid`` is selected, optional ``ns_gid_max_spikes`` and
+noise-significance thresholds.
+
+Time-domain and frequency-domain GID use the same iteration-cap behavior.
+Reaching ``maximum_iterations`` stops the iteration, returns the best accepted
+sparse model after final amplitude refit, and records
+``gid_stop_reason="max_iterations"`` with ``gid_converged=false``.  Stops caused
+by residual or lag-weight floors are reported as converged because the engine
+found a configured reason not to add more spikes.
+
+QC metadata
+~~~~~~~~~~~
+
+``QCMetrics`` records both processing status and diagnostic context.  Useful
+first-pass GID fields include ``decon_operator``, ``decon_processed``,
+``gid_converged``, ``gid_stop_reason``, ``gid_iterations``,
+``gid_number_spikes``, ``residual_L2_initial``, and ``residual_L2_final``.
+
+Greedy lag-weight penalty runs also record ``gid_penalty_function``,
+``gid_penalty_scale_factor``, ``gid_penalty_width``,
+``gid_penalty_effective_width``, ``lag_weight_Linf_final``, and
+``lag_weight_L2_final``.  Adaptive-memory runs add fields such as
+``gid_adaptive_penalty_enabled``, ``gid_penalty_noise_amplitude``,
+``gid_penalty_last_confidence``, ``gid_penalty_last_decay_factor``,
+``gid_penalty_memory_Linf_final``, and ``gid_penalty_memory_L2_final``.
+
+When ``deconvolution_type ns_gid`` is active, additional ``ns_gid_*`` fields
+record inverse stability and stopping diagnostics, including
+``ns_gid_stop_reason``, ``ns_gid_converged``, ``ns_gid_peak_threshold``,
+``ns_gid_noise_amplitude_rms``, ``ns_gid_gain_max_actual``, and
+``ns_gid_effective_bandwidth_fraction``.  The Python wrappers store these QC
+values in receiver-function metadata subdocuments, so they are saved with
+normal database records.
+
+For a beginner-oriented guide to reading these fields after a plot run or
+database save, see `Validation and QC workflow`_.
 
 Lag-weight penalty framework
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Current lag-weight penalty methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Lag-weight penalties apply only to greedy GID.  They modify the score used to
+choose the next candidate lag after a spike has
+already been accepted.  They do not shrink accepted amplitudes, and they are
+separate from the grouped-sparsity solve used by ``deconvolution_type
+group_sparse`` (see `Group-sparse regularized GID`_).  In all greedy modes the
+data-domain residual decrease test remains the final acceptance rule.
 
-In practice, ``none`` is the baseline, ``adaptive_memory`` is the shipped
-lag-penalty default, and the fixed or kernel-derived penalties are diagnostic
-alternatives.  Pair ``adaptive_memory`` with ``deconvolution_type ns_gid`` for
-noisy production workflows where repeated picks around one strong arrival are
-the problem.  Use ``none`` when closely spaced true arrivals are the scientific
-target.
+Recommended use
+^^^^^^^^^^^^^^^
+
+The easiest way to choose a penalty is by failure mode:
 
 .. list-table::
    :header-rows: 1
 
    * - Situation
-     - Suggested penalty
-   * - Noisy receiver functions
-     - ``adaptive_memory`` with ``deconvolution_type ns_gid``
-   * - Closely spaced true arrivals
-     - ``none``
+     - Suggested setting
+   * - Noisy receiver functions repeatedly pick one strong arrival
+     - ``deconvolution_type ns_gid`` with
+       ``lag_weight_penalty_function adaptive_memory``
+   * - Closely spaced true arrivals are the scientific target
+     - ``lag_weight_penalty_function none``
    * - Visual diagnostics
-     - compare ``none`` and ``adaptive_memory``
-   * - Fixed-width testing
+     - compare ``none`` and the active penalty
+   * - Fixed-width controlled tests
      - ``cosine_taper`` or ``boxcar``
-   * - Resolution studies
+   * - Resolution-footprint studies
      - ``resolution_kernel`` or ``shaping_wavelet``
 
-The GID penalty is best viewed as an adaptive prior on future spike locations,
-not as a shrinkage applied to amplitudes that have already been accepted.  At
-iteration :math:`k`, let :math:`\mathbf{a}^{(k)}_j` be the three-component
-detection-function vector at candidate lag sample :math:`j`, and let
-:math:`\ell^{(k)}_j \in [0, 1]` be the accumulated lag weight.  Ignoring
-candidate lags where the residual-update kernel cannot fit inside the working
-window, the implemented selection statistic is
+The shipped GID parameter files set ``lag_weight_penalty_function
+adaptive_memory`` and ``lag_weight_penalty_scale_factor=0.35``.  The default
+``deconvolution_type`` remains ``least_square`` for backward compatibility.
+Treat this as a conservative noisy-data setting, not a universal optimum.
+
+How the greedy penalty enters GID
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+At iteration :math:`k`, let :math:`\mathbf{a}^{(k)}_j` be the
+three-component detection-function vector at lag sample :math:`j`, and let
+:math:`\ell^{(k)}_j \in [0, 1]` be the accumulated lag weight.  The implemented
+selection statistic is
 
 .. math::
 
@@ -427,277 +486,90 @@ window, the implemented selection statistic is
    \qquad
    j_* = \operatorname*{arg\,max}_j q^{(k)}_j .
 
-The candidate spike amplitude is then rescaled against the compact resolution
-kernel and accepted only if the data-domain residual :math:`L_2` norm
-decreases.  Consequently, the penalty influences which lag is tried next, but
-the residual test still protects the physical data-domain fit.
-
-After accepting a spike at :math:`j_*`, the engine multiplies the lag weights
-near :math:`j_*` by a compact penalty kernel :math:`p_m`:
+After accepting a spike at :math:`j_*`, the engine multiplies nearby lag
+weights by a compact penalty kernel :math:`p_m`:
 
 .. math::
 
    \ell^{(k+1)}_j =
-       \operatorname{clip}\left(\ell^{(k)}_j p_{j-j_*}, 0, 1\right).
+      \operatorname{clip}\left(\ell^{(k)}_j p_{j-j_*}, 0, 1\right).
 
 Outside the penalty support, :math:`p_m=1`.  Repeated hits near the same
-arrival therefore multiply down the same neighborhood, making the penalty a
-soft exclusion process.  Equivalently, the spike picker maximizes the
-unweighted detection energy with an adaptive location cost
-:math:`-2\log \ell^{(k)}_j`; already explained neighborhoods become more
-expensive while untouched lags retain cost zero.
+arrival multiply down the same neighborhood, making the penalty a soft
+anti-cycling cost.  The penalty changes which lag is tried next; the
+data-domain residual decrease test still decides whether the candidate is
+accepted.
 
-Let :math:`\alpha` be ``lag_weight_penalty_scale_factor`` and let
-:math:`W=2h+1` be the odd fixed penalty width in samples.  If an even width is
-configured, the implementation increases it by one so the kernel has a center
-sample.  The fixed-width helper kernels are:
+Current lag-weight penalty methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. math::
+``none``
+    Leaves the greedy selector unchanged.  It is the safest support-recovery
+    choice when real arrivals may be tightly clustered.
 
-   p_m =
-   \begin{cases}
-   1, & \text{``none''}, \\
-   1-\alpha, & \text{``boxcar'' and } |m|\le h, \\
-   1-\frac{\alpha}{2}\left[1+\cos\left(\frac{\pi m}{h+1}\right)\right],
-      & \text{``cosine_taper'' and } |m|\le h, \\
-   1, & |m| > h .
-   \end{cases}
+``boxcar``
+    Applies fixed-width hard local suppression.  It is easy to interpret but
+    can move false picks to the first unpenalized sample outside the window.
 
-``none`` leaves the greedy selector unchanged.  It is useful as a diagnostic
-baseline and can be appropriate for very clean data, but it provides no
-mechanism to discourage repeated picks of a strong arrival.  ``boxcar`` is a
-hard local suppression.  It is easy to interpret, but its discontinuous edges
-can move false picks to the first unpenalized samples outside the window.
-``cosine_taper`` is a smooth compact suppression: the accepted sample receives
-the strongest penalty and nearby samples are downweighted gradually.  For
-example, with :math:`\alpha=0.5` and :math:`W=5`, the center sample is
-multiplied by ``0.5``, adjacent samples by ``0.625``, and edge samples by
-``0.875``.
+``cosine_taper``
+    Applies fixed-width smooth compact suppression.  The accepted sample
+    receives the strongest penalty and nearby samples are downweighted
+    gradually.
 
-The kernel-derived modes replace the user-selected width with a resolution
-measure.  Let :math:`h_i` be either the requested output shaping wavelet
-(``shaping_wavelet``) or the compact actual residual-update kernel
-(``resolution_kernel``).  The engines compute the normalized absolute kernel
-coherence
+``shaping_wavelet``
+    Derives the applied penalty footprint from the requested output shaping
+    wavelet.  This is useful for controlled comparisons where the requested
+    output pulse is the desired resolution reference.
 
-.. math::
+``resolution_kernel``
+    Derives the footprint from the compact actual residual-update kernel.  This
+    reflects inverse-operator regularization, trimming, and peak normalization.
 
-   c_m =
-     \frac{\left|\sum_i h_i h_{i+m}\right|}
-          {\sum_i h_i^2},
-   \qquad c_0 = 1,
+``adaptive_memory``
+    Derives the footprint from the resolution kernel and changes memory
+    strength and retention from event to event.  Strong, well-localized
+    arrivals create stronger local memory.  Broad or low-confidence arrivals
+    create weaker memory that decays quickly.
 
-and keep the contiguous full-width-at-half-maximum support around zero lag,
-where :math:`c_m \ge 0.5`.  Because the GID picker ranks squared
-three-component amplitudes, the applied penalty uses coherence energy:
+Adaptive memory theory
+^^^^^^^^^^^^^^^^^^^^^^
 
-.. math::
+``adaptive_memory`` implements a finite-memory local penalty.  After each
+accepted spike it asks three questions:
 
-   p_m = 1-\alpha c_m^2,
+1. Which lags are in the same ambiguous state as the accepted spike?
+2. How reliable is the accepted spike as an explanation of the residual?
+3. How long should that local penalty persist?
 
-with :math:`p_m=1` outside the support.  This gives the accepted spike the same
-center suppression as the fixed helpers, but sets both the width and the
-shoulder shape from the resolving power of the wavelet/operator while keeping
-the shoulders gentler for close arrivals than a raw-coherence penalty.  The
-``shaping_wavelet`` mode is useful for controlled comparisons and for cases
-where the requested output pulse is the desired resolution reference.
-``resolution_kernel`` is more adaptive because it uses the actual kernel after
-the inverse operator, trimming, and peak normalization.  For ``ns_gid`` that
-kernel also reflects noise-dependent regularization.
-
-The optional validation figures demonstrate this framework directly.  The
-``*_least_square_penalty_lag_weights.png`` plots show the final
-:math:`\ell^{(K)}_j` curve above an aligned true sparse impulse response.  A
-dip in that curve is the accumulated adaptive cost for selecting another
-candidate near an already accepted spike.  The companion shaped and sparse
-penalty plots show the resulting receiver functions and raw spike support.
-The stress validation intentionally uses the less stable ``least_square``
-inverse mode in those figures so the penalty behavior is visible; with
-``ns_gid`` the inverse operator is often stable enough that all penalty helpers
-select nearly the same support.
-
-The distributed default penalty is ``adaptive_memory`` with
-``lag_weight_penalty_scale_factor=0.35``.  A high-confidence, high-specificity
-accepted spike can reduce the center-lag selection power to about
-:math:`(1-0.35)^2 \approx 0.42` in one iteration, while broad or noisy
-footprints receive lower retention and are forgotten faster after subsequent
-accepted spikes.  This value was selected as a conservative noisy-data default
-because the combined validation sweeps showed that the half-power lower bound
-:math:`1-1/\sqrt{2}` under-penalized multi-taper stress cases, while the earlier
-``0.5`` adaptive scale could miss or mis-sign close arrivals.  It is not a
-universal optimum.  Dense, physically close arrivals can be harmed by any lag
-tabu memory because the next true spike may lie inside the ambiguity footprint;
-for that regime, ``lag_weight_penalty_function none`` is the safest support
-recovery choice and the optional validation tests include this case explicitly.
-
-The benchmark evidence should be read as support for a guarded anti-cycling
-prior, not as a proof that ``adaptive_memory`` must dominate ``none`` in every
-sparse-recovery metric.  In the moderate-noise default sweep, ``adaptive_0.35``
-had the lowest support-weighted loss among the adaptive scales, meaning the
-validation metric penalized fewer missed or extra sparse-support picks.  It
-also produced fewer false positives than ``none`` (397 versus 422), while
-``none`` had a slightly higher mean F1 score (0.956 versus 0.955) and more
-individual cell wins.  In the high-noise validation sweep, search-adjusted
-confidence made ``adaptive_memory`` collapse toward ``none`` once selected
-peaks were no longer strong relative to the full lag search.  In the table,
-FP/FN means false positives and false negatives in the sparse support check:
-
-.. list-table:: Final high-noise validation sweep
-   :header-rows: 1
-
-   * - ``noise_scale``
-     - ``none`` mean F1, FP/FN
-     - ``adaptive_memory`` mean F1, FP/FN
-     - Interpretation
-   * - 3
-     - 0.806, 128/1
-     - 0.797, 148/0
-     - dense close-arrival cases can still favor ``none``
-   * - 10
-     - 0.602, 365/10
-     - 0.601, 364/10
-     - effectively tied
-   * - 30
-     - 0.451, 584/12
-     - 0.451, 584/12
-     - collapsed to ``none``
-   * - 100
-     - 0.382, 672/28
-     - 0.382, 672/28
-     - collapsed to ``none``
-
-``cosine_taper`` remains the backward-compatible fixed-width option when users
-want the historical compact penalty shape, and ``resolution_kernel`` remains
-useful for seeing the global resolution footprint without event-by-event
-memory.  Multi-taper benchmarks can favor ``shaping_wavelet`` or
-``resolution_kernel`` on residual or target error, so those fixed kernel-derived
-penalties are worth checking when final support recovery is inspected manually.
-``boxcar`` should be reserved for tests or cases where a deliberate hard
-exclusion is desired.  In noisy production workflows, this lag penalty should be
-combined with the ``ns_gid`` inverse mode; the least-square validation plots use
-``least_square`` only because its weaker noise stability makes the differences
-among penalty kernels easier to see.  For backward compatibility, the
-distributed parameter files still default to ``deconvolution_type
-least_square``.  Users should switch the selected GID branch to
-``deconvolution_type ns_gid`` for noisy production deconvolution, and should
-disable the lag penalty when the scientific target is a tightly clustered
-arrival sequence.
-
-Full adaptive anti-cycling penalty framework
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The fixed and kernel-derived penalty methods above are deliberately simple.
-They are best understood as a first anti-cycling rule for a greedy sparse
-pursuit, but they are not a complete theory for avoiding oscillation between
-two or more stable GID states.  The ``adaptive_memory`` helper implements the
-first finite-memory version of the framework below: it uses the compact
-resolution kernel for support, converts the accepted candidate amplitude to a
-noise-normalized statistic, adjusts that statistic by the expected maximum from
-the current valid-lag search, and stores per-lag retention so old memory decays
-according to the evidence and specificity that created it.
-
-In plain language, the adaptive penalty asks three questions after each
-accepted spike: was the spike strong relative to noise, how wide is the
-ambiguity zone around it, and how quickly should that memory be forgotten?
-The answer can improve cycling behavior, but it cannot guarantee a better
-support estimate than ``none`` when the true receiver function contains
-physically close arrivals.
-
-The relevant analogies come from several domains with similar failure modes.
-Tabu search keeps a finite memory of recently explored states so a discrete
-optimizer does not cycle.  Matching pursuit and orthogonal matching pursuit
-avoid repeatedly choosing highly coherent dictionary atoms.  Non-maximum
-suppression suppresses detections in an uncertainty footprint around an
-accepted detection.  Refractory-period models temporarily inhibit repeat
-events after a spike, while active-set and trust-region methods relax
-constraints as the local model changes.  In GID language, these all point to
-the same principle: the penalty should be a finite-memory cost over coherent
-lag states, not a permanent declaration that a lag can never be revisited.
-It should preserve the current invariant that the penalty changes which
-candidate lag is tried next, while the data-domain residual decrease test
-remains the final acceptance rule.
-
-Let :math:`M^{(k)}_j \ge 0` be a lag-memory field, or anti-cycling cost, at
-lag sample :math:`j`.  The current lag-weight picker can be written
-equivalently as
+Let :math:`M^{(k)}_j=-\log \ell^{(k)}_j` be the local penalty cost.  The picker
+can be written as
 
 .. math::
 
    q^{(k)}_j =
       \exp\left[-2M^{(k)}_j\right]
-      \left\|\mathbf{a}^{(k)}_j\right\|_2^2 ,
-   \qquad
-   M^{(k)}_j = -\log \ell^{(k)}_j .
+      \left\|\mathbf{a}^{(k)}_j\right\|_2^2 .
 
-The basic implemented update adds a local cost to :math:`M_j` after each
-accepted spike.  The current helpers are special cases of a broader
-event-conditioned penalty: they use either a fixed support or a
-kernel-derived support, a constant penalty strength, and a purely
-multiplicative accumulated lag weight.  A fuller anti-cycling model separates
-three questions that are combined in the fixed-width helpers:
+An accepted spike adds local memory shaped by the resolution-kernel coherence,
+scaled by a noise-normalized confidence, and retained according to the
+specificity of the footprint.  In the practical extremes, high-SNR sharp
+arrivals create durable local memory, high-SNR broad arrivals create strong
+but quickly forgotten memory, low-SNR sharp arrivals create cautious memory,
+and low-SNR broad arrivals create little durable memory.  This discourages
+immediate cycling without permanently forbidding nearby lags.
 
-1. Which lags are in the same ambiguous state as the accepted spike?
-2. How reliable is the accepted spike as an explanation of the residual?
-3. How long should that anti-cycling memory persist?
-
-For an accepted spike at sample :math:`s`, define a variable-width,
-event-conditioned support or ambiguity footprint :math:`A_s(j)` from the
-coherence of the actual GID resolution-kernel atoms:
+The algorithm estimates confidence from a search-adjusted three-component
+detection statistic.  If :math:`\Sigma_s` is the local
+detection-function noise covariance at the accepted sample :math:`s`, a natural
+single-lag statistic is
 
 .. math::
 
-   A_s(j) =
-      \left(
-      \frac{\left|\langle r_s, r_j\rangle\right|}
-           {\|r_s\|_2\|r_j\|_2}
-      \right)^q ,
+   Z_s^2 = \mathbf{a}_s^T \Sigma_s^{-1}\mathbf{a}_s .
 
-where :math:`r_s` is the compact residual-update kernel shifted to sample
-:math:`s`.  The exponent :math:`q` is shown only to describe possible shoulder
-shapes; a production implementation should tie that shape to the same
-resolution and noise model used elsewhere rather than expose it as an
-independent tuning knob.  This definition makes the penalty width an observed
-property of indistinguishability in the inverse operator and data window.  A
-broad resolution kernel creates a broad ambiguity footprint; a sharp kernel
-creates a narrow footprint; edge effects or asymmetric usable windows can
-produce asymmetric footprints.  The ``resolution_kernel`` penalty is a
-simplified global version of this idea.  ``adaptive_memory`` derives the
-footprint from the resolution-kernel autocorrelation and lets the
-search-adjusted confidence move the coherence energy floor between 0.25 and
-0.5:
-
-.. math::
-
-   c_{sj}^2 \ge
-      \min\left[
-          \frac{1}{2},
-          \max\left(\frac{1}{4}, B_s\right)
-      \right] .
-
-The implementation uses the contiguous central radius whose coherence remains
-above that floor and applies :math:`c_{sj}^2` as the per-lag memory weight
-inside the footprint.  Here :math:`B_s` is the bounded spike confidence defined
-below.  High amplitude relative to the full search-noise bound therefore gives
-better localization and a sharper footprint, but the support is not allowed to
-collapse to an exact-lag only rule.  Low amplitude relative to high noise
-implies broader ambiguity but weaker, short-lived memory.
-
-The strength of the new memory should be tied to spike evidence, not a raw
-hand-tuned constant.  A natural evidence variable is a noise-normalized
-three-component detection statistic, for example
-
-.. math::
-
-   Z_s^2 =
-      \mathbf{a}_s^T \Sigma_s^{-1}\mathbf{a}_s ,
-
-where :math:`\Sigma_s` is a local noise covariance for the detection-function
-components.  With diagonal or scalar noise estimates this reduces to the
-usual squared amplitude divided by noise power.  Because the GID picker takes
-the maximum over all currently valid lags, that single-lag statistic is not
-enough: pure noise also produces a large selected maximum.  The implementation
-therefore compares the accepted candidate to a full-search noise bound.  With
-:math:`N_\mathrm{valid}` valid lag samples, define
+Because GID picks the maximum over all currently valid lags, a pure-noise
+maximum also grows with search size.  With :math:`N_\mathrm{valid}` valid lag
+samples, the helper normalizes by a three-component upper-tail bound,
 
 .. math::
 
@@ -705,87 +577,34 @@ therefore compares the accepted candidate to a full-search noise bound.  With
       1 + 2\sqrt{\frac{2\log N_\mathrm{valid}}{3}}
         + \frac{4\log N_\mathrm{valid}}{3},
 
-using :math:`E_\mathrm{search}=1` when there is only one valid lag.  This is
-the Laurent-Massart upper-tail bound for a three-component vector, normalized
-by the vector RMS noise estimate, with the extra :math:`\log N_\mathrm{valid}`
-factor controlling false memory over repeated lag searches without adding a
-user-tuned threshold.  The selection-adjusted statistic is
-
-.. math::
-
-   Z_{*,s}^2 = \frac{Z_s^2}{E_\mathrm{search}} .
-
-A bounded confidence :math:`B_s` then uses the noise-subtracted fraction of the
-search-adjusted candidate energy:
+using :math:`E_\mathrm{search}=1` when there is only one valid lag.  The
+bounded confidence is then
 
 .. math::
 
    B_s =
       \begin{cases}
         0, & Z_{*,s} \le 1, \\
-        1 - Z_{*,s}^{-2}, & Z_{*,s} > 1 .
+        1 - Z_{*,s}^{-2}, & Z_{*,s} > 1 ,
       \end{cases}
+   \qquad
+   Z_{*,s}^2 = Z_s^2/E_\mathrm{search}.
 
-This ties the confidence directly to spike amplitude and noise power without a
-separate tuning threshold.  It also prevents a noise maximum created by a long
-lag search from becoming an effectively certain tabu event.
-
-The confidence threshold is data-derived; ``lag_weight_penalty_scale_factor``
-still controls the maximum strength of the penalty once confidence has been
-estimated.
-
-The scale in :math:`Z_s` should come from the same residual noise model used for
-stopping or NS-GID significance tests, not from a separate ad hoc tuning
-constant.  In the implemented helper, both engines use a residual-domain
-three-component noise RMS estimate for adaptive confidence.  Time-domain GID
-uses the same inverse-filtered noise window used for residual stopping.
-Frequency-domain GID maps the residual noise window through the active inverse
-wavelet before computing the RMS; for CNR it applies the CNR operator to that
-residual noise window and trims operator transients before measuring the RMS.
-An explicitly supplied CNR noise trace still controls inverse regularization,
-but it does not replace the residual noise window used for adaptive penalty QC.
-NS-GID records this filtered RMS separately from its larger spike-significance
-threshold.  Strong, high-SNR accepted spikes then create durable anti-cycling
-evidence; marginal noisy spikes create only weak memory and can be revised by
-later iterations if the residual evidence changes.
-
-Finally, the memory should be finite.  A decay rule should preserve the
-original anti-cycling purpose without freezing the search.  The key is that
-decay should be faster when the ambiguity footprint is broad and less
-specific, and slower when the footprint is narrow and local.  Decay should
-also be interpreted as evidence invalidation in the broader theory: later
-accepted spikes or a changed local residual can make old tabu evidence stale.
-In the current implementation, existing memory is relaxed only when a later
-accepted spike triggers the next penalty update.  If
-:math:`N_\mathrm{valid}` is the number of valid lag samples and
-:math:`N_{\mathrm{eff},s}` is the participation-ratio width of the actually
-applied footprint,
-
-.. math::
-
-   N_{\mathrm{eff},s} =
-      \frac{\left(\sum_j A_s(j)\right)^2}{\sum_j A_s(j)^2},
-
-then the implemented specificity is the information concentration
+The ambiguity footprint comes from the coherence of shifted resolution-kernel
+atoms.  A broad footprint has low information concentration and should be
+forgotten faster than a sharp footprint.  The implemented specificity is
 
 .. math::
 
    S_s =
       1 - \frac{\log N_{\mathrm{eff},s}}
-               {\log N_\mathrm{valid}} .
+               {\log N_\mathrm{valid}},
+   \qquad
+   N_{\mathrm{eff},s} =
+      \frac{\left(\sum_j A_s(j)\right)^2}{\sum_j A_s(j)^2},
 
-The limiting cases are important.  If a penalty footprint covers nearly the
-whole deconvolution window, it contains little information about where the
-cycle occurs and should be forgotten almost immediately.  If the footprint is
-sharp and local, it is specific anti-cycling evidence and can persist longer.
-Combining spike confidence and footprint specificity gives an event retention
-strength
-
-.. math::
-
-   \gamma_s = B_s S_s ,
-
-with :math:`0 \le \gamma_s < 1`.  The conceptual update can be written as
+where :math:`A_s(j)` is the applied footprint weight.  The retention strength
+is :math:`\gamma_s=B_sS_s`.  Conceptually, the memory update is
 
 .. math::
 
@@ -793,132 +612,396 @@ with :math:`0 \le \gamma_s < 1`.  The conceptual update can be written as
       R^{(k)}_j M^{(k)}_j
       - \log\left[1-\alpha B_s A_s(j)\right],
 
-where :math:`R^{(k)}_j` is the retention carried by the memory already stored
-at lag :math:`j`.  When new memory is added, the implementation blends the old
-retention and the new event retention strength :math:`\gamma_s` in proportion
-to their memory-cost contributions.  Stored adaptive memory is decayed on
-subsequent accepted penalty updates before new memory is added.  This gives
-the newest event enough immediate anti-cycling force to affect the next
-candidate selection, while broad or noisy evidence receives low retention and
-is forgotten faster as the iteration continues.  The model gives the desired
-behavior in the practical extremes:
+where :math:`\alpha` is ``lag_weight_penalty_scale_factor`` and
+:math:`R^{(k)}_j` is the retention already stored at lag :math:`j`.  This is a
+temporary local penalty, not a permanent exclusion rule.
 
-* high-SNR, sharp accepted spike: strong, specific memory that lasts;
-* high-SNR, broad ambiguity: strong immediate anti-cycling, but fast recovery;
-* low-SNR, sharp spike: cautious local memory;
-* low-SNR, broad ambiguity: little durable memory, avoiding global lockout.
+Benchmark interpretation
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-It also gives a rule for revisiting a penalized lag: the lag should become
-competitive again when its new noise-normalized residual evidence is larger
-than the accumulated anti-cycling memory cost.  That is the connection to
-tabu search and active-set methods.  The memory discourages immediate cycling
-among coherent states, but it does not prove global convergence or replace the
-existing residual-decrease acceptance criterion.
+The validation results should be read as evidence for guarded anti-cycling
+behavior, not as proof that ``adaptive_memory`` is universally best.  In the
+moderate-noise synthetic sweep, ``adaptive_memory`` reduced some repeated-pick
+failures and false positives.  In dense close-arrival cases, ``none`` can
+remain better because any local anti-cycling memory can suppress the next true
+arrival.
+In high-noise sweeps, search-adjusted confidence can make ``adaptive_memory``
+collapse toward ``none`` once selected peaks are no longer strong relative to
+the full lag search.
 
-The original motivation is therefore expressed more precisely as follows:
-GID penalty should be a noise-normalized, resolution-coherence-shaped,
-finite-memory tabu cost over lag states.  Variable width identifies the
-ambiguous state; spike amplitude relative to noise measures the evidence for
-remembering it; and adaptive decay controls how quickly nonspecific or weak
-evidence is forgotten.  The existing fixed and kernel-derived helper penalties
-are useful approximations to the spatial-memory part of this framework.
-``adaptive_memory`` adds the first event-specific noise-normalized evidence and
-adaptive decay model while preserving the same residual-decrease acceptance
-criterion as the other GID modes.
+Use the penalty plots and QC fields to decide whether the penalty helped the
+specific data and noise setting being processed.
 
-``NS-GID`` inverse mode
-    Noise-aware stable generalized iterative deconvolution is selected with
-    ``deconvolution_type ns_gid`` in either GID engine.  It is a stable
-    inverse-operator variant of GID, not a separate receiver-function
-    preprocessing workflow.  The core inverse operator is
+Serialization and distributed use
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    .. math::
+Direct ``TimeDomainGIDDecon`` and ``FrequencyDomainGIDDecon`` engine objects
+are pickleable for distributed wrapper use.  Their pickle state preserves the
+parameter-file configuration, successful ``changeparameter()`` updates to the
+underlying inverse operator, and any externally loaded wavelet, ``TimeSeries``
+noise, or ``PowerSpectrum`` noise.  It does not preserve loaded seismograms,
+processed receiver functions, residuals, sparse spike trains, or runtime QC
+state.
 
-       G(f) = B(f)\frac{\overline{S(f)}}{|S(f)|^2 + \mu(f)},
+For Dask or Spark jobs, build and configure the reusable deconvolution
+processor on the driver, then scatter or close over that configured object.
+Avoid loading per-datum scalar data into an ``RFdeconProcessor`` before
+scattering it, because scalar compatibility mode intentionally preserves cached
+input vectors for post-processing diagnostics.
 
-    with frequency-dependent damping from the wavelet and noise spectra, an
-    explicit maximum gain cap, and an optional smooth SNR reliability taper.
-    The implementation enforces ``|G(f)| <= ns_gid_gain_max`` within floating
-    point tolerance.  ``ns_gid_mu_min`` is interpreted as a relative floor
-    scaled by the peak wavelet spectral power, so the same parameter remains
-    meaningful for externally supplied wavelets with different amplitudes.
-    Stability comes from ``G(f)``, ``mu(f)``, the gain cap, and noise-aware
-    stopping; it does not come from the output shaping wavelet.
+Group-sparse regularized GID
+----------------------------
 
-    NS-GID supports externally supplied wavelets through the GID
-    ``loadwavelet`` APIs and the Python wrappers' ``external_wavelet``
-    argument.  This is the intended path when the source wavelet is a prepared
-    P-wave stack from a network, subarray, or other caller-managed procedure.
-    Constructing that stack, selecting events, rotating components, and array
-    stacking are outside this operator.  If no external wavelet is loaded, the
-    engines preserve the existing receiver-function compatibility behavior and
-    estimate the wavelet from the configured component/window.
+``group_sparse`` is a separate GID mode from the greedy lag-weight penalties
+described above.  Lag-weight penalties modify which candidate lag the greedy
+iteration tries next.  ``group_sparse`` instead solves one regularized model
+for the full sparse impulse response, the lag-indexed spike train returned by
+``sparse_output``.  Its group-lasso penalty favors shared support, meaning the
+same nonzero lag samples, across the three components while still allowing
+different component amplitudes.
 
-    The sparse impulse response is kept conceptually separate from the shaped
-    receiver-function representation.  The inverse operator is used only for
-    candidate spike detection and stabilization.  The residual update remains
-    in the GID data domain, and ``getresult`` returns the accepted sparse
-    support convolved with the configured output shaping wavelet.  The sparse
-    impulse response is available through ``sparse_output`` for QC and
-    validation.
-    The underlying ``NoiseStableDecon`` scalar operator is a single stable
-    inverse operation.  It is not a sparse picker and does not apply the GID
-    output shaping wavelet; finite bandwidth comes from the stable inverse
-    operator itself.
-    Candidate acceptance can use an empirical inverse-filtered noise threshold,
-    a sigma threshold, residual-to-noise stopping, maximum spike count, and
-    the existing fractional-improvement limit.  Higher thresholds suppress
-    noise-generated spikes; lower thresholds may recover weaker arrivals but
-    can overfit noise.  ``ns_gid_refit_interval`` controls how often accepted
-    spike amplitudes are jointly refit during iteration; the engines always
-    run a final refit, so values larger than one reduce repeated dense solves
-    without disabling final amplitude correction.
+Relation to classic greedy GID
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``RFdeconProcessor``
-    High-level scalar receiver-function wrapper.  It exposes the scalar
-    frequency-domain methods, time-domain least squares, conventional
-    iterative deconvolution, and both generalized iterative variants through
-    a consistent ``alg`` selector.  The processor loads the wavelet, noise,
-    and data windows once and returns the cropped receiver-function estimate
-    for the configured output lag window.
+``group_sparse`` estimates the full sparse impulse response by solving an
+explicit regularized objective instead of selecting one spike per iteration.
+This makes it a different estimator, not a strict upgrade.  Classic greedy GID
+remains useful for diagnostics, direct per-spike stopping behavior, and cases
+where close arrivals need to remain separate.
 
-Validation plots
-----------------
+Both time-domain and frequency-domain engines still build a GID inverse
+operator and compact actual-output/resolution kernel.  In the current
+implementation ``deconvolution_type group_sparse`` uses the ``ns_gid`` inverse
+branch internally, so the inverse-filtered data and resolution kernel inherit
+NS-GID's gain cap, noise-spectrum damping, and optional reliability taper.
+After those quantities are built, the two engines use the same group-sparse
+objective.
 
-The deconvolution validation tests can optionally write diagnostic plots for
-manual inspection.  Normal test runs do not create figures.  To write the full
-set of scalar, GID, sparse-output, and external-wavelet validation plots, run:
+Model and solver
+~~~~~~~~~~~~~~~~
+
+Let :math:`\mathbf{y}_c` be component :math:`c` of the inverse-filtered data,
+and let :math:`R` be the compact, peak-normalized resolution-kernel convolution
+operator used by GID residual updates.  The unknown sparse impulse response is
+a matrix :math:`H`, where each lag sample :math:`j` has a three-component group
+and each :math:`\mathbf{h}_c` denotes the lag series for component
+:math:`c`.
+
+.. math::
+
+   \mathbf{h}_j = \left(h_{E,j}, h_{N,j}, h_{Z,j}\right)^T .
+
+The implemented model is
+
+.. math::
+
+   \hat{H}
+   = \operatorname*{arg\,min}_{H}
+     \frac{1}{2}\sum_{c \in \{E,N,Z\}}
+       \left\|R \mathbf{h}_c - \mathbf{y}_c\right\|_2^2
+     + \lambda \sum_j \left\|\mathbf{h}_j\right\|_2 .
+
+The first term asks the sparse impulse response, convolved with the actual GID
+resolution kernel, to explain the inverse-filtered data.  The second term is an
+:math:`\ell_{2,1}` group-lasso penalty.  It shrinks all three component
+amplitudes at a lag as one group, favoring shared arrival support.
+
+The solver uses proximal gradient iterations.  Each iteration takes a gradient
+step on the data-misfit term and then applies group soft thresholding,
+
+.. math::
+
+   \mathbf{h}^{(k+1)}_j =
+   \max\left(0, 1 - \frac{\tau \lambda}{\|\mathbf{z}_j\|_2}\right)
+   \mathbf{z}_j .
+
+The multiplier is interpreted as zero when
+:math:`\|\mathbf{z}_j\|_2 = 0`.
+
+The implementation uses a conservative step bound derived from the finite
+impulse response (FIR) resolution kernel and stops when the objective's
+relative change is below ``group_sparse_tolerance`` or when
+``group_sparse_max_iterations`` is reached.
+After support is selected, the engine runs the same final amplitude refit used
+by classic greedy GID and recomputes the reported residual metrics.
+
+At convergence, the group-lasso Karush-Kuhn-Tucker conditions clarify the role
+of ``group_sparse_lambda``.  For inactive lags,
+
+.. math::
+
+   \left\|R_j^T \mathbf{r}\right\|_2 \le \lambda ,
+
+where :math:`\mathbf{r}=R\hat{H}-\mathbf{y}` stacks the residuals for all three
+components and :math:`R_j` denotes the resolution-kernel operator block
+associated with lag :math:`j`.  For active lags,
+
+.. math::
+
+   R_j^T \mathbf{r}
+      = -\lambda
+        \frac{\hat{\mathbf{h}}_j}
+             {\left\|\hat{\mathbf{h}}_j\right\|_2}.
+
+Thus ``group_sparse_lambda`` is the evidence threshold inside the regularized
+objective.  It is not, by itself, the threshold used to decide which nonzero
+coefficients are exported as sparse arrivals.
+
+Regularization and support reporting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``group_sparse_lambda`` controls shrinkage inside the objective.  A positive
+value is used directly.  The default value ``0.0`` selects an automatic
+noise-scaled value:
+
+.. math::
+
+   \lambda =
+   \texttt{group\_sparse\_lambda\_scale}
+   \times
+   \begin{cases}
+      \text{NS-GID inverse-filtered noise threshold},
+         & \text{if available}, \\
+      0.02\,\|\mathbf{y}\|_\infty,
+         & \text{otherwise}.
+   \end{cases}
+
+The exported sparse support has a second adaptive decision rule.  The
+regularized coefficient field can contain tiny numerical coefficients or small
+clustered sidelobe coefficients.  The default support threshold is
+
+.. math::
+
+   \tau_\text{support}
+      =
+      \max\left(
+        \texttt{group\_sparse\_active\_threshold},
+        \texttt{group\_sparse\_active\_threshold\_scale}
+        \;Q_q\left(\left\{\|\hat{\mathbf{h}}_j\|_2\right\}\right)
+      \right),
+
+where :math:`q=\texttt{group\_sparse\_active\_threshold\_quantile}`.  The
+distributed defaults are ``group_sparse_active_threshold=0.02``,
+``group_sparse_active_threshold_scale=1.0``, and
+``group_sparse_active_threshold_quantile=0.90``.
+
+This threshold is the group-sparse analogue of the adaptive part of
+``adaptive_memory``.  The adaptation is global and distributional rather than a
+per-spike memory update, but it lets the support decision follow the solved
+coefficient field instead of a hand-picked constant.  ``group_sparse_lambda``
+is therefore the objective shrinkage strength, while
+``group_sparse_active_threshold_used`` is the actual cutoff applied to
+``sparse_output`` and the final refit model.
+
+If the proximal solve is already sparse, most lag groups are zero and the
+absolute floor controls the exported support.  If coherent leakage fills many
+lag groups, the upper-tail quantile rises and prunes the leaked coefficient
+field.  Benchmark threshold sweeps are therefore important: disabling the
+adaptive upper-tail cutoff can leave many retained coefficients, while an
+overly large fixed floor can remove weak converted phases.
+
+QC and interpretation
+~~~~~~~~~~~~~~~~~~~~~
+
+``QCMetrics`` records ``group_sparse_lambda_requested``,
+``group_sparse_lambda_scale``, ``group_sparse_lambda_used``,
+``group_sparse_active_threshold``, ``group_sparse_active_threshold_scale``,
+``group_sparse_active_threshold_quantile``,
+``group_sparse_active_threshold_quantile_value``,
+``group_sparse_active_threshold_used``, and
+``group_sparse_active_groups``.  It also records ``group_sparse_iterations``
+and ``group_sparse_converged`` for the proximal solve.  These fields let
+downstream QC distinguish the regularized solve from the support-reporting
+layer.
+
+``group_sparse_active_groups`` is a count of retained coefficient groups, not a
+resolved geologic arrival count.  Validation plots and tests use separate
+detection metrics for arrival-level comparisons.
+
+Because this mode uses the NS-GID inverse branch internally, it also records
+group-sparse-prefixed inverse QC fields such as
+``group_sparse_inverse_gain_max_actual``,
+``group_sparse_inverse_noise_amplification``, and
+``group_sparse_inverse_effective_bandwidth_fraction``.
+
+The careful benchmark claim is narrow: in the supplied synthetic validation
+fixtures, group-sparse solving with the adaptive support rule can improve
+sparse-support recovery and false-positive control.  It should not be presented
+as universally better than classic greedy GID, including ``adaptive_memory``
+penalty runs.  Adaptive-memory GID may still produce a lower final residual
+norm or preserve dense close arrivals better.
+
+Validation and QC workflow
+--------------------------
+
+The validation tests can write optional figures that are useful for learning
+how the deconvolution operators behave on controlled synthetic examples.  These
+figures are an audit aid, not a field-data benchmark.  The pytest assertions
+remain the source of pass/fail behavior.
+
+Run the optional validation plots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To write the default diagnostic figures, run:
 
 .. code-block:: bash
 
    python -m pytest \
        python/tests/algorithms/test_decon_algorithm_validation.py \
        --decon-validation-plots \
-       --decon-validation-plot-dir /tmp/mspass-decon-validation-plots \
+       --decon-validation-plot-dir /tmp/mspass-decon-validation-plots
+
+Use ``--decon-validation-noise-scale`` when you want extra stress plots at a
+different synthetic noise amplitude:
+
+.. code-block:: bash
+
+   python -m pytest \
+       python/tests/algorithms/test_decon_algorithm_validation.py \
+       --decon-validation-plots \
+       --decon-validation-plot-dir /tmp/mspass-decon-validation-plots-noise-003 \
        --decon-validation-noise-scale 0.03
 
-The output directory contains overlays for scalar/CNR methods, shaped GID
-receiver functions, raw GID sparse impulse responses, external-wavelet runs,
-and the source-wavelet validation setups used in the synthetic cases.  The
-setup figures include the notched source wavelet, noisy convolved data, true
-three-component impulse response, and the requested manual plot noise scale.
-``--decon-validation-noise-scale`` is passed directly as the Gaussian noise
-amplitude before the synthetic bandpass coloring filter; it is not a target
-SNR or percent-noise value.  The setup figure normalizes the displayed data
-panel, so large changes in absolute noise amplitude are easiest to judge by
-the waveform shape and the noise-scale label.  Adaptive-memory plot labels
-report the last selected-spike confidence as ``conf`` and the last memory
-retention factor as ``decay``.  The sparse GID plots are the most direct visual
-comparison against the known sparse truth; shaped GID and CNR plots
-intentionally have more limited bandwidth.  The external-wavelet overlay uses
-raw scalar inverse results and raw GID sparse outputs so spike support can be
-checked visually.  The same plot run also writes a
-``external_wavelet_all_methods_display_filtered.png`` overlay with a common
-plotting-only Ricker filter so different methods can be compared at a similar
-visual bandwidth.  That display filter is not part of the scalar algorithms
-and is not used by the pass/fail assertions.
+``--decon-validation-noise-scale`` is the Gaussian noise amplitude before the
+synthetic coloring filter.  It is not an SNR value and it is not a percent-noise
+setting.  Changing it changes the optional figures used for visual inspection;
+the core numerical checks still use fixed reproducible validation cases.
 
-These figures are intended as an audit aid.  The numerical assertions in the
-test remain the source of pass/fail behavior and use a fixed reproducible
-noise level.  The command-line noise scale is for the optional stress plots so
-you can visually compare behavior as noise increases.
+What the figures show
+~~~~~~~~~~~~~~~~~~~~~
+
+``complex_colored_validation_wavelet.png``
+    Shows the notched source wavelet, the noisy convolved three-component data,
+    and the known sparse impulse response used as synthetic truth.
+
+``complex_colored_scalar_methods.png`` and
+``scalar_noise_<scale>_stress_spike_results.png``
+    Compare scalar and CNR receiver-function outputs.  These traces are shaped
+    receiver functions, not sparse impulse responses.
+
+``TimeDomainGIDDecon_*`` and ``FrequencyDomainGIDDecon_*`` overlays
+    Compare GID outputs for the time-domain and frequency-domain engines.  Files
+    ending in ``_sparse_results.png`` show raw sparse impulse responses from
+    ``sparse_output`` and are the most direct visual comparison to the known
+    sparse truth.
+
+``external_wavelet_all_methods.png``
+    Compares methods when a prepared external wavelet is supplied.  The
+    companion ``external_wavelet_all_methods_display_filtered.png`` applies a
+    common plotting-only display filter; that filter is not part of the
+    algorithms or the pass/fail assertions.
+
+Reading noise-scale plots
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Start with the setup figure.  The data panel is normalized for display, so use
+the noise-scale label, pre-event RMS, signal RMS, and waveform shape together.
+A larger noise scale should make pre-event and inter-arrival fluctuations more
+visible, but it should not be read as a calibrated prediction of field-data
+performance.
+
+If a high-noise diagnostic run marks a method as failed or omits that method's
+output trace, treat that as stress-run context.  It is a reason to inspect the
+matching QC metadata, not by itself a benchmark result.
+
+Reading sparse-support plots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For GID methods, compare the raw sparse plots to the true impulse response.  The
+main questions are whether expected arrivals are present near the correct lag,
+whether signs are plausible, and whether the result contains many extra
+isolated or clustered spikes.
+
+For ``group_sparse`` labels, ``lam`` is the regularization value used, ``thr``
+is the support threshold used after the solve, ``k`` is the number of retained
+coefficient groups, one three-component lag group per lag sample, and ``it`` is
+the number of proximal iterations.  ``k`` is not automatically a geologic
+arrival count.
+
+Reading penalty comparison plots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The penalty comparison figures should be read as a three-part diagnostic:
+
+* The shaped-result plot shows the receiver-function traces users would
+  normally inspect.
+* The sparse-result plot shows how each penalty changed the accepted sparse
+  support.
+* The lag-weight plot shows the final penalty state.  Values near 1.0 are
+  effectively unpenalized; lower values mark lag neighborhoods that were
+  downweighted after earlier accepted spikes.
+
+The labels report the penalty function, scale factor, effective width, and, for
+``adaptive_memory``, the last confidence and decay values.  These plots can show
+whether a penalty reduced repeated picking near the same arrival, but they
+should not be summarized as one penalty universally beating another.  Prefer
+wording such as "in this synthetic stress case" or "for this configured noise
+level."
+
+Inspecting QC metadata after deconvolution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After running deconvolution, inspect the QC subdocument saved on the output
+datum.  ``RFdecon`` uses ``RFdecon_properties`` by default.  The direct GID
+wrappers use ``TimeDomainGIDDecon_properties`` and
+``FrequencyDomainGIDDecon_properties`` by default.  If you set a custom
+``QCdocument_key`` or ``QCdata_key``, inspect that key instead.
+
+Useful first-pass fields are:
+
+``decon_operator`` and ``decon_processed``
+    Confirm which engine ran and whether it processed the datum.
+
+``decon_window_start``, ``decon_window_end``, ``noise_window_start``, and
+``noise_window_end``
+    Confirm that the analysis and noise windows match the intended workflow.
+
+``residual_L2_initial`` and ``residual_L2_final``
+    Check whether the fitted model reduced residual energy.  Smaller is not
+    automatically better if the sparse support becomes physically implausible.
+
+``gid_converged``, ``gid_stop_reason``, ``gid_iterations``, and
+``gid_number_spikes``
+    Summarize the GID iteration outcome.
+
+``gid_penalty_function``, ``gid_penalty_effective_width``,
+``lag_weight_L2_final``, and the ``gid_penalty_*`` adaptive-memory fields
+    Explain how the lag-weight penalty affected candidate selection.
+
+``group_sparse_enabled``, ``group_sparse_converged``,
+``group_sparse_iterations``, ``group_sparse_lambda_used``,
+``group_sparse_active_threshold_used``, ``group_sparse_active_groups``,
+``group_sparse_objective_initial``, and ``group_sparse_objective_final``
+    Summarize the regularized group-sparse solve and the exported sparse
+    support decision.
+
+``ns_gid_gain_max_actual``, ``ns_gid_noise_amplification``, and
+``ns_gid_effective_bandwidth_fraction``
+    Help audit inverse-operator stability for ``deconvolution_type ns_gid``.
+
+``group_sparse_inverse_gain_max_actual``,
+``group_sparse_inverse_noise_amplification``, and
+``group_sparse_inverse_effective_bandwidth_fraction``
+    Help audit the NS-GID inverse branch used internally by
+    ``deconvolution_type group_sparse``.
+
+Implementation and compatibility notes
+--------------------------------------
+
+The C++/pybind multitaper classes are still registered as
+``MultiTaperXcorDecon`` and ``MultiTaperSpecDivDecon`` for ABI and pickle
+compatibility.  ``MultiTaperPowerXcorDecon`` and
+``MultiTaperPowerSpecDivDecon`` are Python-level class aliases to those
+classes, not distinct runtime types.  The old RF processor algorithm names
+``MultiTaperXcor`` and ``MultiTaperSpecDiv`` remain available as deprecated
+compatibility aliases for the power-stabilized operators.
+
+``MultiTaperSpecDivDecon`` still exposes legacy ``all_inverse_wavelets``,
+``all_rfestimates``, and ``all_actual_outputs`` methods.  In the current
+implementation those compatibility methods normally contain one combined
+multitaper estimate rather than one independent product per taper.
+
+Parameter files tuned against older tapered-numerator multitaper behavior
+should be retuned and revalidated.  ``damping_factor`` is now interpreted in
+the power-domain denominator, so values should not be assumed numerically
+equivalent to historical Park-Levin-style implementations.

--- a/docs/source/user_manual/deconvolution.rst
+++ b/docs/source/user_manual/deconvolution.rst
@@ -247,6 +247,100 @@ because it is more resistant to noise-driven false picks than the legacy
 prior matches the problem, and reserve ``least_square`` for explicit legacy
 comparisons or diagnostics.
 
+Switching GID methods safely
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The shipped GID defaults changed from ``deconvolution_type least_square`` to
+``deconvolution_type ns_gid`` with ``lag_weight_penalty_function
+adaptive_memory``.  New code should switch GID modes through the public Python
+API instead of editing the installed parameter files.  The examples below assume
+normal parameter-file lookup, meaning ``PFPATH`` includes the shipped MsPASS
+``pf`` directory.
+
+For one-off receiver-function calls, pass the GID options directly to
+``RFdecon``:
+
+.. code-block:: python
+
+   from mspasspy.algorithms.RFdeconProcessor import RFdecon
+
+   # Current shipped default: noise-stable GID plus adaptive-memory lag weights.
+   rf_default = RFdecon(seis, alg="TimeDomainGID")
+
+   # Explicit legacy comparison.  Keep this as a diagnostic, not the default.
+   rf_legacy = RFdecon(
+       seis,
+       alg="TimeDomainGID",
+       deconvolution_type="least_square",
+   )
+
+   # Group-sparse GID: one regularized solve with shared lag support.
+   rf_group_sparse = RFdecon(
+       seis,
+       alg="TimeDomainGID",
+       deconvolution_type="group_sparse",
+   )
+
+   # Make the greedy lag-weight penalty stronger or weaker.
+   rf_weaker_penalty = RFdecon(
+       seis,
+       alg="TimeDomainGID",
+       deconvolution_type="ns_gid",
+       lag_weight_penalty_function="adaptive_memory",
+       gid_parameters={"lag_weight_penalty_scale_factor": 0.2},
+   )
+
+For repeated processing, build a configured processor once and reuse it:
+
+.. code-block:: python
+
+   from mspasspy.algorithms.RFdeconProcessor import RFdecon, RFdeconProcessor
+
+   processor = RFdeconProcessor(
+       alg="TimeDomainGID",
+       deconvolution_type="group_sparse",
+       gid_parameters={"group_sparse_active_threshold": 0.03},
+   )
+
+   rf = RFdecon(seis, alg="TimeDomainGID", engine=processor)
+
+For lower-level workflows that use the GID engines directly, use
+``make_gid_engine`` or the corresponding parameter helpers:
+
+.. code-block:: python
+
+   from mspasspy.algorithms.RFdeconProcessor import (
+       make_gid_engine,
+       make_gid_pf,
+       make_gid_pf_text,
+   )
+
+   engine = make_gid_engine(
+       alg="FrequencyDomainGID",
+       gid_mode="ns_gid",
+       gid_penalty_function="adaptive_memory",
+   )
+
+   pf = make_gid_pf(
+       alg="TimeDomainGID",
+       deconvolution_type="group_sparse",
+       gid_parameters={"group_sparse_active_threshold": 0.03},
+   )
+   pf_text = make_gid_pf_text(
+       alg="TimeDomainGID",
+       deconvolution_type="least_square",
+   )
+
+These settings are separate layers.  The ``deconvolution_type`` method layer and
+its alias ``gid_mode`` choose the GID inverse or solver mode, such as ``ns_gid``,
+``least_square``, or ``group_sparse``.  ``lag_weight_penalty_function`` and its
+alias ``gid_penalty_function`` change only the greedy GID lag-selection penalty;
+they do not enable grouped sparsity.  The group-sparse support threshold keys,
+such as ``group_sparse_active_threshold``,
+``group_sparse_active_threshold_scale``, and
+``group_sparse_active_threshold_quantile``, are applied after the group-sparse
+solve to decide which lag groups remain in the sparse output.
+
 Scalar inverse operators
 ------------------------
 

--- a/python/mspasspy/algorithms/CNRDecon.py
+++ b/python/mspasspy/algorithms/CNRDecon.py
@@ -24,6 +24,29 @@ from mspasspy.algorithms.window import WindowData
 from mspasspy.algorithms.basic import ExtractComponent
 
 
+def _validate_component_index(value, name, context):
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{context}: {name} must be integer 0, 1, or 2")
+    if isinstance(value, np.integer):
+        value = int(value)
+    elif not isinstance(value, int):
+        raise ValueError(f"{context}: {name} must be integer 0, 1, or 2")
+    if value not in (0, 1, 2):
+        raise ValueError(f"{context}: {name} must be integer 0, 1, or 2")
+    return value
+
+
+def _coerce_bandwidth_value(value):
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, (bool, np.bool_)):
+        return -1.0
+    if not isinstance(value, (int, float, np.integer, np.floating)):
+        return -1.0
+    value = float(value)
+    return value if np.isfinite(value) else -1.0
+
+
 def fetch_bandwidth_data(md, keys) -> tuple:
     """
     Small convenience function extracts high and low frequency
@@ -46,12 +69,12 @@ def fetch_bandwidth_data(md, keys) -> tuple:
     """
     k = keys[0]
     if k in md:
-        flow = md[k]
+        flow = _coerce_bandwidth_value(md[k])
     else:
         flow = -1.0
     k = keys[1]
     if k in md:
-        fhigh = md[k]
+        fhigh = _coerce_bandwidth_value(md[k])
     else:
         fhigh = -1.0
     return tuple([flow, fhigh])
@@ -402,13 +425,7 @@ def CNRRFDecon(
         )
         message += "Must be an instance of a CNRDeconEngine"
         raise TypeError(message)
-    if component not in [0, 1, 2]:
-        message = (
-            "Illegal value received with component={}.  must be 0, 1, or 2".format(
-                component
-            )
-        )
-        raise ValueError(message)
+    component = _validate_component_index(component, "component", alg)
 
     if signal_window:
         # using the C++ bound function for efficiency here
@@ -721,6 +738,9 @@ def CNRArrayDecon(
             message += "Using windowed scalar beam data to compute noise spectrum"
             ensemble.elog.log_error(prog, message, ErrorSeverity.Complaint)
         if isinstance(beam, Seismogram):
+            beam_component = _validate_component_index(
+                beam_component, "beam_component", prog
+            )
             if not use_3C_noise:
                 n2use = ExtractComponent(n2use, beam_component)
             # noise is extracted, now we need to extract the beam component

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -17,6 +17,7 @@ Created on Fri Jul 31 06:24:10 2020
 
 import numpy as np
 import os
+import re
 import tempfile
 import warnings
 
@@ -90,6 +91,288 @@ def _write_pickled_pf_text(pf, text):
         return fp.name
     finally:
         fp.close()
+
+
+_TIME_DOMAIN_GID_ALIASES = {"GeneralizedIterative", "TimeDomainGID", "time", "td"}
+_FREQUENCY_DOMAIN_GID_ALIASES = {"FrequencyDomainGID", "frequency", "fd"}
+_SUPPORTED_GID_DECONVOLUTION_TYPES = {
+    "least_square",
+    "water_level",
+    "multi_taper",
+    "cnr",
+    "cnr3c",
+    "ns_gid",
+    "noise_stable",
+    "noise_aware_stable",
+    "group_sparse",
+    "group_lasso",
+    "sparse_group_lasso",
+}
+_SUPPORTED_GID_PENALTY_FUNCTIONS = {
+    "none",
+    "boxcar",
+    "cosine_taper",
+    "shaping_wavelet",
+    "resolution_kernel",
+    "adaptive_memory",
+}
+
+
+def _canonical_gid_algorithm(alg):
+    if alg in _TIME_DOMAIN_GID_ALIASES:
+        return "TimeDomainGID"
+    if alg in _FREQUENCY_DOMAIN_GID_ALIASES:
+        return "FrequencyDomainGID"
+    raise ValueError(
+        "GID configuration helpers require alg='TimeDomainGID', "
+        "'GeneralizedIterative', or 'FrequencyDomainGID'"
+    )
+
+
+def _gid_default_pf(alg):
+    return (
+        "TimeDomainGIDDecon.pf"
+        if _canonical_gid_algorithm(alg) == "TimeDomainGID"
+        else "FrequencyDomainGIDDecon.pf"
+    )
+
+
+def _gid_branch_name(alg):
+    return (
+        "time_domain_gid_deconvolution"
+        if _canonical_gid_algorithm(alg) == "TimeDomainGID"
+        else "frequency_domain_gid_deconvolution"
+    )
+
+
+def _format_pf_value(value):
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.15g}"
+    if isinstance(value, str):
+        if value.strip() != value or re.search(r"\s", value):
+            raise ValueError(
+                f"pf scalar string values cannot contain whitespace: {value!r}"
+            )
+        return value
+    raise TypeError(
+        "GID parameter values must be bool, int, float, or whitespace-free string"
+    )
+
+
+def _find_pf_branch_line_range(lines, branch_name, context):
+    branch_pattern = re.compile(r"^\s*" + re.escape(branch_name) + r"\s+&Arr\{\s*$")
+    starts = [i for i, line in enumerate(lines) if branch_pattern.match(line)]
+    if len(starts) != 1:
+        raise MsPASSError(
+            f"{context}: expected one {branch_name!r} branch, found {len(starts)}",
+            ErrorSeverity.Fatal,
+        )
+    start = starts[0]
+    depth = 0
+    for i in range(start, len(lines)):
+        depth += lines[i].count("{")
+        depth -= lines[i].count("}")
+        if i > start and depth == 0:
+            return start, i
+    raise MsPASSError(
+        f"{context}: unterminated {branch_name!r} branch",
+        ErrorSeverity.Fatal,
+    )
+
+
+def _replace_pf_scalar_in_branch(text, branch_name, key, value, context):
+    lines = text.splitlines()
+    start, end = _find_pf_branch_line_range(lines, branch_name, context)
+    key_pattern = re.compile(r"^(\s*)" + re.escape(key) + r"\s+\S+(\s*(#.*)?)$")
+    matches = [
+        (i, key_pattern.match(lines[i]))
+        for i in range(start + 1, end)
+        if key_pattern.match(lines[i])
+    ]
+    if len(matches) != 1:
+        raise MsPASSError(
+            f"{context}: expected one scalar key {key!r} in {branch_name!r}, "
+            f"found {len(matches)}",
+            ErrorSeverity.Fatal,
+        )
+    line_index, match = matches[0]
+    indent = match.group(1)
+    suffix = match.group(2) or ""
+    lines[line_index] = f"{indent}{key} {_format_pf_value(value)}{suffix}"
+    return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+
+
+def _normalize_gid_option_aliases(
+    deconvolution_type=None,
+    gid_mode=None,
+    lag_weight_penalty_function=None,
+    gid_penalty_function=None,
+    gid_parameters=None,
+):
+    gid_parameters = dict(gid_parameters or {})
+
+    parameter_mode = gid_parameters.pop("deconvolution_type", None)
+    modes = [x for x in (deconvolution_type, gid_mode, parameter_mode) if x is not None]
+    if len(set(modes)) > 1:
+        raise ValueError("conflicting GID deconvolution_type/gid_mode values")
+    mode = modes[0] if modes else None
+    if mode is not None and mode not in _SUPPORTED_GID_DECONVOLUTION_TYPES:
+        raise ValueError(f"unsupported GID deconvolution_type={mode!r}")
+
+    parameter_penalty = gid_parameters.pop("lag_weight_penalty_function", None)
+    penalties = [
+        x
+        for x in (
+            lag_weight_penalty_function,
+            gid_penalty_function,
+            parameter_penalty,
+        )
+        if x is not None
+    ]
+    if len(set(penalties)) > 1:
+        raise ValueError("conflicting GID lag_weight_penalty_function values")
+    penalty = penalties[0] if penalties else None
+    if penalty is not None and penalty not in _SUPPORTED_GID_PENALTY_FUNCTIONS:
+        raise ValueError(f"unsupported GID lag_weight_penalty_function={penalty!r}")
+
+    if mode is not None:
+        gid_parameters["deconvolution_type"] = mode
+    if penalty is not None:
+        gid_parameters["lag_weight_penalty_function"] = penalty
+    return gid_parameters
+
+
+def _gid_overrides_requested(
+    deconvolution_type=None,
+    gid_mode=None,
+    lag_weight_penalty_function=None,
+    gid_penalty_function=None,
+    gid_parameters=None,
+):
+    return any(
+        x is not None
+        for x in (
+            deconvolution_type,
+            gid_mode,
+            lag_weight_penalty_function,
+            gid_penalty_function,
+        )
+    ) or bool(gid_parameters)
+
+
+def make_gid_pf_text(
+    alg="TimeDomainGID",
+    pf=None,
+    *,
+    deconvolution_type=None,
+    gid_mode=None,
+    lag_weight_penalty_function=None,
+    gid_penalty_function=None,
+    gid_parameters=None,
+    _pf_text=None,
+):
+    """
+    Return GID parameter-file text with validated GID-branch overrides applied.
+
+    This helper is the supported Python path for comparing GID inverse modes
+    or lag-penalty settings without hand-editing Antelope pf text.  It only
+    changes keys in the top-level GID branch; leaf inverse-operator parameters
+    should still be changed through a custom pf file or the leaf
+    ``changeparameter`` path.  Custom pf files should follow the shipped GID
+    pf style: the GID branch opener on its own line and scalar keys stored as
+    single-token values.
+    """
+    canonical_alg = _canonical_gid_algorithm(alg)
+    pf = _gid_default_pf(canonical_alg) if pf in (None, "RFdeconProcessor.pf") else pf
+    text = _pf_text if _pf_text is not None else _antelope_pf_to_text(AntelopePf(pf))
+    overrides = _normalize_gid_option_aliases(
+        deconvolution_type=deconvolution_type,
+        gid_mode=gid_mode,
+        lag_weight_penalty_function=lag_weight_penalty_function,
+        gid_penalty_function=gid_penalty_function,
+        gid_parameters=gid_parameters,
+    )
+    branch_name = _gid_branch_name(canonical_alg)
+    context = f"make_gid_pf_text({canonical_alg})"
+    for key, value in overrides.items():
+        text = _replace_pf_scalar_in_branch(text, branch_name, key, value, context)
+    return text
+
+
+def make_gid_pf(
+    alg="TimeDomainGID",
+    pf=None,
+    *,
+    deconvolution_type=None,
+    gid_mode=None,
+    lag_weight_penalty_function=None,
+    gid_penalty_function=None,
+    gid_parameters=None,
+):
+    """
+    Build an ``AntelopePf`` for a GID engine with selected GID options.
+
+    Examples
+    --------
+    ``make_gid_pf(alg="TimeDomainGID", deconvolution_type="group_sparse")``
+    returns a parameter object suitable for ``TimeDomainGIDDecon``.
+    """
+    canonical_alg = _canonical_gid_algorithm(alg)
+    pf = _gid_default_pf(canonical_alg) if pf in (None, "RFdeconProcessor.pf") else pf
+    text = make_gid_pf_text(
+        canonical_alg,
+        pf,
+        deconvolution_type=deconvolution_type,
+        gid_mode=gid_mode,
+        lag_weight_penalty_function=lag_weight_penalty_function,
+        gid_penalty_function=gid_penalty_function,
+        gid_parameters=gid_parameters,
+    )
+    pf_to_load = _write_pickled_pf_text(pf, text)
+    try:
+        return AntelopePf(pf_to_load)
+    finally:
+        try:
+            os.unlink(pf_to_load)
+        except OSError:
+            pass
+
+
+def make_gid_engine(
+    alg="TimeDomainGID",
+    pf=None,
+    *,
+    deconvolution_type=None,
+    gid_mode=None,
+    lag_weight_penalty_function=None,
+    gid_penalty_function=None,
+    gid_parameters=None,
+):
+    """
+    Build a configured low-level time- or frequency-domain GID engine.
+
+    The returned object is passed to ``TimeDomainGIDRFDecon`` or
+    ``FrequencyDomainGIDRFDecon`` directly.  For the high-level ``RFdecon``
+    wrapper, use ``RFdeconProcessor`` or pass the same GID keywords directly
+    to ``RFdecon``.
+    """
+    canonical_alg = _canonical_gid_algorithm(alg)
+    pfhandle = make_gid_pf(
+        canonical_alg,
+        pf,
+        deconvolution_type=deconvolution_type,
+        gid_mode=gid_mode,
+        lag_weight_penalty_function=lag_weight_penalty_function,
+        gid_penalty_function=gid_penalty_function,
+        gid_parameters=gid_parameters,
+    )
+    if canonical_alg == "TimeDomainGID":
+        return TimeDomainGIDDecon(pfhandle)
+    return FrequencyDomainGIDDecon(pfhandle)
 
 
 class RFdeconProcessor:
@@ -205,7 +488,18 @@ class RFdeconProcessor:
             if hasattr(self, attr):
                 delattr(self, attr)
 
-    def __init__(self, alg="LeastSquares", pf="RFdeconProcessor.pf", _pf_text=None):
+    def __init__(
+        self,
+        alg="LeastSquares",
+        pf="RFdeconProcessor.pf",
+        _pf_text=None,
+        *,
+        deconvolution_type=None,
+        gid_mode=None,
+        lag_weight_penalty_function=None,
+        gid_penalty_function=None,
+        gid_parameters=None,
+    ):
         self.algorithm = alg
         self.__is_3c_engine = False
         if pf == "RFdeconProcessor.pf":
@@ -213,6 +507,29 @@ class RFdeconProcessor:
                 pf = "TimeDomainGIDDecon.pf"
             elif alg == "FrequencyDomainGID":
                 pf = "FrequencyDomainGIDDecon.pf"
+        if _gid_overrides_requested(
+            deconvolution_type=deconvolution_type,
+            gid_mode=gid_mode,
+            lag_weight_penalty_function=lag_weight_penalty_function,
+            gid_penalty_function=gid_penalty_function,
+            gid_parameters=gid_parameters,
+        ):
+            if alg not in (
+                "GeneralizedIterative",
+                "TimeDomainGID",
+                "FrequencyDomainGID",
+            ):
+                raise ValueError("GID configuration keywords require a GID algorithm")
+            _pf_text = make_gid_pf_text(
+                alg,
+                pf,
+                deconvolution_type=deconvolution_type,
+                gid_mode=gid_mode,
+                lag_weight_penalty_function=lag_weight_penalty_function,
+                gid_penalty_function=gid_penalty_function,
+                gid_parameters=gid_parameters,
+                _pf_text=_pf_text,
+            )
         self.pf = pf
         pf_to_load = pf
         if _pf_text is not None:
@@ -776,6 +1093,11 @@ def RFdecon(
     engine=None,
     alg="LeastSquares",
     pf="RFdeconProcessor.pf",
+    deconvolution_type=None,
+    gid_mode=None,
+    lag_weight_penalty_function=None,
+    gid_penalty_function=None,
+    gid_parameters=None,
     wavelet=None,
     noisedata=None,
     wcomp=2,
@@ -861,6 +1183,20 @@ def RFdecon(
         RFdeconProcessor.  Ignored if engine is used.
     :type pf:  string defining an absolute path for the file name
         or a path relative to a directory defined by PFPATH.
+    :param deconvolution_type: optional GID inverse mode override used only
+        when ``alg`` selects ``GeneralizedIterative``, ``TimeDomainGID``, or
+        ``FrequencyDomainGID``.  Common values are ``ns_gid``,
+        ``least_square``, ``cnr``, and ``group_sparse``.  This builds a fresh
+        configured GID processor instead of requiring callers to edit a pf
+        file.
+    :param gid_mode: compatibility alias for ``deconvolution_type``.
+    :param lag_weight_penalty_function: optional GID lag-weight penalty
+        override, e.g. ``adaptive_memory`` or ``none``.
+    :param gid_penalty_function: compatibility alias for
+        ``lag_weight_penalty_function``.
+    :param gid_parameters: optional dictionary of additional scalar keys in
+        the top-level GID branch to override, such as
+        ``{"group_sparse_lambda_scale": 0.8}``.
     :param wavelet:   vector of doubles (numpy array or the
         std::vector container internal to TimeSeries object) or TimeSeries
         defining the wavelet to use to compute deconvolution operator.
@@ -935,6 +1271,17 @@ def RFdecon(
     if d.dead():
         return d
     if engine:
+        if _gid_overrides_requested(
+            deconvolution_type=deconvolution_type,
+            gid_mode=gid_mode,
+            lag_weight_penalty_function=lag_weight_penalty_function,
+            gid_penalty_function=gid_penalty_function,
+            gid_parameters=gid_parameters,
+        ):
+            raise ValueError(
+                "GID configuration keywords cannot be used with an already "
+                "constructed RFdeconProcessor engine"
+            )
         if isinstance(engine, RFdeconProcessor):
             processor = engine
         else:
@@ -946,7 +1293,15 @@ def RFdecon(
             message += "If defined must be an instance of RFdeconProcessor"
             raise TypeError(message)
     else:
-        processor = RFdeconProcessor(alg, pf)
+        processor = RFdeconProcessor(
+            alg,
+            pf,
+            deconvolution_type=deconvolution_type,
+            gid_mode=gid_mode,
+            lag_weight_penalty_function=lag_weight_penalty_function,
+            gid_penalty_function=gid_penalty_function,
+            gid_parameters=gid_parameters,
+        )
 
     if processor.is_3c_engine:
         try:

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -1008,6 +1008,21 @@ class RFdeconProcessor:
         # merge in an output of the implementations QCMetrics method
         qcmeth_output = dict(self.processor.QCMetrics())
         qcmd.update(qcmeth_output)
+        decon_type = qcmeth_output.get(
+            "deconvolution_type", qcmd.get("deconvolution_type")
+        )
+        if decon_type != "group_sparse":
+            qcmd = {
+                key: value
+                for key, value in qcmd.items()
+                if not key.startswith("group_sparse")
+            }
+        if decon_type != "ns_gid":
+            qcmd = {
+                key: value
+                for key, value in qcmd.items()
+                if not key.startswith("ns_gid")
+            }
         if self.__is_3c_engine:
             return dict(qcmd)
         # always compute the prediction error

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -166,6 +166,37 @@ def _format_pf_value(value):
     )
 
 
+def _normalize_metadata_scalar_value(value, key, context):
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        if value.ndim == 0:
+            return value.item()
+        raise TypeError(f"{context}: metadata parameter {key!r} must be scalar")
+    if isinstance(value, (list, tuple, dict, Metadata)):
+        raise TypeError(f"{context}: metadata parameter {key!r} must be scalar")
+    return value
+
+
+def _normalize_metadata_scalars(md, context):
+    result = Metadata()
+    for key in md.keys():
+        result[key] = _normalize_metadata_scalar_value(md[key], key, context)
+    return result
+
+
+def _validate_component_index(value, name, context):
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{context}: {name} must be integer 0, 1, or 2")
+    if isinstance(value, np.integer):
+        value = int(value)
+    elif not isinstance(value, int):
+        raise ValueError(f"{context}: {name} must be integer 0, 1, or 2")
+    if value not in (0, 1, 2):
+        raise ValueError(f"{context}: {name} must be integer 0, 1, or 2")
+    return value
+
+
 def _find_pf_branch_line_range(lines, branch_name, context):
     branch_pattern = re.compile(r"^\s*" + re.escape(branch_name) + r"\s+&Arr\{\s*$")
     starts = [i for i, line in enumerate(lines) if branch_pattern.match(line)]
@@ -191,11 +222,14 @@ def _replace_pf_scalar_in_branch(text, branch_name, key, value, context):
     lines = text.splitlines()
     start, end = _find_pf_branch_line_range(lines, branch_name, context)
     key_pattern = re.compile(r"^(\s*)" + re.escape(key) + r"\s+\S+(\s*(#.*)?)$")
-    matches = [
-        (i, key_pattern.match(lines[i]))
-        for i in range(start + 1, end)
-        if key_pattern.match(lines[i])
-    ]
+    matches = []
+    depth = 1
+    for i in range(start + 1, end):
+        match = key_pattern.match(lines[i])
+        if depth == 1 and match:
+            matches.append((i, match))
+        depth += lines[i].count("{")
+        depth -= lines[i].count("}")
     if len(matches) != 1:
         raise MsPASSError(
             f"{context}: expected one scalar key {key!r} in {branch_name!r}, "
@@ -1054,7 +1088,9 @@ class RFdeconProcessor:
         :param md: is a mspass.Metadata object containing required parameters
             for the alternative algorithm.
         """
-        parameter_md = Metadata(md)
+        parameter_md = _normalize_metadata_scalars(
+            md, "RFdeconProcessor.change_parameters"
+        )
         if hasattr(self.processor, "changeparameter"):
             self.processor.changeparameter(parameter_md)
         elif hasattr(self.processor, "change_parameter"):
@@ -1295,6 +1331,8 @@ def RFdecon(
         raise TypeError(message)
     if d.dead():
         return d
+    wcomp = _validate_component_index(wcomp, "wcomp", "RFdecon")
+    ncomp = _validate_component_index(ncomp, "ncomp", "RFdecon")
     if engine:
         if _gid_overrides_requested(
             deconvolution_type=deconvolution_type,

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -315,10 +315,10 @@ def make_gid_pf_text(
     """
     Return GID parameter-file text with validated GID-branch overrides applied.
 
-    This helper is the supported Python path for comparing GID inverse modes
-    or lag-penalty settings without hand-editing Antelope pf text.  It only
-    changes keys in the top-level GID branch; leaf inverse-operator parameters
-    should still be changed through a custom pf file or the leaf
+    This helper is the supported Python path for comparing GID inverse or solver
+    modes and lag-penalty settings without hand-editing Antelope pf text.  It
+    only changes keys in the top-level GID branch; leaf inverse-operator
+    parameters should still be changed through a custom pf file or the leaf
     ``changeparameter`` path.  Custom pf files should follow the shipped GID
     pf style: the GID branch opener on its own line and scalar keys stored as
     single-token values.
@@ -1244,9 +1244,9 @@ def RFdecon(
         RFdeconProcessor.  Ignored if engine is used.
     :type pf:  string defining an absolute path for the file name
         or a path relative to a directory defined by PFPATH.
-    :param deconvolution_type: optional GID inverse mode override used only
-        when ``alg`` selects ``GeneralizedIterative``, ``TimeDomainGID``, or
-        ``FrequencyDomainGID``.  Common values are ``ns_gid``,
+    :param deconvolution_type: optional GID inverse or solver mode override
+        used only when ``alg`` selects ``GeneralizedIterative``,
+        ``TimeDomainGID``, or ``FrequencyDomainGID``.  Common values are ``ns_gid``,
         ``least_square``, ``cnr``, and ``group_sparse``.  This builds a fresh
         configured GID processor instead of requiring callers to edit a pf
         file.
@@ -1278,9 +1278,11 @@ def RFdecon(
         For GID algorithms, raw vectors are converted to a TimeSeries using
         target_sample_interval and noise_window_start.  If noisedata is None,
         a reused GID processor preserves any previously loaded external noise.
-        External PowerSpectrum noise is supported only by the NS-GID inverse
-        mode; other GID modes require TimeSeries/vector noise or the
-        configured noise window.
+        External PowerSpectrum noise is supported by the NS-GID inverse mode
+        and by ``group_sparse`` GID, which uses the NS-GID inverse internally.
+        It regularizes only the inverse operator; residual-domain stopping and
+        sparse support decisions still use the configured noise window or
+        loaded TimeSeries/vector noise where applicable.
     :type noisedata:  None, TimeSeries, PowerSpectrum, or an iterable vector container
         (in MsPASS that means a python array, a numpy array, or a DoubleVector)
     :param wcomp:  When defined from Seismogram d the wavelet

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -146,20 +146,23 @@ def _gid_branch_name(alg):
 
 
 def _format_pf_value(value):
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, int) and not isinstance(value, bool):
-        return str(value)
-    if isinstance(value, float):
-        return f"{value:.15g}"
+    if isinstance(value, (bool, np.bool_)):
+        return "true" if bool(value) else "false"
+    if isinstance(value, (int, np.integer)) and not isinstance(
+        value, (bool, np.bool_)
+    ):
+        return str(int(value))
+    if isinstance(value, (float, np.floating)):
+        return f"{float(value):.15g}"
     if isinstance(value, str):
         if value.strip() != value or re.search(r"\s", value):
             raise ValueError(
                 f"pf scalar string values cannot contain whitespace: {value!r}"
-            )
+        )
         return value
     raise TypeError(
-        "GID parameter values must be bool, int, float, or whitespace-free string"
+        "GID parameter values must be bool, int, float, numpy scalar, "
+        "or whitespace-free string"
     )
 
 

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -148,9 +148,7 @@ def _gid_branch_name(alg):
 def _format_pf_value(value):
     if isinstance(value, (bool, np.bool_)):
         return "true" if bool(value) else "false"
-    if isinstance(value, (int, np.integer)) and not isinstance(
-        value, (bool, np.bool_)
-    ):
+    if isinstance(value, (int, np.integer)) and not isinstance(value, (bool, np.bool_)):
         return str(int(value))
     if isinstance(value, (float, np.floating)):
         return f"{float(value):.15g}"
@@ -158,7 +156,7 @@ def _format_pf_value(value):
         if value.strip() != value or re.search(r"\s", value):
             raise ValueError(
                 f"pf scalar string values cannot contain whitespace: {value!r}"
-        )
+            )
         return value
     raise TypeError(
         "GID parameter values must be bool, int, float, numpy scalar, "

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -1020,6 +1020,13 @@ class RFdeconProcessor:
                 for key, value in qcmd.items()
                 if not key.startswith("group_sparse")
             }
+        else:
+            qcmd = {
+                key: value
+                for key, value in qcmd.items()
+                if not key.startswith("gid_penalty")
+                and not key.startswith("lag_weight")
+            }
         if decon_type != "ns_gid":
             qcmd = {
                 key: value

--- a/python/mspasspy/data/pf/FrequencyDomainGIDDecon.pf
+++ b/python/mspasspy/data/pf/FrequencyDomainGIDDecon.pf
@@ -2,7 +2,7 @@
 
 deconvolution_operator_type &Arr{
     frequency_domain_gid_deconvolution &Arr{
-        deconvolution_type least_square
+        deconvolution_type ns_gid
         target_sample_interval 0.05
         full_data_window_start -8.0
         full_data_window_end 20.0

--- a/python/mspasspy/data/pf/FrequencyDomainGIDDecon.pf
+++ b/python/mspasspy/data/pf/FrequencyDomainGIDDecon.pf
@@ -23,6 +23,11 @@ deconvolution_operator_type &Arr{
         ns_gid_refit_interval 5
         ns_gid_ridge_beta 1.0e-10
         ns_gid_external_wavelet_allowed true
+
+        # The group_sparse_* parameters are used only when
+        # deconvolution_type is group_sparse.  group_sparse_lambda 0.0 means
+        # use the automatic noise-scaled lambda.  active-threshold parameters
+        # control the sparse support exported after the regularized solve.
         group_sparse_lambda 0.0
         group_sparse_lambda_scale 1.0
         group_sparse_tolerance 1.0e-4

--- a/python/mspasspy/data/pf/FrequencyDomainGIDDecon.pf
+++ b/python/mspasspy/data/pf/FrequencyDomainGIDDecon.pf
@@ -23,6 +23,13 @@ deconvolution_operator_type &Arr{
         ns_gid_refit_interval 5
         ns_gid_ridge_beta 1.0e-10
         ns_gid_external_wavelet_allowed true
+        group_sparse_lambda 0.0
+        group_sparse_lambda_scale 1.0
+        group_sparse_tolerance 1.0e-4
+        group_sparse_max_iterations 200
+        group_sparse_active_threshold 0.02
+        group_sparse_active_threshold_scale 1.0
+        group_sparse_active_threshold_quantile 0.90
 
         # adaptive_memory derives its applied footprint from the resolution
         # kernel.  lag_weight_function_width is used by fixed-width penalties

--- a/python/mspasspy/data/pf/TimeDomainGIDDecon.pf
+++ b/python/mspasspy/data/pf/TimeDomainGIDDecon.pf
@@ -30,6 +30,13 @@ deconvolution_operator_type &Arr{
         ns_gid_refit_interval 5
         ns_gid_ridge_beta 1.0e-10
         ns_gid_external_wavelet_allowed true
+        group_sparse_lambda 0.0
+        group_sparse_lambda_scale 1.0
+        group_sparse_tolerance 1.0e-4
+        group_sparse_max_iterations 200
+        group_sparse_active_threshold 0.02
+        group_sparse_active_threshold_scale 1.0
+        group_sparse_active_threshold_quantile 0.90
 
         # adaptive_memory derives its applied footprint from the resolution
         # kernel.  lag_weight_function_width is used by fixed-width penalties

--- a/python/mspasspy/data/pf/TimeDomainGIDDecon.pf
+++ b/python/mspasspy/data/pf/TimeDomainGIDDecon.pf
@@ -30,6 +30,11 @@ deconvolution_operator_type &Arr{
         ns_gid_refit_interval 5
         ns_gid_ridge_beta 1.0e-10
         ns_gid_external_wavelet_allowed true
+
+        # The group_sparse_* parameters are used only when
+        # deconvolution_type is group_sparse.  group_sparse_lambda 0.0 means
+        # use the automatic noise-scaled lambda.  active-threshold parameters
+        # control the sparse support exported after the regularized solve.
         group_sparse_lambda 0.0
         group_sparse_lambda_scale 1.0
         group_sparse_tolerance 1.0e-4

--- a/python/mspasspy/data/pf/TimeDomainGIDDecon.pf
+++ b/python/mspasspy/data/pf/TimeDomainGIDDecon.pf
@@ -7,7 +7,7 @@
 
 deconvolution_operator_type &Arr{
     time_domain_gid_deconvolution &Arr{
-        deconvolution_type least_square
+        deconvolution_type ns_gid
         target_sample_interval 0.05
         full_data_window_start -8.0
         full_data_window_end 20.0

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -32,7 +32,11 @@ from mspasspy.ccore.seismic import (
 )
 from mspasspy.ccore.algorithms.basic import TimeWindow
 from mspasspy.ccore.algorithms.deconvolution import CNRDeconEngine
-from mspasspy.algorithms.CNRDecon import CNRRFDecon, CNRArrayDecon
+from mspasspy.algorithms.CNRDecon import (
+    CNRRFDecon,
+    CNRArrayDecon,
+    fetch_bandwidth_data,
+)
 from mspasspy.algorithms.basic import ExtractComponent
 from mspasspy.algorithms.window import WindowData
 from mspasspy.util.seismic import print_metadata
@@ -409,7 +413,29 @@ def test_CNRRFDecon_error_handlers():
         noise_window=nw,
     )
     assert d.elog.size() >= 1
-    assert "illegal value" in d.elog.get_error_log()[-1].message.lower()
+    assert "component" in d.elog.get_error_log()[-1].message.lower()
+    for bad_component in (True, np.bool_(True), 2.0, "2"):
+        d = Seismogram(d0wn)
+        d_decon = CNRRFDecon(
+            d,
+            engine,
+            component=bad_component,
+            signal_window=sw,
+            noise_window=nw,
+        )
+        assert d_decon.dead()
+        assert d_decon.elog.size() >= 1
+        assert "component" in d_decon.elog.get_error_log()[-1].message.lower()
+
+    d = Seismogram(d0wn)
+    d_decon = CNRRFDecon(
+        d,
+        engine,
+        component=np.int64(2),
+        signal_window=sw,
+        noise_window=nw,
+    )
+    assert d_decon.live
     # verify handling of dead datum
     d = Seismogram(d0wn)
     d.kill()
@@ -452,6 +478,25 @@ def test_CNRRFDecon_error_handlers():
 
     # partial test of how this could go wrong - may need
     # additional variations
+    d = Seismogram(d0wn)
+    nw = TimeWindow(-45.0, -5.0)
+    for bad_bandwidth in ("2.0", None, [2.0], np.nan):
+        d = Seismogram(d0wn)
+        d["low_f_band_edge"] = bad_bandwidth
+        d["high_f_band_edge"] = 8.0
+        assert fetch_bandwidth_data(
+            d, ["low_f_band_edge", "high_f_band_edge"]
+        ) == (-1.0, 8.0)
+        d_decon = CNRRFDecon(
+            d,
+            engine,
+            signal_window=sw,
+            noise_window=nw,
+        )
+        assert d_decon.dead()
+        assert d_decon.elog.size() > 0
+        assert "low frequency corner" in d_decon.elog.get_error_log()[-1].message
+
     d = Seismogram(d0wn)
     d_decon = CNRRFDecon(
         d,
@@ -606,6 +651,26 @@ def test_CNRArrayDecon_error_handlers():
     errs = e.member[0].elog.get_error_log()
     assert len(errs) >= 1
     assert "illegal argument combination" in errs[-1].message.lower()
+
+    e = SeismogramEnsemble(e0)
+    w = Seismogram(d0)
+    w["low_f_band_edge"] = 2.0
+    w["high_f_band_edge"] = 8.0
+    e_d = CNRArrayDecon(
+        e,
+        w,
+        engine,
+        beam_component=True,
+        noise_window=nw,
+        signal_window=sw,
+    )
+    assert e_d.dead()
+    nerrs = e_d.elog.size() + sum(member.elog.size() for member in e_d.member)
+    assert nerrs > 0
+    messages = [err.message for err in e_d.elog.get_error_log()]
+    for member in e_d.member:
+        messages.extend(err.message for err in member.elog.get_error_log())
+    assert any("beam_component" in message for message in messages)
 
     # verify handlling of dead input
     e = SeismogramEnsemble(e0)

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -284,7 +284,8 @@ def verify_decon_output(d_decon, engine, wavelet):
     ],
 )
 def test_CNRDeconEngine_rejects_invalid_windows(tmp_path, old, new, match):
-    text = open("data/pf/CNRDeconEngine.pf", encoding="utf-8").read()
+    with open("data/pf/CNRDeconEngine.pf", encoding="utf-8") as fp:
+        text = fp.read()
     pf = tmp_path / "CNRDeconEngine.pf"
     pf.write_text(text.replace(old, new))
 

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -485,9 +485,10 @@ def test_CNRRFDecon_error_handlers():
         d = Seismogram(d0wn)
         d["low_f_band_edge"] = bad_bandwidth
         d["high_f_band_edge"] = 8.0
-        assert fetch_bandwidth_data(
-            d, ["low_f_band_edge", "high_f_band_edge"]
-        ) == (-1.0, 8.0)
+        assert fetch_bandwidth_data(d, ["low_f_band_edge", "high_f_band_edge"]) == (
+            -1.0,
+            8.0,
+        )
         d_decon = CNRRFDecon(
             d,
             engine,

--- a/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
+++ b/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
@@ -21,6 +21,7 @@ from test_TimeDomainGIDDecon import (
     _assert_single_penalty_footprint,
     _assert_valid_rf,
     _make_external_noise,
+    _make_external_noise_spectrum,
     _make_external_wavelet_3c_data,
     _make_gid_test_data,
     _make_single_spike_convolution_data,
@@ -419,26 +420,34 @@ def test_FrequencyDomainGIDDecon_group_sparse_honors_external_noise_spectrum(tmp
         "frequency_domain_gid_deconvolution",
         "group_sparse",
     )
-    engine = FrequencyDomainGIDDecon(pf)
-    engine.loadwavelet(wavelet)
-    engine.loadnoise(
-        PowerSpectrum(
-            Metadata(), DoubleVector([1.0, 1.0, 1.0]), 1.0, "valid", -1.0, 1.0, 3
+
+    def run_with_spectrum(power):
+        engine = FrequencyDomainGIDDecon(pf)
+        engine.loadwavelet(wavelet)
+        engine.loadnoise(_make_external_noise_spectrum(power))
+        rf = FrequencyDomainGIDRFDecon(
+            data,
+            engine,
+            signal_window=TimeWindow(-8.0, 22.0),
+            noise_window=TimeWindow(-35.0, -8.0),
         )
-    )
+        assert rf.live
+        return rf["FrequencyDomainGIDDecon_properties"]
 
-    rf = FrequencyDomainGIDRFDecon(
-        data,
-        engine,
-        signal_window=TimeWindow(-8.0, 22.0),
-        noise_window=TimeWindow(-35.0, -8.0),
-    )
+    low_qc = run_with_spectrum(1.0e-8)
+    high_qc = run_with_spectrum(1.0e6)
 
-    assert rf.live
-    qc = rf["FrequencyDomainGIDDecon_properties"]
-    assert qc["group_sparse_inverse_external_wavelet_used"]
-    assert qc["group_sparse_inverse_external_noise_spectrum_used"]
-    assert qc["group_sparse_noise_threshold"] > 0.0
+    assert low_qc["group_sparse_inverse_external_wavelet_used"]
+    assert high_qc["group_sparse_inverse_external_wavelet_used"]
+    assert low_qc["group_sparse_inverse_external_noise_spectrum_used"]
+    assert high_qc["group_sparse_inverse_external_noise_spectrum_used"]
+    assert low_qc["group_sparse_noise_threshold"] > high_qc[
+        "group_sparse_noise_threshold"
+    ]
+    assert low_qc["group_sparse_lambda_used"] > high_qc["group_sparse_lambda_used"]
+    assert high_qc["group_sparse_inverse_noise_amplification"] > low_qc[
+        "group_sparse_inverse_noise_amplification"
+    ]
 
 
 def test_FrequencyDomainGIDDecon_clear_external_state_drops_pickle_payload(
@@ -536,7 +545,8 @@ def test_FrequencyDomainGIDDecon_validates_single_spike_recovery():
 
 
 def test_FrequencyDomainGIDDecon_rejects_leaf_window_drift(tmp_path):
-    text = open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8").read()
+    with open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8") as fp:
+        text = fp.read()
     text = _replace_gid_deconvolution_type(
         text, "frequency_domain_gid_deconvolution", "least_square"
     )
@@ -678,7 +688,9 @@ def test_FrequencyDomainGIDDecon_rejects_invalid_external_noise_spectrum(tmp_pat
 
 
 @pytest.mark.parametrize("mode", ["multi_taper", "least_square", "water_level", "cnr"])
-def test_FrequencyDomainGIDDecon_rejects_non_ns_power_spectrum_noise(tmp_path, mode):
+def test_FrequencyDomainGIDDecon_rejects_power_spectrum_noise_without_ns_inverse(
+    tmp_path, mode
+):
     pf = _pf_with_mode(
         tmp_path,
         "FrequencyDomainGIDDecon.pf",
@@ -690,7 +702,7 @@ def test_FrequencyDomainGIDDecon_rejects_non_ns_power_spectrum_noise(tmp_path, m
         Metadata(), DoubleVector([1.0, 1.0, 1.0]), 1.0, "valid", -1.0, 1.0, 3
     )
 
-    with pytest.raises(MsPASSError, match="only supported for ns_gid"):
+    with pytest.raises(MsPASSError, match="only supported for ns_gid and group_sparse"):
         engine.loadnoise(spectrum)
 
 
@@ -857,6 +869,17 @@ def test_FrequencyDomainGIDDecon_changeparameter_handles_cnr_mode(tmp_path):
     cnr_md = pf.get_branch("deconvolution_operator_type").get_branch("cnr")
 
     engine.changeparameter(cnr_md)
+
+
+def test_FrequencyDomainGIDDecon_QCMetrics_rejects_unsupported_changed_leaf_metadata():
+    pf = pfread("./data/pf/FrequencyDomainGIDDecon.pf")
+    engine = FrequencyDomainGIDDecon(pf)
+    leaf_md = pf.get_branch("deconvolution_operator_type").get_branch("ns_gid")
+    leaf_md["diagnostic_object"] = [1, 2, 3]
+    engine.changeparameter(leaf_md)
+
+    with pytest.raises(MsPASSError, match="unsupported Metadata type.*diagnostic_object"):
+        engine.QCMetrics()
 
 
 def test_FrequencyDomainGIDDecon_preprocess_outputs_are_guarded():
@@ -1268,7 +1291,8 @@ def test_FrequencyDomainGIDDecon_changeparameter_rejects_leaf_shaping_dt_drift()
 def test_FrequencyDomainGIDDecon_rejects_invalid_top_level_parameters(
     tmp_path, old, new, match
 ):
-    text = open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8").read()
+    with open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8") as fp:
+        text = fp.read()
     pf = tmp_path / "FrequencyDomainGIDDecon.pf"
     pf.write_text(text.replace(old, new))
 
@@ -1280,7 +1304,8 @@ def test_FrequencyDomainGIDDecon_rejects_invalid_top_level_parameters(
 def test_FrequencyDomainGIDDecon_defaults_missing_lag_penalty_function_to_none(
     tmp_path,
 ):
-    text = open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8").read()
+    with open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8") as fp:
+        text = fp.read()
     text = text.replace("        lag_weight_penalty_function adaptive_memory\n", "")
     pf = tmp_path / "FrequencyDomainGIDDecon_legacy_no_penalty_function.pf"
     pf.write_text(text)
@@ -1301,7 +1326,8 @@ def test_FrequencyDomainGIDDecon_defaults_missing_lag_penalty_function_to_none(
 
 
 def test_FrequencyDomainGIDDecon_reports_missing_fixed_penalty_width(tmp_path):
-    text = open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8").read()
+    with open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8") as fp:
+        text = fp.read()
     text = text.replace(
         "lag_weight_penalty_function adaptive_memory",
         "lag_weight_penalty_function cosine_taper",

--- a/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
+++ b/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
@@ -411,6 +411,36 @@ def test_FrequencyDomainGIDDecon_pickle_preserves_external_wavelet_and_noise(tmp
     assert qc_spectrum["ns_gid_external_noise_spectrum_used"]
 
 
+def test_FrequencyDomainGIDDecon_group_sparse_honors_external_noise_spectrum(tmp_path):
+    data, wavelet, _ = _make_external_wavelet_3c_data(noise_level=2.0e-4)
+    pf = _pf_with_mode(
+        tmp_path,
+        "FrequencyDomainGIDDecon.pf",
+        "frequency_domain_gid_deconvolution",
+        "group_sparse",
+    )
+    engine = FrequencyDomainGIDDecon(pf)
+    engine.loadwavelet(wavelet)
+    engine.loadnoise(
+        PowerSpectrum(
+            Metadata(), DoubleVector([1.0, 1.0, 1.0]), 1.0, "valid", -1.0, 1.0, 3
+        )
+    )
+
+    rf = FrequencyDomainGIDRFDecon(
+        data,
+        engine,
+        signal_window=TimeWindow(-8.0, 22.0),
+        noise_window=TimeWindow(-35.0, -8.0),
+    )
+
+    assert rf.live
+    qc = rf["FrequencyDomainGIDDecon_properties"]
+    assert qc["group_sparse_inverse_external_wavelet_used"]
+    assert qc["group_sparse_inverse_external_noise_spectrum_used"]
+    assert qc["group_sparse_noise_threshold"] > 0.0
+
+
 def test_FrequencyDomainGIDDecon_clear_external_state_drops_pickle_payload(
     tmp_path,
 ):
@@ -1040,6 +1070,39 @@ def test_FrequencyDomainGIDDecon_replacing_external_noise_refreshes_threshold(
     high_threshold = dict(engine.QCMetrics())["ns_gid_peak_threshold"]
 
     assert high_threshold > 10.0 * low_threshold
+
+
+def test_FrequencyDomainGIDDecon_group_sparse_external_noise_sets_lambda(tmp_path):
+    data = _make_single_spike_convolution_data()
+    pf = _pf_with_mode(
+        tmp_path,
+        "FrequencyDomainGIDDecon.pf",
+        "frequency_domain_gid_deconvolution",
+        "group_sparse",
+    )
+    dwin = TimeWindow(-10.0, 20.0)
+    low_noise = _make_external_noise(scale=1.0)
+    high_noise = _make_external_noise(scale=1000.0)
+
+    engine = FrequencyDomainGIDDecon(pf)
+    engine.loadnoise(low_noise)
+    assert engine.load(data, dwin) == 0
+    engine.process()
+    low_qc = dict(engine.QCMetrics())
+
+    engine.loadnoise(high_noise)
+    assert engine.load(data, dwin) == 0
+    engine.process()
+    high_qc = dict(engine.QCMetrics())
+
+    assert low_qc["group_sparse_inverse_external_noise_used"]
+    assert high_qc["group_sparse_inverse_external_noise_used"]
+    assert high_qc["group_sparse_noise_threshold"] > (
+        10.0 * low_qc["group_sparse_noise_threshold"]
+    )
+    assert high_qc["group_sparse_lambda_used"] > (
+        10.0 * low_qc["group_sparse_lambda_used"]
+    )
 
 
 def test_FrequencyDomainGIDDecon_failed_external_noise_replacement_preserves_state(

--- a/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
+++ b/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
@@ -441,13 +441,14 @@ def test_FrequencyDomainGIDDecon_group_sparse_honors_external_noise_spectrum(tmp
     assert high_qc["group_sparse_inverse_external_wavelet_used"]
     assert low_qc["group_sparse_inverse_external_noise_spectrum_used"]
     assert high_qc["group_sparse_inverse_external_noise_spectrum_used"]
-    assert low_qc["group_sparse_noise_threshold"] > high_qc[
-        "group_sparse_noise_threshold"
-    ]
+    assert (
+        low_qc["group_sparse_noise_threshold"] > high_qc["group_sparse_noise_threshold"]
+    )
     assert low_qc["group_sparse_lambda_used"] > high_qc["group_sparse_lambda_used"]
-    assert high_qc["group_sparse_inverse_noise_amplification"] > low_qc[
-        "group_sparse_inverse_noise_amplification"
-    ]
+    assert (
+        high_qc["group_sparse_inverse_noise_amplification"]
+        > low_qc["group_sparse_inverse_noise_amplification"]
+    )
 
 
 def test_FrequencyDomainGIDDecon_clear_external_state_drops_pickle_payload(
@@ -878,7 +879,9 @@ def test_FrequencyDomainGIDDecon_QCMetrics_rejects_unsupported_changed_leaf_meta
     leaf_md["diagnostic_object"] = [1, 2, 3]
     engine.changeparameter(leaf_md)
 
-    with pytest.raises(MsPASSError, match="unsupported Metadata type.*diagnostic_object"):
+    with pytest.raises(
+        MsPASSError, match="unsupported Metadata type.*diagnostic_object"
+    ):
         engine.QCMetrics()
 
 

--- a/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
+++ b/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
@@ -15,6 +15,7 @@ from mspasspy.algorithms.FrequencyDomainGIDDecon import FrequencyDomainGIDRFDeco
 
 from test_TimeDomainGIDDecon import (
     _assert_actual_and_output_shaping_are_distinct,
+    _assert_group_sparse_qc,
     _assert_single_spike_recovery,
     _assert_single_penalty_footprint,
     _assert_valid_rf,
@@ -688,7 +689,9 @@ def test_FrequencyDomainGIDDecon_rejects_external_timeseries_dt_mismatch(tmp_pat
         engine.loadnoise(noise)
 
 
-@pytest.mark.parametrize("mode", ["least_square", "water_level", "multi_taper", "cnr"])
+@pytest.mark.parametrize(
+    "mode", ["least_square", "water_level", "multi_taper", "cnr", "group_sparse"]
+)
 def test_FrequencyDomainGIDDecon_inverse_modes_are_valid(tmp_path, mode):
     data = _make_single_spike_convolution_data()
     pf = _pf_with_mode(
@@ -709,6 +712,10 @@ def test_FrequencyDomainGIDDecon_inverse_modes_are_valid(tmp_path, mode):
     qc = rf["FrequencyDomainGIDDecon_properties"]
     assert qc["iteration_count"] > 0
     assert qc["residual_L2_final"] < qc["residual_L2_initial"]
+    if mode == "group_sparse":
+        _assert_group_sparse_qc(qc)
+    else:
+        assert not qc["group_sparse_enabled"]
     _assert_single_spike_recovery(rf, ratio_tolerance=5.0e-2)
 
 
@@ -1099,6 +1106,41 @@ def test_FrequencyDomainGIDDecon_changeparameter_rejects_leaf_shaping_dt_drift()
             "lag_weight_penalty_function",
         ),
         (
+            "group_sparse_lambda 0.0",
+            "group_sparse_lambda -1.0",
+            "group_sparse_lambda",
+        ),
+        (
+            "group_sparse_lambda_scale 1.0",
+            "group_sparse_lambda_scale -1.0",
+            "group_sparse_lambda_scale",
+        ),
+        (
+            "group_sparse_tolerance 1.0e-4",
+            "group_sparse_tolerance 0.0",
+            "group_sparse_tolerance",
+        ),
+        (
+            "group_sparse_max_iterations 200",
+            "group_sparse_max_iterations 0",
+            "group_sparse_max_iterations",
+        ),
+        (
+            "group_sparse_active_threshold 0.02",
+            "group_sparse_active_threshold -0.01",
+            "group_sparse_active_threshold",
+        ),
+        (
+            "group_sparse_active_threshold_scale 1.0",
+            "group_sparse_active_threshold_scale -0.01",
+            "group_sparse_active_threshold_scale",
+        ),
+        (
+            "group_sparse_active_threshold_quantile 0.90",
+            "group_sparse_active_threshold_quantile 1.5",
+            "group_sparse_active_threshold_quantile",
+        ),
+        (
             "maximum_iterations 100",
             "maximum_iterations 0",
             "maximum_iterations",
@@ -1192,6 +1234,7 @@ def test_FrequencyDomainGIDDecon_reports_missing_fixed_penalty_width(tmp_path):
         ("ns_gid_refit_interval", 2),
         ("lag_weight_penalty_scale_factor", 0.5),
         ("lag_weight_function_width", 5),
+        ("group_sparse_lambda_scale", 1.0),
         ("noise_window_start", -30.0),
         ("noise_window_end", -3.0),
     ],

--- a/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
+++ b/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
@@ -26,6 +26,7 @@ from test_TimeDomainGIDDecon import (
     _ns_gid_pf,
     _pf_with_short_decon_window,
     _pf_with_mode,
+    _replace_gid_deconvolution_type,
 )
 
 
@@ -111,8 +112,13 @@ def test_FrequencyDomainGIDDecon_penalty_reduces_multispike_residual(tmp_path):
     signal_window = TimeWindow(-8.0, 20.0)
     noise_window = TimeWindow(-25.0, -8.0)
 
+    penalty_pf = tmp_path / "FrequencyDomainGIDDecon_penalty.pf"
     no_penalty_pf = tmp_path / "FrequencyDomainGIDDecon_no_penalty.pf"
     text = Path("./data/pf/FrequencyDomainGIDDecon.pf").read_text()
+    text = _replace_gid_deconvolution_type(
+        text, "frequency_domain_gid_deconvolution", "least_square"
+    )
+    penalty_pf.write_text(text)
     no_penalty_pf.write_text(
         text.replace(
             "lag_weight_penalty_function adaptive_memory",
@@ -122,7 +128,7 @@ def test_FrequencyDomainGIDDecon_penalty_reduces_multispike_residual(tmp_path):
 
     penalty_rf = FrequencyDomainGIDRFDecon(
         data,
-        FrequencyDomainGIDDecon(pfread("./data/pf/FrequencyDomainGIDDecon.pf")),
+        FrequencyDomainGIDDecon(pfread(str(penalty_pf))),
         signal_window=signal_window,
         noise_window=noise_window,
     )
@@ -158,6 +164,9 @@ def test_FrequencyDomainGIDDecon_kernel_penalty_modes_are_adaptive(
 
     pf = tmp_path / f"FrequencyDomainGIDDecon_{penalty_function}.pf"
     text = Path("./data/pf/FrequencyDomainGIDDecon.pf").read_text()
+    text = _replace_gid_deconvolution_type(
+        text, "frequency_domain_gid_deconvolution", "least_square"
+    )
     text = text.replace(
         "lag_weight_penalty_function adaptive_memory",
         f"lag_weight_penalty_function {penalty_function}",
@@ -497,6 +506,9 @@ def test_FrequencyDomainGIDDecon_validates_single_spike_recovery():
 
 def test_FrequencyDomainGIDDecon_rejects_leaf_window_drift(tmp_path):
     text = open("data/pf/FrequencyDomainGIDDecon.pf", encoding="utf-8").read()
+    text = _replace_gid_deconvolution_type(
+        text, "frequency_domain_gid_deconvolution", "least_square"
+    )
     text = text.replace(
         "least_square &Arr{\n        target_sample_interval 0.05\n        operator_nfft 512\n        deconvolution_data_window_start -5.0",
         "least_square &Arr{\n        target_sample_interval 0.05\n        operator_nfft 512\n        deconvolution_data_window_start -4.0",
@@ -775,7 +787,12 @@ def test_FrequencyDomainGIDDecon_cnr_penalty_qc_tracks_residual_noise(
 
 def test_FrequencyDomainGIDDecon_short_kernel_crop_is_bounded(tmp_path):
     data = _make_single_spike_convolution_data()
-    pf = _pf_with_short_decon_window(tmp_path, "FrequencyDomainGIDDecon.pf")
+    pf = _pf_with_short_decon_window(
+        tmp_path,
+        "FrequencyDomainGIDDecon.pf",
+        "frequency_domain_gid_deconvolution",
+        "least_square",
+    )
 
     rf, actual_output, output_shaping_wavelet = _run_frequency_gid(data, pf)
 
@@ -854,9 +871,16 @@ def test_FrequencyDomainGIDDecon_changeparameter_invalidates_outer_state():
         engine.actual_output()
 
 
-def test_FrequencyDomainGIDDecon_failed_changeparameter_invalidates_without_poisoning_leaf():
+def test_FrequencyDomainGIDDecon_failed_changeparameter_invalidates_without_poisoning_leaf(
+    tmp_path,
+):
     data = _make_single_spike_convolution_data()
-    pf = pfread("./data/pf/FrequencyDomainGIDDecon.pf")
+    pf = _pf_with_mode(
+        tmp_path,
+        "FrequencyDomainGIDDecon.pf",
+        "frequency_domain_gid_deconvolution",
+        "least_square",
+    )
     engine = FrequencyDomainGIDDecon(pf)
     FrequencyDomainGIDRFDecon(
         data,

--- a/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
+++ b/python/tests/algorithms/test_FrequencyDomainGIDDecon.py
@@ -15,6 +15,7 @@ from mspasspy.algorithms.FrequencyDomainGIDDecon import FrequencyDomainGIDRFDeco
 
 from test_TimeDomainGIDDecon import (
     _assert_actual_and_output_shaping_are_distinct,
+    _assert_group_sparse_disabled_qc,
     _assert_group_sparse_qc,
     _assert_single_spike_recovery,
     _assert_single_penalty_footprint,
@@ -727,7 +728,7 @@ def test_FrequencyDomainGIDDecon_inverse_modes_are_valid(tmp_path, mode):
     if mode == "group_sparse":
         _assert_group_sparse_qc(qc)
     else:
-        assert not qc["group_sparse_enabled"]
+        _assert_group_sparse_disabled_qc(qc)
     _assert_single_spike_recovery(rf, ratio_tolerance=5.0e-2)
 
 

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -274,6 +274,23 @@ def test_make_gid_pf_text_overrides_mode_and_penalty_without_pf_edits(alg):
 
 
 @pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+def test_make_gid_pf_text_accepts_numpy_scalar_gid_parameters(alg):
+    with _test_pfpath():
+        text = make_gid_pf_text(
+            alg=alg,
+            gid_parameters={
+                "maximum_iterations": np.int64(9),
+                "group_sparse_lambda_scale": np.float64(0.75),
+                "ns_gid_use_empirical_noise_threshold": np.bool_(False),
+            },
+        )
+
+    assert "maximum_iterations 9" in text
+    assert "group_sparse_lambda_scale 0.75" in text
+    assert "ns_gid_use_empirical_noise_threshold false" in text
+
+
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
 def test_make_gid_pf_applies_public_aliases_without_pf_edits(alg):
     with _test_pfpath():
         pf = make_gid_pf(

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -98,8 +98,7 @@ def _assert_public_gid_mode_qc(qc, mode):
         assert qc["group_sparse_enabled"]
         assert qc["group_sparse_inverse_operator"] == "ns_gid"
     else:
-        assert not qc["group_sparse_enabled"]
-        assert qc["group_sparse_inverse_operator"] == "not_enabled"
+        assert not any(key.startswith("group_sparse") for key in dict(qc))
 
 
 def _run_public_gid_engine(alg, **kwargs):

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -412,9 +412,12 @@ def test_RFdecon_gid_keywords_switch_modes_without_pf_edits(alg, mode):
     assert rf.live
     qc = rf["RFdecon_properties"]
     _assert_public_gid_mode_qc(qc, mode)
-    assert qc["gid_penalty_function"] == "none"
     if mode == "group_sparse":
         assert qc["group_sparse_lambda_scale"] == pytest.approx(0.5)
+        assert "gid_penalty_function" not in qc
+        assert "lag_weight_penalty_function" not in qc
+    else:
+        assert qc["gid_penalty_function"] == "none"
 
 
 @pytest.mark.parametrize(

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -32,10 +32,27 @@ from mspasspy.algorithms.basic import ExtractComponent
 from mspasspy.util.seismic import print_metadata
 
 
+DEFAULT_GID_DECONVOLUTION_TYPE = "ns_gid"
+
+
 def _distributed_roundtrip(obj):
     distributed_protocol = pytest.importorskip("distributed.protocol")
     header, frames = distributed_protocol.serialize(obj)
     return distributed_protocol.deserialize(header, frames)
+
+
+def _gid_pf_with_mode(tmp_path, mode, pf_name="TimeDomainGIDDecon.pf"):
+    text = open(f"data/pf/{pf_name}", encoding="utf-8").read()
+    old = (
+        "time_domain_gid_deconvolution &Arr{\n        "
+        f"deconvolution_type {DEFAULT_GID_DECONVOLUTION_TYPE}"
+    )
+    new = f"time_domain_gid_deconvolution &Arr{{\n        deconvolution_type {mode}"
+    assert text.count(old) == 1
+    text = text.replace(old, new, 1)
+    pf = tmp_path / pf_name
+    pf.write_text(text)
+    return pf
 
 
 def prediction_error_norm(ao, io):
@@ -475,8 +492,9 @@ def test_RFdecon_enables_generalized_iterative():
         qc = rf["RFdecon_properties"]
         assert qc["algorithm"] == "GeneralizedIterative"
         assert qc["iteration_count"] > 0
-        assert qc["gid_leaf_damping_factor"] == pytest.approx(1.0)
-        assert not qc["gid_leaf_parameters_changed"]
+        assert qc["deconvolution_type"] == DEFAULT_GID_DECONVOLUTION_TYPE
+        assert qc["ns_gid_enabled"]
+        assert qc["ns_gid_peak_sigma_threshold"] == pytest.approx(4.0)
     finally:
         if old_pfpath is None:
             os.environ.pop("PFPATH", None)
@@ -485,13 +503,7 @@ def test_RFdecon_enables_generalized_iterative():
 
 
 def test_RFdecon_gid_qc_namespaces_leaf_metadata(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-    text = text.replace(
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type cnr",
-    )
-    pf = tmp_path / "TimeDomainGIDDecon.pf"
-    pf.write_text(text)
+    pf = _gid_pf_with_mode(tmp_path, "cnr")
 
     wavelet = make_simulation_wavelet()
     truth = make_impulse_data()
@@ -544,7 +556,7 @@ def test_RFdecon_generalized_iterative_accepts_external_wavelet():
         qc = rf["RFdecon_properties"]
         assert qc["iteration_count"] > 0
         assert "prediction_error" not in qc
-        assert qc["deconvolution_type"] == "least_square"
+        assert qc["deconvolution_type"] == DEFAULT_GID_DECONVOLUTION_TYPE
         assert "deconvolution_data_window_start" in qc
         assert "target_sample_interval" in qc
     finally:
@@ -595,13 +607,7 @@ def test_RFdecon_gid_accepts_raw_vector_wavelet_and_noise(alg, pf):
 def test_RFdecon_preserves_preconfigured_gid_external_wavelet_when_omitted(tmp_path):
     os.environ["PFPATH"] = "./data/pf"
     try:
-        text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-        text = text.replace(
-            "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-            "time_domain_gid_deconvolution &Arr{\n        deconvolution_type ns_gid",
-        )
-        pf = tmp_path / "TimeDomainGIDDecon.pf"
-        pf.write_text(text)
+        pf = _gid_pf_with_mode(tmp_path, "ns_gid")
         wavelet = make_simulation_wavelet()
         impulses = make_impulse_data()
         seis0 = addnoise(convolve_wavelet(impulses, wavelet), nscale=0.0, padlength=800)
@@ -856,13 +862,7 @@ def test_RFdecon_invalid_configured_windows_return_dead_without_qc(alg, pf):
 
 
 def test_RFdeconProcessor_apply_3c_uses_loaded_external_wavelet(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-    text = text.replace(
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type ns_gid",
-    )
-    pf = tmp_path / "TimeDomainGIDDecon.pf"
-    pf.write_text(text)
+    pf = _gid_pf_with_mode(tmp_path, "ns_gid")
 
     wavelet = make_simulation_wavelet()
     truth = make_impulse_data()
@@ -902,13 +902,7 @@ def test_RFdeconProcessor_apply_3c_uses_loaded_external_wavelet(tmp_path):
 
 
 def test_RFdeconProcessor_apply_3c_external_wavelet_is_dask_serializable(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-    text = text.replace(
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type ns_gid",
-    )
-    pf = tmp_path / "TimeDomainGIDDecon.pf"
-    pf.write_text(text)
+    pf = _gid_pf_with_mode(tmp_path, "ns_gid")
 
     wavelet = make_simulation_wavelet()
     truth = make_impulse_data()
@@ -936,13 +930,7 @@ def test_RFdeconProcessor_apply_3c_external_wavelet_is_dask_serializable(tmp_pat
 
 
 def test_RFdeconProcessor_clear_external_state_drops_pickle_payload(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-    text = text.replace(
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type ns_gid",
-    )
-    pf = tmp_path / "TimeDomainGIDDecon.pf"
-    pf.write_text(text)
+    pf = _gid_pf_with_mode(tmp_path, "ns_gid")
 
     processor = RFdeconProcessor(alg="GeneralizedIterative", pf=str(pf))
     baseline_size = len(pickle.dumps(processor))
@@ -993,13 +981,7 @@ def test_RFdeconProcessor_clear_external_methods_are_gid_only():
 
 
 def test_RFdeconProcessor_gid_loadwavelet_is_transactional(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-    text = text.replace(
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type ns_gid",
-    )
-    pf = tmp_path / "TimeDomainGIDDecon.pf"
-    pf.write_text(text)
+    pf = _gid_pf_with_mode(tmp_path, "ns_gid")
 
     wavelet = make_simulation_wavelet()
     truth = make_impulse_data()
@@ -1030,13 +1012,7 @@ def test_RFdeconProcessor_gid_loadwavelet_is_transactional(tmp_path):
 
 
 def test_RFdeconProcessor_gid_loadnoise_timeseries_and_clear(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-    text = text.replace(
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type ns_gid",
-    )
-    pf = tmp_path / "TimeDomainGIDDecon.pf"
-    pf.write_text(text)
+    pf = _gid_pf_with_mode(tmp_path, "ns_gid")
 
     wavelet = make_simulation_wavelet()
     truth = make_impulse_data()
@@ -1067,13 +1043,7 @@ def test_RFdeconProcessor_gid_loadnoise_timeseries_and_clear(tmp_path):
 
 
 def test_RFdeconProcessor_gid_getstate_does_not_invalidate_processed_state(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-    text = text.replace(
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type ns_gid",
-    )
-    pf = tmp_path / "TimeDomainGIDDecon.pf"
-    pf.write_text(text)
+    pf = _gid_pf_with_mode(tmp_path, "ns_gid")
 
     wavelet = make_simulation_wavelet()
     truth = make_impulse_data()
@@ -1095,13 +1065,7 @@ def test_RFdeconProcessor_gid_getstate_does_not_invalidate_processed_state(tmp_p
 
 
 def test_RFdeconProcessor_gid_dask_roundtrip_does_not_invalidate_state(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
-    text = text.replace(
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type least_square",
-        "time_domain_gid_deconvolution &Arr{\n        deconvolution_type ns_gid",
-    )
-    pf = tmp_path / "TimeDomainGIDDecon.pf"
-    pf.write_text(text)
+    pf = _gid_pf_with_mode(tmp_path, "ns_gid")
 
     wavelet = make_simulation_wavelet()
     truth = make_impulse_data()

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -420,6 +420,22 @@ def test_RFdecon_gid_keywords_switch_modes_without_pf_edits(alg, mode):
         assert qc["gid_penalty_function"] == "none"
 
 
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+def test_RFdecon_gid_accepts_integral_values_for_double_parameters(alg):
+    with _test_pfpath():
+        rf = RFdecon(
+            Seismogram(_make_gid_switching_data()),
+            alg=alg,
+            gid_mode="group_sparse",
+            gid_parameters={"group_sparse_lambda_scale": 2},
+        )
+
+    assert rf.live
+    qc = rf["RFdecon_properties"]
+    assert qc["group_sparse_enabled"]
+    assert qc["group_sparse_lambda_scale"] == pytest.approx(2.0)
+
+
 @pytest.mark.parametrize(
     "alg,pf",
     [

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -5,6 +5,7 @@ import sys
 import os
 import pickle
 import cloudpickle
+from contextlib import contextmanager
 import numpy as np
 import pytest
 
@@ -25,20 +26,101 @@ from decon_data_generators import (
     make_simulation_wavelet,
 )
 from mspasspy.algorithms.window import WindowData
-from mspasspy.algorithms.RFdeconProcessor import RFdeconProcessor, RFdecon
+from mspasspy.algorithms.RFdeconProcessor import (
+    RFdeconProcessor,
+    RFdecon,
+    make_gid_engine,
+    make_gid_pf,
+    make_gid_pf_text,
+)
+from mspasspy.algorithms.TimeDomainGIDDecon import TimeDomainGIDRFDecon
+from mspasspy.algorithms.FrequencyDomainGIDDecon import FrequencyDomainGIDRFDecon
 from mspasspy.ccore.seismic import Seismogram, TimeSeries
 from mspasspy.ccore.utility import AntelopePf, ErrorSeverity, Metadata, MsPASSError
+from mspasspy.ccore.algorithms.basic import TimeWindow
 from mspasspy.algorithms.basic import ExtractComponent
 from mspasspy.util.seismic import print_metadata
 
-
 DEFAULT_GID_DECONVOLUTION_TYPE = "ns_gid"
+GID_SWITCHING_ALGORITHMS = ("TimeDomainGID", "FrequencyDomainGID")
+PUBLIC_GID_SWITCHING_MODES = ("ns_gid", "least_square", "group_sparse")
+
+
+@contextmanager
+def _test_pfpath(path="./data/pf"):
+    old_pfpath = os.environ.get("PFPATH")
+    os.environ["PFPATH"] = path
+    try:
+        yield
+    finally:
+        if old_pfpath is None:
+            os.environ.pop("PFPATH", None)
+        else:
+            os.environ["PFPATH"] = old_pfpath
 
 
 def _distributed_roundtrip(obj):
     distributed_protocol = pytest.importorskip("distributed.protocol")
     header, frames = distributed_protocol.serialize(obj)
     return distributed_protocol.deserialize(header, frames)
+
+
+def _make_gid_switching_data(noise_scale=1.0e-4):
+    wavelet = make_simulation_wavelet()
+    impulses = make_impulse_data()
+    data = addnoise(
+        convolve_wavelet(impulses, wavelet), nscale=noise_scale, padlength=800
+    )
+    data["low_f_band_edge"] = 0.02
+    data["high_f_band_edge"] = 2.0
+    return data
+
+
+def _gid_branch_name_for_test(alg):
+    return (
+        "frequency_domain_gid_deconvolution"
+        if alg == "FrequencyDomainGID"
+        else "time_domain_gid_deconvolution"
+    )
+
+
+def _gid_qc_key_for_test(alg):
+    return (
+        "FrequencyDomainGIDDecon_properties"
+        if alg == "FrequencyDomainGID"
+        else "TimeDomainGIDDecon_properties"
+    )
+
+
+def _assert_public_gid_mode_qc(qc, mode):
+    assert qc["deconvolution_type"] == mode
+    if mode == "group_sparse":
+        assert qc["group_sparse_enabled"]
+        assert qc["group_sparse_inverse_operator"] == "ns_gid"
+    else:
+        assert not qc["group_sparse_enabled"]
+        assert qc["group_sparse_inverse_operator"] == "not_enabled"
+
+
+def _run_public_gid_engine(alg, **kwargs):
+    engine = make_gid_engine(alg=alg, **kwargs)
+    data = _make_gid_switching_data()
+    if alg == "FrequencyDomainGID":
+        rf = FrequencyDomainGIDRFDecon(
+            data,
+            engine,
+            signal_window=TimeWindow(-10.0, 20.0),
+            noise_window=TimeWindow(-35.0, -5.0),
+        )
+    else:
+        rf = TimeDomainGIDRFDecon(
+            data,
+            engine,
+            signal_window=TimeWindow(-10.0, 20.0),
+            noise_window=TimeWindow(-35.0, -5.0),
+        )
+    assert rf.live
+    return rf[_gid_qc_key_for_test(alg)]
 
 
 def _gid_pf_with_mode(tmp_path, mode, pf_name="TimeDomainGIDDecon.pf"):
@@ -174,6 +256,149 @@ def test_RFdeconProcessor_gid_defaults_resolve_from_package_pf_path():
             os.environ.pop("PFPATH", None)
         else:
             os.environ["PFPATH"] = old_pfpath
+
+
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+def test_make_gid_pf_text_overrides_mode_and_penalty_without_pf_edits(alg):
+    with _test_pfpath():
+        text = make_gid_pf_text(
+            alg=alg,
+            gid_mode="least_square",
+            gid_penalty_function="cosine_taper",
+            gid_parameters={"maximum_iterations": 7},
+        )
+
+    assert f"{_gid_branch_name_for_test(alg)} &Arr" in text
+    assert "deconvolution_type least_square" in text
+    assert "lag_weight_penalty_function cosine_taper" in text
+    assert "maximum_iterations 7" in text
+
+
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+def test_make_gid_pf_applies_public_aliases_without_pf_edits(alg):
+    with _test_pfpath():
+        pf = make_gid_pf(
+            alg=alg,
+            gid_mode="group_sparse",
+            lag_weight_penalty_function="none",
+            gid_parameters={"group_sparse_lambda_scale": 0.5},
+        )
+
+    branch_md = Metadata(
+        pf.get_branch("deconvolution_operator_type").get_branch(
+            _gid_branch_name_for_test(alg)
+        )
+    )
+    assert branch_md["deconvolution_type"] == "group_sparse"
+    assert branch_md["lag_weight_penalty_function"] == "none"
+    assert branch_md["group_sparse_lambda_scale"] == pytest.approx(0.5)
+
+
+def test_make_gid_pf_accepts_cxx_gid_mode_aliases_without_pf_edits():
+    with _test_pfpath():
+        ns_pf = make_gid_pf(alg="TimeDomainGID", gid_mode="noise_stable")
+        group_pf = make_gid_pf(alg="FrequencyDomainGID", gid_mode="group_lasso")
+
+    ns_md = Metadata(
+        ns_pf.get_branch("deconvolution_operator_type").get_branch(
+            "time_domain_gid_deconvolution"
+        )
+    )
+    group_md = Metadata(
+        group_pf.get_branch("deconvolution_operator_type").get_branch(
+            "frequency_domain_gid_deconvolution"
+        )
+    )
+    assert ns_md["deconvolution_type"] == "noise_stable"
+    assert group_md["deconvolution_type"] == "group_lasso"
+
+
+def test_gid_public_helpers_reject_conflicting_or_invalid_options():
+    with _test_pfpath():
+        with pytest.raises(ValueError, match="conflicting GID deconvolution_type"):
+            make_gid_pf_text(
+                alg="TimeDomainGID",
+                deconvolution_type="ns_gid",
+                gid_mode="least_square",
+            )
+        with pytest.raises(ValueError, match="unsupported GID deconvolution_type"):
+            make_gid_pf_text(alg="TimeDomainGID", deconvolution_type="bad_mode")
+        with pytest.raises(ValueError, match="unsupported GID lag_weight"):
+            make_gid_pf_text(
+                alg="TimeDomainGID",
+                lag_weight_penalty_function="bad_penalty",
+            )
+        with pytest.raises(MsPASSError, match="no_such_gid_key"):
+            make_gid_pf_text(
+                alg="TimeDomainGID",
+                gid_parameters={"no_such_gid_key": 1},
+            )
+
+
+def test_gid_keywords_reject_non_gid_algorithms_and_existing_engines():
+    with _test_pfpath():
+        with pytest.raises(ValueError, match="GID configuration keywords require"):
+            RFdeconProcessor(alg="LeastSquares", deconvolution_type="ns_gid")
+
+        processor = RFdeconProcessor(alg="TimeDomainGID")
+        result = RFdecon(
+            Seismogram(_make_gid_switching_data()),
+            engine=processor,
+            gid_mode="least_square",
+        )
+        assert result.dead()
+        assert result.elog.size() > 0
+
+
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+@pytest.mark.parametrize("mode", PUBLIC_GID_SWITCHING_MODES)
+def test_make_gid_engine_switches_modes_without_pf_edits(alg, mode):
+    with _test_pfpath():
+        qc = _run_public_gid_engine(alg, deconvolution_type=mode)
+
+    _assert_public_gid_mode_qc(qc, mode)
+
+
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+def test_RFdeconProcessor_gid_keywords_switch_penalty_without_pf_edits(alg):
+    with _test_pfpath():
+        processor = RFdeconProcessor(
+            alg=alg,
+            deconvolution_type="least_square",
+            lag_weight_penalty_function="cosine_taper",
+            gid_parameters={"maximum_iterations": 8},
+        )
+        rf = RFdecon(Seismogram(_make_gid_switching_data()), engine=processor)
+
+    assert rf.live
+    qc = rf["RFdecon_properties"]
+    _assert_public_gid_mode_qc(qc, "least_square")
+    assert qc["gid_penalty_function"] == "cosine_taper"
+    assert qc["maximum_iterations"] == 8
+
+
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+@pytest.mark.parametrize("mode", PUBLIC_GID_SWITCHING_MODES)
+def test_RFdecon_gid_keywords_switch_modes_without_pf_edits(alg, mode):
+    gid_parameters = {}
+    if mode == "group_sparse":
+        gid_parameters["group_sparse_lambda_scale"] = 0.5
+
+    with _test_pfpath():
+        rf = RFdecon(
+            Seismogram(_make_gid_switching_data()),
+            alg=alg,
+            gid_mode=mode,
+            gid_penalty_function="none",
+            gid_parameters=gid_parameters,
+        )
+
+    assert rf.live
+    qc = rf["RFdecon_properties"]
+    _assert_public_gid_mode_qc(qc, mode)
+    assert qc["gid_penalty_function"] == "none"
+    if mode == "group_sparse":
+        assert qc["group_sparse_lambda_scale"] == pytest.approx(0.5)
 
 
 @pytest.mark.parametrize(

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -123,7 +123,8 @@ def _run_public_gid_engine(alg, **kwargs):
 
 
 def _gid_pf_with_mode(tmp_path, mode, pf_name="TimeDomainGIDDecon.pf"):
-    text = open(f"data/pf/{pf_name}", encoding="utf-8").read()
+    with open(f"data/pf/{pf_name}", encoding="utf-8") as fp:
+        text = fp.read()
     old = (
         "time_domain_gid_deconvolution &Arr{\n        "
         f"deconvolution_type {DEFAULT_GID_DECONVOLUTION_TYPE}"
@@ -730,7 +731,8 @@ def test_RFdeconProcessor_pickle_uses_same_pf_when_pfpath_has_multiple_matches(
         pf_name = "TimeDomainGIDDecon.pf"
     else:
         pf_name = "RFdeconProcessor.pf"
-    text = open(f"data/pf/{pf_name}", encoding="utf-8").read()
+    with open(f"data/pf/{pf_name}", encoding="utf-8") as fp:
+        text = fp.read()
     (pf1 / pf_name).write_text(text)
     (pf2 / pf_name).write_text(text.replace(replacement[0], replacement[1], 1))
     old_pfpath = os.environ.get("PFPATH")
@@ -1173,7 +1175,8 @@ bad
 def test_RFdeconProcessor_malformed_preferred_multitaper_branch_does_not_fallback(
     tmp_path, preferred_alg, malformed_text, expected_message
 ):
-    pf_text = open("data/pf/RFdeconProcessor.pf", encoding="utf-8").read()
+    with open("data/pf/RFdeconProcessor.pf", encoding="utf-8") as fp:
+        pf_text = fp.read()
     pf_text += malformed_text
     pf = tmp_path / "RFdeconProcessor_bad_preferred.pf"
     pf.write_text(pf_text)

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -291,6 +291,26 @@ def test_make_gid_pf_text_accepts_numpy_scalar_gid_parameters(alg):
 
 
 @pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+def test_make_gid_pf_text_overrides_top_level_keys_that_exist_in_leaf_branches(alg):
+    with _test_pfpath():
+        pf = make_gid_pf(
+            alg=alg,
+            gid_parameters={
+                "target_sample_interval": 1,
+                "deconvolution_data_window_start": -4,
+            },
+        )
+
+    operator_branch = pf.get_branch("deconvolution_operator_type")
+    gid_md = Metadata(operator_branch.get_branch(_gid_branch_name_for_test(alg)))
+    least_square_md = Metadata(operator_branch.get_branch("least_square"))
+    assert gid_md["target_sample_interval"] == 1
+    assert gid_md["deconvolution_data_window_start"] == -4
+    assert least_square_md["target_sample_interval"] == pytest.approx(0.05)
+    assert least_square_md["deconvolution_data_window_start"] == pytest.approx(-5.0)
+
+
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
 def test_make_gid_pf_applies_public_aliases_without_pf_edits(alg):
     with _test_pfpath():
         pf = make_gid_pf(
@@ -436,6 +456,25 @@ def test_RFdecon_gid_accepts_integral_values_for_double_parameters(alg):
     assert qc["group_sparse_lambda_scale"] == pytest.approx(2.0)
 
 
+@pytest.mark.parametrize("alg", GID_SWITCHING_ALGORITHMS)
+def test_RFdecon_gid_accepts_integral_lag_penalty_double_parameters(alg):
+    with _test_pfpath():
+        rf = RFdecon(
+            Seismogram(_make_gid_switching_data()),
+            alg=alg,
+            gid_mode="least_square",
+            gid_penalty_function="cosine_taper",
+            gid_parameters={"lag_weight_penalty_scale_factor": 1},
+        )
+
+    assert rf.live
+    qc = rf["RFdecon_properties"]
+    _assert_public_gid_mode_qc(qc, "least_square")
+    assert qc["gid_penalty_function"] == "cosine_taper"
+    assert qc["gid_penalty_scale_factor"] == pytest.approx(1.0)
+    assert not any(key.startswith("group_sparse") for key in dict(qc))
+
+
 @pytest.mark.parametrize(
     "alg,pf",
     [
@@ -564,6 +603,56 @@ def test_RFdeconProcessor_change_parameters_uses_public_engine_api():
             assert np.allclose(
                 np.asarray(rf_changed.data), np.asarray(rf_restored.data)
             )
+    finally:
+        if old_pfpath is None:
+            os.environ.pop("PFPATH", None)
+        else:
+            os.environ["PFPATH"] = old_pfpath
+
+
+def test_RFdeconProcessor_change_parameters_normalizes_numpy_scalars():
+    old_pfpath = os.environ.get("PFPATH")
+    os.environ["PFPATH"] = "./data/pf"
+    try:
+        processor = RFdeconProcessor(alg="MultiTaperPowerXcor")
+        md = Metadata(processor.md)
+        md["damping_factor"] = np.float32(0.25)
+        md["number_tapers"] = np.int64(4)
+        processor.change_parameters(md)
+        assert processor.md["damping_factor"] == pytest.approx(0.25)
+        assert processor.md["number_tapers"] == 4
+
+        with pytest.raises(TypeError, match="must be scalar"):
+            processor.change_parameters({"damping_factor": np.array([0.25])})
+    finally:
+        if old_pfpath is None:
+            os.environ.pop("PFPATH", None)
+        else:
+            os.environ["PFPATH"] = old_pfpath
+
+
+@pytest.mark.parametrize("wcomp", [True, np.bool_(True), 2.0, "2"])
+def test_RFdecon_rejects_non_integer_component_indexes(wcomp):
+    data = _make_gid_switching_data()
+    rf = RFdecon(Seismogram(data), alg="LeastSquares", wcomp=wcomp)
+    assert rf.dead()
+    assert rf.elog.size() > 0
+    assert "wcomp" in rf.elog.get_error_log()[-1].message
+
+
+def test_RFdecon_accepts_numpy_integer_component_indexes():
+    old_pfpath = os.environ.get("PFPATH")
+    os.environ["PFPATH"] = "./data/pf"
+    try:
+        seis0 = get_live_seismogram(3000, 20.0)
+        seis0.t0 = -35.0
+        rf = RFdecon(
+            Seismogram(seis0),
+            alg="LeastSquares",
+            wcomp=np.int64(2),
+            ncomp=np.int64(2),
+        )
+        assert rf.live
     finally:
         if old_pfpath is None:
             os.environ.pop("PFPATH", None)

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -109,7 +109,7 @@ def _assert_single_spike_recovery(rf, ratio_tolerance):
 
 def _assert_group_sparse_qc(qc):
     assert qc["group_sparse_enabled"]
-    assert not qc["ns_gid_enabled"]
+    assert "ns_gid_enabled" not in dict(qc)
     assert qc["group_sparse_inverse_operator"] == "ns_gid"
     assert qc["group_sparse_lambda_requested"] == pytest.approx(0.0)
     assert qc["group_sparse_lambda_scale"] == pytest.approx(1.0)
@@ -141,8 +141,8 @@ def _assert_group_sparse_qc(qc):
 
 
 def _assert_group_sparse_disabled_qc(qc):
-    assert not qc["group_sparse_enabled"]
-    assert qc["group_sparse_inverse_operator"] == "not_enabled"
+    keys = set(dict(qc).keys())
+    assert not any(key.startswith("group_sparse") for key in keys)
 
 
 def _make_single_spike_convolution_data():

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -114,6 +114,10 @@ def _assert_group_sparse_qc(qc):
     assert qc["group_sparse_lambda_requested"] == pytest.approx(0.0)
     assert qc["group_sparse_lambda_scale"] == pytest.approx(1.0)
     assert qc["group_sparse_lambda_used"] >= 0.0
+    assert qc["group_sparse_noise_threshold"] > 0.0
+    assert qc["group_sparse_lambda_used"] == pytest.approx(
+        qc["group_sparse_lambda_scale"] * qc["group_sparse_noise_threshold"]
+    )
     assert qc["group_sparse_active_threshold"] == pytest.approx(0.02)
     assert qc["group_sparse_active_threshold_scale"] == pytest.approx(1.0)
     assert qc["group_sparse_active_threshold_quantile"] == pytest.approx(0.90)
@@ -134,6 +138,8 @@ def _assert_group_sparse_qc(qc):
     assert not qc["group_sparse_inverse_external_wavelet_used"]
     assert not qc["group_sparse_inverse_external_noise_used"]
     assert not qc["group_sparse_inverse_external_noise_spectrum_used"]
+    assert not any(key.startswith("gid_penalty") for key in dict(qc))
+    assert not any(key.startswith("lag_weight_penalty") for key in dict(qc))
     assert qc["gid_stop_reason"] in {
         "group_sparse_converged",
         "group_sparse_max_iterations",
@@ -831,6 +837,36 @@ def test_TimeDomainGIDDecon_pickle_preserves_external_wavelet_and_noise(tmp_path
     assert qc_spectrum["ns_gid_external_noise_spectrum_used"]
 
 
+def test_TimeDomainGIDDecon_group_sparse_honors_external_noise_spectrum(tmp_path):
+    data, wavelet, _ = _make_external_wavelet_3c_data(noise_level=2.0e-4)
+    pf = _pf_with_mode(
+        tmp_path,
+        "TimeDomainGIDDecon.pf",
+        "time_domain_gid_deconvolution",
+        "group_sparse",
+    )
+    engine = TimeDomainGIDDecon(pf)
+    engine.loadwavelet(wavelet)
+    engine.loadnoise(
+        PowerSpectrum(
+            Metadata(), DoubleVector([1.0, 1.0, 1.0]), 1.0, "valid", -1.0, 1.0, 3
+        )
+    )
+
+    rf = TimeDomainGIDRFDecon(
+        data,
+        engine,
+        signal_window=TimeWindow(-8.0, 22.0),
+        noise_window=TimeWindow(-35.0, -8.0),
+    )
+
+    assert rf.live
+    qc = rf["TimeDomainGIDDecon_properties"]
+    assert qc["group_sparse_inverse_external_wavelet_used"]
+    assert qc["group_sparse_inverse_external_noise_spectrum_used"]
+    assert qc["group_sparse_noise_threshold"] > 0.0
+
+
 def test_TimeDomainGIDDecon_clear_external_state_drops_pickle_payload(tmp_path):
     pf = _ns_gid_pf(tmp_path, "TimeDomainGIDDecon.pf", "time_domain_gid_deconvolution")
     engine = TimeDomainGIDDecon(pf)
@@ -1270,6 +1306,39 @@ def test_TimeDomainGIDDecon_replacing_external_noise_refreshes_threshold(tmp_pat
     high_threshold = dict(engine.QCMetrics())["ns_gid_peak_threshold"]
 
     assert high_threshold > 10.0 * low_threshold
+
+
+def test_TimeDomainGIDDecon_group_sparse_external_noise_sets_lambda(tmp_path):
+    data = _make_single_spike_convolution_data()
+    pf = _pf_with_mode(
+        tmp_path,
+        "TimeDomainGIDDecon.pf",
+        "time_domain_gid_deconvolution",
+        "group_sparse",
+    )
+    dwin = TimeWindow(-10.0, 20.0)
+    low_noise = _make_external_noise(scale=1.0)
+    high_noise = _make_external_noise(scale=1000.0)
+
+    engine = TimeDomainGIDDecon(pf)
+    engine.loadnoise(low_noise)
+    assert engine.load(data, dwin) == 0
+    engine.process()
+    low_qc = dict(engine.QCMetrics())
+
+    engine.loadnoise(high_noise)
+    assert engine.load(data, dwin) == 0
+    engine.process()
+    high_qc = dict(engine.QCMetrics())
+
+    assert low_qc["group_sparse_inverse_external_noise_used"]
+    assert high_qc["group_sparse_inverse_external_noise_used"]
+    assert high_qc["group_sparse_noise_threshold"] > (
+        10.0 * low_qc["group_sparse_noise_threshold"]
+    )
+    assert high_qc["group_sparse_lambda_used"] > (
+        10.0 * low_qc["group_sparse_lambda_used"]
+    )
 
 
 def test_TimeDomainGIDDecon_failed_external_noise_replacement_preserves_state(

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -22,7 +22,6 @@ from decon_data_generators import (
     make_simulation_wavelet,
 )
 
-
 DEFAULT_GID_DECONVOLUTION_TYPE = "ns_gid"
 
 
@@ -139,6 +138,11 @@ def _assert_group_sparse_qc(qc):
         "group_sparse_converged",
         "group_sparse_max_iterations",
     }
+
+
+def _assert_group_sparse_disabled_qc(qc):
+    assert not qc["group_sparse_enabled"]
+    assert qc["group_sparse_inverse_operator"] == "not_enabled"
 
 
 def _make_single_spike_convolution_data():
@@ -998,7 +1002,7 @@ def test_TimeDomainGIDDecon_inverse_modes_are_valid(tmp_path, mode):
     if mode == "group_sparse":
         _assert_group_sparse_qc(qc)
     else:
-        assert not qc["group_sparse_enabled"]
+        _assert_group_sparse_disabled_qc(qc)
     _assert_single_spike_recovery(rf, ratio_tolerance=5.0e-2)
 
 

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -106,9 +106,9 @@ def _assert_group_sparse_qc(qc):
     assert qc["group_sparse_active_threshold_scale"] == pytest.approx(1.0)
     assert qc["group_sparse_active_threshold_quantile"] == pytest.approx(0.90)
     assert qc["group_sparse_active_threshold_quantile_value"] >= 0.0
-    assert qc["group_sparse_active_threshold_used"] >= qc[
-        "group_sparse_active_threshold"
-    ]
+    assert (
+        qc["group_sparse_active_threshold_used"] >= qc["group_sparse_active_threshold"]
+    )
     assert qc["group_sparse_iterations"] == qc["iteration_count"]
     assert qc["group_sparse_active_groups"] == qc["gid_number_spikes"]
     assert qc["group_sparse_objective_final"] <= qc["group_sparse_objective_initial"]

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -877,13 +877,14 @@ def test_TimeDomainGIDDecon_group_sparse_honors_external_noise_spectrum(tmp_path
     assert high_qc["group_sparse_inverse_external_wavelet_used"]
     assert low_qc["group_sparse_inverse_external_noise_spectrum_used"]
     assert high_qc["group_sparse_inverse_external_noise_spectrum_used"]
-    assert low_qc["group_sparse_noise_threshold"] > high_qc[
-        "group_sparse_noise_threshold"
-    ]
+    assert (
+        low_qc["group_sparse_noise_threshold"] > high_qc["group_sparse_noise_threshold"]
+    )
     assert low_qc["group_sparse_lambda_used"] > high_qc["group_sparse_lambda_used"]
-    assert high_qc["group_sparse_inverse_noise_amplification"] > low_qc[
-        "group_sparse_inverse_noise_amplification"
-    ]
+    assert (
+        high_qc["group_sparse_inverse_noise_amplification"]
+        > low_qc["group_sparse_inverse_noise_amplification"]
+    )
 
 
 def test_TimeDomainGIDDecon_clear_external_state_drops_pickle_payload(tmp_path):
@@ -1123,7 +1124,9 @@ def test_TimeDomainGIDDecon_QCMetrics_rejects_unsupported_changed_leaf_metadata(
     leaf_md["diagnostic_object"] = [1, 2, 3]
     engine.changeparameter(leaf_md)
 
-    with pytest.raises(MsPASSError, match="unsupported Metadata type.*diagnostic_object"):
+    with pytest.raises(
+        MsPASSError, match="unsupported Metadata type.*diagnostic_object"
+    ):
         engine.QCMetrics()
 
 

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -95,6 +95,39 @@ def _assert_single_spike_recovery(rf, ratio_tolerance):
     )
 
 
+def _assert_group_sparse_qc(qc):
+    assert qc["group_sparse_enabled"]
+    assert not qc["ns_gid_enabled"]
+    assert qc["group_sparse_inverse_operator"] == "ns_gid"
+    assert qc["group_sparse_lambda_requested"] == pytest.approx(0.0)
+    assert qc["group_sparse_lambda_scale"] == pytest.approx(1.0)
+    assert qc["group_sparse_lambda_used"] >= 0.0
+    assert qc["group_sparse_active_threshold"] == pytest.approx(0.02)
+    assert qc["group_sparse_active_threshold_scale"] == pytest.approx(1.0)
+    assert qc["group_sparse_active_threshold_quantile"] == pytest.approx(0.90)
+    assert qc["group_sparse_active_threshold_quantile_value"] >= 0.0
+    assert qc["group_sparse_active_threshold_used"] >= qc[
+        "group_sparse_active_threshold"
+    ]
+    assert qc["group_sparse_iterations"] == qc["iteration_count"]
+    assert qc["group_sparse_active_groups"] == qc["gid_number_spikes"]
+    assert qc["group_sparse_objective_final"] <= qc["group_sparse_objective_initial"]
+    assert qc["group_sparse_fractional_improvement_final"] >= 0.0
+    assert qc["group_sparse_inverse_operator_nfft"] > 0
+    assert qc["group_sparse_inverse_gain_max_actual"] <= (
+        qc["group_sparse_inverse_gain_max_requested"] * (1.0 + 1.0e-10)
+    )
+    assert qc["group_sparse_inverse_noise_amplification"] >= 0.0
+    assert 0.0 <= qc["group_sparse_inverse_effective_bandwidth_fraction"] <= 1.0
+    assert not qc["group_sparse_inverse_external_wavelet_used"]
+    assert not qc["group_sparse_inverse_external_noise_used"]
+    assert not qc["group_sparse_inverse_external_noise_spectrum_used"]
+    assert qc["gid_stop_reason"] in {
+        "group_sparse_converged",
+        "group_sparse_max_iterations",
+    }
+
+
 def _make_single_spike_convolution_data():
     n = 1400
     dt = 0.05
@@ -918,7 +951,9 @@ def test_TimeDomainGIDDecon_validates_single_spike_recovery():
     _assert_single_spike_recovery(rf, ratio_tolerance=2.0e-3)
 
 
-@pytest.mark.parametrize("mode", ["least_square", "water_level", "multi_taper", "cnr"])
+@pytest.mark.parametrize(
+    "mode", ["least_square", "water_level", "multi_taper", "cnr", "group_sparse"]
+)
 def test_TimeDomainGIDDecon_inverse_modes_are_valid(tmp_path, mode):
     data = _make_single_spike_convolution_data()
     pf = _pf_with_mode(
@@ -943,6 +978,10 @@ def test_TimeDomainGIDDecon_inverse_modes_are_valid(tmp_path, mode):
     qc = rf["TimeDomainGIDDecon_properties"]
     assert qc["iteration_count"] > 0
     assert qc["residual_L2_final"] < qc["residual_L2_initial"]
+    if mode == "group_sparse":
+        _assert_group_sparse_qc(qc)
+    else:
+        assert not qc["group_sparse_enabled"]
     _assert_single_spike_recovery(rf, ratio_tolerance=5.0e-2)
 
 
@@ -1294,6 +1333,41 @@ def test_TimeDomainGIDDecon_changeparameter_rejects_leaf_shaping_dt_drift():
             "lag_weight_penalty_function",
         ),
         (
+            "group_sparse_lambda 0.0",
+            "group_sparse_lambda -1.0",
+            "group_sparse_lambda",
+        ),
+        (
+            "group_sparse_lambda_scale 1.0",
+            "group_sparse_lambda_scale -1.0",
+            "group_sparse_lambda_scale",
+        ),
+        (
+            "group_sparse_tolerance 1.0e-4",
+            "group_sparse_tolerance 0.0",
+            "group_sparse_tolerance",
+        ),
+        (
+            "group_sparse_max_iterations 200",
+            "group_sparse_max_iterations 0",
+            "group_sparse_max_iterations",
+        ),
+        (
+            "group_sparse_active_threshold 0.02",
+            "group_sparse_active_threshold -0.01",
+            "group_sparse_active_threshold",
+        ),
+        (
+            "group_sparse_active_threshold_scale 1.0",
+            "group_sparse_active_threshold_scale -0.01",
+            "group_sparse_active_threshold_scale",
+        ),
+        (
+            "group_sparse_active_threshold_quantile 0.90",
+            "group_sparse_active_threshold_quantile 1.5",
+            "group_sparse_active_threshold_quantile",
+        ),
+        (
             "maximum_iterations 100",
             "maximum_iterations 0",
             "maximum_iterations",
@@ -1399,6 +1473,7 @@ def test_TimeDomainGIDDecon_changeparameter_rejects_gid_level_metadata():
         ("ns_gid_refit_interval", 2),
         ("lag_weight_penalty_scale_factor", 0.5),
         ("lag_weight_function_width", 5),
+        ("group_sparse_lambda_scale", 1.0),
         ("noise_window_start", -30.0),
         ("noise_window_end", -3.0),
     ],

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -23,6 +23,19 @@ from decon_data_generators import (
 )
 
 
+DEFAULT_GID_DECONVOLUTION_TYPE = "ns_gid"
+
+
+def _replace_gid_deconvolution_type(text, branch_name, mode):
+    old = (
+        f"{branch_name} &Arr{{\n        "
+        f"deconvolution_type {DEFAULT_GID_DECONVOLUTION_TYPE}"
+    )
+    new = f"{branch_name} &Arr{{\n        deconvolution_type {mode}"
+    assert text.count(old) == 1
+    return text.replace(old, new, 1)
+
+
 def _distributed_roundtrip(obj):
     distributed_protocol = pytest.importorskip("distributed.protocol")
     header, frames = distributed_protocol.serialize(obj)
@@ -159,18 +172,17 @@ def _make_single_spike_convolution_data():
 def _pf_with_mode(tmp_path, pf_name, branch_name, mode):
     src = Path("./data/pf") / pf_name
     text = src.read_text()
-    text = text.replace(
-        f"{branch_name} &Arr{{\n        deconvolution_type least_square",
-        f"{branch_name} &Arr{{\n        deconvolution_type {mode}",
-    )
+    text = _replace_gid_deconvolution_type(text, branch_name, mode)
     dst = tmp_path / pf_name
     dst.write_text(text)
     return pfread(str(dst))
 
 
-def _pf_with_short_decon_window(tmp_path, pf_name):
+def _pf_with_short_decon_window(tmp_path, pf_name, branch_name=None, mode=None):
     src = Path("./data/pf") / pf_name
     text = src.read_text()
+    if mode is not None:
+        text = _replace_gid_deconvolution_type(text, branch_name, mode)
     text = text.replace(
         "deconvolution_data_window_start -5.0",
         "deconvolution_data_window_start -0.5",
@@ -222,10 +234,7 @@ def _make_external_wavelet_3c_data(noise_level=1.0e-4):
 def _ns_gid_pf(tmp_path, pf_name, branch_name, gain_max=30.0, peak_sigma=3.0):
     src = Path("./data/pf") / pf_name
     text = src.read_text()
-    text = text.replace(
-        f"{branch_name} &Arr{{\n        deconvolution_type least_square",
-        f"{branch_name} &Arr{{\n        deconvolution_type ns_gid",
-    )
+    text = _replace_gid_deconvolution_type(text, branch_name, "ns_gid")
     text = text.replace("ns_gid_gain_max 1.0e3", f"ns_gid_gain_max {gain_max}")
     text = text.replace(
         "ns_gid_peak_sigma_threshold 4.0",
@@ -525,8 +534,13 @@ def test_TimeDomainGIDDecon_penalty_reduces_multispike_residual(tmp_path):
     signal_window = TimeWindow(-8.0, 20.0)
     noise_window = TimeWindow(-25.0, -8.0)
 
+    penalty_pf = tmp_path / "TimeDomainGIDDecon_penalty.pf"
     no_penalty_pf = tmp_path / "TimeDomainGIDDecon_no_penalty.pf"
     text = Path("./data/pf/TimeDomainGIDDecon.pf").read_text()
+    text = _replace_gid_deconvolution_type(
+        text, "time_domain_gid_deconvolution", "least_square"
+    )
+    penalty_pf.write_text(text)
     no_penalty_pf.write_text(
         text.replace(
             "lag_weight_penalty_function adaptive_memory",
@@ -536,7 +550,7 @@ def test_TimeDomainGIDDecon_penalty_reduces_multispike_residual(tmp_path):
 
     penalty_rf = TimeDomainGIDRFDecon(
         data,
-        TimeDomainGIDDecon(pfread("./data/pf/TimeDomainGIDDecon.pf")),
+        TimeDomainGIDDecon(pfread(str(penalty_pf))),
         signal_window=signal_window,
         noise_window=noise_window,
     )
@@ -571,6 +585,9 @@ def test_TimeDomainGIDDecon_kernel_penalty_modes_are_adaptive(
 
     pf = tmp_path / f"TimeDomainGIDDecon_{penalty_function}.pf"
     text = Path("./data/pf/TimeDomainGIDDecon.pf").read_text()
+    text = _replace_gid_deconvolution_type(
+        text, "time_domain_gid_deconvolution", "least_square"
+    )
     text = text.replace(
         "lag_weight_penalty_function adaptive_memory",
         f"lag_weight_penalty_function {penalty_function}",
@@ -1010,7 +1027,12 @@ def test_TimeDomainGIDDecon_cnr_honors_external_noise(tmp_path):
 
 def test_TimeDomainGIDDecon_short_kernel_crop_is_bounded(tmp_path):
     data = _make_single_spike_convolution_data()
-    pf = _pf_with_short_decon_window(tmp_path, "TimeDomainGIDDecon.pf")
+    pf = _pf_with_short_decon_window(
+        tmp_path,
+        "TimeDomainGIDDecon.pf",
+        "time_domain_gid_deconvolution",
+        "least_square",
+    )
     engine = TimeDomainGIDDecon(pf)
 
     rf = TimeDomainGIDRFDecon(
@@ -1078,9 +1100,16 @@ def test_TimeDomainGIDDecon_changeparameter_invalidates_outer_state():
         engine.actual_output()
 
 
-def test_TimeDomainGIDDecon_failed_changeparameter_invalidates_without_poisoning_leaf():
+def test_TimeDomainGIDDecon_failed_changeparameter_invalidates_without_poisoning_leaf(
+    tmp_path,
+):
     data = _make_single_spike_convolution_data()
-    pf = pfread("./data/pf/TimeDomainGIDDecon.pf")
+    pf = _pf_with_mode(
+        tmp_path,
+        "TimeDomainGIDDecon.pf",
+        "time_domain_gid_deconvolution",
+        "least_square",
+    )
     engine = TimeDomainGIDDecon(pf)
     TimeDomainGIDRFDecon(
         data,

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -60,6 +60,12 @@ def _make_external_noise(npts=300, dt=0.05, t0=-35.0, scale=1.0):
     return noise
 
 
+def _make_external_noise_spectrum(power):
+    return PowerSpectrum(
+        Metadata(), DoubleVector([power, power, power]), 1.0, "valid", -1.0, 1.0, 3
+    )
+
+
 def _assert_valid_rf(rf):
     assert rf.live
     assert rf.npts > 0
@@ -126,9 +132,12 @@ def _assert_group_sparse_qc(qc):
         qc["group_sparse_active_threshold_used"] >= qc["group_sparse_active_threshold"]
     )
     assert qc["group_sparse_iterations"] == qc["iteration_count"]
+    assert qc["gid_maximum_iterations"] == qc["group_sparse_max_iterations"]
     assert qc["group_sparse_active_groups"] == qc["gid_number_spikes"]
     assert qc["group_sparse_objective_final"] <= qc["group_sparse_objective_initial"]
     assert qc["group_sparse_fractional_improvement_final"] >= 0.0
+    assert np.isfinite(qc["group_sparse_debiased_objective_final"])
+    assert np.isfinite(qc["group_sparse_debiased_fractional_improvement_final"])
     assert qc["group_sparse_inverse_operator_nfft"] > 0
     assert qc["group_sparse_inverse_gain_max_actual"] <= (
         qc["group_sparse_inverse_gain_max_requested"] * (1.0 + 1.0e-10)
@@ -385,7 +394,9 @@ def test_TimeDomainGIDDecon_rejects_invalid_external_noise_spectrum(tmp_path):
 
 
 @pytest.mark.parametrize("mode", ["multi_taper", "least_square", "water_level", "cnr"])
-def test_TimeDomainGIDDecon_rejects_non_ns_power_spectrum_noise(tmp_path, mode):
+def test_TimeDomainGIDDecon_rejects_power_spectrum_noise_without_ns_inverse(
+    tmp_path, mode
+):
     pf = _pf_with_mode(
         tmp_path,
         "TimeDomainGIDDecon.pf",
@@ -397,7 +408,7 @@ def test_TimeDomainGIDDecon_rejects_non_ns_power_spectrum_noise(tmp_path, mode):
         Metadata(), DoubleVector([1.0, 1.0, 1.0]), 1.0, "valid", -1.0, 1.0, 3
     )
 
-    with pytest.raises(MsPASSError, match="only supported for ns_gid"):
+    with pytest.raises(MsPASSError, match="only supported for ns_gid and group_sparse"):
         engine.loadnoise(spectrum)
 
 
@@ -845,26 +856,34 @@ def test_TimeDomainGIDDecon_group_sparse_honors_external_noise_spectrum(tmp_path
         "time_domain_gid_deconvolution",
         "group_sparse",
     )
-    engine = TimeDomainGIDDecon(pf)
-    engine.loadwavelet(wavelet)
-    engine.loadnoise(
-        PowerSpectrum(
-            Metadata(), DoubleVector([1.0, 1.0, 1.0]), 1.0, "valid", -1.0, 1.0, 3
+
+    def run_with_spectrum(power):
+        engine = TimeDomainGIDDecon(pf)
+        engine.loadwavelet(wavelet)
+        engine.loadnoise(_make_external_noise_spectrum(power))
+        rf = TimeDomainGIDRFDecon(
+            data,
+            engine,
+            signal_window=TimeWindow(-8.0, 22.0),
+            noise_window=TimeWindow(-35.0, -8.0),
         )
-    )
+        assert rf.live
+        return rf["TimeDomainGIDDecon_properties"]
 
-    rf = TimeDomainGIDRFDecon(
-        data,
-        engine,
-        signal_window=TimeWindow(-8.0, 22.0),
-        noise_window=TimeWindow(-35.0, -8.0),
-    )
+    low_qc = run_with_spectrum(1.0e-8)
+    high_qc = run_with_spectrum(1.0e6)
 
-    assert rf.live
-    qc = rf["TimeDomainGIDDecon_properties"]
-    assert qc["group_sparse_inverse_external_wavelet_used"]
-    assert qc["group_sparse_inverse_external_noise_spectrum_used"]
-    assert qc["group_sparse_noise_threshold"] > 0.0
+    assert low_qc["group_sparse_inverse_external_wavelet_used"]
+    assert high_qc["group_sparse_inverse_external_wavelet_used"]
+    assert low_qc["group_sparse_inverse_external_noise_spectrum_used"]
+    assert high_qc["group_sparse_inverse_external_noise_spectrum_used"]
+    assert low_qc["group_sparse_noise_threshold"] > high_qc[
+        "group_sparse_noise_threshold"
+    ]
+    assert low_qc["group_sparse_lambda_used"] > high_qc["group_sparse_lambda_used"]
+    assert high_qc["group_sparse_inverse_noise_amplification"] > low_qc[
+        "group_sparse_inverse_noise_amplification"
+    ]
 
 
 def test_TimeDomainGIDDecon_clear_external_state_drops_pickle_payload(tmp_path):
@@ -1095,6 +1114,17 @@ def test_TimeDomainGIDDecon_changeparameter_handles_cnr_mode(tmp_path):
     cnr_md = pf.get_branch("deconvolution_operator_type").get_branch("cnr")
 
     engine.changeparameter(cnr_md)
+
+
+def test_TimeDomainGIDDecon_QCMetrics_rejects_unsupported_changed_leaf_metadata():
+    pf = pfread("./data/pf/TimeDomainGIDDecon.pf")
+    engine = TimeDomainGIDDecon(pf)
+    leaf_md = pf.get_branch("deconvolution_operator_type").get_branch("ns_gid")
+    leaf_md["diagnostic_object"] = [1, 2, 3]
+    engine.changeparameter(leaf_md)
+
+    with pytest.raises(MsPASSError, match="unsupported Metadata type.*diagnostic_object"):
+        engine.QCMetrics()
 
 
 def test_TimeDomainGIDDecon_preprocess_outputs_are_guarded():
@@ -1509,7 +1539,8 @@ def test_TimeDomainGIDDecon_changeparameter_rejects_leaf_shaping_dt_drift():
 def test_TimeDomainGIDDecon_rejects_invalid_probability_and_lag_parameters(
     tmp_path, old, new, match
 ):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
+    with open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8") as fp:
+        text = fp.read()
     pf = tmp_path / "TimeDomainGIDDecon.pf"
     pf.write_text(text.replace(old, new))
 
@@ -1521,7 +1552,8 @@ def test_TimeDomainGIDDecon_rejects_invalid_probability_and_lag_parameters(
 def test_TimeDomainGIDDecon_defaults_missing_lag_penalty_function_to_none(
     tmp_path,
 ):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
+    with open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8") as fp:
+        text = fp.read()
     text = text.replace("        lag_weight_penalty_function adaptive_memory\n", "")
     pf = tmp_path / "TimeDomainGIDDecon_legacy_no_penalty_function.pf"
     pf.write_text(text)
@@ -1542,7 +1574,8 @@ def test_TimeDomainGIDDecon_defaults_missing_lag_penalty_function_to_none(
 
 
 def test_TimeDomainGIDDecon_reports_missing_fixed_penalty_width(tmp_path):
-    text = open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8").read()
+    with open("data/pf/TimeDomainGIDDecon.pf", encoding="utf-8") as fp:
+        text = fp.read()
     text = text.replace(
         "lag_weight_penalty_function adaptive_memory",
         "lag_weight_penalty_function cosine_taper",

--- a/python/tests/algorithms/test_decon_algorithm_validation.py
+++ b/python/tests/algorithms/test_decon_algorithm_validation.py
@@ -190,6 +190,26 @@ def _make_stress_colored_validation_data(noise_scale=0.025, return_truth=False):
     return data
 
 
+def _make_weak_stress_colored_validation_data(noise_scale=0.025, return_truth=False):
+    """Stress fixture with weak converted phases and a strong direct arrival."""
+    _, truth, wavelet = _make_stress_colored_validation_data(
+        noise_scale=0.0, return_truth=True
+    )
+    direct_sample = int(round((0.0 - truth.t0) / truth.dt))
+    for sample in range(truth.npts):
+        if sample == direct_sample:
+            continue
+        truth.data[0, sample] *= 0.35
+        truth.data[1, sample] *= 0.35
+    data = convolve_wavelet(truth, wavelet)
+    data = addnoise(data, nscale=noise_scale, padlength=900, corners=[0.04, 3.0])
+    data["low_f_band_edge"] = 0.02
+    data["high_f_band_edge"] = 2.0
+    if return_truth:
+        return data, truth, wavelet
+    return data
+
+
 def _make_direct_only_noisy_validation_data(noise_scale=3.0):
     np.random.seed(424242)
     wavelet = make_simulation_wavelet(corners=[0.35, 7.5])
@@ -590,6 +610,12 @@ def _count_unmatched_close_arrival_revisits(
     return revisits
 
 
+def _assert_group_sparse_detection_metrics(metrics):
+    assert metrics["recall"] >= 0.95
+    assert metrics["precision"] >= 0.75
+    assert metrics["false_positive"] <= 2
+
+
 def _classify_spike_detections_against_times(
     matrix, t0, dt, truth_times, detection_threshold=0.02, match_tolerance=0.15
 ):
@@ -980,6 +1006,14 @@ def _plot_gid_sparse_results(
 
 
 def _gid_plot_label(core_method, qc):
+    if qc["group_sparse_enabled"]:
+        return (
+            f"group_sparse/{qc['group_sparse_inverse_operator']}"
+            f" lam={qc['group_sparse_lambda_used']:.3g}"
+            f" thr={qc['group_sparse_active_threshold_used']:.3g}"
+            f" k={qc['group_sparse_active_groups']}"
+            f" it={qc['group_sparse_iterations']}"
+        )
     try:
         adaptive_enabled = qc["gid_adaptive_penalty_enabled"]
     except Exception:
@@ -1448,6 +1482,7 @@ def test_external_wavelet_validation_across_deconvolution_methods(
         "NoiseStable": _noise_stable_rf_matrix(data, external_wavelet=wavelet),
         "CNR": _cnr_rf_matrix(data, external_wavelet=wavelet),
     }
+    gid_sparse_names = []
     for engine_class, wrapper, pfname, branch_name in [
         (
             TimeDomainGIDDecon,
@@ -1462,25 +1497,35 @@ def test_external_wavelet_validation_across_deconvolution_methods(
             "frequency_domain_gid_deconvolution",
         ),
     ]:
-        pf = _pf_with_gid_mode(tmp_path, pfname, branch_name, "ns_gid")
-        engine = engine_class(pf)
-        rf = wrapper(
-            data,
-            engine,
-            signal_window=TimeWindow(-8.0, 20.0),
-            noise_window=TimeWindow(-35.0, -5.0),
-            external_wavelet=wavelet,
-        )
-        assert rf.live
-        results[f"{engine_class.__name__}:ns_gid"] = np.asarray(rf.data)
-        results[f"{engine_class.__name__}:ns_gid_sparse"] = np.asarray(
-            engine.sparse_output().data
-        )
-        qc = dict(rf[f"{engine_class.__name__}_properties"])
-        assert qc["ns_gid_external_wavelet_used"]
-        assert qc["ns_gid_gain_max_actual"] <= qc["ns_gid_gain_max_requested"] * (
-            1.0 + 1.0e-10
-        )
+        modes = ("ns_gid", "group_sparse")
+        for mode in modes:
+            pf = _pf_with_gid_mode(tmp_path, pfname, branch_name, mode)
+            engine = engine_class(pf)
+            rf = wrapper(
+                data,
+                engine,
+                signal_window=TimeWindow(-8.0, 20.0),
+                noise_window=TimeWindow(-35.0, -5.0),
+                external_wavelet=wavelet,
+            )
+            assert rf.live
+            prefix = f"{engine_class.__name__}:{mode}"
+            results[prefix] = np.asarray(rf.data)
+            sparse_name = f"{prefix}_sparse"
+            results[sparse_name] = np.asarray(engine.sparse_output().data)
+            gid_sparse_names.append(sparse_name)
+            qc = dict(rf[f"{engine_class.__name__}_properties"])
+            if mode == "ns_gid":
+                assert qc["ns_gid_external_wavelet_used"]
+                assert qc["ns_gid_gain_max_actual"] <= qc[
+                    "ns_gid_gain_max_requested"
+                ] * (1.0 + 1.0e-10)
+            else:
+                assert qc["group_sparse_enabled"]
+                assert qc["group_sparse_inverse_external_wavelet_used"]
+                assert qc["group_sparse_inverse_gain_max_actual"] <= qc[
+                    "group_sparse_inverse_gain_max_requested"
+                ] * (1.0 + 1.0e-10)
 
     reference = results["LeastSquares"]
     amp = np.sqrt(reference[0, :] ** 2 + reference[1, :] ** 2 + reference[2, :] ** 2)
@@ -1521,22 +1566,18 @@ def test_external_wavelet_validation_across_deconvolution_methods(
         np.asarray(sorted(STRESS_SPIKES.keys()), dtype=np.float64)
         + external_wavelet_shift
     )
-    td_metrics = _classify_spike_detections_against_times(
-        results["TimeDomainGIDDecon:ns_gid_sparse"],
-        -8.0,
-        truth.dt,
-        shifted_truth_times,
-    )
-    fd_metrics = _classify_spike_detections_against_times(
-        results["FrequencyDomainGIDDecon:ns_gid_sparse"],
-        -8.0,
-        truth.dt,
-        shifted_truth_times,
-    )
-    assert td_metrics["recall"] >= 0.95
-    assert td_metrics["precision"] >= 0.45
-    assert fd_metrics["recall"] >= 0.95
-    assert fd_metrics["precision"] >= 0.75
+    for sparse_name in gid_sparse_names:
+        metrics = _classify_spike_detections_against_times(
+            results[sparse_name],
+            -8.0,
+            truth.dt,
+            shifted_truth_times,
+        )
+        assert metrics["recall"] >= 0.95, sparse_name
+        if "FrequencyDomainGIDDecon" in sparse_name or "group_sparse" in sparse_name:
+            assert metrics["precision"] >= 0.75, sparse_name
+        else:
+            assert metrics["precision"] >= 0.45, sparse_name
 
     plot_npts = int(round((20.0 - SIGNAL_WINDOW.start) / truth.dt)) + 1
     plot_results = {}
@@ -1560,6 +1601,76 @@ def test_external_wavelet_validation_across_deconvolution_methods(
     )
 
 
+def test_group_sparse_adaptive_support_threshold_controls_clustered_coefficients(
+    tmp_path,
+):
+    data, truth, wavelet = _make_stress_colored_validation_data(
+        noise_scale=0.01,
+        return_truth=True,
+    )
+    reference = _scalar_rf_matrix_external_wavelet("LeastSquares", data, wavelet)
+    amp = np.sqrt(reference[0, :] ** 2 + reference[1, :] ** 2 + reference[2, :] ** 2)
+    external_wavelet_shift = SIGNAL_WINDOW.start + truth.dt * int(np.argmax(amp))
+    shifted_truth_times = (
+        np.asarray(sorted(STRESS_SPIKES.keys()), dtype=np.float64)
+        + external_wavelet_shift
+    )
+
+    def run_time_domain_group_sparse(replacements=None):
+        replacements = replacements or {}
+        pf = _pf_with_gid_mode_and_replacements(
+            tmp_path,
+            "data/pf/TimeDomainGIDDecon.pf",
+            "time_domain_gid_deconvolution",
+            "group_sparse",
+            replacements,
+        )
+        engine = TimeDomainGIDDecon(pf)
+        rf = TimeDomainGIDRFDecon(
+            data,
+            engine,
+            signal_window=TimeWindow(-8.0, 20.0),
+            noise_window=TimeWindow(-35.0, -5.0),
+            external_wavelet=wavelet,
+        )
+        assert rf.live
+        sparse = engine.sparse_output()
+        metrics = _classify_spike_detections_against_times(
+            np.asarray(sparse.data),
+            sparse.t0,
+            sparse.dt,
+            shifted_truth_times,
+        )
+        return metrics, dict(rf["TimeDomainGIDDecon_properties"])
+
+    default_metrics, default_qc = run_time_domain_group_sparse()
+    fixed_floor_metrics, fixed_floor_qc = run_time_domain_group_sparse(
+        {
+            "group_sparse_active_threshold 0.02": (
+                "group_sparse_active_threshold 0.000000001"
+            ),
+            "group_sparse_active_threshold_scale 1.0": (
+                "group_sparse_active_threshold_scale 0.0"
+            ),
+        }
+    )
+
+    assert default_qc["group_sparse_active_threshold_quantile"] == pytest.approx(0.90)
+    assert default_qc["group_sparse_active_threshold_used"] > default_qc[
+        "group_sparse_active_threshold"
+    ]
+    assert default_metrics["precision"] == pytest.approx(1.0)
+    assert default_metrics["recall"] == pytest.approx(1.0)
+    assert default_qc["group_sparse_active_groups"] == len(STRESS_SPIKES)
+
+    assert fixed_floor_qc["group_sparse_active_threshold_used"] == pytest.approx(
+        1.0e-9
+    )
+    assert fixed_floor_qc["group_sparse_active_groups"] > 100
+    assert fixed_floor_metrics["precision"] < default_metrics["precision"]
+    assert fixed_floor_metrics["f1"] < default_metrics["f1"]
+
+
 @pytest.mark.parametrize(
     "engine_class, wrapper, pfname, branch_name, modes, qc_key",
     [
@@ -1574,6 +1685,7 @@ def test_external_wavelet_validation_across_deconvolution_methods(
                 "multi_taper",
                 "cnr",
                 "ns_gid",
+                "group_sparse",
             ],
             "TimeDomainGIDDecon_properties",
         ),
@@ -1588,6 +1700,7 @@ def test_external_wavelet_validation_across_deconvolution_methods(
                 "multi_taper",
                 "cnr",
                 "ns_gid",
+                "group_sparse",
             ],
             "FrequencyDomainGIDDecon_properties",
         ),
@@ -1635,9 +1748,13 @@ def test_gid_methods_recover_colored_multi_spike_rf_for_all_inverse_modes(
             detection_threshold=0.05,
             match_tolerance=0.20,
         )
-        assert metrics["recall"] >= 0.95, mode
-        assert metrics["f1"] >= 0.30, mode
-        assert metrics["false_positive"] <= 16, mode
+        if mode == "group_sparse":
+            _assert_group_sparse_detection_metrics(metrics)
+            assert qc["group_sparse_enabled"]
+        else:
+            assert metrics["recall"] >= 0.95, mode
+            assert metrics["f1"] >= 0.30, mode
+            assert metrics["false_positive"] <= 16, mode
         zrf = ExtractComponent(rf, 2)
         peak_sample = int(np.argmax(np.abs(zrf.data)))
         assert abs(zrf.time(peak_sample)) <= 0.15, mode
@@ -1746,6 +1863,7 @@ def test_gid_output_shaping_wavelet_is_configurable_and_separate_from_sparse_sup
                 "multi_taper",
                 "cnr",
                 "ns_gid",
+                "group_sparse",
             ],
             "TimeDomainGIDDecon_properties",
         ),
@@ -1760,6 +1878,7 @@ def test_gid_output_shaping_wavelet_is_configurable_and_separate_from_sparse_sup
                 "multi_taper",
                 "cnr",
                 "ns_gid",
+                "group_sparse",
             ],
             "FrequencyDomainGIDDecon_properties",
         ),
@@ -1800,7 +1919,14 @@ def test_gid_methods_recover_stress_spike_signs_for_all_inverse_modes(
         matrix = np.asarray(rf.data)
         sparse = engine.sparse_output()
         sparse_matrix = np.asarray(sparse.data)
-        _assert_stress_gid_signs_recovered(sparse_matrix, sparse.t0, sparse.dt)
+        if mode == "group_sparse":
+            metrics = _classify_gid_spike_detections(
+                sparse_matrix, sparse.t0, sparse.dt
+            )
+            _assert_group_sparse_detection_metrics(metrics)
+            assert qc["group_sparse_enabled"]
+        else:
+            _assert_stress_gid_signs_recovered(sparse_matrix, sparse.t0, sparse.dt)
         plot_results[plot_label] = matrix
         plot_sparse_results[plot_label] = sparse_matrix
         plot_t0 = rf.t0
@@ -1859,6 +1985,83 @@ def test_gid_methods_recover_stress_spike_signs_for_all_inverse_modes(
         f"noise_{decon_validation_noise_scale:g}_stress",
         failed_methods=skipped_plot_modes,
     )
+
+
+@pytest.mark.parametrize(
+    "engine_class, wrapper, pfname, branch_name, qc_key",
+    [
+        (
+            TimeDomainGIDDecon,
+            TimeDomainGIDRFDecon,
+            "data/pf/TimeDomainGIDDecon.pf",
+            "time_domain_gid_deconvolution",
+            "TimeDomainGIDDecon_properties",
+        ),
+        (
+            FrequencyDomainGIDDecon,
+            FrequencyDomainGIDRFDecon,
+            "data/pf/FrequencyDomainGIDDecon.pf",
+            "frequency_domain_gid_deconvolution",
+            "FrequencyDomainGIDDecon_properties",
+        ),
+    ],
+)
+def test_group_sparse_recovers_weak_arrivals_like_adaptive_memory(
+    tmp_path, engine_class, wrapper, pfname, branch_name, qc_key
+):
+    for noise_scale in (0.0, 0.03):
+        data, _, _ = _make_weak_stress_colored_validation_data(
+            noise_scale=noise_scale,
+            return_truth=True,
+        )
+        results = {}
+        for label, mode in [
+            ("adaptive_memory_default", "least_square"),
+            ("adaptive_memory_ns_gid", "ns_gid"),
+            ("group_sparse", "group_sparse"),
+        ]:
+            pf = _pf_with_gid_mode(tmp_path, pfname, branch_name, mode)
+            engine = engine_class(pf)
+            rf = wrapper(
+                data,
+                engine,
+                signal_window=TimeWindow(-8.0, 20.0),
+                noise_window=TimeWindow(-35.0, -5.0),
+            )
+            assert rf.live, (engine_class.__name__, label, noise_scale)
+            qc = dict(rf[qc_key])
+            sparse = engine.sparse_output()
+            metrics = _classify_gid_spike_detections(
+                np.asarray(sparse.data),
+                sparse.t0,
+                sparse.dt,
+                detection_threshold=0.025,
+            )
+            results[label] = (metrics, qc)
+
+        default_metrics, default_qc = results["adaptive_memory_default"]
+        assert default_qc["gid_penalty_function"] == "adaptive_memory"
+        assert default_metrics["recall"] >= 0.95, noise_scale
+        assert default_metrics["precision"] >= 0.75, noise_scale
+
+        stable_metrics, stable_qc = results["adaptive_memory_ns_gid"]
+        assert stable_qc["gid_penalty_function"] == "adaptive_memory"
+        assert stable_metrics["recall"] >= 0.95, noise_scale
+        assert stable_metrics["precision"] >= 0.95, noise_scale
+
+        group_metrics, group_qc = results["group_sparse"]
+        assert group_qc["group_sparse_enabled"]
+        assert group_qc["group_sparse_active_threshold"] == pytest.approx(0.02)
+        assert group_qc["group_sparse_active_threshold_quantile"] == pytest.approx(
+            0.90
+        )
+        assert group_qc["group_sparse_active_threshold_used"] >= group_qc[
+            "group_sparse_active_threshold"
+        ]
+        assert group_metrics["recall"] >= stable_metrics["recall"] - 1.0e-12
+        assert group_metrics["precision"] >= stable_metrics["precision"] - 1.0e-12
+        assert group_metrics["f1"] >= default_metrics["f1"] - 1.0e-12
+        assert group_metrics["false_positive"] <= stable_metrics["false_positive"]
 
 
 @pytest.mark.parametrize(

--- a/python/tests/algorithms/test_decon_algorithm_validation.py
+++ b/python/tests/algorithms/test_decon_algorithm_validation.py
@@ -1656,16 +1656,15 @@ def test_group_sparse_adaptive_support_threshold_controls_clustered_coefficients
     )
 
     assert default_qc["group_sparse_active_threshold_quantile"] == pytest.approx(0.90)
-    assert default_qc["group_sparse_active_threshold_used"] > default_qc[
-        "group_sparse_active_threshold"
-    ]
+    assert (
+        default_qc["group_sparse_active_threshold_used"]
+        > default_qc["group_sparse_active_threshold"]
+    )
     assert default_metrics["precision"] == pytest.approx(1.0)
     assert default_metrics["recall"] == pytest.approx(1.0)
     assert default_qc["group_sparse_active_groups"] == len(STRESS_SPIKES)
 
-    assert fixed_floor_qc["group_sparse_active_threshold_used"] == pytest.approx(
-        1.0e-9
-    )
+    assert fixed_floor_qc["group_sparse_active_threshold_used"] == pytest.approx(1.0e-9)
     assert fixed_floor_qc["group_sparse_active_groups"] > 100
     assert fixed_floor_metrics["precision"] < default_metrics["precision"]
     assert fixed_floor_metrics["f1"] < default_metrics["f1"]
@@ -2052,12 +2051,11 @@ def test_group_sparse_recovers_weak_arrivals_like_adaptive_memory(
         group_metrics, group_qc = results["group_sparse"]
         assert group_qc["group_sparse_enabled"]
         assert group_qc["group_sparse_active_threshold"] == pytest.approx(0.02)
-        assert group_qc["group_sparse_active_threshold_quantile"] == pytest.approx(
-            0.90
+        assert group_qc["group_sparse_active_threshold_quantile"] == pytest.approx(0.90)
+        assert (
+            group_qc["group_sparse_active_threshold_used"]
+            >= group_qc["group_sparse_active_threshold"]
         )
-        assert group_qc["group_sparse_active_threshold_used"] >= group_qc[
-            "group_sparse_active_threshold"
-        ]
         assert group_metrics["recall"] >= stable_metrics["recall"] - 1.0e-12
         assert group_metrics["precision"] >= stable_metrics["precision"] - 1.0e-12
         assert group_metrics["f1"] >= default_metrics["f1"] - 1.0e-12

--- a/python/tests/algorithms/test_decon_algorithm_validation.py
+++ b/python/tests/algorithms/test_decon_algorithm_validation.py
@@ -1013,7 +1013,8 @@ def _plot_gid_sparse_results(
 
 
 def _gid_plot_label(core_method, qc):
-    if qc["group_sparse_enabled"]:
+    qc = dict(qc)
+    if qc.get("group_sparse_enabled", False):
         return (
             f"group_sparse/{qc['group_sparse_inverse_operator']}"
             f" lam={qc['group_sparse_lambda_used']:.3g}"

--- a/python/tests/algorithms/test_decon_algorithm_validation.py
+++ b/python/tests/algorithms/test_decon_algorithm_validation.py
@@ -40,6 +40,7 @@ EXPECTED_TRANSVERSE_RATIOS = {
     7.5: (-20.0 / 150.0, -3.0 / 150.0),
     9.0: (15.0 / 150.0, 2.0 / 150.0),
 }
+DEFAULT_GID_DECONVOLUTION_TYPE = "ns_gid"
 STRESS_SPIKES = {
     0.0: (-15.0, 10.0, 150.0),
     1.2: (12.0, 18.0, 0.0),
@@ -374,7 +375,10 @@ def _pf_with_gid_mode(tmp_path, pfname, branch_name, mode):
     text = open(pfname, encoding="utf-8").read()
     text = _replace_once(
         text,
-        f"{branch_name} &Arr{{\n        deconvolution_type least_square",
+        (
+            f"{branch_name} &Arr{{\n        "
+            f"deconvolution_type {DEFAULT_GID_DECONVOLUTION_TYPE}"
+        ),
         f"{branch_name} &Arr{{\n        deconvolution_type {mode}",
         pfname,
     )
@@ -403,7 +407,10 @@ def _pf_with_gid_mode_and_replacements(
     text = open(pfname, encoding="utf-8").read()
     text = _replace_once(
         text,
-        f"{branch_name} &Arr{{\n        deconvolution_type least_square",
+        (
+            f"{branch_name} &Arr{{\n        "
+            f"deconvolution_type {DEFAULT_GID_DECONVOLUTION_TYPE}"
+        ),
         f"{branch_name} &Arr{{\n        deconvolution_type {mode}",
         pfname,
     )
@@ -2015,7 +2022,7 @@ def test_group_sparse_recovers_weak_arrivals_like_adaptive_memory(
         )
         results = {}
         for label, mode in [
-            ("adaptive_memory_default", "least_square"),
+            ("adaptive_memory_least_square", "least_square"),
             ("adaptive_memory_ns_gid", "ns_gid"),
             ("group_sparse", "group_sparse"),
         ]:
@@ -2038,15 +2045,18 @@ def test_group_sparse_recovers_weak_arrivals_like_adaptive_memory(
             )
             results[label] = (metrics, qc)
 
-        default_metrics, default_qc = results["adaptive_memory_default"]
-        assert default_qc["gid_penalty_function"] == "adaptive_memory"
-        assert default_metrics["recall"] >= 0.95, noise_scale
-        assert default_metrics["precision"] >= 0.75, noise_scale
+        legacy_metrics, legacy_qc = results["adaptive_memory_least_square"]
+        assert legacy_qc["gid_penalty_function"] == "adaptive_memory"
+        assert legacy_metrics["recall"] >= 0.95, noise_scale
+        assert legacy_metrics["precision"] >= 0.75, noise_scale
 
         stable_metrics, stable_qc = results["adaptive_memory_ns_gid"]
         assert stable_qc["gid_penalty_function"] == "adaptive_memory"
+        assert stable_qc["deconvolution_type"] == DEFAULT_GID_DECONVOLUTION_TYPE
         assert stable_metrics["recall"] >= 0.95, noise_scale
         assert stable_metrics["precision"] >= 0.95, noise_scale
+        assert stable_metrics["f1"] >= legacy_metrics["f1"] - 1.0e-12
+        assert stable_metrics["false_positive"] <= legacy_metrics["false_positive"]
 
         group_metrics, group_qc = results["group_sparse"]
         assert group_qc["group_sparse_enabled"]
@@ -2058,7 +2068,7 @@ def test_group_sparse_recovers_weak_arrivals_like_adaptive_memory(
         )
         assert group_metrics["recall"] >= stable_metrics["recall"] - 1.0e-12
         assert group_metrics["precision"] >= stable_metrics["precision"] - 1.0e-12
-        assert group_metrics["f1"] >= default_metrics["f1"] - 1.0e-12
+        assert group_metrics["f1"] >= legacy_metrics["f1"] - 1.0e-12
         assert group_metrics["false_positive"] <= stable_metrics["false_positive"]
 
 

--- a/python/tests/algorithms/test_decon_algorithm_validation.py
+++ b/python/tests/algorithms/test_decon_algorithm_validation.py
@@ -372,7 +372,8 @@ def _assert_scalar_result_is_not_discrete_sparse_output(matrix, name):
 def _pf_with_gid_mode(tmp_path, pfname, branch_name, mode):
     # The C++ engines expect an AntelopePf tree, so write a temporary pf file
     # after changing only the GID inverse mode under test.
-    text = open(pfname, encoding="utf-8").read()
+    with open(pfname, encoding="utf-8") as fp:
+        text = fp.read()
     text = _replace_once(
         text,
         (
@@ -404,7 +405,8 @@ def test_replace_once_rejects_missing_or_duplicate_targets():
 def _pf_with_gid_mode_and_replacements(
     tmp_path, pfname, branch_name, mode, replacements
 ):
-    text = open(pfname, encoding="utf-8").read()
+    with open(pfname, encoding="utf-8") as fp:
+        text = fp.read()
     text = _replace_once(
         text,
         (
@@ -2111,7 +2113,7 @@ def test_group_sparse_recovers_weak_arrivals_like_adaptive_memory(
         ),
     ],
 )
-def test_gid_lag_penalty_improves_stress_fit_and_plots_diagnostics(
+def test_gid_lag_penalty_controls_stress_fit_and_plots_diagnostics(
     tmp_path,
     decon_validation_plot_dir,
     decon_validation_noise_scale,

--- a/python/tests/algorithms/test_decon_algorithm_validation.py
+++ b/python/tests/algorithms/test_decon_algorithm_validation.py
@@ -1609,8 +1609,27 @@ def test_external_wavelet_validation_across_deconvolution_methods(
     )
 
 
+@pytest.mark.parametrize(
+    "engine_class, wrapper, pfname, branch_name, qc_key",
+    [
+        (
+            TimeDomainGIDDecon,
+            TimeDomainGIDRFDecon,
+            "data/pf/TimeDomainGIDDecon.pf",
+            "time_domain_gid_deconvolution",
+            "TimeDomainGIDDecon_properties",
+        ),
+        (
+            FrequencyDomainGIDDecon,
+            FrequencyDomainGIDRFDecon,
+            "data/pf/FrequencyDomainGIDDecon.pf",
+            "frequency_domain_gid_deconvolution",
+            "FrequencyDomainGIDDecon_properties",
+        ),
+    ],
+)
 def test_group_sparse_adaptive_support_threshold_controls_clustered_coefficients(
-    tmp_path,
+    tmp_path, engine_class, wrapper, pfname, branch_name, qc_key
 ):
     data, truth, wavelet = _make_stress_colored_validation_data(
         noise_scale=0.01,
@@ -1624,17 +1643,17 @@ def test_group_sparse_adaptive_support_threshold_controls_clustered_coefficients
         + external_wavelet_shift
     )
 
-    def run_time_domain_group_sparse(replacements=None):
+    def run_group_sparse(replacements=None):
         replacements = replacements or {}
         pf = _pf_with_gid_mode_and_replacements(
             tmp_path,
-            "data/pf/TimeDomainGIDDecon.pf",
-            "time_domain_gid_deconvolution",
+            pfname,
+            branch_name,
             "group_sparse",
             replacements,
         )
-        engine = TimeDomainGIDDecon(pf)
-        rf = TimeDomainGIDRFDecon(
+        engine = engine_class(pf)
+        rf = wrapper(
             data,
             engine,
             signal_window=TimeWindow(-8.0, 20.0),
@@ -1649,10 +1668,10 @@ def test_group_sparse_adaptive_support_threshold_controls_clustered_coefficients
             sparse.dt,
             shifted_truth_times,
         )
-        return metrics, dict(rf["TimeDomainGIDDecon_properties"])
+        return metrics, dict(rf[qc_key])
 
-    default_metrics, default_qc = run_time_domain_group_sparse()
-    fixed_floor_metrics, fixed_floor_qc = run_time_domain_group_sparse(
+    default_metrics, default_qc = run_group_sparse()
+    fixed_floor_metrics, fixed_floor_qc = run_group_sparse(
         {
             "group_sparse_active_threshold 0.02": (
                 "group_sparse_active_threshold 0.000000001"

--- a/python/tests/algorithms/test_decon_math_correctness.py
+++ b/python/tests/algorithms/test_decon_math_correctness.py
@@ -132,9 +132,78 @@ def _run_scalar_engine(engine_class, pf, wavelet, data):
     return np.asarray(engine.getresult(), dtype=np.float64)
 
 
+def _base_numeric_metadata():
+    md = Metadata()
+    md["target_sample_interval"] = 1
+    md["operator_nfft"] = 64
+    md["deconvolution_data_window_start"] = 0
+    md["deconvolution_data_window_end"] = 63
+    md["shaping_wavelet_dt"] = 1
+    md["shaping_wavelet_type"] = "none"
+    return md
+
+
 def test_multitaper_power_stabilized_aliases_are_exported():
     assert MultiTaperPowerXcorDecon is MultiTaperXcorDecon
     assert MultiTaperPowerSpecDivDecon is MultiTaperSpecDivDecon
+
+
+@pytest.mark.parametrize(
+    "engine_class,extra",
+    [
+        (LeastSquareDecon, {"damping_factor": 1}),
+        (WaterLevelDecon, {"water_level": 1}),
+        (TimeDomainLeastSquareDecon, {"damping_factor": 1, "model_length": 64}),
+        (
+            MultiTaperXcorDecon,
+            {
+                "damping_factor": 1,
+                "time_bandwidth_product": 2,
+                "number_tapers": 4.0,
+            },
+        ),
+        (
+            MultiTaperSpecDivDecon,
+            {
+                "damping_factor": 1,
+                "time_bandwidth_product": 2,
+                "number_tapers": 4.0,
+            },
+        ),
+        (
+            NoiseStableDecon,
+            {
+                "ns_gid_mu_min": 1,
+                "ns_gid_alpha": 1,
+                "ns_gid_noise_floor": 1,
+                "ns_gid_gain_max": 1000,
+                "ns_gid_use_reliability_taper": "false",
+                "ns_gid_snr_taper_low": 1,
+                "ns_gid_snr_taper_high": 3,
+            },
+        ),
+    ],
+)
+def test_decon_operators_accept_integral_metadata_for_numeric_fields(
+    engine_class, extra
+):
+    md = _base_numeric_metadata()
+    for key, value in extra.items():
+        md[key] = value
+
+    engine = engine_class(md)
+
+    assert engine is not None
+
+
+def test_decon_operators_reject_non_integral_metadata_for_integer_fields():
+    md = _base_numeric_metadata()
+    md["damping_factor"] = 1
+    md["time_bandwidth_product"] = 2
+    md["number_tapers"] = 4.5
+
+    with pytest.raises(MsPASSError, match="integer-valued"):
+        MultiTaperXcorDecon(md)
 
 
 def test_deconvolution_binding_imports_diagnostic_return_types():

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -438,6 +438,12 @@ def test_Metadata_typed_getters_accept_compatible_scalar_types():
     md["numpy_float32"] = np.float32(1.25)
     md["numpy_int64"] = np.int64(8)
     md["numpy_bool"] = np.bool_(True)
+    md["long_min_float"] = float(-sys.maxsize - 1)
+    if sys.maxsize > 2**53:
+        float_below_long_max = np.nextafter(float(sys.maxsize), 0.0)
+        md["float_below_long_max"] = float_below_long_max
+    else:
+        md["long_max_float"] = float(sys.maxsize)
     md.put("put_numpy_float32", np.float32(3.5))
     md.put("put_numpy_int64", np.int64(11))
     md_from_dict = Metadata(
@@ -460,6 +466,11 @@ def test_Metadata_typed_getters_accept_compatible_scalar_types():
     assert md.get_double("numpy_float32") == pytest.approx(1.25)
     assert md.get_long("numpy_int64") == 8
     assert md.get_bool("numpy_bool") is True
+    assert md.get_long("long_min_float") == -sys.maxsize - 1
+    if sys.maxsize > 2**53:
+        assert md.get_long("float_below_long_max") == int(float_below_long_max)
+    else:
+        assert md.get_long("long_max_float") == sys.maxsize
     assert md.get_double("put_numpy_float32") == pytest.approx(3.5)
     assert md.get_long("put_numpy_int64") == 11
     assert md_from_dict.get_double("dict_numpy_float32") == pytest.approx(2.5)
@@ -490,6 +501,8 @@ def test_Metadata_typed_getters_reject_incompatible_scalar_types():
     md["not_boolean"] = 2
     md["true_bool"] = True
     md["too_large_long"] = float(np.iinfo(np.int64).max) * 2.0
+    if sys.maxsize > 2**53:
+        md["rounded_float_long_max"] = float(sys.maxsize)
     md_from_dict = Metadata(
         {"numpy_uint64_out_of_range": np.uint64(np.iinfo(np.uint64).max)}
     )
@@ -519,6 +532,9 @@ def test_Metadata_typed_getters_reject_incompatible_scalar_types():
         md.get_double("true_bool")
     with pytest.raises(MsPASSError, match="integer-valued|outside long range"):
         md.get_long("too_large_long")
+    if sys.maxsize > 2**53:
+        with pytest.raises(MsPASSError, match="outside long range"):
+            md.get_long("rounded_float_long_max")
     with pytest.raises(MsPASSError, match="integer-valued|outside long range"):
         md_from_dict.get_long("numpy_uint64_out_of_range")
 

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -20,19 +20,22 @@ from mspasspy.ccore.seismic import (
 )
 from mspasspy.ccore.utility import (
     AtomicType,
+    copy_selected_metadata,
     dmatrix,
     ErrorLogger,
     ErrorSeverity,
     LogData,
     Metadata,
     MetadataDefinitions,
+    Metadata_typedef,
+    MDtype,
     MsPASSError,
     ProcessingHistory,
     SphericalCoordinate,
 )
 
 from mspasspy.util.error_logger import PyErrorLogger
-from mspasspy.ccore.algorithms.basic import _ExtractComponent
+from mspasspy.ccore.algorithms.basic import Butterworth, _ExtractComponent
 from mspasspy.ccore.algorithms.deconvolution import MTPowerSpectrumEngine
 from mspasspy.ccore.algorithms.basic import TimeWindow
 
@@ -420,6 +423,208 @@ def test_Metadata():
     for i in md:
         assert md[i] == md_copy[i]
     assert md.modified() == md_copy.modified()
+
+
+def test_Metadata_typed_getters_accept_compatible_scalar_types():
+    md = Metadata()
+    md["integer_value"] = 5
+    md["double_integer"] = 6.0
+    md["double_true"] = 1.0
+    md["integer_false"] = 0
+    md["string_true"] = "YES"
+    md["string_false"] = "no"
+    md["string_true_with_space"] = " true "
+    md["string_false_with_newline"] = "false\n"
+    md["numpy_float32"] = np.float32(1.25)
+    md["numpy_int64"] = np.int64(8)
+    md["numpy_bool"] = np.bool_(True)
+    md.put("put_numpy_float32", np.float32(3.5))
+    md.put("put_numpy_int64", np.int64(11))
+    md_from_dict = Metadata(
+        {
+            "dict_numpy_float32": np.float32(2.5),
+            "dict_numpy_int32": np.int32(9),
+            "dict_numpy_bool": np.bool_(False),
+            "numpy_array": np.array([3, 4]),
+        }
+    )
+
+    assert md.get_double("integer_value") == pytest.approx(5.0)
+    assert md.get_long("double_integer") == 6
+    assert md.get_bool("double_true") is True
+    assert md.get_bool("integer_false") is False
+    assert md.get_bool("string_true") is True
+    assert md.get_bool("string_false") is False
+    assert md.get_bool("string_true_with_space") is True
+    assert md.get_bool("string_false_with_newline") is False
+    assert md.get_double("numpy_float32") == pytest.approx(1.25)
+    assert md.get_long("numpy_int64") == 8
+    assert md.get_bool("numpy_bool") is True
+    assert md.get_double("put_numpy_float32") == pytest.approx(3.5)
+    assert md.get_long("put_numpy_int64") == 11
+    assert md_from_dict.get_double("dict_numpy_float32") == pytest.approx(2.5)
+    assert md_from_dict.get_long("dict_numpy_int32") == 9
+    assert md_from_dict.get_bool("dict_numpy_bool") is False
+    assert md_from_dict.type("dict_numpy_float32") == "double"
+    assert md_from_dict.type("dict_numpy_int32") == "long"
+    assert md_from_dict.type("dict_numpy_bool") == "bool"
+    assert (md_from_dict["numpy_array"] == np.array([3, 4])).all()
+    md_roundtrip = pickle.loads(pickle.dumps(md_from_dict))
+    assert md_roundtrip.get_double("dict_numpy_float32") == pytest.approx(2.5)
+    assert md_roundtrip.get_long("dict_numpy_int32") == 9
+    assert md_roundtrip.get_bool("dict_numpy_bool") is False
+
+
+def test_Metadata_typed_getters_reject_incompatible_scalar_types():
+    md = Metadata()
+    md["fractional_integer"] = 4.5
+    md["numpy_fractional_integer"] = np.float32(4.5)
+    md["numpy_bool_not_numeric"] = np.bool_(True)
+    md["numpy_uint64_small"] = np.uint64(3)
+    md["native_long_max"] = sys.maxsize
+    md["native_long_min"] = -sys.maxsize - 1
+    md["numpy_int64_max"] = np.int64(np.iinfo(np.int64).max)
+    md["numpy_int64_min"] = np.int64(np.iinfo(np.int64).min)
+    md["huge_python_integer"] = 2**100
+    md["not_numeric"] = "abc"
+    md["not_boolean"] = 2
+    md["true_bool"] = True
+    md["too_large_long"] = float(np.iinfo(np.int64).max) * 2.0
+    md_from_dict = Metadata(
+        {"numpy_uint64_out_of_range": np.uint64(np.iinfo(np.uint64).max)}
+    )
+
+    assert md.get_long("numpy_uint64_small") == 3
+    assert md.get_long("native_long_max") == sys.maxsize
+    assert md.get_long("native_long_min") == -sys.maxsize - 1
+    assert md.get_long("numpy_int64_max") == np.iinfo(np.int64).max
+    assert md.get_long("numpy_int64_min") == np.iinfo(np.int64).min
+    assert md_from_dict.get_double("numpy_uint64_out_of_range") == pytest.approx(
+        float(np.iinfo(np.uint64).max)
+    )
+    assert md.get_double("huge_python_integer") == pytest.approx(float(2**100))
+    with pytest.raises(MsPASSError, match="integer-valued"):
+        md.get_long("fractional_integer")
+    with pytest.raises(MsPASSError, match="integer-valued"):
+        md.get_long("numpy_fractional_integer")
+    with pytest.raises(MsPASSError, match="outside long range"):
+        md.get_long("huge_python_integer")
+    with pytest.raises(MsPASSError, match="not numeric"):
+        md.get_double("numpy_bool_not_numeric")
+    with pytest.raises(MsPASSError, match="not numeric"):
+        md.get_double("not_numeric")
+    with pytest.raises(MsPASSError, match="not boolean"):
+        md.get_bool("not_boolean")
+    with pytest.raises(MsPASSError, match="not numeric"):
+        md.get_double("true_bool")
+    with pytest.raises(MsPASSError, match="integer-valued|outside long range"):
+        md.get_long("too_large_long")
+    with pytest.raises(MsPASSError, match="integer-valued|outside long range"):
+        md_from_dict.get_long("numpy_uint64_out_of_range")
+
+
+def test_Metadata_template_getters_accept_compatible_scalar_types_through_cpp():
+    md = Metadata()
+    md["sample_interval"] = 1
+    md["zerophase"] = "false"
+    md["filter_type"] = "lowpass"
+    md["filter_definition_method"] = "corner_pole"
+    md["npoles_high"] = 4.0
+    md["corner_high"] = 0.25
+
+    filt = Butterworth(md)
+
+    assert filt.dt() == pytest.approx(1.0)
+    assert filt.npoles_high() == 4
+    assert filt.is_zerophase() is False
+
+
+def test_copy_selected_metadata_uses_root_scalar_coercion():
+    source = Metadata()
+    source["as_float"] = 1
+    source["as_double"] = np.float32(2.25)
+    source["as_int"] = 4.0
+    source["as_long"] = np.int64(7)
+    source["as_bool"] = " true "
+    source["as_string"] = "ok"
+    source["skip"] = "ignored"
+    target = Metadata()
+    mdlist = []
+    for tag, mdt in [
+        ("as_float", MDtype.Real32),
+        ("as_double", MDtype.Double),
+        ("as_int", MDtype.Int32),
+        ("as_long", MDtype.Int64),
+        ("as_bool", MDtype.Boolean),
+        ("as_string", MDtype.String),
+        ("skip", MDtype.Invalid),
+    ]:
+        item = Metadata_typedef()
+        item.tag = tag
+        item.mdt = mdt
+        mdlist.append(item)
+
+    copied_count = copy_selected_metadata(source, target, mdlist)
+
+    assert copied_count == 6
+    assert target.get_double("as_float") == pytest.approx(1.0)
+    assert target.get_double("as_double") == pytest.approx(2.25)
+    assert target.get_long("as_int") == 4
+    assert target.get_long("as_long") == 7
+    assert target.get_bool("as_bool") is True
+    assert target.get_string("as_string") == "ok"
+    assert not target.is_defined("skip")
+    assert target["as_float"] == pytest.approx(1.0)
+    assert target["as_int"] == 4
+    target_dict = dict(target)
+    assert target_dict["as_float"] == pytest.approx(1.0)
+    assert target_dict["as_int"] == 4
+    assert target_dict["as_bool"] is True
+    assert "as_float" in str(target)
+    assert "as_int" in repr(target)
+    target_roundtrip = pickle.loads(pickle.dumps(target))
+    assert target_roundtrip["as_float"] == pytest.approx(1.0)
+    assert target_roundtrip["as_int"] == 4
+
+    bad_source = Metadata(source)
+    bad_source["as_int"] = 4.5
+    with pytest.raises(MsPASSError, match="integer-valued"):
+        copy_selected_metadata(bad_source, Metadata(), mdlist)
+
+    int_overflow_source = Metadata(source)
+    int_overflow_source["as_int"] = float(np.iinfo(np.int32).max) + 1.0
+    with pytest.raises(MsPASSError, match="outside int range"):
+        copy_selected_metadata(int_overflow_source, Metadata(), mdlist)
+
+    float_overflow_source = Metadata(source)
+    float_overflow_source["as_float"] = float(np.finfo(np.float32).max) * 2.0
+    with pytest.raises(MsPASSError, match="outside float range"):
+        copy_selected_metadata(float_overflow_source, Metadata(), mdlist)
+
+
+def test_Metadata_scalar_coercion_in_seismic_constructors():
+    ts_md = Metadata()
+    ts_md["delta"] = 1
+    ts_md["starttime"] = 0
+    ts_md["npts"] = 5.0
+    ts = TimeSeries(ts_md)
+    assert ts.dt == pytest.approx(1.0)
+    assert ts.t0 == pytest.approx(0.0)
+    assert ts.npts == 5
+
+    seis_md = Metadata()
+    seis_md["delta"] = 1
+    seis_md["starttime"] = 0
+    seis_md["npts"] = 4.0
+    seis = _CoreSeismogram(seis_md, False)
+    assert seis.dt == pytest.approx(1.0)
+    assert seis.t0 == pytest.approx(0.0)
+    assert seis.npts == 4
+
+    bad_md = Metadata(ts_md)
+    bad_md["npts"] = 5.5
+    with pytest.raises(MsPASSError, match="integer-valued"):
+        TimeSeries(bad_md)
 
 
 @pytest.fixture(params=[Seismogram, SeismogramEnsemble, TimeSeries, TimeSeriesEnsemble])


### PR DESCRIPTION
## Summary

- add `deconvolution_type group_sparse` for `TimeDomainGIDDecon` and `FrequencyDomainGIDDecon`, using the NS-GID inverse branch with a shared group-sparse solve path
- set the shipped time-domain and frequency-domain GID parameter files to the validated noisy-data default: `deconvolution_type ns_gid` with `lag_weight_penalty_function adaptive_memory`
- add public GID switching helpers (`make_gid_pf_text`, `make_gid_pf`, `make_gid_engine`) plus `RFdeconProcessor`/`RFdecon` keywords for `deconvolution_type`/`gid_mode`, lag-penalty selection, and scalar GID-branch overrides
- add group-sparse solver controls and QC metadata, including automatic `group_sparse_lambda` selection, adaptive `group_sparse_active_threshold_*` support reporting, solver convergence, retained groups, and inverse-stability fields
- preserve group-sparse, NS-GID, lag-penalty, selected `deconvolution_type`, and residual/QC metadata through the direct GID wrappers and `RFdeconProcessor` for downstream quality control
- harden deconvolution parameter ingestion across GID, scalar FFT, NS-GID, multitaper, time-domain LS, and CNR operators so integer-valued PF literals and Python/NumPy scalar metadata work consistently where numeric values are expected
- keep non-applicable QC fields absent, and reject or log malformed component, bandwidth, and non-scalar metadata values through the normal wrapper/error paths
- extend validation tests and optional plots to cover group-sparse support recovery, adaptive support-threshold behavior, penalty comparisons, readable legends, aligned sparse-truth strips, public method switching, invalid-option guardrails, scalar metadata coercion, and Copilot regression cases
- reorganize `deconvolution.rst` with an early terminology section, a copyable `Switching GID methods safely` recipe, and clearer sections for scalar methods, greedy GID, lag-weight penalties, group-sparse GID, validation plots, and QC metadata
- address Copilot review issues by documenting the default behavior change, omitting inactive group-sparse QC fields, avoiding an extra quantile-vector copy, accepting NumPy scalar values in the public GID parameter helpers, computing the frequency-domain group-sparse noise threshold before lambda selection, recomputing the group-sparse objective from the coefficient argument, and limiting PF scalar replacement to immediate GID-branch keys

## Validation

- `conda run -n mspass python setup.py build_ext --inplace`
- `conda run -n mspass env PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python python -m pytest -q -p no:cacheprovider python/tests/algorithms/test_RFdeconProcessor.py python/tests/algorithms/test_decon_math_correctness.py python/tests/algorithms/test_CNRDeconEngine.py python/tests/algorithms/test_TimeDomainGIDDecon.py python/tests/algorithms/test_FrequencyDomainGIDDecon.py python/tests/algorithms/test_decon_algorithm_validation.py` (`386 passed`)
- `conda run -n mspass env PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python python -m pytest -q -p no:cacheprovider python/tests/algorithms/test_CNRDeconEngine.py` (`6 passed`)
- custom GID benchmark sweep over stress, weak-arrival, close-arrival, and direct-only noisy synthetic cases: `group_sparse_lambda_scale=1.0` and `group_sparse_active_threshold_quantile=0.90` remained in the best-performing default bucket for both GID engines; `lambda_scale=1.5` and `2` reduced recall, so the shipped group-sparse defaults were kept
- quick group-sparse timing check on 8 stress synthetic runs after loop cleanup: about `0.0034 s/run` for time-domain and `0.0038 s/run` for frequency-domain in this local environment
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python /home/iwang/.conda/envs/mspass/bin/python -m pytest python/tests/algorithms/test_decon_algorithm_validation.py -q -p no:cacheprovider --decon-validation-plots --decon-validation-plot-dir /tmp/mspass-decon-validation-adaptive-penalty --decon-validation-noise-scale 0.03`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python /home/iwang/.conda/envs/mspass/bin/python -m pytest python/tests/algorithms/test_decon_algorithm_validation.py -q -p no:cacheprovider --decon-validation-plots --decon-validation-plot-dir /tmp/mspass-decon-validation-adaptive-penalty-0p30 --decon-validation-noise-scale 0.30`
- `git diff --check`
- local RST heading/reference scan for `docs/source/user_manual/deconvolution.rst`
- five read-only sub-agent review passes over C++ scalar coercion, RF wrapper/Copilot regressions, CNR behavior, Copilot comment coverage, and performance/numerical-risk scope; the one CNR finding was fixed and revalidated

## Notes

The group-sparse mode is separate from greedy GID lag-weight penalties. `group_sparse_lambda` controls the regularized solve, while `group_sparse_active_threshold_used` controls the exported sparse support and final refit. The documentation calls out that distinction so benchmark plots and QC metadata can be interpreted correctly.

Benchmark sweeps across weak-arrival, close-arrival, direct-only, and high-noise cases showed that `least_square + adaptive_memory` can still produce noise-driven false picks. The shipped GID default is now `ns_gid + adaptive_memory`, which matched the stable signal cases across the focused sweeps while keeping `least_square` available for explicit legacy comparisons and diagnostics. `group_sparse` remains an opt-in advanced mode when a shared sparse support prior is appropriate; in the latest sparse-support benchmark it suppressed direct-only noise peaks more strongly than `ns_gid + adaptive_memory`, but it also encodes a stronger sparse-support prior.

Users can now switch GID modes without raw pf edits, for example `RFdecon(seis, alg="TimeDomainGID", deconvolution_type="group_sparse")` or `RFdecon(..., gid_mode="least_square", gid_penalty_function="none")`. Lower-level code can use `make_gid_engine` with the direct GID wrappers.