### PR TITLE
Optimize Docker and Conda CI builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,8 +23,18 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Cache Boost 1.86
+      uses: actions/cache@v5
+      with:
+        path: ${{ runner.temp }}/mspass-boost-1.86.0
+        key: mspass-boost-1.86.0-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/boost-download.cmake') }}
+
+    - name: Configure Boost 1.86 cache
+      shell: bash
+      run: echo "MSPASS_BOOST_ROOT=${RUNNER_TEMP}/mspass-boost-1.86.0" >> "$GITHUB_ENV"
+
     - name: Install Dependencies
-      run: sudo apt-get update && sudo apt-get install -yq gfortran libboost-dev libboost-serialization-dev libgsl-dev liblapack-dev libyaml-cpp-dev
+      run: sudo apt-get update && sudo apt-get install -yq gfortran libgsl-dev liblapack-dev libyaml-cpp-dev
 
     - name: Create Build Environment
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,16 @@
 name: CMake
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -11,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
-      run: sudo apt-get update && sudo apt-get install -yq gfortran libboost-dev libboost-serialization-dev liblapack-dev
+      run: sudo apt-get update && sudo apt-get install -yq gfortran libboost-dev libboost-serialization-dev libgsl-dev liblapack-dev libyaml-cpp-dev
 
     - name: Create Build Environment
       shell: bash

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -8,6 +8,9 @@ on:
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   conda-build-arm64:
     runs-on: ubuntu-24.04-arm
@@ -38,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ${{ fromJSON((github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) && '["3.10", "3.11", "3.12", "3.13"]' || '["3.13"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -62,7 +65,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
-          python-version: ['3.10', '3.11', '3.12', '3.13']
+          python-version: ${{ fromJSON((github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) && '["3.10", "3.11", "3.12", "3.13"]' || '["3.13"]') }}
           os: ["macos-26", "macos-15"]
       steps:
         - uses: actions/checkout@v6
@@ -92,4 +95,3 @@ jobs:
             else
               anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label py${{ matrix.python-version }} --force
             fi
-

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -71,6 +71,16 @@ jobs:
         - uses: actions/checkout@v6
           with:
             fetch-depth: 0
+
+        - name: Cache Boost 1.86
+          uses: actions/cache@v5
+          with:
+            path: ${{ runner.temp }}/mspass-boost-1.86.0
+            key: mspass-boost-1.86.0-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/boost-download.cmake') }}
+
+        - name: Configure Boost 1.86 cache
+          shell: bash
+          run: echo "MSPASS_BOOST_ROOT=${RUNNER_TEMP}/mspass-boost-1.86.0" >> "$GITHUB_ENV"
   
         - name: Setup Conda
           uses: conda-incubator/setup-miniconda@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
@@ -433,6 +437,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -462,14 +467,14 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push dev image (amd64)
+      - name: Build dev image (amd64)
         uses: docker/build-push-action@v7
         if: ${{ github.event_name == 'pull_request' }}
         with:
           context: .
           target: dev
           platforms: linux/amd64
-          push: true
+          push: false
           tags: ${{ steps.amd64-dev-tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
@@ -543,6 +548,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -572,14 +578,14 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push dev image (arm64)
+      - name: Build dev image (arm64)
         uses: docker/build-push-action@v7
         if: ${{ github.event_name == 'pull_request' }}
         with:
           context: .
           target: dev
           platforms: linux/arm64
-          push: true
+          push: false
           tags: ${{ steps.arm64-dev-tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
@@ -607,6 +613,7 @@ jobs:
 
   publish-dev-manifest:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
     needs:
       - build-dev
       - build-dev-arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -437,7 +437,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -467,14 +466,14 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build dev image (amd64)
+      - name: Build and push dev image (amd64)
         uses: docker/build-push-action@v7
         if: ${{ github.event_name == 'pull_request' }}
         with:
           context: .
           target: dev
           platforms: linux/amd64
-          push: false
+          push: true
           tags: ${{ steps.amd64-dev-tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
@@ -548,7 +547,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -578,14 +576,14 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build dev image (arm64)
+      - name: Build and push dev image (arm64)
         uses: docker/build-push-action@v7
         if: ${{ github.event_name == 'pull_request' }}
         with:
           context: .
           target: dev
           platforms: linux/arm64
-          push: false
+          push: true
           tags: ${{ steps.arm64-dev-tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
@@ -613,7 +611,6 @@ jobs:
 
   publish-dev-manifest:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
     needs:
       - build-dev
       - build-dev-arm64

--- a/.github/workflows/documentation-backfill.yml
+++ b/.github/workflows/documentation-backfill.yml
@@ -43,6 +43,16 @@ jobs:
         ref: ${{ steps.docs-ref.outputs.ref }}
         path: source
 
+    - name: Cache Boost 1.86
+      uses: actions/cache@v5
+      with:
+        path: ${{ runner.temp }}/mspass-boost-1.86.0
+        key: mspass-boost-1.86.0-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/boost-download.cmake') }}
+
+    - name: Configure Boost 1.86 cache
+      shell: bash
+      run: echo "MSPASS_BOOST_ROOT=${RUNNER_TEMP}/mspass-boost-1.86.0" >> "$GITHUB_ENV"
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -62,7 +72,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -yq cmake doxygen gfortran graphviz libboost-dev libboost-serialization-dev libgsl-dev liblapack-dev libyaml-cpp-dev pandoc
+        sudo apt-get install -yq cmake doxygen gfortran graphviz libgsl-dev liblapack-dev libyaml-cpp-dev pandoc
 
     - name: Install Python dependencies
       working-directory: source

--- a/.github/workflows/documentation-backfill.yml
+++ b/.github/workflows/documentation-backfill.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -yq cmake doxygen gfortran graphviz libboost-dev libboost-serialization-dev liblapack-dev pandoc
+        sudo apt-get install -yq cmake doxygen gfortran graphviz libboost-dev libboost-serialization-dev libgsl-dev liblapack-dev libyaml-cpp-dev pandoc
 
     - name: Install Python dependencies
       working-directory: source
@@ -72,7 +72,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade --upgrade-strategy eager \
-          setuptools setuptools_scm wheel numpy cmake pyspark pytest-spark
+          setuptools setuptools_scm wheel numpy pyspark pytest-spark
         python -m pip install --no-cache-dir --no-build-isolation -v '.[seisbench]'
         python -m pip install -r docs/requirements.txt
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,8 +2,15 @@ name: Python package
 
 "on":
   push:
+    branches: [ master ]
+    tags: [ 'v*.*.*' ]
   pull_request:
+    branches: [ master ]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -32,14 +39,14 @@ jobs:
         distribution: temurin
         java-version: '17'
     - name: Install CXX Dependencies
-      run: sudo apt-get update && sudo apt-get install -yq cmake gfortran libboost-dev libboost-serialization-dev liblapack-dev
+      run: sudo apt-get update && sudo apt-get install -yq gfortran libboost-dev libboost-serialization-dev libgsl-dev liblapack-dev libyaml-cpp-dev
     - name: Install MongoDB
       uses: supercharge/mongodb-github-action@1.12.1
     - name: Install Python Dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade --upgrade-strategy eager \
-          setuptools setuptools_scm wheel numpy cmake pytest pytest-cov
+          setuptools setuptools_scm wheel numpy pytest pytest-cov
     - name: Install Spark Python Dependencies
       env:
         PYSPARK_HADOOP_VERSION: "3"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,6 +25,14 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Cache Boost 1.86
+      uses: actions/cache@v5
+      with:
+        path: ${{ runner.temp }}/mspass-boost-1.86.0
+        key: mspass-boost-1.86.0-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/boost-download.cmake') }}
+    - name: Configure Boost 1.86 cache
+      shell: bash
+      run: echo "MSPASS_BOOST_ROOT=${RUNNER_TEMP}/mspass-boost-1.86.0" >> "$GITHUB_ENV"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -39,7 +47,7 @@ jobs:
         distribution: temurin
         java-version: '17'
     - name: Install CXX Dependencies
-      run: sudo apt-get update && sudo apt-get install -yq gfortran libboost-dev libboost-serialization-dev libgsl-dev liblapack-dev libyaml-cpp-dev
+      run: sudo apt-get update && sudo apt-get install -yq gfortran libgsl-dev liblapack-dev libyaml-cpp-dev
     - name: Install MongoDB
       uses: supercharge/mongodb-github-action@1.12.1
     - name: Install Python Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,7 +164,6 @@ RUN apt-get update \
        python3-dev python3-pip \
        openjdk-8-jdk \
        git cmake gfortran gdb \
-       libboost-dev libboost-serialization-dev \
        libgsl-dev liblapack-dev libyaml-dev \
        zip unzip \
     && apt-get clean \
@@ -363,8 +362,6 @@ RUN set -eux; \
         gfortran \
         git \
         libblas-dev \
-        libboost-dev \
-        libboost-serialization-dev \
         libgsl-dev \
         liblapack-dev \
         libyaml-cpp-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,7 +164,8 @@ RUN apt-get update \
        python3-dev python3-pip \
        openjdk-8-jdk \
        git cmake gfortran gdb \
-       liblapack-dev libyaml-dev \
+       libboost-dev libboost-serialization-dev \
+       libgsl-dev liblapack-dev libyaml-dev \
        zip unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
@@ -230,42 +231,29 @@ ENV MSPASS_HOME=/mspass
 
 FROM mspass-source AS runtime-package
 
-# Add cxx library
-RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp && cd /mspass/cxx \
-    && mkdir build && cd build \
-    && cmake .. \
-    && make \
-    && make install \
-    && rm -rf ../build \
-	&& docker-clean
-
-# Install python components
+# Build the Python extension and C++ library once, then install the C++ artifacts
+# from the CMake build tree retained by setuptools.
 ADD data /mspass/data
 ADD setup.py /mspass/setup.py
 ADD pyproject.toml /mspass/pyproject.toml
 ADD python /mspass/python
 ADD .git /mspass/.git
-RUN pip3 install /mspass -v \
+RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp \
+	&& pip3 install /mspass -v \
+	&& cmake --install /mspass/build/temp.* \
 	&& rm -rf /mspass/build /mspass/.git && docker-clean
 
 FROM mspass-source AS dev-package
 
-# Add cxx library with debug symbols
-RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp && cd /mspass/cxx \
-    && mkdir build && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Debug .. \
-    && make \
-    && make install \
-    && rm -rf ../build \
-	&& docker-clean
-
-# Add seisbench dependency in the dev container for development purpose
+# Build the debug Python extension and C++ library once.
 ADD data /mspass/data
 ADD setup.py /mspass/setup.py
 ADD pyproject.toml /mspass/pyproject.toml
 ADD python /mspass/python
 ADD .git /mspass/.git
-RUN MSPASS_CMAKE_BUILD_TYPE=Debug pip3 install '/mspass[seisbench]' -v \
+RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp \
+	&& MSPASS_CMAKE_BUILD_TYPE=Debug pip3 install '/mspass[seisbench]' -v \
+	&& cmake --install /mspass/build/temp.* \
 	&& rm -rf /mspass/build /mspass/.git && docker-clean
 
 # Add docs and dependencies to build docs
@@ -375,6 +363,8 @@ RUN set -eux; \
         gfortran \
         git \
         libblas-dev \
+        libboost-dev \
+        libboost-serialization-dev \
         libgsl-dev \
         liblapack-dev \
         libyaml-cpp-dev \

--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -46,7 +46,7 @@ endif ()
 message (STATUS "YAML_CPP_LIBRARIES   = ${YAML_CPP_LIBRARIES}")
 message (STATUS "YAML_CPP_INCLUDE_DIR = ${YAML_CPP_INCLUDE_DIR}")
 
-find_package (Boost 1.86.0 EXACT COMPONENTS serialization)
+find_package (Boost 1.74.0 COMPONENTS serialization)
 if (NOT Boost_FOUND)
   message (STATUS "Building Boost")
   include (cmake/boost.cmake)

--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -46,7 +46,13 @@ endif ()
 message (STATUS "YAML_CPP_LIBRARIES   = ${YAML_CPP_LIBRARIES}")
 message (STATUS "YAML_CPP_INCLUDE_DIR = ${YAML_CPP_INCLUDE_DIR}")
 
-find_package (Boost 1.74.0 COMPONENTS serialization)
+# Boost.Serialization archives are shared across MsPASS builds, so the Boost
+# version is a compatibility constraint rather than a minimum dependency.
+set (Boost_USE_STATIC_LIBS ON)
+if (DEFINED ENV{MSPASS_BOOST_ROOT} AND NOT "$ENV{MSPASS_BOOST_ROOT}" STREQUAL "")
+  set (BOOST_ROOT "$ENV{MSPASS_BOOST_ROOT}")
+endif ()
+find_package (Boost 1.86.0 EXACT COMPONENTS serialization)
 if (NOT Boost_FOUND)
   message (STATUS "Building Boost")
   include (cmake/boost.cmake)

--- a/cxx/cmake/boost-download.cmake
+++ b/cxx/cmake/boost-download.cmake
@@ -12,9 +12,9 @@ ExternalProject_Add(
   URL_HASH
     SHA256=2575e74ffc3ef1cd0babac2c1ee8bdb5782a0ee672b1912da40e5b4b591ca01f
 
-  CONFIGURE_COMMAND ./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-toolset=gcc
-  BUILD_COMMAND ./b2 cxxflags=-fPIC --with-serialization -j 8
+  CONFIGURE_COMMAND ./bootstrap.sh "--prefix=@BOOST_INSTALL_ROOT@" --with-toolset=gcc
+  BUILD_COMMAND ./b2 cxxflags=-fPIC link=static variant=release threading=multi --with-serialization -j 8
   BUILD_IN_SOURCE 1
-  INSTALL_COMMAND ./b2 cxxflags=-fPIC --with-serialization -j 8 install
+  INSTALL_COMMAND ./b2 cxxflags=-fPIC link=static variant=release threading=multi --with-serialization -j 8 install
   TEST_COMMAND ""
   )

--- a/cxx/cmake/boost-download.cmake
+++ b/cxx/cmake/boost-download.cmake
@@ -15,6 +15,6 @@ ExternalProject_Add(
   CONFIGURE_COMMAND ./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-toolset=gcc
   BUILD_COMMAND ./b2 cxxflags=-fPIC --with-serialization -j 8
   BUILD_IN_SOURCE 1
-  INSTALL_COMMAND ./b2 install
+  INSTALL_COMMAND ./b2 cxxflags=-fPIC --with-serialization -j 8 install
   TEST_COMMAND ""
   )

--- a/cxx/cmake/boost.cmake
+++ b/cxx/cmake/boost.cmake
@@ -1,5 +1,9 @@
 macro(fetch_boost _download_module_path _download_root)
     set(BOOST_DOWNLOAD_ROOT ${_download_root})
+    set(BOOST_INSTALL_ROOT ${_download_root})
+    if (DEFINED ENV{MSPASS_BOOST_ROOT} AND NOT "$ENV{MSPASS_BOOST_ROOT}" STREQUAL "")
+        set(BOOST_INSTALL_ROOT "$ENV{MSPASS_BOOST_ROOT}")
+    endif()
     configure_file(
         ${_download_module_path}/boost-download.cmake
         ${_download_root}/CMakeLists.txt
@@ -12,18 +16,26 @@ macro(fetch_boost _download_module_path _download_root)
             "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
         WORKING_DIRECTORY
             ${_download_root}
+        RESULT_VARIABLE BOOST_CONFIGURE_RESULT
         )
+    if (NOT BOOST_CONFIGURE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to configure the Boost 1.86 build")
+    endif()
     execute_process(
         COMMAND
             "${CMAKE_COMMAND}" --build .
         WORKING_DIRECTORY
             ${_download_root}
+        RESULT_VARIABLE BOOST_BUILD_RESULT
         )
+    if (NOT BOOST_BUILD_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to build Boost 1.86 serialization")
+    endif()
 
-    set (BOOST_ROOT ${PROJECT_BINARY_DIR}/boost)
+    set (BOOST_ROOT ${BOOST_INSTALL_ROOT})
     set (Boost_NO_BOOST_CMAKE ON)
     set (Boost_USE_STATIC_LIBS ON)
-    set (Boost_INCLUDE_DIR ${BOOST_ROOT}/boost-src)
+    set (Boost_INCLUDE_DIR ${BOOST_ROOT}/include)
 
-    find_package (Boost 1.86.0 REQUIRED COMPONENTS serialization)
+    find_package (Boost 1.86.0 EXACT REQUIRED COMPONENTS serialization)
 endmacro()

--- a/meta.yaml
+++ b/meta.yaml
@@ -14,6 +14,8 @@ source:
 
 build:
   script: scripts/conda_build.sh
+  script_env:
+    - MSPASS_BOOST_ROOT
   include_recipe: False
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   string: py{{ CONDA_PY }}_{{ GIT_DESCRIBE_NUMBER|int }}_g{{ GIT_FULL_HASH[:8] }}
@@ -35,7 +37,8 @@ requirements:
     - numpy>=2.2.6
     - cmake>=3.18
     - gsl
-    - boost-cpp
+    # Boost.Serialization 1.86 is built statically by cxx/cmake.  Conda-forge
+    # does not provide 1.86, so a boost-cpp dependency would mix in 1.85.
     - liblapack
     - yaml-cpp
 
@@ -67,7 +70,6 @@ requirements:
     - libzlib
     - cartopy
     - gsl
-    - libboost
     - liblapack
     - yaml-cpp
 

--- a/scripts/Dockerfile_conda_build
+++ b/scripts/Dockerfile_conda_build
@@ -14,6 +14,7 @@ ARG TARGETARCH
 ARG ANACONDA_API_TOKEN
 
 ENV PATH /opt/conda/bin:$PATH
+ENV MSPASS_BOOST_ROOT=/tmp/mspass-boost-1.86.0
 
 RUN apt-get update --fix-missing && \
     apt-get install -y cmake wget bzip2 ca-certificates curl git && \
@@ -27,4 +28,3 @@ RUN cd /mspasspy_build \
     && if [ "$PYTHON_VERSION" = "3.13" ]; then \
        anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label main --label py${PYTHON_VERSION} --force ; \
        else anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label py${PYTHON_VERSION} --force ; fi
-

--- a/scripts/dependency_map.toml
+++ b/scripts/dependency_map.toml
@@ -27,7 +27,6 @@ packages = [
     "libzlib",
     "cartopy",
     "gsl",
-    "libboost",
     "liblapack",
     "yaml-cpp",
 ]


### PR DESCRIPTION
## Summary

- keep Boost.Serialization pinned to exactly 1.86.0 and link it statically in every build
- build only Boost's serialization component when the exact version is unavailable, instead of rebuilding all Boost libraries during install
- cache the exact 1.86 install prefix across the CMake, Python, documentation, and macOS Conda workflows
- remove Ubuntu/Conda Boost 1.74-1.85 packages so they cannot be mixed with the serialization ABI used by MsPASS
- install binary GSL and yaml-cpp development packages where available
- build the Docker Python extension and C++ library once, then install the C++ artifacts from the retained CMake tree
- keep PR dev images and their multi-arch manifest updated for container testing, while cancelling superseded PR runs
- run the full Conda Python 3.10-3.13 matrix for tags/weeklies, while ordinary master builds publish Python 3.13 only
- avoid duplicate branch-push and PR runs for the CMake/Python workflows

## Motivation

Boost 1.86 is a serialization compatibility constraint, not a minimum dependency version. Ubuntu currently provides Boost 1.74 or 1.83, and Conda-forge resolves `boost-cpp`/`libboost` to 1.85, so those packages must not replace the exact 1.86 build.

The slow path had a second, independent problem: it first built `serialization`, then ran an unconstrained `b2 install` that rebuilt every Boost library. The Conda logs also reported the 1.85 runtime package as unused because MsPASS was already statically linked to the fallback 1.86 library.

This PR preserves `find_package(Boost 1.86.0 EXACT ...)`, limits the fallback to a static serialization build, and caches that exact install prefix. A cold fallback now takes about 54 seconds locally; a fresh configure using the cached prefix takes about 3 seconds.

## CI reductions

- Docker no longer performs separate C++ builds for the native library and Python extension.
- GSL and yaml-cpp use binary system packages instead of source fallbacks in CI/container builds.
- Ordinary master Conda publishing runs 3 jobs instead of 12; tags and weekly builds retain the full Python 3.10-3.13/platform matrix.
- Docker PR runtime, GeoLab, TACC, and MPI builds validate without publishing; dev amd64/arm64 images and the dev manifest remain published for PR testing.
- Superseded PR runs are cancelled, and CMake/Python push triggers are limited to master and release tags.

## CI results

All checks pass with the exact Boost 1.86 implementation.

| Job | Exact-pin master | This PR |
| --- | ---: | ---: |
| CMake | ~15m 29s | 6m 42s |
| Python (slowest matrix job) | ~27m 44s | 19m 51s |
| Docker runtime + GeoLab + TACC | ~45m 10s | 14m 02s |
| Docker runtime arm64 | ~26m | 6m 38s |
| Docker dev amd64 (including push) | ~33m | 14m 18s |
| Docker dev arm64 (including push) | ~28m | 11m 37s |
| Docker MPI | ~30m | 7m 23s |

The first CMake run populated the exact-version cache; its cold dependency configure took 1m 28s and subsequent clean configures can reuse the cached prefix.

## Validation

- cold and warm CMake configuration both selected exact Boost 1.86; the cached build linked `libboost_serialization.a`
- full CMake build passed all 11 tests, including `test_decon_serialization`
- Conda recipe rendered successfully for Python 3.13 with no `boost-cpp` or `libboost` 1.85 dependency
- all 8 GitHub Actions workflow YAML files parsed successfully
- the PR workflow pushed both dev architecture images and published the Docker Hub and GHCR multi-arch `dev` manifests
- clean standard `runtime-package` Docker build succeeded and imported the installed ccore modules
- clean GeoLab Docker build succeeded, selected exact Boost 1.86, and imported ccore as the non-root UID 1000 user
