### PR TITLE
[codex] Fix top-level seismic operators

### DIFF
--- a/cxx/include/mspass/seismic/Seismogram.h
+++ b/cxx/include/mspass/seismic/Seismogram.h
@@ -176,6 +176,50 @@ with serialization.
   virtual ~Seismogram() {};
   /*! Standard assignment operator. */
   Seismogram &operator=(const Seismogram &parent);
+  Seismogram &operator+=(const Seismogram &d) {
+    dynamic_cast<CoreSeismogram &>(*this) +=
+        dynamic_cast<const CoreSeismogram &>(d);
+    this->elog += d.elog;
+    return (*this);
+  };
+  Seismogram &operator+=(const CoreSeismogram &d) {
+    dynamic_cast<CoreSeismogram &>(*this) += d;
+    return (*this);
+  };
+  const Seismogram operator+(const Seismogram &other) const {
+    Seismogram result(*this);
+    result += other;
+    return result;
+  };
+  const CoreSeismogram operator+(const CoreSeismogram &other) const {
+    CoreSeismogram result(dynamic_cast<const CoreSeismogram &>(*this));
+    result += other;
+    return result;
+  };
+  Seismogram &operator*=(const double scale) {
+    dynamic_cast<CoreSeismogram &>(*this) *= scale;
+    return *this;
+  };
+  Seismogram &operator-=(const Seismogram &d) {
+    dynamic_cast<CoreSeismogram &>(*this) -=
+        dynamic_cast<const CoreSeismogram &>(d);
+    this->elog += d.elog;
+    return (*this);
+  };
+  Seismogram &operator-=(const CoreSeismogram &d) {
+    dynamic_cast<CoreSeismogram &>(*this) -= d;
+    return (*this);
+  };
+  const Seismogram operator-(const Seismogram &other) const {
+    Seismogram result(*this);
+    result -= other;
+    return result;
+  };
+  const CoreSeismogram operator-(const CoreSeismogram &other) const {
+    CoreSeismogram result(dynamic_cast<const CoreSeismogram &>(*this));
+    result -= other;
+    return result;
+  };
   /*! \brief Load just the ProcessingHistory data from another data source.
 
   Some algorithms don't handle processing history.   In those situations it

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -136,7 +136,22 @@ public:
   TimeSeries &operator+=(const TimeSeries &d) {
     dynamic_cast<CoreTimeSeries &>(*this) +=
         dynamic_cast<const CoreTimeSeries &>(d);
+    this->elog += d.elog;
     return (*this);
+  };
+  TimeSeries &operator+=(const CoreTimeSeries &d) {
+    dynamic_cast<CoreTimeSeries &>(*this) += d;
+    return (*this);
+  };
+  const TimeSeries operator+(const TimeSeries &other) const {
+    TimeSeries result(*this);
+    result += other;
+    return result;
+  };
+  const CoreTimeSeries operator+(const CoreTimeSeries &other) const {
+    CoreTimeSeries result(dynamic_cast<const CoreTimeSeries &>(*this));
+    result += other;
+    return result;
   };
   TimeSeries &operator*=(const double scale) {
     dynamic_cast<CoreTimeSeries &>(*this) *= scale;
@@ -145,7 +160,22 @@ public:
   TimeSeries &operator-=(const TimeSeries &d) {
     dynamic_cast<CoreTimeSeries &>(*this) -=
         dynamic_cast<const CoreTimeSeries &>(d);
+    this->elog += d.elog;
     return (*this);
+  };
+  TimeSeries &operator-=(const CoreTimeSeries &d) {
+    dynamic_cast<CoreTimeSeries &>(*this) -= d;
+    return (*this);
+  };
+  const TimeSeries operator-(const TimeSeries &other) const {
+    TimeSeries result(*this);
+    result -= other;
+    return result;
+  };
+  const CoreTimeSeries operator-(const CoreTimeSeries &other) const {
+    CoreTimeSeries result(dynamic_cast<const CoreTimeSeries &>(*this));
+    result -= other;
+    return result;
   };
   void load_history(const mspass::utility::ProcessingHistory &h);
   /*! Return an estimate of the memmory use by the data in this object.

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -407,6 +407,15 @@ PYBIND11_MODULE(seismic, m) {
     .def("load_history",&Seismogram::load_history,
        "Load ProcessingHistory from another data object that contains relevant history")
     .def("__sizeof__",[](const Seismogram& self){return self.memory_use();})
+    .def(py::self += py::self)
+    .def(py::self -= py::self)
+    .def(py::self + py::self)
+    .def(py::self - py::self)
+    .def(py::self *= double())
+    .def(py::self += CoreSeismogram())
+    .def(py::self -= CoreSeismogram())
+    .def(py::self + CoreSeismogram())
+    .def(py::self - CoreSeismogram())
     .def(py::pickle(
       [](const Seismogram &self) {
         pybind11::object sbuf;
@@ -519,6 +528,15 @@ PYBIND11_MODULE(seismic, m) {
       .def("load_history",&TimeSeries::load_history,
          "Load ProcessingHistory from another data object that contains relevant history")
       .def("__sizeof__",[](const TimeSeries& self){return self.memory_use();})
+      .def(py::self += py::self)
+      .def(py::self -= py::self)
+      .def(py::self + py::self)
+      .def(py::self - py::self)
+      .def(py::self *= double())
+      .def(py::self += CoreTimeSeries())
+      .def(py::self -= CoreTimeSeries())
+      .def(py::self + CoreTimeSeries())
+      .def(py::self - CoreTimeSeries())
       // Not sure this constructor needs to be exposed to python
       /*
       .def(py::init<const BasicTimeSeries&,const Metadata&,

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -1166,10 +1166,12 @@ def test_operators():
     assert np.allclose(d3.data, [3, 3, 3, 3, 1, 1, 1, 1, 1, 1])
     d3 = TimeSeries(dsave)
     d = d3 + d4
+    assert type(d) is TimeSeries
     assert np.allclose(d.data, [3, 3, 3, 3, 1, 1, 1, 1, 1, 1])
     d1 = _CoreTimeSeries(dsave)
     d3 = TimeSeries(dsave)
     d3 *= 2.5
+    assert type(d3) is TimeSeries
     assert np.allclose(d3.data, [2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5])
     x = np.linspace(-0.7, 1.2, 20)
     for t in x:
@@ -1263,6 +1265,7 @@ def test_operators():
     )
     d3 = Seismogram(dsave)
     d = d3 + d4
+    assert type(d) is Seismogram
     assert np.allclose(
         d.data,
         np.array(
@@ -1275,8 +1278,9 @@ def test_operators():
     )
     d3 = Seismogram(dsave)
     d3 *= 2.5
+    assert type(d3) is Seismogram
     assert np.allclose(
-        d1.data,
+        d3.data,
         np.array(
             [
                 [2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5],
@@ -1384,6 +1388,7 @@ def test_operators():
     assert np.allclose(d3.data, [-1, -1, -1, -1, 1, 1, 1, 1, 1, 1])
     d3 = TimeSeries(dsave)
     d = d3 - d4
+    assert type(d) is TimeSeries
     assert np.allclose(d.data, [-1, -1, -1, -1, 1, 1, 1, 1, 1, 1])
     x = np.linspace(-0.7, 1.2, 20)
     for t in x:
@@ -1466,8 +1471,145 @@ def test_operators():
     )
     d3 = Seismogram(dsave)
     d = d3 - d4
+    assert type(d) is Seismogram
     assert np.allclose(
         d.data,
+        np.array(
+            [
+                [-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+    )
+
+    d3 = make_constant_data_ts(TimeSeries(10), nsamp=10)
+    d4 = make_constant_data_ts(TimeSeries(6), t0=-0.2, nsamp=6, val=2.0)
+    d3.elog.log_error("lhs", "left message", ErrorSeverity.Complaint)
+    d4.elog.log_error("rhs", "right message", ErrorSeverity.Invalid)
+    d = d3 + d4
+    assert type(d) is TimeSeries
+    assert d.elog.size() == 2
+    assert d.elog[0].algorithm == "lhs"
+    assert d.elog[1].algorithm == "rhs"
+    d3 += d4
+    assert type(d3) is TimeSeries
+    assert d3.elog.size() == 2
+    assert d3.elog[0].algorithm == "lhs"
+    assert d3.elog[1].algorithm == "rhs"
+    assert d3.elog[1].badness == ErrorSeverity.Invalid
+
+    d3 = make_constant_data_ts(TimeSeries(10), nsamp=10)
+    d4 = make_constant_data_ts(TimeSeries(6), t0=-0.2, nsamp=6, val=2.0)
+    d3.elog.log_error("lhs", "left message", ErrorSeverity.Complaint)
+    d4.elog.log_error("rhs", "right message", ErrorSeverity.Invalid)
+    d = d3 - d4
+    assert type(d) is TimeSeries
+    assert d.elog.size() == 2
+    assert d.elog[0].algorithm == "lhs"
+    assert d.elog[1].algorithm == "rhs"
+    d3 -= d4
+    assert type(d3) is TimeSeries
+    assert d3.elog.size() == 2
+    assert d3.elog[0].algorithm == "lhs"
+    assert d3.elog[1].algorithm == "rhs"
+    assert d3.elog[1].badness == ErrorSeverity.Invalid
+
+    d3 = make_constant_data_seis(Seismogram(10), nsamp=10)
+    d4 = make_constant_data_seis(Seismogram(6), t0=-0.2, nsamp=6, val=2.0)
+    d3.elog.log_error("lhs", "left message", ErrorSeverity.Complaint)
+    d4.elog.log_error("rhs", "right message", ErrorSeverity.Invalid)
+    d = d3 + d4
+    assert type(d) is Seismogram
+    assert d.elog.size() == 2
+    assert d.elog[0].algorithm == "lhs"
+    assert d.elog[1].algorithm == "rhs"
+    d3 += d4
+    assert type(d3) is Seismogram
+    assert d3.elog.size() == 2
+    assert d3.elog[0].algorithm == "lhs"
+    assert d3.elog[1].algorithm == "rhs"
+    assert d3.elog[1].badness == ErrorSeverity.Invalid
+
+    d3 = make_constant_data_seis(Seismogram(10), nsamp=10)
+    d4 = make_constant_data_seis(Seismogram(6), t0=-0.2, nsamp=6, val=2.0)
+    d3.elog.log_error("lhs", "left message", ErrorSeverity.Complaint)
+    d4.elog.log_error("rhs", "right message", ErrorSeverity.Invalid)
+    d = d3 - d4
+    assert type(d) is Seismogram
+    assert d.elog.size() == 2
+    assert d.elog[0].algorithm == "lhs"
+    assert d.elog[1].algorithm == "rhs"
+    d3 -= d4
+    assert type(d3) is Seismogram
+    assert d3.elog.size() == 2
+    assert d3.elog[0].algorithm == "lhs"
+    assert d3.elog[1].algorithm == "rhs"
+    assert d3.elog[1].badness == ErrorSeverity.Invalid
+
+    d3 = make_constant_data_ts(TimeSeries(10), nsamp=10)
+    d4 = make_constant_data_ts(_CoreTimeSeries(6), t0=-0.2, nsamp=6, val=2.0)
+    d = d3 + d4
+    assert type(d) is _CoreTimeSeries
+    assert np.allclose(d.data, [3, 3, 3, 3, 1, 1, 1, 1, 1, 1])
+    d3 += d4
+    assert type(d3) is TimeSeries
+    assert np.allclose(d3.data, [3, 3, 3, 3, 1, 1, 1, 1, 1, 1])
+
+    d3 = make_constant_data_ts(TimeSeries(10), nsamp=10)
+    d4 = make_constant_data_ts(_CoreTimeSeries(6), t0=-0.2, nsamp=6, val=2.0)
+    d = d3 - d4
+    assert type(d) is _CoreTimeSeries
+    assert np.allclose(d.data, [-1, -1, -1, -1, 1, 1, 1, 1, 1, 1])
+    d3 -= d4
+    assert type(d3) is TimeSeries
+    assert np.allclose(d3.data, [-1, -1, -1, -1, 1, 1, 1, 1, 1, 1])
+
+    d3 = make_constant_data_seis(Seismogram(10), nsamp=10)
+    d4 = make_constant_data_seis(_CoreSeismogram(6), t0=-0.2, nsamp=6, val=2.0)
+    d = d3 + d4
+    assert type(d) is _CoreSeismogram
+    assert np.allclose(
+        d.data,
+        np.array(
+            [
+                [3.0, 3.0, 3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [3.0, 3.0, 3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [3.0, 3.0, 3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+    )
+    d3 += d4
+    assert type(d3) is Seismogram
+    assert np.allclose(
+        d3.data,
+        np.array(
+            [
+                [3.0, 3.0, 3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [3.0, 3.0, 3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [3.0, 3.0, 3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+    )
+
+    d3 = make_constant_data_seis(Seismogram(10), nsamp=10)
+    d4 = make_constant_data_seis(_CoreSeismogram(6), t0=-0.2, nsamp=6, val=2.0)
+    d = d3 - d4
+    assert type(d) is _CoreSeismogram
+    assert np.allclose(
+        d.data,
+        np.array(
+            [
+                [-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+    )
+    d3 -= d4
+    assert type(d3) is Seismogram
+    assert np.allclose(
+        d3.data,
         np.array(
             [
                 [-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],


### PR DESCRIPTION
## Summary
- Add top-level `TimeSeries` and `Seismogram` arithmetic operators so same-type `+`, `-`, `+=`, `-=`, and scalar `*=` dispatch on the concrete objects instead of inherited `_Core*` bindings.
- Merge rhs `elog` entries for same-type top-level arithmetic.
- Preserve mixed concrete-left/core-right compatibility by returning `_CoreTimeSeries` / `_CoreSeismogram` for non-mutating mixed operations and keeping in-place mixed operations on the concrete lhs.
- Extend `test_operators` coverage for concrete return types, `elog` propagation, scalar in-place type preservation, and mixed core/concrete operands.

Fixes #730.

## Validation
- `conda run -n mspass python setup.py build_ext --inplace`
- `conda run -n mspass python -m pytest python/tests/test_ccore.py::test_operators -q`
- `MSPASS_HOME=/home/iwang/git/mspass conda run -n mspass python -m pytest python/tests/test_ccore.py -q`
- `git diff --check`

## Review
Four independent Codex sub-agents reviewed the change across C++ operator semantics, pybind dispatch, regression-test coverage, and integration/PR scope. Actionable findings around stronger `elog` assertions, scalar in-place type coverage, and mixed core/concrete operand compatibility were addressed before publication.