### PR TITLE
[codex] Fix docs versioning, C++ API layout, and versioned publishing

### DIFF
--- a/.github/workflows/documentation-backfill.yml
+++ b/.github/workflows/documentation-backfill.yml
@@ -1,0 +1,112 @@
+name: Documentation backfill
+
+"on":
+  workflow_dispatch:
+    inputs:
+      docs_ref:
+        description: "Existing release tag to publish, for example v2.4.0"
+        required: true
+        type: string
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Validate documentation ref
+      id: docs-ref
+      env:
+        DOCS_REF: ${{ inputs.docs_ref }}
+      run: |
+        case "$DOCS_REF" in
+          v[0-9]*)
+            echo "ref=$DOCS_REF" >> "$GITHUB_OUTPUT"
+            echo "version_match=$DOCS_REF" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "::error::docs_ref must be a release tag like v2.4.0"
+            exit 1
+            ;;
+        esac
+
+    - name: Check out documentation support
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        path: support
+
+    - name: Check out release documentation source
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ steps.docs-ref.outputs.ref }}
+        path: source
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: pip
+        cache-dependency-path: |
+          source/pyproject.toml
+          source/docs/requirements.txt
+          support/.github/workflows/documentation-backfill.yml
+
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: "17"
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -yq cmake doxygen gfortran graphviz libboost-dev libboost-serialization-dev liblapack-dev pandoc
+
+    - name: Install Python dependencies
+      working-directory: source
+      env:
+        MSPASS_CMAKE_BUILD_TYPE: Debug
+        PYSPARK_HADOOP_VERSION: "3"
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade --upgrade-strategy eager \
+          setuptools setuptools_scm wheel numpy cmake pyspark pytest-spark
+        python -m pip install --no-cache-dir --no-build-isolation -v '.[seisbench]'
+        python -m pip install -r docs/requirements.txt
+
+    - name: Apply current documentation publishing support
+      run: |
+        cp support/docs/source/conf.py source/docs/source/conf.py
+        rm -rf source/docs/source/_templates source/docs/source/that_style
+        cp -R support/docs/source/_templates source/docs/source/_templates
+        cp -R support/docs/source/that_style source/docs/source/that_style
+        mkdir -p source/docs/source/_static/css
+        cp support/docs/source/_static/css/mspass.css source/docs/source/_static/css/mspass.css
+
+    - name: Build documentation
+      working-directory: source/docs
+      env:
+        MSPASS_DOCS_SITE_URL: https://www.mspass.org
+        MSPASS_DOCS_VERSION_MATCH: ${{ steps.docs-ref.outputs.version_match }}
+        MSPASS_HOME: ${{ github.workspace }}/source
+        MPLCONFIGDIR: /tmp/mspass-matplotlib
+      run: |
+        SPHINXOPTS="-W --keep-going" make html
+
+    - name: Prepare Documentation for GitHub Pages
+      working-directory: source
+      run: |
+        python ../support/docs/scripts/prepare_versioned_docs.py \
+          --html-dir docs/build/html \
+          --site-dir docs/build/site \
+          --site-url https://www.mspass.org \
+          --version-match "${{ steps.docs-ref.outputs.version_match }}"
+
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@3.7.1
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: source/docs/build/site
+        CLEAN: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,9 @@
 name: Python package
 
-on: [push, pull_request]
+"on":
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -36,7 +39,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade --upgrade-strategy eager \
-          setuptools setuptools_scm wheel numpy cmake pytest pytest-cov 
+          setuptools setuptools_scm wheel numpy cmake pytest pytest-cov
     - name: Install Spark Python Dependencies
       env:
         PYSPARK_HADOOP_VERSION: "3"
@@ -71,23 +74,37 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: false 
+        fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }} # required
         env_vars: OS,PYTHON
         verbose: true
     - name: Build Documentation
       if: ${{ matrix.python-version == '3.10' }}
+      env:
+        MSPASS_DOCS_SITE_URL: https://www.mspass.org
+        MSPASS_DOCS_VERSION_MATCH: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'latest' }}
       run: |
         export MSPASS_HOME=$(pwd)
         sudo apt-get update && sudo apt-get install -yq doxygen graphviz pandoc
         pip install -r docs/requirements.txt
         cd docs
         SPHINXOPTS="-W --keep-going" MPLCONFIGDIR=/tmp/mspass-matplotlib make html
-    - name: Deploy to GitHub Pages 
-      if: ${{ github.ref == 'refs/heads/master' && matrix.python-version == '3.10' }}
+    - name: Prepare Documentation for GitHub Pages
+      if: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && matrix.python-version == '3.10' }}
+      env:
+        MSPASS_DOCS_SITE_URL: https://www.mspass.org
+        MSPASS_DOCS_VERSION_MATCH: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'latest' }}
+      run: |
+        python docs/scripts/prepare_versioned_docs.py \
+          --html-dir docs/build/html \
+          --site-dir docs/build/site \
+          --site-url "$MSPASS_DOCS_SITE_URL" \
+          --version-match "$MSPASS_DOCS_VERSION_MATCH"
+    - name: Deploy to GitHub Pages
+      if: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && matrix.python-version == '3.10' }}
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages 
-        FOLDER: docs/build/html 
+        BRANCH: gh-pages
+        FOLDER: docs/build/site
         CLEAN: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/docs/scripts/prepare_versioned_docs.py
+++ b/docs/scripts/prepare_versioned_docs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Prepare the GitHub Pages deployment tree for versioned MsPASS docs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _copy_tree(source: Path, destination: Path) -> None:
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(source, destination)
+
+
+def _git_tags() -> list[str]:
+    result = subprocess.run(
+        ["git", "tag", "--list", "v[0-9]*", "--sort=-v:refname"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [tag.strip() for tag in result.stdout.splitlines() if tag.strip()]
+
+
+def _with_trailing_slash(url: str) -> str:
+    return url.rstrip("/") + "/"
+
+
+def _switcher_entries(site_url: str, current_version: str) -> list[dict[str, object]]:
+    site_url = site_url.rstrip("/")
+    tags = _git_tags()
+    if current_version.startswith("v") and current_version not in tags:
+        tags.insert(0, current_version)
+
+    entries: list[dict[str, object]] = [
+        {
+            "name": "latest",
+            "version": "latest",
+            "url": _with_trailing_slash(site_url),
+        }
+    ]
+    for index, tag in enumerate(tags):
+        entry: dict[str, object] = {
+            "name": tag,
+            "version": tag,
+            "url": _with_trailing_slash(f"{site_url}/{tag}"),
+        }
+        if index == 0:
+            entry["preferred"] = True
+        entries.append(entry)
+    return entries
+
+
+def prepare_docs(html_dir: Path, site_dir: Path, site_url: str, version_match: str) -> None:
+    if not html_dir.is_dir():
+        raise FileNotFoundError(f"HTML build directory does not exist: {html_dir}")
+
+    if site_dir.exists():
+        shutil.rmtree(site_dir)
+    site_dir.mkdir(parents=True)
+    (site_dir / ".nojekyll").touch()
+
+    if version_match == "latest":
+        for item in html_dir.iterdir():
+            destination = site_dir / item.name
+            if item.is_dir():
+                shutil.copytree(item, destination)
+            else:
+                shutil.copy2(item, destination)
+        _copy_tree(html_dir, site_dir / "latest")
+    else:
+        _copy_tree(html_dir, site_dir / version_match)
+
+    switcher = _switcher_entries(site_url, version_match)
+    (site_dir / "switcher.json").write_text(
+        json.dumps(switcher, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--html-dir", required=True, type=Path)
+    parser.add_argument("--site-dir", required=True, type=Path)
+    parser.add_argument("--site-url", required=True)
+    parser.add_argument("--version-match", required=True)
+    args = parser.parse_args()
+
+    prepare_docs(
+        html_dir=args.html_dir,
+        site_dir=args.site_dir,
+        site_url=args.site_url,
+        version_match=args.version_match,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,11 @@ def _get_project_version():
     try:
         from setuptools_scm import get_version
 
-        scm_version = get_version(root=repo_root, fallback_version=fallback_version)
+        scm_version = get_version(
+            root=repo_root,
+            fallback_version=fallback_version,
+            local_scheme=_docs_local_scheme,
+        )
         if scm_version != fallback_version:
             return scm_version
     except Exception:
@@ -114,9 +118,23 @@ def _get_project_version():
         return fallback_version
 
 
+def _docs_local_scheme(scm_version):
+    """Keep the Git node in docs versions without adding dirty-date suffixes."""
+    node = getattr(scm_version, "node", None)
+    if node and (scm_version.distance or scm_version.dirty):
+        return f"+{node}"
+    return ""
+
+
 # The full version, including alpha/beta/rc tags
 release = _get_project_version()
 version = release.split("+", 1)[0]
+docs_version_match = os.environ.get("MSPASS_DOCS_VERSION_MATCH", "latest")
+docs_site_url = os.environ.get("MSPASS_DOCS_SITE_URL", "https://www.mspass.org")
+docs_switcher_json_url = os.environ.get(
+    "MSPASS_DOCS_SWITCHER_JSON_URL",
+    f"{docs_site_url.rstrip('/')}/switcher.json",
+)
 
 
 # -- General configuration ---------------------------------------------------
@@ -175,11 +193,17 @@ html_theme_options = {
     "navigation_depth": 4,
     "collapse_navigation": False,
     "navbar_align": "content",
+    "navbar_start": ["navbar-logo", "version-switcher"],
     "navbar_center": ["navbar-sections.html"],
     "navbar_persistent": ["search-button-field"],
     "search_bar_text": "Search MsPASS docs...",
     "primary_sidebar_end": [],
     "footer_end": [],
+    "switcher": {
+        "json_url": docs_switcher_json_url,
+        "version_match": docs_version_match,
+    },
+    "check_switcher": False,
 }
 
 html_sidebars = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,9 +114,16 @@ def _get_project_version():
         return fallback_version
 
 
-# The full version, including alpha/beta/rc tags
-release = _get_project_version()
-version = release.split("+", 1)[0]
+def _public_docs_version(resolved_version):
+    """Return a stable public version string for rendered documentation."""
+    return resolved_version.split("+", 1)[0]
+
+
+# The rendered docs should show the public PEP 440 version.  The local
+# setuptools_scm suffix is useful for wheels, but it makes published docs noisy.
+_resolved_release = _get_project_version()
+release = _public_docs_version(_resolved_release)
+version = release
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,16 +114,9 @@ def _get_project_version():
         return fallback_version
 
 
-def _public_docs_version(resolved_version):
-    """Return a stable public version string for rendered documentation."""
-    return resolved_version.split("+", 1)[0]
-
-
-# The rendered docs should show the public PEP 440 version.  The local
-# setuptools_scm suffix is useful for wheels, but it makes published docs noisy.
-_resolved_release = _get_project_version()
-release = _public_docs_version(_resolved_release)
-version = release
+# The full version, including alpha/beta/rc tags
+release = _get_project_version()
+version = release.split("+", 1)[0]
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/that_style/that_style.css
+++ b/docs/source/that_style/that_style.css
@@ -491,6 +491,20 @@ table.doxtable th {
   white-space: normal;
 }
 
+@media (min-width: 721px) {
+  table.memberdecls .memItemLeft,
+  table.memberdecls .memTemplItemLeft {
+    overflow-wrap: normal;
+    white-space: nowrap;
+    width: 1%;
+  }
+
+  table.memberdecls .memItemRight,
+  table.memberdecls .memTemplItemRight {
+    width: 100%;
+  }
+}
+
 .fragment,
 pre.fragment,
 div.line,

--- a/docs/source/that_style/that_style.css
+++ b/docs/source/that_style/that_style.css
@@ -528,6 +528,23 @@ div.line {
   font: 400 0.92rem/1.5 "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
 }
 
+span.lineno {
+  background: var(--mspass-surface-strong);
+  border-right: 2px solid var(--mspass-border);
+  color: var(--mspass-muted);
+}
+
+span.lineno a {
+  background: transparent;
+  color: inherit;
+}
+
+span.lineno a:hover,
+span.lineno a:focus {
+  background: var(--mspass-surface);
+  color: var(--mspass-primary-strong);
+}
+
 code,
 .computeroutput {
   border: 1px solid var(--mspass-border);
@@ -739,6 +756,23 @@ html[data-theme="dark"] input,
 html[data-theme="dark"] select,
 html[data-theme="dark"] textarea {
   background: var(--mspass-code) !important;
+}
+
+html[data-theme="dark"] span.lineno {
+  background: var(--mspass-surface-strong) !important;
+  border-right-color: var(--mspass-border) !important;
+  color: var(--mspass-muted) !important;
+}
+
+html[data-theme="dark"] span.lineno a {
+  background: transparent !important;
+  color: inherit !important;
+}
+
+html[data-theme="dark"] span.lineno a:hover,
+html[data-theme="dark"] span.lineno a:focus {
+  background: var(--mspass-surface) !important;
+  color: var(--mspass-primary-strong) !important;
 }
 
 html[data-theme="dark"] div.dyncontent,


### PR DESCRIPTION
## Summary

This PR fixes the documentation publishing and C++ API presentation issues found after the v2.4.0 release.

- Fetch full Git history/tags in docs CI so `setuptools_scm` can resolve real versions instead of falling back to `0.1.dev...`.
- Keep the useful Git node in development docs versions while suppressing the redundant dirty-date suffix.
- Fix Doxygen C++ API member tables so return types do not collapse into vertical text.
- Fix Doxygen dark-mode source line numbers so hard-coded light Doxygen colors do not make them unreadable.
- Add a PyData version switcher backed by `/switcher.json`.
- Publish `master` docs at the site root and `/latest/`, and publish pushed release tags under `/vX.Y.Z/`.
- Add a manual documentation backfill workflow for existing release tags such as `v2.4.0`.

## Validation

- Parsed all `.github/workflows/*.yml` with PyYAML.
- Ran `python -m py_compile docs/scripts/prepare_versioned_docs.py docs/source/conf.py`.
- Ran `git diff --check`.
- Ran `make html SPHINXOPTS="-W --keep-going"` with `MSPASS_DOCS_VERSION_MATCH=latest`.
- Verified generated docs include the PyData version switcher markup.
- Verified generated Sphinx/Doxygen version output uses `2.4.1.devN+g<sha>` without `.dYYYYMMDD`.
- Verified `prepare_versioned_docs.py` stages root/latest docs and tag docs under `/v2.4.0/` as expected.