### PR TITLE
[codex] Fix GeoLab Dask startup

### DIFF
--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -1,5 +1,6 @@
 import os
 import pymongo
+from urllib.parse import urlsplit
 
 from mspasspy.db.client import DBClient
 from mspasspy.util.db_utils import MongoDBWorker
@@ -26,6 +27,25 @@ except ImportError:
     _mspasspy_has_dask_distributed = False
 
 from mspasspy.ccore.utility import MsPASSError
+
+
+def _address_has_port(address):
+    if "://" in address:
+        parsed_address = urlsplit(address)
+    else:
+        parsed_address = urlsplit("//" + address)
+    try:
+        return parsed_address.port is not None
+    except ValueError:
+        return False
+
+
+def _build_dask_scheduler_address(scheduler_address, scheduler_port=None):
+    if _address_has_port(scheduler_address):
+        return scheduler_address
+    if scheduler_port is None or scheduler_port == "":
+        scheduler_port = "8786"
+    return scheduler_address + ":" + str(scheduler_port)
 
 
 class Client:
@@ -209,22 +229,14 @@ class Client:
             if not scheduler_host and not MSPASS_SCHEDULER_ADDRESS:
                 self._dask_client = DaskClient()
             else:
-                scheduler_host_has_port = False
-                # set host
                 if scheduler_host:
-                    self._dask_client_address = scheduler_host
-                    # check if scheduler_host contains port number already
-                    if ":" in scheduler_host:
-                        scheduler_host_has_port = True
+                    scheduler_address = scheduler_host
                 else:
-                    self._dask_client_address = MSPASS_SCHEDULER_ADDRESS
+                    scheduler_address = MSPASS_SCHEDULER_ADDRESS
 
-                # add port
-                if not scheduler_host_has_port and DASK_SCHEDULER_PORT:
-                    self._dask_client_address += ":" + DASK_SCHEDULER_PORT
-                else:
-                    # use to port 8786 by default if not specified
-                    self._dask_client_address += ":8786"
+                self._dask_client_address = _build_dask_scheduler_address(
+                    scheduler_address, DASK_SCHEDULER_PORT
+                )
                 # sanity check
                 try:
                     self._dask_client = DaskClient(self._dask_client_address)
@@ -429,19 +441,9 @@ class Client:
                 del self._dask_client
 
         elif scheduler == "dask":
-            scheduler_host_has_port = False
-            self._dask_client_address = scheduler_host
-            # check if scheduler_host contains port number already
-            if ":" in scheduler_host:
-                scheduler_host_has_port = True
-
-            # add port
-            if not scheduler_host_has_port:
-                if scheduler_port:
-                    self._dask_client_address += ":" + scheduler_port
-                else:
-                    # use to port 8786 by default if not specified
-                    self._dask_client_address += ":8786"
+            self._dask_client_address = _build_dask_scheduler_address(
+                scheduler_host, scheduler_port
+            )
 
             # sanity check
             prev_dask_client = None

--- a/python/tests/test_mspass_client_spark_dask.py
+++ b/python/tests/test_mspass_client_spark_dask.py
@@ -38,6 +38,99 @@ def mock_excpt(*args, **kwargs):
     raise Exception("mocked exception")
 
 
+def _patch_client_startup_for_scheduler_address(monkeypatch):
+    monkeypatch.setattr(DBClient, "server_info", lambda self: {})
+    monkeypatch.setattr(
+        GlobalHistoryManager, "__init__", lambda self, *args, **kwargs: None
+    )
+
+
+def _dask_client_error_match(address):
+    return re.escape("cannot create a dask client with: " + address)
+
+
+def test_dask_scheduler_full_uri_constructor_address(monkeypatch):
+    _patch_client_startup_for_scheduler_address(monkeypatch)
+    monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    with pytest.raises(
+        MsPASSError,
+        match=_dask_client_error_match("tcp://127.0.0.1:41585"),
+    ):
+        Client(scheduler="dask", scheduler_host="tcp://127.0.0.1:41585")
+
+
+def test_dask_scheduler_full_uri_env_address(monkeypatch):
+    _patch_client_startup_for_scheduler_address(monkeypatch)
+    monkeypatch.setenv("MSPASS_SCHEDULER", "dask")
+    monkeypatch.setenv("MSPASS_SCHEDULER_ADDRESS", "tcp://127.0.0.1:41585")
+    monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    with pytest.raises(
+        MsPASSError,
+        match=_dask_client_error_match("tcp://127.0.0.1:41585"),
+    ):
+        Client()
+
+
+def test_dask_scheduler_bare_host_uses_env_port(monkeypatch):
+    _patch_client_startup_for_scheduler_address(monkeypatch)
+    monkeypatch.setenv("DASK_SCHEDULER_PORT", "12345")
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    with pytest.raises(
+        MsPASSError,
+        match=_dask_client_error_match("168.0.0.1:12345"),
+    ):
+        Client(scheduler="dask", scheduler_host="168.0.0.1")
+
+
+def test_dask_scheduler_bare_host_uses_default_port(monkeypatch):
+    _patch_client_startup_for_scheduler_address(monkeypatch)
+    monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    with pytest.raises(
+        MsPASSError,
+        match=_dask_client_error_match("168.0.0.1:8786"),
+    ):
+        Client(scheduler="dask", scheduler_host="168.0.0.1")
+
+
+def test_set_scheduler_dask_uses_full_uri_address(monkeypatch):
+    client = Client.__new__(Client)
+    client._scheduler = "spark"
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    with pytest.raises(
+        MsPASSError,
+        match=_dask_client_error_match("tcp://127.0.0.1:41585"),
+    ):
+        client.set_scheduler("dask", "tcp://127.0.0.1:41585")
+    assert client._scheduler == "spark"
+
+
+def test_set_scheduler_dask_coerces_non_string_port(monkeypatch):
+    client = Client.__new__(Client)
+    client._scheduler = "spark"
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    with pytest.raises(
+        MsPASSError,
+        match=_dask_client_error_match("168.0.0.1:12345"),
+    ):
+        client.set_scheduler("dask", "168.0.0.1", scheduler_port=12345)
+    assert client._scheduler == "spark"
+
+
+def test_set_scheduler_dask_empty_port_uses_default(monkeypatch):
+    client = Client.__new__(Client)
+    client._scheduler = "spark"
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    with pytest.raises(
+        MsPASSError,
+        match=_dask_client_error_match("168.0.0.1:8786"),
+    ):
+        client.set_scheduler("dask", "168.0.0.1", scheduler_port="")
+    assert client._scheduler == "spark"
+
+
 class TestMsPASSClient:
     @staticmethod
     def _close_dask_scheduler(client):
@@ -144,6 +237,7 @@ class TestMsPASSClient:
             self.client = Client()
 
     def test_dask_scheduler(self, monkeypatch):
+        monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
         monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
         with pytest.raises(
             MsPASSError,
@@ -161,6 +255,46 @@ class TestMsPASSClient:
             match="Runntime error: cannot create a dask client with: 168.0.0.1:12345",
         ):
             client = Client()
+        monkeypatch.undo()
+
+        monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
+        monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+        with pytest.raises(
+            MsPASSError,
+            match=_dask_client_error_match("tcp://127.0.0.1:41585"),
+        ):
+            client = Client(
+                scheduler="dask", scheduler_host="tcp://127.0.0.1:41585"
+            )
+        monkeypatch.undo()
+
+        monkeypatch.setenv("MSPASS_SCHEDULER", "dask")
+        monkeypatch.setenv("MSPASS_SCHEDULER_ADDRESS", "tcp://127.0.0.1:41585")
+        monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
+        monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+        with pytest.raises(
+            MsPASSError,
+            match=_dask_client_error_match("tcp://127.0.0.1:41585"),
+        ):
+            client = Client()
+        monkeypatch.undo()
+
+        monkeypatch.setenv("DASK_SCHEDULER_PORT", "12345")
+        monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+        with pytest.raises(
+            MsPASSError,
+            match=_dask_client_error_match("168.0.0.1:12345"),
+        ):
+            client = Client(scheduler="dask", scheduler_host="168.0.0.1")
+        monkeypatch.undo()
+
+        monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
+        monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+        with pytest.raises(
+            MsPASSError,
+            match=_dask_client_error_match("168.0.0.1:8786"),
+        ):
+            client = Client(scheduler="dask", scheduler_host="168.0.0.1")
         monkeypatch.undo()
 
     def test_spark_scheduler(self, monkeypatch):
@@ -265,6 +399,17 @@ class TestMsPASSClient:
             match="Runntime error: cannot create a dask client with: localhost:8786",
         ):
             self.client.set_scheduler("dask", "localhost", scheduler_port="8786")
+        monkeypatch.undo()
+        assert self.client._scheduler == "dask"
+        assert isinstance(self.client._dask_client, DaskClient)
+        assert self.client._dask_client == temp_dask_client
+
+        monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+        with pytest.raises(
+            MsPASSError,
+            match=_dask_client_error_match("tcp://127.0.0.1:41585"),
+        ):
+            self.client.set_scheduler("dask", "tcp://127.0.0.1:41585")
         monkeypatch.undo()
         assert self.client._scheduler == "dask"
         assert isinstance(self.client._dask_client, DaskClient)

--- a/scripts/start-mspass.sh
+++ b/scripts/start-mspass.sh
@@ -78,6 +78,50 @@ function configure_tacc_interactive_access_if_needed {
   fi
 }
 
+function is_jupyterhub_singleuser_command {
+  local arg
+  for arg in "$@"; do
+    if [[ "$(basename "$arg")" = "jupyterhub-singleuser" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+function scheduler_address_has_port {
+  local address="$1"
+  local without_scheme="${address#*://}"
+
+  if [[ "$without_scheme" =~ ^\[.*\]:[0-9]+$ ]]; then
+    return 0
+  fi
+
+  if [[ "$without_scheme" =~ ^[^:]+:[0-9]+$ ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+function build_dask_scheduler_uri {
+  local address="$1"
+  local port="${2:-8786}"
+
+  if scheduler_address_has_port "$address"; then
+    if [[ "$address" = *"://"* ]]; then
+      printf '%s' "$address"
+    else
+      printf 'tcp://%s' "$address"
+    fi
+  else
+    if [[ "$address" = *"://"* ]]; then
+      printf '%s:%s' "$address" "$port"
+    else
+      printf 'tcp://%s:%s' "$address" "$port"
+    fi
+  fi
+}
+
 # define SLEEP_TIME
 if [[ -z $MSPASS_SLEEP_TIME ]]; then
   MSPASS_SLEEP_TIME=15
@@ -102,7 +146,14 @@ MONGO_LOG=${MSPASS_LOG_DIR}/mongo_log
 export SPARK_WORKER_DIR=${MSPASS_WORKER_DIR}
 export SPARK_LOG_DIR=${MSPASS_LOG_DIR}
 
+MSPASS_START_LOCAL_SERVICES=false
 if [ $# -eq 0 ] || [ "$1" = "--batch" ]; then
+  MSPASS_START_LOCAL_SERVICES=true
+elif is_jupyterhub_singleuser_command "$@" && [ "${MSPASS_ROLE:-all}" = "all" ]; then
+  MSPASS_START_LOCAL_SERVICES=true
+fi
+
+if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
 
   function start_mspass_frontend {
       RUN_JUPYTER_AS_NB_USER=false
@@ -181,7 +232,7 @@ if [ $# -eq 0 ] || [ "$1" = "--batch" ]; then
           fi
       else
           # Dask scheduler configuration
-          export DASK_SCHEDULER_ADDRESS=${MSPASS_SCHEDULER_ADDRESS}:${DASK_SCHEDULER_PORT}
+          export DASK_SCHEDULER_ADDRESS="$(build_dask_scheduler_uri "${MSPASS_SCHEDULER_ADDRESS}" "${DASK_SCHEDULER_PORT}")"
           if [ -z "$1" ]; then
               # Interactive Jupyter Lab mode for Dask
               if [[ "$RUN_JUPYTER_AS_NB_USER" = "true" ]]; then
@@ -298,13 +349,25 @@ if [ $# -eq 0 ] || [ "$1" = "--batch" ]; then
     mongod --port $MONGODB_PORT --dbpath /tmp/db/data --logpath /tmp/logs/mongo_log --bind_ip_all &
   }
 
+  function start_local_mspass_services {
+    export MSPASS_DB_ADDRESS=$HOSTNAME
+    export MSPASS_SCHEDULER_ADDRESS=$HOSTNAME
+    eval $MSPASS_SCHEDULER_CMD
+    eval $MSPASS_WORKER_CMD
+    if [ "$MSPASS_DB_PATH" = "tmp" ]; then
+      start_db_tmp
+    else
+      start_db_scratch
+    fi
+  }
+
   MY_ID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
   if [ "$MSPASS_SCHEDULER" = "spark" ]; then
     MSPASS_SCHEDULER_CMD='$SPARK_HOME/sbin/start-master.sh'
     MSPASS_WORKER_CMD='$SPARK_HOME/sbin/start-slave.sh spark://$MSPASS_SCHEDULER_ADDRESS:$SPARK_MASTER_PORT'
   else # if [ "$MSPASS_SCHEDULER" = "dask" ]
     MSPASS_SCHEDULER_CMD='dask scheduler --port $DASK_SCHEDULER_PORT > ${MSPASS_LOG_DIR}/dask-scheduler_log_${MY_ID} 2>&1 & sleep 5'
-    MSPASS_WORKER_CMD='dask worker ${MSPASS_WORKER_ARG} --memory-limit=${MSPASS_DASK_WORKER_MEMORY_LIMIT:-0} --local-directory $MSPASS_WORKER_DIR tcp://$MSPASS_SCHEDULER_ADDRESS:$DASK_SCHEDULER_PORT > ${MSPASS_LOG_DIR}/dask-worker_log_${MY_ID} 2>&1 &'
+    MSPASS_WORKER_CMD='dask worker ${MSPASS_WORKER_ARG} --memory-limit=${MSPASS_DASK_WORKER_MEMORY_LIMIT:-0} --local-directory $MSPASS_WORKER_DIR "$(build_dask_scheduler_uri "$MSPASS_SCHEDULER_ADDRESS" "$DASK_SCHEDULER_PORT")" > ${MSPASS_LOG_DIR}/dask-worker_log_${MY_ID} 2>&1 &'
   fi
 
   if [ "$MSPASS_ROLE" = "db" ]; then
@@ -482,20 +545,17 @@ if [ $# -eq 0 ] || [ "$1" = "--batch" ]; then
   else # if [ "$MSPASS_ROLE" = "all" ]
     FRONTEND_CLEANUP_MODE=single
     enable_frontend_cleanup_trap
-    MSPASS_DB_ADDRESS=$HOSTNAME
-    MSPASS_SCHEDULER_ADDRESS=$HOSTNAME
-    eval $MSPASS_SCHEDULER_CMD
-    eval $MSPASS_WORKER_CMD
-    if [ "$MSPASS_DB_PATH" = "tmp" ]; then
-      start_db_tmp
+    start_local_mspass_services
+    if is_jupyterhub_singleuser_command "$@"; then
+      docker-entrypoint.sh "$@"
+      frontend_status=$?
     else
-      start_db_scratch
+      if [ "$1" != "--batch" ]; then
+        configure_tacc_interactive_access_if_needed
+      fi
+      start_mspass_frontend "$2"
+      frontend_status=$?
     fi
-    if [ "$1" != "--batch" ]; then
-      configure_tacc_interactive_access_if_needed
-    fi
-    start_mspass_frontend "$2"
-    frontend_status=$?
     run_frontend_cleanup "$frontend_status"
     if [ "$1" = "--batch" ]
     then


### PR DESCRIPTION
## Summary

Fixes two GeoLab/JupyterHub startup problems around Dask scheduler discovery:

- centralizes Dask scheduler address construction in `mspasspy.client.Client` so full scheduler URIs such as `tcp://127.0.0.1:41585` are not corrupted by appending another port
- adds focused client tests for constructor, environment-variable, bare-host, default-port, and `set_scheduler` paths
- updates `scripts/start-mspass.sh` so `jupyterhub-singleuser` command paths initialize the local MsPASS services before delegating to the supplied JupyterHub command
- exports `MSPASS_DB_ADDRESS` and `MSPASS_SCHEDULER_ADDRESS` for local all-role startup and uses a shell helper for Dask scheduler URIs

## Validation

- `bash -n scripts/start-mspass.sh`
- `python -m py_compile python/mspasspy/client.py python/tests/test_mspass_client_spark_dask.py`
- `git diff --check`
- `conda run -n mspass pytest python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_full_uri_constructor_address python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_full_uri_env_address python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_bare_host_uses_env_port python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_bare_host_uses_default_port python/tests/test_mspass_client_spark_dask.py::test_set_scheduler_dask_uses_full_uri_address`

Note: the full legacy `python/tests/test_mspass_client_spark_dask.py` file could not be completed in this local tool environment because its class setup depends on live local service startup; the focused address-construction tests pass without requiring those services.