### PR TITLE
[codex] Add GeoLab Dask Gateway support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -309,26 +309,58 @@ FROM runtime AS mpi
 
 FROM runtime AS geolab
 
-# Create a non-root user (UID 1000) for JupyterLab so that a Kubernetes PVC
-# mounted at /home/mspass is writable without requiring root inside the pod.
-# mongosh still needs a valid HOME, which /home/mspass satisfies.
+# Match EarthScope GeoLab's canonical persistent workspace while keeping the
+# MsPASS Unix username.  GeoLab mounts /home/jovyan at runtime, so image-layer
+# contents can be hidden, but the user metadata and defaults should agree with
+# the runtime workspace.
 ARG NB_USER=mspass
 ARG NB_UID=1000
-ARG NB_HOME=/home/mspass
+ARG NB_GID=1000
+ARG NB_HOME=/home/jovyan
 ENV NB_USER=${NB_USER} \
     NB_UID=${NB_UID} \
+    NB_GID=${NB_GID} \
     NB_HOME=${NB_HOME} \
     HOME=${NB_HOME} \
+    MSPASS_WORK_DIR=${NB_HOME} \
     MSPASS_USE_HOME_WORKDIR=true \
-    MSPASS_RUN_JUPYTER_AS_NB_USER=true
+    MSPASS_RUN_JUPYTER_AS_NB_USER=true \
+    MSPASS_SCHEDULER=none \
+    MSPASS_ENABLE_LOCAL_DASK=false
 
-RUN useradd --create-home --home-dir ${NB_HOME} --uid ${NB_UID} --gid 100 \
-        --shell /bin/bash ${NB_USER} && \
+RUN set -eux; \
+    if ! getent group "${NB_GID}" >/dev/null; then \
+        groupadd --gid "${NB_GID}" "${NB_USER}"; \
+    fi; \
+    existing_user="$(getent passwd "${NB_UID}" | cut -d: -f1 || true)"; \
+    if [ -n "${existing_user}" ] && [ "${existing_user}" != "${NB_USER}" ]; then \
+        usermod --login "${NB_USER}" "${existing_user}"; \
+    fi; \
+    if id -u "${NB_USER}" >/dev/null 2>&1; then \
+        usermod --home "${NB_HOME}" --uid "${NB_UID}" --gid "${NB_GID}" "${NB_USER}"; \
+        mkdir -p "${NB_HOME}"; \
+    else \
+        useradd --create-home --home-dir "${NB_HOME}" --uid "${NB_UID}" --gid "${NB_GID}" \
+            --shell /bin/bash "${NB_USER}"; \
+    fi; \
     echo "${NB_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Grant the notebook user write access to its runtime home.
-RUN chown -R ${NB_USER}:100 ${NB_HOME} && \
+RUN chown -R ${NB_UID}:${NB_GID} ${NB_HOME} && \
     chmod g+w /etc/passwd
+
+# EarthScope GeoLab's distributed Dask path uses Dask Gateway.  These packages
+# must be present in the image so Gateway-created scheduler and worker pods can
+# import the same runtime packages as the notebook pod.  Require at least the
+# observed GeoLab Gateway-compatible Dask/Distributed versions without pinning
+# them down, so newer base images are not downgraded.
+RUN pip3 install \
+        'dask>=2026.3.0' \
+        'distributed>=2026.3.0' \
+        dask-gateway==2026.3.0 \
+    && docker-clean
+
+WORKDIR ${NB_HOME}
 
 FROM dev-package AS dev
 

--- a/docs/source/getting_started/deploy_mspass_on_geolab.rst
+++ b/docs/source/getting_started/deploy_mspass_on_geolab.rst
@@ -1,0 +1,101 @@
+.. _deploy_mspass_on_geolab:
+
+Using MsPASS With EarthScope GeoLab
+===================================
+
+EarthScope GeoLab provides distributed Dask through Dask Gateway.  The Gateway
+cluster is created from the running Jupyter image, so the MsPASS GeoLab image
+includes the Dask, Distributed, Dask Gateway, and MsPASS runtime packages needed
+by notebook, scheduler, and worker pods.  Installing ``dask-gateway`` manually
+inside a running notebook pod is not sufficient because Gateway-created
+scheduler and worker pods are started from the image, not from the notebook
+pod's mutated runtime filesystem.
+
+A Gateway cluster starts with no workers until it is scaled or configured for
+adaptive scaling.  A typical MsPASS setup is:
+
+.. code-block:: python
+
+    from dask_gateway import Gateway
+    from mspasspy.client import Client
+
+    gateway = Gateway()
+    cluster = gateway.new_cluster()
+    cluster.scale(2)
+
+    dask_client = cluster.get_client()
+    dask_client.wait_for_workers(2, timeout="120s")
+
+    mspass_client = Client(scheduler="dask", dask_client=dask_client)
+
+Keep the ``cluster`` object alive while using ``mspass_client``.  MsPASS uses
+the provided Dask client but does not own or shut down the Gateway cluster.
+
+Rebuilt image smoke checks
+--------------------------
+
+In a fresh GeoLab server using the MsPASS GeoLab image, first verify Gateway can
+create a cluster:
+
+.. code-block:: python
+
+    from dask_gateway import Gateway
+
+    gateway = Gateway()
+    cluster = gateway.new_cluster()
+    cluster.scale(1)
+
+    dask_client = cluster.get_client()
+    dask_client.wait_for_workers(1, timeout="120s")
+    print(dask_client.scheduler_info())
+
+Then verify that the Gateway worker pod was created from an image containing
+the MsPASS and Gateway runtime packages:
+
+.. code-block:: python
+
+    def check_worker():
+        import os
+        import socket
+        import sys
+
+        import dask
+        import dask_gateway
+        import distributed
+        import mspasspy
+
+        return {
+            "host": socket.gethostname(),
+            "python": sys.executable,
+            "home": os.environ.get("HOME"),
+            "cwd": os.getcwd(),
+            "dask": dask.__version__,
+            "distributed": distributed.__version__,
+            "dask_gateway": dask_gateway.__version__,
+            "mspasspy": mspasspy.__file__,
+        }
+
+    print(dask_client.submit(check_worker).result())
+
+If ``gateway.new_cluster()`` still fails after rebuilding the image with these
+packages, the next diagnostic is the EarthScope/2i2c Dask Gateway server-side
+logs for the failed cluster name.
+
+GeoLab local Dask fallback
+--------------------------
+
+The GeoLab image defaults to ``MSPASS_SCHEDULER=none`` so that
+``Client()`` does not silently create an in-pod Dask ``LocalCluster``.  This is
+separate from Dask Gateway, which is the normal distributed Dask path on
+GeoLab.
+
+For fallback or debugging only, local in-pod Dask can be enabled before the
+JupyterHub single-user server starts:
+
+.. code-block:: bash
+
+    MSPASS_ENABLE_LOCAL_DASK=true
+
+When this flag is set in the GeoLab/JupyterHub command path, the startup script
+starts the local Dask scheduler and worker and exports ``MSPASS_SCHEDULER=dask``
+for notebook kernels.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,7 @@ package.
    getting_started/deploy_mspass_on_HPC
    getting_started/HPCClusterLauncher_configuration
    getting_started/deploy_mspass_with_conda_and_coiled
+   getting_started/deploy_mspass_on_geolab
    getting_started/getting_started_overview
 
 .. toctree::

--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -59,6 +59,11 @@ class Client:
 
     For the address and port of each client/instances, we first check the user specified parameters, if not then
     serach the environment varibales values, if not againm then use the default settings.
+
+    An existing :class:`dask.distributed.Client` can be supplied with ``dask_client``.
+    This is useful for externally managed Dask clusters, including Dask Gateway
+    clusters.  The caller owns the external cluster and should keep it alive while
+    the MsPASS client is using it.
     """
 
     def __init__(
@@ -66,6 +71,7 @@ class Client:
         database_host=None,
         scheduler=None,
         scheduler_host=None,
+        dask_client=None,
         job_name="mspass",
         database_name="mspass",
         schema=None,
@@ -79,9 +85,9 @@ class Client:
                 + " is found.",
                 "Fatal",
             )
-        if scheduler is not None and scheduler != "dask" and scheduler != "spark":
+        if scheduler is not None and scheduler not in ("dask", "spark", "none"):
             raise MsPASSError(
-                "scheduler should be either dask or spark but "
+                "scheduler should be dask, spark, or none but "
                 + str(scheduler)
                 + " is found.",
                 "Fatal",
@@ -113,6 +119,26 @@ class Client:
                 + " is found.",
                 "Fatal",
             )
+        if dask_client is not None:
+            if scheduler == "none":
+                raise MsPASSError(
+                    "dask_client cannot be used when scheduler is none.",
+                    "Fatal",
+                )
+            if scheduler == "spark":
+                raise MsPASSError(
+                    "dask_client can only be used with the dask scheduler.",
+                    "Fatal",
+                )
+            if not _mspasspy_has_dask_distributed or not isinstance(
+                dask_client, DaskClient
+            ):
+                raise MsPASSError(
+                    "dask_client should be a dask.distributed.Client but "
+                    + str(type(dask_client))
+                    + " is found.",
+                    "Fatal",
+                )
 
         # check env variables
         MSPASS_DB_ADDRESS = os.environ.get("MSPASS_DB_ADDRESS")
@@ -166,10 +192,19 @@ class Client:
         )
 
         # set scheduler
-        if scheduler:
-            self._scheduler = scheduler
+        if dask_client is not None:
+            self._scheduler = "dask"
+        elif scheduler:
+            self._scheduler = None if scheduler == "none" else scheduler
         elif MSPASS_SCHEDULER:
-            self._scheduler = MSPASS_SCHEDULER
+            if MSPASS_SCHEDULER not in ("dask", "spark", "none"):
+                raise MsPASSError(
+                    "MSPASS_SCHEDULER should be dask, spark, or none but "
+                    + str(MSPASS_SCHEDULER)
+                    + " is found.",
+                    "Fatal",
+                )
+            self._scheduler = None if MSPASS_SCHEDULER == "none" else MSPASS_SCHEDULER
         else:
             if _mspasspy_has_dask_distributed:
                 self._scheduler = "dask"
@@ -226,7 +261,9 @@ class Client:
 
         elif self._scheduler == "dask":
             # if no defind scheduler_host and no MSPASS_SCHEDULER_ADDRESS, use local cluster to create a client
-            if not scheduler_host and not MSPASS_SCHEDULER_ADDRESS:
+            if dask_client is not None:
+                self._dask_client = dask_client
+            elif not scheduler_host and not MSPASS_SCHEDULER_ADDRESS:
                 self._dask_client = DaskClient()
             else:
                 if scheduler_host:

--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -71,11 +71,11 @@ class Client:
         database_host=None,
         scheduler=None,
         scheduler_host=None,
-        dask_client=None,
         job_name="mspass",
         database_name="mspass",
         schema=None,
         collection=None,
+        dask_client=None,
     ):
         # job_name should be a string
         if database_host is not None and not type(database_host) is str:
@@ -192,10 +192,15 @@ class Client:
         )
 
         # set scheduler
+        self._scheduler_disabled = False
         if dask_client is not None:
             self._scheduler = "dask"
         elif scheduler:
-            self._scheduler = None if scheduler == "none" else scheduler
+            if scheduler == "none":
+                self._scheduler = None
+                self._scheduler_disabled = True
+            else:
+                self._scheduler = scheduler
         elif MSPASS_SCHEDULER:
             if MSPASS_SCHEDULER not in ("dask", "spark", "none"):
                 raise MsPASSError(
@@ -204,7 +209,11 @@ class Client:
                     + " is found.",
                     "Fatal",
                 )
-            self._scheduler = None if MSPASS_SCHEDULER == "none" else MSPASS_SCHEDULER
+            if MSPASS_SCHEDULER == "none":
+                self._scheduler = None
+                self._scheduler_disabled = True
+            else:
+                self._scheduler = MSPASS_SCHEDULER
         else:
             if _mspasspy_has_dask_distributed:
                 self._scheduler = "dask"
@@ -283,7 +292,7 @@ class Client:
                         + self._dask_client_address,
                         "Fatal",
                     )
-        else:
+        elif not self._scheduler_disabled:
             print("There is no spark or dask installed, this client has no scheduler")
 
         # Auto-register MongoDB worker plugin for dask to avoid DB serialization leaks
@@ -329,6 +338,8 @@ class Client:
             return self._spark_context
         elif self._scheduler == "dask":
             return self._dask_client
+        elif self._scheduler_disabled:
+            return None
         else:
             print(
                 "There is no spark or dask installed, this client has no scheduler, returned None"

--- a/python/tests/test_mspass_client_no_dask_spark.py
+++ b/python/tests/test_mspass_client_no_dask_spark.py
@@ -48,7 +48,7 @@ with mock.patch.dict(
 
             with pytest.raises(
                 MsPASSError,
-                match="scheduler should be either dask or spark but xxx is found.",
+                match="scheduler should be dask, spark, or none but xxx is found.",
             ):
                 Client(scheduler="xxx")
 

--- a/python/tests/test_mspass_client_spark_dask.py
+++ b/python/tests/test_mspass_client_spark_dask.py
@@ -135,7 +135,7 @@ def test_set_scheduler_dask_empty_port_uses_default(monkeypatch):
     assert client._scheduler == "spark"
 
 
-def test_scheduler_none_constructor_does_not_create_scheduler(monkeypatch):
+def test_scheduler_none_constructor_does_not_create_scheduler(monkeypatch, capsys):
     _patch_client_startup_for_scheduler_address(monkeypatch)
     monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
     client = Client(scheduler="none")
@@ -143,14 +143,34 @@ def test_scheduler_none_constructor_does_not_create_scheduler(monkeypatch):
     assert client.get_scheduler() is None
     assert not hasattr(client, "_dask_client")
     assert not hasattr(client, "_spark_context")
+    assert capsys.readouterr().out == ""
 
 
-def test_scheduler_none_from_environment_does_not_create_scheduler(monkeypatch):
+def test_scheduler_none_from_environment_does_not_create_scheduler(monkeypatch, capsys):
     _patch_client_startup_for_scheduler_address(monkeypatch)
     monkeypatch.setenv("MSPASS_SCHEDULER", "none")
     monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
     client = Client()
     assert client._scheduler is None
+    assert client.get_scheduler() is None
+    assert not hasattr(client, "_dask_client")
+    assert capsys.readouterr().out == ""
+
+
+def test_fourth_positional_argument_still_sets_job_name(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(DBClient, "server_info", lambda self: {})
+
+    def mock_global_history_manager(self, history_db, job_name, collection=None):
+        captured["job_name"] = job_name
+
+    monkeypatch.setattr(GlobalHistoryManager, "__init__", mock_global_history_manager)
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+
+    client = Client("127.0.0.1", "none", None, "my_job")
+
+    assert captured["job_name"] == "my_job"
     assert client.get_scheduler() is None
     assert not hasattr(client, "_dask_client")
 

--- a/python/tests/test_mspass_client_spark_dask.py
+++ b/python/tests/test_mspass_client_spark_dask.py
@@ -354,9 +354,7 @@ class TestMsPASSClient:
             MsPASSError,
             match=_dask_client_error_match("tcp://127.0.0.1:41585"),
         ):
-            client = Client(
-                scheduler="dask", scheduler_host="tcp://127.0.0.1:41585"
-            )
+            client = Client(scheduler="dask", scheduler_host="tcp://127.0.0.1:41585")
         monkeypatch.undo()
 
         monkeypatch.setenv("MSPASS_SCHEDULER", "dask")

--- a/python/tests/test_mspass_client_spark_dask.py
+++ b/python/tests/test_mspass_client_spark_dask.py
@@ -49,6 +49,10 @@ def _dask_client_error_match(address):
     return re.escape("cannot create a dask client with: " + address)
 
 
+def _new_uninitialized_dask_client():
+    return DaskClient.__new__(DaskClient)
+
+
 def test_dask_scheduler_full_uri_constructor_address(monkeypatch):
     _patch_client_startup_for_scheduler_address(monkeypatch)
     monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
@@ -131,6 +135,93 @@ def test_set_scheduler_dask_empty_port_uses_default(monkeypatch):
     assert client._scheduler == "spark"
 
 
+def test_scheduler_none_constructor_does_not_create_scheduler(monkeypatch):
+    _patch_client_startup_for_scheduler_address(monkeypatch)
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    client = Client(scheduler="none")
+    assert client._scheduler is None
+    assert client.get_scheduler() is None
+    assert not hasattr(client, "_dask_client")
+    assert not hasattr(client, "_spark_context")
+
+
+def test_scheduler_none_from_environment_does_not_create_scheduler(monkeypatch):
+    _patch_client_startup_for_scheduler_address(monkeypatch)
+    monkeypatch.setenv("MSPASS_SCHEDULER", "none")
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    client = Client()
+    assert client._scheduler is None
+    assert client.get_scheduler() is None
+    assert not hasattr(client, "_dask_client")
+
+
+def test_dask_scheduler_uses_provided_dask_client(monkeypatch):
+    _patch_client_startup_for_scheduler_address(monkeypatch)
+    provided_client = _new_uninitialized_dask_client()
+    registered_plugins = []
+
+    def mock_register_plugin(self, plugin, name=None):
+        registered_plugins.append((self, plugin, name))
+
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    monkeypatch.setattr(DaskClient, "register_plugin", mock_register_plugin)
+
+    client = Client(scheduler="dask", dask_client=provided_client)
+
+    assert client.get_scheduler() is provided_client
+    assert registered_plugins
+    assert registered_plugins[0][0] is provided_client
+    assert registered_plugins[0][2] == "mongodb_worker"
+
+
+def test_dask_client_takes_precedence_over_scheduler_host(monkeypatch):
+    _patch_client_startup_for_scheduler_address(monkeypatch)
+    provided_client = _new_uninitialized_dask_client()
+    registered_plugins = []
+
+    monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+    monkeypatch.setattr(
+        DaskClient,
+        "register_plugin",
+        lambda self, plugin, name=None: registered_plugins.append(name),
+    )
+
+    client = Client(
+        scheduler="dask",
+        scheduler_host="tcp://127.0.0.1:41585",
+        dask_client=provided_client,
+    )
+
+    assert client.get_scheduler() is provided_client
+    assert registered_plugins == ["mongodb_worker"]
+
+
+def test_dask_client_with_scheduler_none_raises(monkeypatch):
+    provided_client = _new_uninitialized_dask_client()
+    with pytest.raises(
+        MsPASSError,
+        match="dask_client cannot be used when scheduler is none.",
+    ):
+        Client(scheduler="none", dask_client=provided_client)
+
+
+def test_dask_client_with_scheduler_spark_raises(monkeypatch):
+    provided_client = _new_uninitialized_dask_client()
+    with pytest.raises(
+        MsPASSError,
+        match="dask_client can only be used with the dask scheduler.",
+    ):
+        Client(scheduler="spark", dask_client=provided_client)
+
+
+def test_dask_client_requires_distributed_client(monkeypatch):
+    with pytest.raises(
+        MsPASSError,
+        match="dask_client should be a dask.distributed.Client",
+    ):
+        Client(scheduler="dask", dask_client=object())
+
+
 class TestMsPASSClient:
     @staticmethod
     def _close_dask_scheduler(client):
@@ -153,7 +244,7 @@ class TestMsPASSClient:
 
         with pytest.raises(
             MsPASSError,
-            match="scheduler should be either dask or spark but xxx is found.",
+            match="scheduler should be dask, spark, or none but xxx is found.",
         ):
             Client(scheduler="xxx")
 

--- a/scripts/start-mspass.sh
+++ b/scripts/start-mspass.sh
@@ -180,7 +180,7 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
 
       function run_frontend_as_nb_user {
           NB_USER=${NB_USER:-mspass}
-          chown -R ${NB_UID:-${NB_USER}}:${NB_GID:-${NB_UID:-100}} "${MSPASS_WORKDIR}" 2>/dev/null || true
+          chown -R ${NB_UID:-${NB_USER}}:${NB_GID:-100} "${MSPASS_WORKDIR}" 2>/dev/null || true
           local quoted_command
           quoted_command=$(quote_command "$@")
           su --preserve-environment -c "export PATH=${CONDA_DIR:-/opt/conda}/bin:\$PATH; ${quoted_command}" "${NB_USER}"
@@ -230,6 +230,26 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
                   --conf "spark.master=spark://${MSPASS_SCHEDULER_ADDRESS}:${SPARK_MASTER_PORT}" \
                   --packages org.mongodb.spark:mongo-spark-connector_2.12:3.0.0 \
                   "$script_file"
+          fi
+      elif [ "$MSPASS_SCHEDULER" = "none" ]; then
+          if [ -z "$1" ]; then
+              # No local scheduler is configured.  This is the GeoLab Dask
+              # Gateway path; notebooks can attach an external Dask client.
+              if [[ "$RUN_JUPYTER_AS_NB_USER" = "true" ]]; then
+                  run_frontend_as_nb_user jupyter lab "${NOTEBOOK_ARGS[@]}"
+              else
+                  jupyter lab "${NOTEBOOK_ARGS[@]}"
+              fi
+          else
+              input_file="$1"
+              if [[ "$input_file" == *.ipynb ]]; then
+                  echo "Converting notebook to Python script: $input_file"
+                  jupyter nbconvert --to script "$input_file"
+                  script_file="${input_file%.*}.py"
+              else
+                  script_file="$input_file"
+              fi
+              python "$script_file"
           fi
       else
           # Dask scheduler configuration
@@ -389,6 +409,9 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
   if [ "$MSPASS_SCHEDULER" = "spark" ]; then
     MSPASS_SCHEDULER_CMD='$SPARK_HOME/sbin/start-master.sh'
     MSPASS_WORKER_CMD='$SPARK_HOME/sbin/start-slave.sh spark://$MSPASS_SCHEDULER_ADDRESS:$SPARK_MASTER_PORT'
+  elif [ "$MSPASS_SCHEDULER" = "none" ]; then
+    MSPASS_SCHEDULER_CMD=':'
+    MSPASS_WORKER_CMD=':'
   else # if [ "$MSPASS_SCHEDULER" = "dask" ]
     MSPASS_SCHEDULER_CMD='dask scheduler --port $DASK_SCHEDULER_PORT > ${MSPASS_LOG_DIR}/dask-scheduler_log_${MY_ID} 2>&1 & sleep 5'
     MSPASS_WORKER_CMD='dask worker ${MSPASS_WORKER_ARG} --memory-limit=${MSPASS_DASK_WORKER_MEMORY_LIMIT:-0} --local-directory $MSPASS_WORKER_DIR "$(build_dask_scheduler_uri "$MSPASS_SCHEDULER_ADDRESS" "$DASK_SCHEDULER_PORT")" > ${MSPASS_LOG_DIR}/dask-worker_log_${MY_ID} 2>&1 &'

--- a/scripts/start-mspass.sh
+++ b/scripts/start-mspass.sh
@@ -138,6 +138,7 @@ fi
 if [[ -z ${MSPASS_WORKER_DIR} ]]; then
   MSPASS_WORKER_DIR=${MSPASS_WORKDIR}/work
 fi
+export MSPASS_WORKDIR MSPASS_DB_DIR MSPASS_LOG_DIR MSPASS_WORKER_DIR
 # Note that only log is required for all roles. Other dirs will be created later when needed.
 [[ -d $MSPASS_LOG_DIR ]] || mkdir -p $MSPASS_LOG_DIR
 
@@ -179,7 +180,7 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
 
       function run_frontend_as_nb_user {
           NB_USER=${NB_USER:-mspass}
-          chown -R ${NB_USER}:100 "${MSPASS_WORKDIR}" 2>/dev/null || true
+          chown -R ${NB_UID:-${NB_USER}}:${NB_GID:-${NB_UID:-100}} "${MSPASS_WORKDIR}" 2>/dev/null || true
           local quoted_command
           quoted_command=$(quote_command "$@")
           su --preserve-environment -c "export PATH=${CONDA_DIR:-/opt/conda}/bin:\$PATH; ${quoted_command}" "${NB_USER}"
@@ -349,11 +350,34 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
     mongod --port $MONGODB_PORT --dbpath /tmp/db/data --logpath /tmp/logs/mongo_log --bind_ip_all &
   }
 
+  function env_flag_true {
+    case "$1" in
+      true|TRUE|True|1|yes|YES|Yes) return 0 ;;
+      *) return 1 ;;
+    esac
+  }
+
+  function local_scheduler_enabled_for_command {
+    if [ "${MSPASS_SCHEDULER:-}" = "none" ]; then
+      if is_jupyterhub_singleuser_command "$@" && env_flag_true "${MSPASS_ENABLE_LOCAL_DASK:-false}"; then
+        # GeoLab's distributed Dask path is Dask Gateway.  This opt-in flag keeps
+        # the local in-pod Dask fallback available without making it the default.
+        export MSPASS_SCHEDULER=dask
+      else
+        return 1
+      fi
+    fi
+
+    return 0
+  }
+
   function start_local_mspass_services {
     export MSPASS_DB_ADDRESS=$HOSTNAME
-    export MSPASS_SCHEDULER_ADDRESS=$HOSTNAME
-    eval $MSPASS_SCHEDULER_CMD
-    eval $MSPASS_WORKER_CMD
+    if local_scheduler_enabled_for_command "$@"; then
+      export MSPASS_SCHEDULER_ADDRESS=$HOSTNAME
+      eval $MSPASS_SCHEDULER_CMD
+      eval $MSPASS_WORKER_CMD
+    fi
     if [ "$MSPASS_DB_PATH" = "tmp" ]; then
       start_db_tmp
     else
@@ -545,8 +569,12 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
   else # if [ "$MSPASS_ROLE" = "all" ]
     FRONTEND_CLEANUP_MODE=single
     enable_frontend_cleanup_trap
-    start_local_mspass_services
+    start_local_mspass_services "$@"
     if is_jupyterhub_singleuser_command "$@"; then
+      cd "$MSPASS_WORKDIR" || {
+        echo "Cannot change to MSPASS_WORKDIR: $MSPASS_WORKDIR" >&2
+        exit 1
+      }
       docker-entrypoint.sh "$@"
       frontend_status=$?
     else


### PR DESCRIPTION
## Summary

- update the GeoLab image defaults to use `/home/jovyan`, disable implicit scheduler creation with `MSPASS_SCHEDULER=none`, and install Dask Gateway support without pinning Dask/Distributed down to an exact version
- keep local in-pod Dask available as an explicit `MSPASS_ENABLE_LOCAL_DASK=true` fallback while preserving existing non-GeoLab local Dask behavior
- add `Client(scheduler="none")`, `MSPASS_SCHEDULER=none`, and generic `Client(..., dask_client=<distributed.Client>)` support for externally managed Dask clients such as Dask Gateway
- document the generic GeoLab Gateway usage pattern and manual validation checks

## Validation

- `conda run -n mspass pytest python/tests/test_mspass_client_spark_dask.py::test_scheduler_none_constructor_does_not_create_scheduler python/tests/test_mspass_client_spark_dask.py::test_scheduler_none_from_environment_does_not_create_scheduler python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_uses_provided_dask_client python/tests/test_mspass_client_spark_dask.py::test_dask_client_takes_precedence_over_scheduler_host python/tests/test_mspass_client_spark_dask.py::test_dask_client_with_scheduler_none_raises python/tests/test_mspass_client_spark_dask.py::test_dask_client_with_scheduler_spark_raises python/tests/test_mspass_client_spark_dask.py::test_dask_client_requires_distributed_client python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_full_uri_constructor_address python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_full_uri_env_address python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_bare_host_uses_env_port python/tests/test_mspass_client_spark_dask.py::test_dask_scheduler_bare_host_uses_default_port python/tests/test_mspass_client_spark_dask.py::test_set_scheduler_dask_uses_full_uri_address python/tests/test_mspass_client_spark_dask.py::test_set_scheduler_dask_coerces_non_string_port python/tests/test_mspass_client_spark_dask.py::test_set_scheduler_dask_empty_port_uses_default`
- `python -m py_compile python/mspasspy/client.py python/tests/test_mspass_client_spark_dask.py`
- `bash -n scripts/start-mspass.sh`
- `git diff --check`
- `docker buildx build --check --target geolab .`

## Notes

A full run of `python/tests/test_mspass_client_spark_dask.py` was attempted. The new focused tests passed, but the older class-level tests failed during setup because this sandbox cannot connect to MongoDB at `127.0.0.1:27017`, and `mongod` is not available on PATH here. Fresh GeoLab image validation is still required for the live Dask Gateway cluster path.