### PR TITLE
Apply #763 formatting and align container Python with GeoLab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@
 
 ARG MSPASS_BASE_IMAGE=ghcr.io/seisscoped/container-base:ubuntu22.04_jupyterlab
 ARG GEOLAB_BASE_IMAGE=ghcr.io/mspass-team/geolab-base-mirror@sha256:7aa0b713de225288188163c13519efce1ac5248ea386e734d88ad7c54b0abe27
+ARG PYTHON_VERSION=3.12
 ARG DASK_LABEXTENSION_VERSION=7.0.0
 ARG SPARK_VERSION=3.0.0
 ARG SPARK_PACKAGE=spark-${SPARK_VERSION}-bin-hadoop2.7
@@ -42,7 +43,20 @@ RUN --mount=type=bind,from=spark-build-assets,source=/,target=/mnt/build-assets,
 
 FROM ${MSPASS_BASE_IMAGE} AS mspass-base
 
+ARG PYTHON_VERSION
+
 LABEL maintainer="Ian Wang <yinzhi.wang.cug@gmail.com>"
+
+# The SCOPED base currently pins Python 3.10.  GeoLab's notebook environment
+# uses Python 3.12, so move every target derived from mspass-base (runtime, dev,
+# mpi, and tacc) to the same Python ABI before compiling MsPASS.
+RUN set -eux; \
+	sed -i '/^python[[:space:]]/d' /opt/conda/conda-meta/pinned; \
+	mamba install --yes "python=${PYTHON_VERSION}"; \
+	mamba clean --all --force-pkgs-dirs --yes; \
+	python -c "import sys; expected='${PYTHON_VERSION}'; actual=f'{sys.version_info.major}.{sys.version_info.minor}'; assert actual == expected, (actual, expected)"; \
+	mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> /opt/conda/conda-meta/pinned; \
+	docker-clean
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
@@ -316,6 +330,8 @@ FROM ${GEOLAB_BASE_IMAGE} AS geolab
 # Gateway server.
 USER root
 
+ARG PYTHON_VERSION
+
 # Keep the base GeoLab uid/gid/user identity so mounted /home/jovyan workspaces
 # and Dask Gateway scheduler/worker pods match the official GeoLab runtime.
 ARG NB_USER=jovyan
@@ -387,6 +403,7 @@ ADD python /mspass/python
 ADD .git /mspass/.git
 
 RUN set -eux; \
+    /srv/conda/envs/notebook/bin/python -c "import sys; expected='${PYTHON_VERSION}'; actual=f'{sys.version_info.major}.{sys.version_info.minor}'; assert actual == expected, (actual, expected)"; \
     printf '%s\n' \
         'dask==2026.3.0' \
         'distributed==2026.3.0' \

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -44,7 +44,6 @@ from mspasspy.algorithms._decon_input_validation import (
     validate_gid_rf_lag_domain,
 )
 
-
 # These presets describe the output wavelet and time scales used by the
 # downstream imaging objective.  The selected no-argument reference targets
 # robust, low-frequency plane-wave/Kirchhoff MTZ imaging; it is not a universal
@@ -64,7 +63,9 @@ def _resolve_scalar_preset(preset):
         return RFDECON_PRESET_FILES[preset]
     except KeyError as err:
         choices = ", ".join(sorted(RFDECON_PRESET_FILES))
-        raise ValueError(f"unknown RF preset {preset!r}; choices are {choices}") from err
+        raise ValueError(
+            f"unknown RF preset {preset!r}; choices are {choices}"
+        ) from err
 
 
 def _packaged_rf_preset_path(pf_name):
@@ -131,9 +132,7 @@ def _checked_time_origin(value, caller, parameter="wavelet_t0"):
     try:
         result = float(value)
     except (TypeError, ValueError, OverflowError) as err:
-        raise TypeError(
-            f"{caller}: {parameter} must be a finite real number"
-        ) from err
+        raise TypeError(f"{caller}: {parameter} must be a finite real number") from err
     if not np.isfinite(result):
         raise ValueError(f"{caller}: {parameter} must be finite")
     return result
@@ -182,9 +181,7 @@ def _as_gid_timeseries(x, dt, t0, argname, tref=None):
         )
     if not np.isfinite(values).all():
         raise ValueError(
-            "RFdecon: for GID algorithms, {} contains nonfinite samples".format(
-                argname
-            )
+            "RFdecon: for GID algorithms, {} contains nonfinite samples".format(argname)
         )
     ts = TimeSeries(len(values))
     ts.set_t0(t0)

--- a/python/mspasspy/algorithms/_decon_input_validation.py
+++ b/python/mspasspy/algorithms/_decon_input_validation.py
@@ -38,9 +38,7 @@ def validate_external_wavelet_timeseries(
             f"{caller}: external wavelet is marked dead", ErrorSeverity.Invalid
         )
     if wavelet.npts <= 0:
-        raise MsPASSError(
-            f"{caller}: external wavelet is empty", ErrorSeverity.Invalid
-        )
+        raise MsPASSError(f"{caller}: external wavelet is empty", ErrorSeverity.Invalid)
     if not np.isfinite(wavelet.dt) or wavelet.dt <= 0.0:
         raise MsPASSError(
             f"{caller}: external TimeSeries dt must be finite and positive",
@@ -70,13 +68,10 @@ def validate_external_wavelet_timeseries(
             )
         if dt_policy == "gid":
             matches = abs(float(wavelet.dt) - float(expected_dt)) <= (
-                1.0e-6
-                * max(1.0, abs(float(wavelet.dt)), abs(float(expected_dt)))
+                1.0e-6 * max(1.0, abs(float(wavelet.dt)), abs(float(expected_dt)))
             )
         elif dt_policy == "scalar":
-            matches = np.isclose(
-                wavelet.dt, expected_dt, rtol=1.0e-7, atol=1.0e-10
-            )
+            matches = np.isclose(wavelet.dt, expected_dt, rtol=1.0e-7, atol=1.0e-10)
         else:
             raise ValueError(f"{caller}: unknown dt tolerance policy={dt_policy}")
         if not matches:
@@ -88,9 +83,7 @@ def validate_external_wavelet_timeseries(
     return wavelet
 
 
-def validate_external_wavelet_analysis_context(
-    wavelet, datum, analysis_t0, caller
-):
+def validate_external_wavelet_analysis_context(wavelet, datum, analysis_t0, caller):
     """Validate datum-dependent GID compatibility without changing an engine.
 
     Overlap is intentionally not required.  The C++ common-grid builder
@@ -108,9 +101,7 @@ def validate_external_wavelet_analysis_context(
             f"{caller}: input datum dt must be finite and positive",
             ErrorSeverity.Invalid,
         )
-    gid_dt_tolerance = 1.0e-6 * max(
-        1.0, abs(float(wavelet.dt)), abs(float(datum.dt))
-    )
+    gid_dt_tolerance = 1.0e-6 * max(1.0, abs(float(wavelet.dt)), abs(float(datum.dt)))
     if abs(float(wavelet.dt) - float(datum.dt)) > gid_dt_tolerance:
         raise MsPASSError(
             f"{caller}: external wavelet dt does not match the input datum",
@@ -141,9 +132,7 @@ def validate_external_wavelet_analysis_context(
 
     checked_grid_coordinate(wavelet.t0, "wavelet start")
     checked_grid_coordinate(wavelet.endtime(), "wavelet endpoint")
-    datum_grid_offset = (
-        float(analysis_t0) - float(datum.t0)
-    ) / float(datum.dt)
+    datum_grid_offset = (float(analysis_t0) - float(datum.t0)) / float(datum.dt)
     if not np.isfinite(datum_grid_offset) or not np.isclose(
         datum_grid_offset,
         round(datum_grid_offset),

--- a/python/tests/algorithms/test_CNRDeconEngine.py
+++ b/python/tests/algorithms/test_CNRDeconEngine.py
@@ -756,9 +756,7 @@ def test_CNRDeconEngine_configured_dead_input_preserves_legacy_state(dead_kind):
     assert result.npts == 0
     assert result.elog.size() >= 1
     assert dict(engine.QCMetrics()) == qc_before
-    assert np.array_equal(
-        engine.output_shaping_wavelet().data, shaping_before.data
-    )
+    assert np.array_equal(engine.output_shaping_wavelet().data, shaping_before.data)
     assert np.array_equal(engine.actual_output(source).data, actual_before.data)
     inverse_after = engine.inverse_wavelet(source, 0.0)
     assert np.array_equal(inverse_after.data, inverse_before.data)
@@ -847,9 +845,7 @@ def test_CNRDeconEngine_rejects_invalid_wavelet_without_corrupting_inverse(
 @pytest.mark.parametrize(
     "algorithm", ["colored_noise_damping", "generalized_water_level"]
 )
-def test_CNRDeconEngine_rejects_zero_wavelet_without_state_change(
-    tmp_path, algorithm
-):
+def test_CNRDeconEngine_rejects_zero_wavelet_without_state_change(tmp_path, algorithm):
     """A zero source cannot install or replace an inverse operator."""
     with open("data/pf/CNRDeconEngine.pf", encoding="utf-8") as fp:
         text = fp.read()
@@ -1196,9 +1192,7 @@ def test_CNRDeconEngine_process_rejects_invalid_geometry_transactionally(
             engine.process_configured(invalid, noise_spectrum)
 
     assert dict(engine.QCMetrics()) == qc_before
-    assert np.array_equal(
-        engine.output_shaping_wavelet().data, shaping_before.data
-    )
+    assert np.array_equal(engine.output_shaping_wavelet().data, shaping_before.data)
     actual_after = engine.actual_output(source)
     inverse_after = engine.inverse_wavelet(source, 0.0)
     assert np.array_equal(actual_after.data, actual_before.data)
@@ -1349,9 +1343,7 @@ def test_CNRDeconEngine_rejects_overflowing_frequency_grid_transactionally():
     recovered = engine.process(datum, valid_spectrum, 0.02, 2.0)
     assert np.array_equal(recovered.data, baseline.data)
     assert np.array_equal(engine.actual_output(source).data, actual_before.data)
-    assert np.array_equal(
-        engine.output_shaping_wavelet().data, shaping_before.data
-    )
+    assert np.array_equal(engine.output_shaping_wavelet().data, shaping_before.data)
     assert dict(engine.QCMetrics()) == qc_before
 
 
@@ -1479,9 +1471,7 @@ def test_CNRRFDecon_generalized_water_level_accepts_short_wavelet(
 @pytest.mark.parametrize(
     "algorithm", ["colored_noise_damping", "generalized_water_level"]
 )
-def test_CNRDeconEngine_exact_nfft_wavelet_uses_all_samples(
-    tmp_path, algorithm
-):
+def test_CNRDeconEngine_exact_nfft_wavelet_uses_all_samples(tmp_path, algorithm):
     """Exact-buffer inverse construction must not scalar-fill from sample 0."""
     with open("data/pf/CNRDeconEngine.pf", encoding="utf-8") as fp:
         text = fp.read()
@@ -1815,9 +1805,7 @@ def test_CNRDeconEngine_timeseries_noise_uses_cnr_dt_tolerance(
 
 @pytest.mark.parametrize("three_component", [False, True])
 @pytest.mark.parametrize("npts", range(4))
-def test_CNRDeconEngine_short_noise_spectrum_input_is_safe(
-    three_component, npts
-):
+def test_CNRDeconEngine_short_noise_spectrum_input_is_safe(three_component, npts):
     """Noise shorter than the taper count is rejected before DPSS setup."""
     d0 = make_test_data(noise_level=0.1)
     scalar_noise = WindowData(ExtractComponent(d0, 2), -45.0, -5.0)

--- a/python/tests/algorithms/test_RFdeconProcessor.py
+++ b/python/tests/algorithms/test_RFdeconProcessor.py
@@ -152,7 +152,11 @@ def test_gid_accepted_spike_lag_and_component_trace_on_known_synthetic(alg):
     retain a parallel accepted-spike trace with the same physical lag axis."""
     with _test_pfpath():
         qc = dict(_run_public_gid_engine(alg))
-    lags = [float(value) for value in qc["gid_accepted_spike_lag_seconds"].split(",") if value]
+    lags = [
+        float(value)
+        for value in qc["gid_accepted_spike_lag_seconds"].split(",")
+        if value
+    ]
     components = [
         {int(value) for value in token.split("+") if value}
         for token in qc["gid_accepted_spike_components"].split(",")
@@ -160,7 +164,9 @@ def test_gid_accepted_spike_lag_and_component_trace_on_known_synthetic(alg):
     ]
     assert lags
     assert len(lags) == len(components)
-    assert all(component_set <= {0, 1, 2} and component_set for component_set in components)
+    assert all(
+        component_set <= {0, 1, 2} and component_set for component_set in components
+    )
     assert any(
         abs(lag) <= 2 * 0.05 and component_set & {0, 1} and 2 in component_set
         for lag, component_set in zip(lags, components)
@@ -524,7 +530,9 @@ def test_RFdeconProcessor_scalar_timeseries_wavelet_preserves_independent_origin
     processor.loadwavelet(wavelet, dtype="TimeSeries")
     expected_offset = int(round((-5.0 - processor.dwin.start) / 0.05))
     assert len(processor.wvector) == 2601
-    assert np.allclose(processor.wvector[expected_offset : expected_offset + 3], [1, 2, 3])
+    assert np.allclose(
+        processor.wvector[expected_offset : expected_offset + 3], [1, 2, 3]
+    )
     assert np.count_nonzero(processor.wvector) == 3
 
 
@@ -577,9 +585,7 @@ def test_RFdeconProcessor_scalar_vector_wavelet_t0_matches_timeseries():
             np.asarray(wavelet.data), dtype="raw_vector", wavelet_t0=np.nan
         )
     with pytest.raises(ValueError, match="only valid for raw_vector"):
-        vector_aware.loadwavelet(
-            wavelet, dtype="TimeSeries", wavelet_t0=wavelet.t0
-        )
+        vector_aware.loadwavelet(wavelet, dtype="TimeSeries", wavelet_t0=wavelet.t0)
 
 
 def test_RFdeconProcessor_scalar_timeseries_wavelet_validation_is_transactional():
@@ -641,9 +647,7 @@ def test_RFdeconProcessor_scalar_timeseries_wavelet_validation_is_transactional(
     seismogram.set_live()
     for component in range(3):
         seismogram.data[component, :] = DoubleVector(data)
-    rejected = RFdecon(
-        seismogram, engine=processor, wavelet=bad_wavelets[-1]
-    )
+    rejected = RFdecon(seismogram, engine=processor, wavelet=bad_wavelets[-1])
     assert rejected.dead()
     assert rejected.elog.size() > 0
     assert np.array_equal(processor.wvector, cached_wavelet)
@@ -1486,9 +1490,7 @@ def test_RFdecon_gid_accepts_raw_vector_wavelet_and_noise(alg, pf):
         assert np.isfinite(rf.data).all()
         assert rf.is_defined("RFdecon_properties")
         assert rf["RFdecon_properties"]["iteration_count"] > 0
-        assert rf["RFdecon_properties"]["gid_wavelet_t0"] == pytest.approx(
-            wavelet.t0
-        )
+        assert rf["RFdecon_properties"]["gid_wavelet_t0"] == pytest.approx(wavelet.t0)
     finally:
         if old_pfpath is None:
             os.environ.pop("PFPATH", None)
@@ -1927,9 +1929,7 @@ def test_RFdeconProcessor_gid_loadwavelet_is_transactional(alg, pf):
     for bad_wavelet in bad_wavelets:
         with pytest.raises(MsPASSError):
             processor.loadwavelet(bad_wavelet, dtype="TimeSeries")
-        assert np.array_equal(
-            np.asarray(processor.wtimeseries.data), cached_samples
-        )
+        assert np.array_equal(np.asarray(processor.wtimeseries.data), cached_samples)
         second = processor.apply_3c(Seismogram(data))
         assert second.live
         qc = dict(processor.processor.QCMetrics())
@@ -1953,9 +1953,7 @@ def test_RFdeconProcessor_gid_loadwavelet_is_transactional(alg, pf):
     processor.loadwavelet(wavelet, dtype="TimeSeries")
 
     for candidate in context_only_cases:
-        bad_call = RFdecon(
-            Seismogram(data), engine=processor, wavelet=candidate
-        )
+        bad_call = RFdecon(Seismogram(data), engine=processor, wavelet=candidate)
         assert bad_call.dead()
         assert np.array_equal(np.asarray(processor.wtimeseries.data), cached_samples)
         recovered = processor.apply_3c(Seismogram(data))
@@ -1970,9 +1968,7 @@ def test_RFdeconProcessor_gid_loadwavelet_is_transactional(alg, pf):
     utc_wavelet = TimeSeries(wavelet)
     utc_wavelet.set_t0(utc_wavelet.t0 + utc_epoch)
     utc_wavelet.tref = TimeReferenceType.UTC
-    utc_result = RFdecon(
-        utc_data, engine=processor, wavelet=utc_wavelet
-    )
+    utc_result = RFdecon(utc_data, engine=processor, wavelet=utc_wavelet)
     assert utc_result.dead()
     assert utc_result.elog.size() > 0
     assert "ator(P-arrival epoch)" in utc_result.elog.get_error_log()[-1].message

--- a/python/tests/algorithms/test_TimeDomainGIDDecon.py
+++ b/python/tests/algorithms/test_TimeDomainGIDDecon.py
@@ -119,9 +119,7 @@ def _assert_external_wavelet_wrapper_error_contract(engine, wrapper, qc_key):
         "noise_window": TimeWindow(-35.0, -5.0),
     }
     invalid = TimeSeries()
-    invalid_result = wrapper(
-        data, engine, external_wavelet=invalid, **common
-    )
+    invalid_result = wrapper(data, engine, external_wavelet=invalid, **common)
     assert not invalid_result.live
     assert not engine.external_wavelet_is_loaded()
 
@@ -135,16 +133,12 @@ def _assert_external_wavelet_wrapper_error_contract(engine, wrapper, qc_key):
     assert not rejected.live
     assert not engine.external_wavelet_is_loaded()
 
-    recovered = wrapper(
-        data, engine, **common
-    )
+    recovered = wrapper(data, engine, **common)
     assert recovered.live
     assert not recovered[qc_key]["gid_external_wavelet_used"]
 
     good = _make_wrapper_external_wavelet()
-    baseline = wrapper(
-        Seismogram(data), engine, external_wavelet=good, **common
-    )
+    baseline = wrapper(Seismogram(data), engine, external_wavelet=good, **common)
     assert baseline.live
 
     utc_epoch = 1.7e9
@@ -154,9 +148,7 @@ def _assert_external_wavelet_wrapper_error_contract(engine, wrapper, qc_key):
     utc_wavelet = TimeSeries(good)
     utc_wavelet.set_t0(utc_wavelet.t0 + utc_epoch)
     utc_wavelet.tref = TimeReferenceType.UTC
-    utc_result = wrapper(
-        utc_data, engine, external_wavelet=utc_wavelet
-    )
+    utc_result = wrapper(utc_data, engine, external_wavelet=utc_wavelet)
     assert utc_result.dead()
     assert utc_result.elog.size() > 0
     assert "ator(P-arrival epoch)" in utc_result.elog.get_error_log()[-1].message
@@ -176,9 +168,7 @@ def _assert_external_wavelet_wrapper_error_contract(engine, wrapper, qc_key):
     )
     assert close_dt_result.live
     # Restore the reference source before transactional rejection checks.
-    baseline = wrapper(
-        Seismogram(data), engine, external_wavelet=good, **common
-    )
+    baseline = wrapper(Seismogram(data), engine, external_wavelet=good, **common)
     assert baseline.live
 
     bad_wavelets = []
@@ -216,9 +206,7 @@ def _assert_external_wavelet_wrapper_error_contract(engine, wrapper, qc_key):
     bad_wavelets.append(off_grid)
 
     for bad in bad_wavelets:
-        rejected = wrapper(
-            Seismogram(data), engine, external_wavelet=bad, **common
-        )
+        rejected = wrapper(Seismogram(data), engine, external_wavelet=bad, **common)
         assert rejected.dead()
         assert rejected.elog.size() > 0
         assert engine.external_wavelet_is_loaded()
@@ -474,7 +462,9 @@ def _assert_gid_constructor_rejects_oversized_window_without_allocation(
     # 60 Ms at 20 Hz is 1.2e9 samples: finite and int-representable, but its
     # 3C BLAS length and FFT/shaping buffers are not.  Constructor rejection
     # proves no waveform-sized allocation was attempted.
-    text = text.replace("full_data_window_end 20.0", "full_data_window_end 60000000.0", 1)
+    text = text.replace(
+        "full_data_window_end 20.0", "full_data_window_end 60000000.0", 1
+    )
     text = text.replace(
         "deconvolution_data_window_end 20.0",
         "deconvolution_data_window_end 60000000.0",
@@ -581,7 +571,8 @@ def _assert_two_sample_analysis_candidate_exhaustion_control_flow(
             assert qc[terminal + "accepted"] == 0
             assert qc[terminal + "stop_condition"] == expected_reason
             assert qc[terminal + "stop_condition"] in (
-                "continue", qc["ns_gid_stop_reason"]
+                "continue",
+                qc["ns_gid_stop_reason"],
             )
             assert 0 <= qc[terminal + "candidate_lag_samples"] < 2
             for suffix in (
@@ -679,8 +670,7 @@ def _assert_td_rejected_residual_trial_audit(tmp_path):
     baseline_engine = TimeDomainGIDDecon(pfread(str(path)))
     baseline_engine.loadwavelet(wavelet)
     assert (
-        baseline_engine.load(data, TimeWindow(0.0, 0.5), TimeWindow(-35.0, -5.0))
-        == 0
+        baseline_engine.load(data, TimeWindow(0.0, 0.5), TimeWindow(-35.0, -5.0)) == 0
     )
     baseline_engine.process()
     baseline_qc = dict(baseline_engine.QCMetrics())
@@ -1001,10 +991,14 @@ def _assert_shipped_default_long_window_result(
     assert qc["ns_gid_max_raw_candidate_amplitude"] >= 0.0
     assert qc["ns_gid_max_raw_candidate_significance"] >= 0.0
     assert qc["ns_gid_initial_stationary_null_expected_noise_exceedances"] >= 0.0
-    assert 0 < qc["ns_gid_initial_stationary_null_search_lag_count"] < qc[
-        "gid_analysis_samples"
-    ]
-    assert qc["ns_gid_initial_stationary_null_expected_noise_exceedances"] == pytest.approx(
+    assert (
+        0
+        < qc["ns_gid_initial_stationary_null_search_lag_count"]
+        < qc["gid_analysis_samples"]
+    )
+    assert qc[
+        "ns_gid_initial_stationary_null_expected_noise_exceedances"
+    ] == pytest.approx(
         qc["ns_gid_initial_stationary_null_search_lag_count"]
         * qc["ns_gid_noise_samples_at_or_above_peak_threshold"]
         / qc["ns_gid_initial_stationary_null_noise_amplitude_samples"]
@@ -1046,9 +1040,7 @@ def _assert_long_window_gid_result(rf, qc):
         )
     )
     assert qc["ns_gid_peak_threshold_scope"] == "pointwise_candidate_lag"
-    assert qc["ns_gid_peak_threshold_controlling_term"] in (
-        "empirical", "sigma", "tie"
-    )
+    assert qc["ns_gid_peak_threshold_controlling_term"] in ("empirical", "sigma", "tie")
     assert qc["ns_gid_residual_rms_initial"] >= 0.0
     assert qc["ns_gid_residual_rms_final"] >= 0.0
     assert qc["ns_gid_residual_rms_ratio"] == pytest.approx(
@@ -1196,7 +1188,8 @@ def _assert_ns_terminal_trace_controls(
         # Candidate rows are historical: a later hard cap is global QC and
         # must not overwrite the accepted candidate's local ``continue``.
         assert qc[f"ns_gid_iteration_{terminal}_stop_condition"] in (
-            "continue", expected_reason
+            "continue",
+            expected_reason,
         )
         assert qc[
             f"ns_gid_iteration_{terminal}_post_residual_rms_ratio"
@@ -1414,9 +1407,7 @@ def _assert_all_leaf_physical_lag_alignment(
                 # narrow resolution kernel can split a recovered pulse across
                 # adjacent samples; it still rejects the historical multi-
                 # second wavelet-origin shift.
-                assert peak_time == pytest.approx(
-                    arrival, abs=2.0 * sparse.dt + 1.0e-9
-                )
+                assert peak_time == pytest.approx(arrival, abs=2.0 * sparse.dt + 1.0e-9)
 
 
 def _assert_shipped_default_recovers_weak_conversion(
@@ -1555,10 +1546,7 @@ def _assert_quantized_nonzero_noise_uses_sigma_fallback(
         qc["ns_gid_peak_threshold_sigma"]
     )
     assert not qc["ns_gid_use_empirical_noise_threshold"]
-    assert (
-        qc["ns_gid_peak_threshold_controlling_term"]
-        == "sigma_empirical_disabled"
-    )
+    assert qc["ns_gid_peak_threshold_controlling_term"] == "sigma_empirical_disabled"
 
 
 def _assert_invalid_sigma_threshold_product_is_rejected(
@@ -1650,7 +1638,10 @@ def _assert_mantle_profile_weak_and_noise_control(
     margin_path = tmp_path / ("high_margin_" + pf_name)
     margin_path.write_text(
         path.read_text()
-        .replace("ns_gid_use_empirical_noise_threshold true", "ns_gid_use_empirical_noise_threshold false")
+        .replace(
+            "ns_gid_use_empirical_noise_threshold true",
+            "ns_gid_use_empirical_noise_threshold false",
+        )
         .replace("ns_gid_peak_sigma_threshold 4.0", "ns_gid_peak_sigma_threshold 20.0")
     )
     data, wavelet, _ = _make_external_wavelet_3c_data(0.005, 0.0, seed=421)
@@ -1691,7 +1682,8 @@ def _assert_mantle_profile_weak_and_noise_control(
             assert qc[f"ns_gid_iteration_{i}_accepted"] in (0, 1)
         if rows:
             assert qc[f"ns_gid_iteration_{rows[-1]}_stop_condition"] in (
-                "continue", qc["ns_gid_stop_reason"]
+                "continue",
+                qc["ns_gid_stop_reason"],
             )
     assert margin["ns_gid_iteration_0_accepted"] == 0
     assert margin["ns_gid_iteration_0_stop_condition"] == "candidate_not_significant"
@@ -1770,7 +1762,8 @@ def _assert_terminal_refit_final_noise_floor_canonicalization(
         text = text.replace("residual_ratio_floor 0.01", "residual_ratio_floor 1.0")
     path.write_text(text)
     rf = wrapper(
-        _make_long_window_gid_data(), engine_class(pfread(str(path))),
+        _make_long_window_gid_data(),
+        engine_class(pfread(str(path))),
         signal_window=TimeWindow(-10.0, 160.0),
         noise_window=TimeWindow(-200.0, -10.0),
     )
@@ -1779,7 +1772,8 @@ def _assert_terminal_refit_final_noise_floor_canonicalization(
     # floor immediately after acceptance.  Both retain the provisional state
     # while the terminal refit must publish the final canonical floor state.
     assert qc["ns_gid_provisional_stop_reason_before_final_refit"] in (
-        "max_spikes", "residual_reached_noise_floor"
+        "max_spikes",
+        "residual_reached_noise_floor",
     )
     assert qc["ns_gid_final_refit_applied"]
     assert qc["ns_gid_residual_noise_rms_ratio"] <= 100.0
@@ -1842,9 +1836,10 @@ def _assert_final_refit_audit_does_not_bypass_first_floor(
     assert qc["ns_gid_final_scan_global_acceptable_candidate_count"] > 0
     assert qc["ns_gid_final_scan_acceptable_candidate_remaining"]
     assert qc["ns_gid_final_scan_best_trial_lag_samples"] != decision_lag
-    assert qc["ns_gid_final_scan_best_trial_residual_l2"] < qc[
-        "ns_gid_final_scan_decision_trial_residual_l2"
-    ]
+    assert (
+        qc["ns_gid_final_scan_best_trial_residual_l2"]
+        < qc["ns_gid_final_scan_decision_trial_residual_l2"]
+    )
     assert qc["ns_gid_final_scan_best_trial_fractional_improvement"] > 0.003
     assert qc["ns_gid_stop_reason"] == "fractional_improvement_floor"
     assert qc["gid_stop_reason"] == qc["ns_gid_stop_reason"]
@@ -1893,9 +1888,7 @@ def _assert_final_refit_reopens_candidate_significance(
         for key in qc.keys()
         if key.startswith("ns_gid_iteration_") and key.endswith("_accepted")
     )
-    accepted_rows = [
-        row for row in rows if qc[f"ns_gid_iteration_{row}_accepted"] == 1
-    ]
+    accepted_rows = [row for row in rows if qc[f"ns_gid_iteration_{row}_accepted"] == 1]
     assert len(accepted_rows) == qc["ns_gid_iterations"]
     assert qc["gid_number_spikes"] == qc["ns_gid_iterations"]
     assert len(accepted_rows) <= qc["gid_maximum_iterations"]
@@ -1909,8 +1902,7 @@ def _assert_final_refit_reopens_candidate_significance(
     post_refit_rows = [row for row in accepted_rows if row > first_refit_row]
     assert post_refit_rows
     accepted_lags = [
-        qc[f"ns_gid_iteration_{row}_candidate_lag_samples"]
-        for row in accepted_rows
+        qc[f"ns_gid_iteration_{row}_candidate_lag_samples"] for row in accepted_rows
     ]
     assert len(accepted_lags) == len(set(accepted_lags))
     # A post-refit accepted lag was absent from the support before that refit.
@@ -1988,7 +1980,8 @@ def _assert_ns_fractional_floor_uses_pre_refit_candidate(
         if f"ns_gid_iteration_{i}_stop_condition" in qc
     )
     assert qc[f"ns_gid_iteration_{terminal}_stop_condition"] in (
-        "continue", qc["ns_gid_stop_reason"]
+        "continue",
+        qc["ns_gid_stop_reason"],
     )
 
 
@@ -2024,10 +2017,7 @@ def _assert_ns_default_ridge_candidate_trace(
     )
     assert qc["ns_gid_final_refit_applied"]
     assert qc[f"ns_gid_iteration_{accepted[-1]}_final_refit_applied"]
-    assert (
-        qc[f"ns_gid_iteration_{accepted[-1]}_stop_condition"]
-        == "continue"
-    )
+    assert qc[f"ns_gid_iteration_{accepted[-1]}_stop_condition"] == "continue"
     rejected = qc["ns_gid_iterations"]
     prefix = f"ns_gid_iteration_{rejected}_"
     assert not qc[prefix + "accepted"]
@@ -2083,7 +2073,14 @@ def _assert_nonfinite_noise_inputs_are_rejected(
     engine_class, pf_name, branch_name, tmp_path
 ):
     """Every GID noise ingress rejects NaN/Inf before processing starts."""
-    modes = ("ns_gid", "group_sparse", "water_level", "least_square", "multi_taper", "cnr")
+    modes = (
+        "ns_gid",
+        "group_sparse",
+        "water_level",
+        "least_square",
+        "multi_taper",
+        "cnr",
+    )
     for bad_value in (np.nan, np.inf):
         internal = _make_gid_test_data(noise_level=None)
         sample = internal.sample_number(-20.0)
@@ -2096,7 +2093,9 @@ def _assert_nonfinite_noise_inputs_are_rejected(
         for mode in modes:
             engine = engine_class(_pf_with_mode(tmp_path, pf_name, branch_name, mode))
             valid = _make_gid_test_data(noise_level=None)
-            assert engine.load(valid, TimeWindow(-8.0, 20.0), TimeWindow(-35.0, -5.0)) == 0
+            assert (
+                engine.load(valid, TimeWindow(-8.0, 20.0), TimeWindow(-35.0, -5.0)) == 0
+            )
             engine.process()
             assert dict(engine.QCMetrics())["decon_processed"]
             with pytest.raises(MsPASSError, match="noise window contains nonfinite"):
@@ -2106,14 +2105,15 @@ def _assert_nonfinite_noise_inputs_are_rejected(
                 engine.process()
 
             engine = engine_class(_pf_with_mode(tmp_path, pf_name, branch_name, mode))
-            assert engine.load(valid, TimeWindow(-8.0, 20.0), TimeWindow(-35.0, -5.0)) == 0
+            assert (
+                engine.load(valid, TimeWindow(-8.0, 20.0), TimeWindow(-35.0, -5.0)) == 0
+            )
             engine.process()
             with pytest.raises(MsPASSError, match="external noise contains nonfinite"):
                 engine.loadnoise(external)
             assert not dict(engine.QCMetrics())["decon_processed"]
             with pytest.raises(MsPASSError, match="valid (data|noise) window"):
                 engine.process()
-
 
 
 def _assert_nonfinite_noise_spectra_are_rejected(
@@ -2124,7 +2124,9 @@ def _assert_nonfinite_noise_spectra_are_rejected(
         for mode in ("ns_gid", "group_sparse"):
             engine = engine_class(_pf_with_mode(tmp_path, pf_name, branch_name, mode))
             valid = _make_gid_test_data(noise_level=None)
-            assert engine.load(valid, TimeWindow(-8.0, 20.0), TimeWindow(-35.0, -5.0)) == 0
+            assert (
+                engine.load(valid, TimeWindow(-8.0, 20.0), TimeWindow(-35.0, -5.0)) == 0
+            )
             engine.process()
             with pytest.raises(MsPASSError, match="PowerSpectrum contains nonfinite"):
                 engine.loadnoise(_make_external_noise_spectrum(bad_value))
@@ -2324,13 +2326,13 @@ def _assert_group_sparse_empirical_threshold_can_be_disabled(
     )
     assert rf.live
     qc = rf[qc_key]
-    assert qc["group_sparse_peak_threshold_empirical"] > qc[
-        "group_sparse_peak_threshold_sigma"
-    ]
+    assert (
+        qc["group_sparse_peak_threshold_empirical"]
+        > qc["group_sparse_peak_threshold_sigma"]
+    )
     assert not qc["group_sparse_use_empirical_noise_threshold"]
     assert (
-        qc["group_sparse_peak_threshold_controlling_term"]
-        == "sigma_empirical_disabled"
+        qc["group_sparse_peak_threshold_controlling_term"] == "sigma_empirical_disabled"
     )
     assert qc["group_sparse_noise_threshold"] == pytest.approx(
         qc["group_sparse_peak_threshold_sigma"]
@@ -2386,9 +2388,7 @@ def _pf_with_least_square_damping(
 ):
     """Select legacy least-square GID and set only its leaf damping."""
     src = Path("./data/pf") / pf_name
-    text = _replace_gid_deconvolution_type(
-        src.read_text(), branch_name, "least_square"
-    )
+    text = _replace_gid_deconvolution_type(src.read_text(), branch_name, "least_square")
     old = (
         "    least_square &Arr{\n"
         "        target_sample_interval 0.05\n"
@@ -2436,9 +2436,7 @@ def _assert_least_square_raw_gain_damping_invariance(
     qcs = {}
     for damping in (1.0, 1.0e7):
         engine = engine_class(
-            _pf_with_least_square_damping(
-                tmp_path, pf_name, branch_name, damping
-            )
+            _pf_with_least_square_damping(tmp_path, pf_name, branch_name, damping)
         )
         rf = wrapper(
             _make_single_spike_convolution_data(),
@@ -2456,9 +2454,7 @@ def _assert_least_square_raw_gain_damping_invariance(
         assert qc["gid_inverse_domain_amplitude_scale"] == pytest.approx(
             1.0 / qc["gid_leaf_raw_zero_lag_gain"]
         )
-        assert qc["gid_inverse_domain_scaling_policy"] == (
-            "raw_zero_lag_normalized_v2"
-        )
+        assert qc["gid_inverse_domain_scaling_policy"] == ("raw_zero_lag_normalized_v2")
         assert qc["gid_inverse_domain_scaling_valid"]
         assert qc["gid_inverse_domain_scaling_applied"]
         assert qc["gid_inverse_domain_scaling_modes"] == (
@@ -2681,9 +2677,7 @@ def _assert_generic_residual_rms_qc(
         assert qc["gid_inverse_domain_amplitude_scale"] == pytest.approx(
             1.0 / qc["gid_leaf_raw_zero_lag_gain"]
         )
-        assert qc["gid_inverse_domain_scaling_policy"] == (
-            "raw_zero_lag_normalized_v2"
-        )
+        assert qc["gid_inverse_domain_scaling_policy"] == ("raw_zero_lag_normalized_v2")
         assert qc["gid_inverse_domain_scaling_valid"]
         assert qc["gid_inverse_domain_scaling_applied"]
         assert qc["gid_inverse_domain_scaling_modes"] == (
@@ -2899,9 +2893,7 @@ def _pf_with_short_decon_window(
     return pfread(str(dst))
 
 
-def _make_external_wavelet_3c_data(
-    noise_level=1.0e-4, conversion_scale=1.0, seed=421
-):
+def _make_external_wavelet_3c_data(noise_level=1.0e-4, conversion_scale=1.0, seed=421):
     n = 1400
     dt = 0.05
     t0 = -45.0


### PR DESCRIPTION
## Summary

- reapply the Black formatting from #763 on top of `master`
- define Python 3.12 as the shared container Python version
- upgrade and re-pin the SCOPED-based container environment before MsPASS is compiled
- assert that the GeoLab base remains on the same Python major/minor version

## Root cause

PR #763 targeted `agent/fix-gid-window-model`, the feature branch used by #759. Because #759 was rebase-and-merged into `master` before #763 was merged into that feature branch, #763's formatting commit never reached `master`.

The Docker targets also use two independent base environments. GeoLab currently provides Python 3.12, while the SCOPED base used by runtime, dev, MPI, and TACC pins Python 3.10. The shared `mspass-base` stage now removes that old pin, installs Python 3.12, verifies it, and writes a new resolved pin before compiling MsPASS.

## Impact

Runtime, dev, MPI, TACC, and GeoLab images now use the same Python 3.12 ABI. The build-time assertions will fail early if either base image drifts away from the configured version.

## Validation

- `black --check` on all five files changed by #763
- `git diff --check`
- BuildKit Dockerfile target parsing for all targets
- confirmed the cached runtime image was Python 3.10.14 and GeoLab was Python 3.12.13
- built the upgrade layer against the cached runtime image and verified Python 3.12.13 plus a `python 3.12.13` conda pin

Full target builds will run in GitHub Actions.