### PR TITLE
Fix assorted longstanding I/O, algorithm, workflow, and documentation issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,7 +159,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 EXPOSE 27017
 
 RUN apt-get update \
-    && apt-get install -y wget ssh rsync vim-tiny less \
+    && apt-get install -y wget ssh rsync vim-tiny less graphviz \
        build-essential python3-setuptools \
        python3-dev python3-pip \
        openjdk-8-jdk \
@@ -361,6 +361,7 @@ RUN set -eux; \
         cmake \
         gfortran \
         git \
+        graphviz \
         libblas-dev \
         libgsl-dev \
         liblapack-dev \

--- a/docs/source/getting_started/deploy_mspass_with_docker_compose.rst
+++ b/docs/source/getting_started/deploy_mspass_with_docker_compose.rst
@@ -146,7 +146,9 @@ Other common changes are:
   Do not request more CPU or memory than Docker has available.
 * Add the same bind mount to every service that needs access to waveform data
   stored outside the project directory.  Paths used by notebooks and workers
-  must refer to the common path inside the containers.
+  must refer to the common path inside the containers.  This includes targets
+  of symbolic links: a link into an unmounted host directory is broken inside
+  the containers.
 
 After editing the file, check its resolved configuration before restarting:
 

--- a/docs/source/getting_started/run_mspass_with_docker.rst
+++ b/docs/source/getting_started/run_mspass_with_docker.rst
@@ -48,6 +48,14 @@ path on the host does not automatically exist at the same path inside the
 container.  The mount option explicitly connects the host project directory
 to the container's ``/home`` directory.
 
+.. warning::
+
+   A symbolic link inside a bind-mounted directory works only when its target
+   is also visible at the corresponding path inside the container.  A link to
+   an unmounted host directory appears broken to MsPASS.  Bind-mount every
+   external waveform directory explicitly and use the container-side path in
+   waveform metadata.
+
 The two important options are:
 
 ``-p 8888:8888``

--- a/docs/source/user_manual/development_strategies.rst
+++ b/docs/source/user_manual/development_strategies.rst
@@ -151,6 +151,10 @@ following:
 
       docker run --mount src=/home/myname/python,target=/mnt,type=bind -p 8888:8888 mspass/mspass
 
+    The same rule applies to symbolic links.  If a mounted directory contains
+    a link whose target is outside that mount, add a mount for the target as
+    well; otherwise the link is not resolvable inside Docker or Apptainer.
+
     To make that module accessible with the same import command as above you
     would need to change the python search path.  For this example, you could
     add that directory to the Python search path before importing:

--- a/meta.yaml
+++ b/meta.yaml
@@ -67,6 +67,8 @@ requirements:
     - numba
     - multitaper
     - ipympl
+    - python-graphviz
+    - graphviz
     - libzlib
     - cartopy
     - gsl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "numba",
     "multitaper",
     "ipympl",
+    "graphviz",
 ]
 dynamic = ["version"]
 requires-python = ">=3.10"
@@ -78,4 +79,3 @@ cmake-extension = "setup:CMakeExtension"
 cmake-build = "setup:CMakeBuild"
 
 [tool.setuptools_scm]
-

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -1235,7 +1235,7 @@ class RFdeconProcessor:
             on zero lag.
         """
         if self.__is_3c_engine:
-            return self.processor.actual_output()
+            return TimeSeries(self.processor.actual_output())
         if hasattr(self, "dvector"):
             self.processor.loaddata(DoubleVector(self.dvector))
         if hasattr(self, "wvector"):
@@ -1243,7 +1243,7 @@ class RFdeconProcessor:
         if self.__uses_noise and hasattr(self, "nvector"):
             self.processor.loadnoise(DoubleVector(self.nvector))
         self.processor.process()
-        return self.processor.actual_output()
+        return TimeSeries(self.processor.actual_output())
 
     def output_shaping_wavelet(self):
         """
@@ -1257,7 +1257,7 @@ class RFdeconProcessor:
         suitable for WindowData and other metadata-aware TimeSeries APIs.
         """
         if self.__is_3c_engine:
-            return self.processor.output_shaping_wavelet()
+            return TimeSeries(self.processor.output_shaping_wavelet())
         if hasattr(self, "dvector"):
             self.processor.loaddata(DoubleVector(self.dvector))
         if hasattr(self, "wvector"):
@@ -1265,7 +1265,7 @@ class RFdeconProcessor:
         if self.__uses_noise and hasattr(self, "nvector"):
             self.processor.loadnoise(DoubleVector(self.nvector))
         self.processor.process()
-        return self.processor.output_shaping_wavelet()
+        return TimeSeries(self.processor.output_shaping_wavelet())
 
     def ideal_output(self):
         """

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -610,9 +610,11 @@ def FD_snr_estimator(
       object using it's size() method and if it the log is not empty (size >0)
       the caller should handle that condition.   For normal use that means
       pushing any messages the log contains to the original data object's
-      error log.  Component 0 will also be empty with no log entry if
-      the estimated bandwidth falls below the threshold defined by the
-      parameter signal_detection_minimum_bandwidth.
+      error log.  Component 0 is normally empty when the estimated bandwidth
+      falls below ``signal_detection_minimum_bandwidth``.  When
+      ``save_spectra`` is True, it instead contains the saved spectra and
+      window metadata, but no bandwidth metrics.  The logger contains an
+      Invalid entry in either case.
     """
     algname = "FN_snr_estimator"
     my_logger = ErrorLogger()
@@ -707,13 +709,20 @@ def FD_snr_estimator(
                 bandwidth = 0.0
         else:
             bandwidth = bwd.bandwidth()
+        if save_spectra:
+            snrdata["signal_spectrum"] = pickle.dumps(S)
+            snrdata["noise_spectrum"] = pickle.dumps(N)
+            snrdata["signal_window_start_time"] = signal_window.start
+            snrdata["signal_window_end_time"] = signal_window.end
+            snrdata["noise_window_start_time"] = noise_window.start
+            snrdata["noise_window_end_time"] = noise_window.end
         # here we return empty result if the bandwidth is too low
         if bandwidth < signal_detection_minimum_bandwidth:
             message = "Estimated bandwidth={} below detection minimum={}".format(
                 bandwidth, signal_detection_minimum_bandwidth
             )
             my_logger.log_error(algname, message, ErrorSeverity.Invalid)
-            return [dict(), my_logger]
+            return [snrdata, my_logger]
         # These estimates are always computed and posted once we pass the above test for validity
         snrdata["low_f_band_edge"] = bwd.low_edge_f
         snrdata["high_f_band_edge"] = bwd.high_edge_f
@@ -722,14 +731,6 @@ def FD_snr_estimator(
         snrdata["spectrum_frequency_range"] = bwd.f_range
         snrdata["bandwidth"] = bandwidth
         snrdata["bandwidth_fraction"] = bwd.bandwidth_fraction()
-        if save_spectra:
-            snrdata["signal_spectrum"] = pickle.dumps(S)
-            snrdata["noise_spectrum"] = pickle.dumps(N)
-            snrdata["signal_window_start_time"] = signal_window.start
-            snrdata["signal_window_end_time"] = signal_window.end
-            snrdata["noise_window_start_time"] = noise_window.start
-            snrdata["noise_window_end_time"] = noise_window.end
-
     except MsPASSError as err:
         newmessage = _reformat_mspass_error(
             err,
@@ -1061,10 +1062,9 @@ def arrival_snr(
     )
     if elog.size() > 0:
         data_object.elog += elog
-    # FD_snr_estimator returns an empty dictionary if the snr
-    # calculation fails or indicates no signal is present.  This
-    # block combines that with the kill_null_signals in this logic
-    if len(snrdata) > 0:
+    # A low-bandwidth result can contain diagnostic spectra without valid
+    # SNR metrics, so bandwidth is the validity marker here.
+    if "bandwidth" in snrdata:
         snrdata["phase"] = phase_name
         data_object[metadata_output_key] = snrdata
     elif kill_null_signals:
@@ -1314,10 +1314,9 @@ def broadband_snr_QC(
     )
     if elog.size() > 0:
         data_object.elog += elog
-    # FD_snr_estimator returns an empty dictionary if the snr
-    # calculation fails or indicates no signal is present.  This
-    # block combines that with the kill_null_signals in this logic
-    if len(snrdata) == 0:
+    # A low-bandwidth result can contain diagnostic spectra without valid
+    # SNR metrics, so bandwidth is the validity marker here.
+    if "bandwidth" not in snrdata:
         data_object.elog.log_error(
             "broadband_snr_QC",
             "FD_snr_estimator flagged this datum as having no detectable signal",

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -935,28 +935,18 @@ def merge(
     This function is a workhorse for handling continuous data that are
     universally stored today as a series of files.   The input to this
     function is an array of TimeSeries objects that are assummed to be
-    created from a set of data stored in such files.   The data are assumed
-    to be from a common stream of a single channel and sorted so the
-    array index defines a time order.  The algorithm attempts to glue the
-    segments together into a single time series that is returned.
+    created from a set of data stored in such files.  The data are assumed
+    to be from a common stream of a single channel.  They are sorted by start
+    time internally before the algorithm glues the segments together into a
+    single time series that is returned.
     The algorithm by default assumes the input is "clean" which means
     the endtime of each input TimeSeries is 1 sample ahead of the start time
     of the next segment (i.e. (segment[i+1].t0()-segment[i].endtime()) == dt).
     The actual test is that the time difference is less than dt/2.
 
-    This algorithm treats two conditions as a fatal error and will throw
-    a MsPASSError when the condition occurs:
-
-        1.   It checks that the input array of TimeSeries data are in
-             time order.
-        2.   It checks that the inputs all have the same sample rate.
-        3.   If fix_overlaps is False if an overlap is found it
-             is considered an exception.
-
-    Either of these conditions will cause the function to throw an
-    exception.  The assumption is that either is a user error created
-    by failing to reading the directions that emphasize this requirement
-    for the input.
+    Inputs with inconsistent sample rates are treated as a fatal error and
+    cause a :class:`MsPASSError` to be thrown.  If ``fix_overlaps`` is False,
+    an overlap produces a dead output with an error-log entry.
 
     Other conditions can cause the output to be marked dead with an
     error message posted to the output's elog attribute.  These are:
@@ -1036,8 +1026,9 @@ def merge(
     stored as a list of "TimeWindow" objects with the Metadata key "gaps".
 
     :param tsvector:  array of TimeSeries data that are to be spliced
-      together to create a single output.   The contents must all have
-      the same sample rate and be sorted by starttime.
+      together to create a single output.  The contents must all have
+      the same sample rate.  Input order is arbitrary; the function sorts
+      segments by start time.
     :type tsvector:  expected to be a TimeSeriesVector, which is the name
       we give in the pybind11 code to a C++ std:vector<TimeSeries> container.
       Any iterable container of TimeSeries data will be accepted, however,
@@ -1089,14 +1080,11 @@ def merge(
       time range.  The result may be marked dead for a variety of reasons
       with error messages explaining why in the return elog attribute.
     """
-    if not isinstance(tsvector, TimeSeriesVector):
-        # We assume this will throw an exception if tsvector is not iterable
-        # or doesn't contain TimeSeries objects
-        dvector = TimeSeriesVector()
-        for d in tsvector:
-            dvector.append(d)
-    else:
-        dvector = tsvector
+    # sorted will raise a useful exception if the input is not iterable or
+    # does not contain objects with the TimeSeries t0 attribute.
+    dvector = TimeSeriesVector()
+    for d in sorted(tsvector, key=lambda datum: datum.t0):
+        dvector.append(d)
     if fix_overlaps:
         dvector = repair_overlaps(dvector)
     spliced_data = splice_segments(dvector, object_history)

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1530,6 +1530,7 @@ class Database(pymongo.database.Database):
             wf_collection = self[wf_collection_name]
             # We need to make sure storage_mode is set in all live data
             if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
+                mspass_object.sync_metadata()
                 for d in mspass_object.member:
                     if d.live:
                         d["storage_mode"] = storage_mode
@@ -1567,7 +1568,6 @@ class Database(pymongo.database.Database):
 
             else:
                 # note else not elif because above guarantees only ensembles land here
-                mspass_object.sync_metadata()
                 for d in mspass_object.member:
                     d = self._atomic_save_all_documents(
                         d,
@@ -4392,6 +4392,7 @@ class Database(pymongo.database.Database):
                                 alg, message, ErrorSeverity.Invalid
                             )
                             mspass_object.kill()
+                            return
 
                         # These two lines are needed to properly initialize
                         # the DoubleVector before calling Trace2TimeSeries
@@ -4485,8 +4486,14 @@ class Database(pymongo.database.Database):
                     message += "Metadata value for npts is {} but datum attribute npts is {}\n".format(
                         mspass_object["npts"], mspass_object.npts
                     )
-                    message += "Illegal inconsistency that should not happen and is a fatal error"
-                    raise ValueError(message)
+                    message += "Illegal inconsistency; sample data were not loaded"
+                    mspass_object.elog.log_error(
+                        "Database._read_data_from_gridfs",
+                        message,
+                        ErrorSeverity.Invalid,
+                    )
+                    mspass_object.kill()
+                    return
             npts = mspass_object.npts
         if isinstance(mspass_object, TimeSeries):
             # fh.seek(16)
@@ -4498,8 +4505,8 @@ class Database(pymongo.database.Database):
             file_size = fh.tell()
             if file_size != npts * 8 * 3:
                 message = "Size mismatch in sample data.\n"
-                message += "Number of points in gridfs file=%d but wf document expected %d".format(
-                    file_size / 8, (3 * mspass_object["npts"])
+                message += "Number of points in gridfs file={} but wf document expected {}".format(
+                    file_size // 8, (3 * mspass_object["npts"])
                 )
                 mspass_object.elog.log_error(
                     "Database._read_data_from_gridfs",
@@ -5328,7 +5335,7 @@ class Database(pymongo.database.Database):
                 result.extend([netw])
         return result
 
-    def get_seed_site(self, net, sta, loc="NONE", time=-1.0, verbose=True):
+    def get_seed_site(self, net, sta, loc="NONE", time=-1.0, verbose=False):
         """
         The site collection is assumed to have a one to one
         mapping of net:sta:loc:starttime - endtime.
@@ -5339,16 +5346,9 @@ class Database(pymongo.database.Database):
         Returns None if there is no match.
 
         An all to common metadata problem is to have duplicate entries in
-        site for the same data.   The default behavior of this method is
-        to print a warning whenever a match is ambiguous
-        (i.e. more than on document matches the keys).  Set verbose false to
-        silence such warnings if you know they are harmless.
-
-        An all to common metadata problem is to have duplicate entries in
-        site for the same data.   The default behavior of this method is
-        to print a warning whenever a match is ambiguous
-        (i.e. more than on document matches the keys).  Set verbose false to
-        silence such warnings if you know they are harmless.
+        site for the same data.  Set ``verbose=True`` to print a warning
+        whenever a match is ambiguous (i.e. more than one document matches
+        the keys).  Such warnings are suppressed by default.
 
         The seed modifier in the name is to emphasize this method is
         for data originating as the SEED format that use net:sta:loc:chan
@@ -5366,12 +5366,9 @@ class Database(pymongo.database.Database):
           and will cause the function to simply return the first document
           matching the name keys only.   (This is rarely what you want, but
           there is no standard default for this argument.)
-        :param verbose:  When True (the default) this method will issue a
+        :param verbose:  When True this method will issue a
           print warning message when the match is ambiguous - multiple
-          docs match the specified keys.   When set False such warnings
-          will be suppressed.  Use false only if you know the duplicates
-          are harmless and you are running on a large data set and
-          you want to reduce the log size.
+          docs match the specified keys.  The default is False.
 
         :return: MongoDB doc matching query
         :rtype:  python dict (document) of result.  None if there is no match.
@@ -5396,7 +5393,7 @@ class Database(pymongo.database.Database):
             stadoc = dbsite.find_one(query)
             return stadoc
 
-    def get_seed_channel(self, net, sta, chan, loc=None, time=-1.0, verbose=True):
+    def get_seed_channel(self, net, sta, chan, loc=None, time=-1.0, verbose=False):
         """
         The channel collection is assumed to have a one to one
         mapping of net:sta:loc:chan:starttime - endtime.
@@ -5434,12 +5431,9 @@ class Database(pymongo.database.Database):
         :param loc:   optional loc code to made (empty string ok and common)
            default ignores loc in query.
         :param time: epoch time for requested metadata
-        :param verbose:  When True (the default) this method will issue a
+        :param verbose:  When True this method will issue a
            print warning message when the match is ambiguous - multiple
-           docs match the specified keys.   When set False such warnings
-           will be suppressed.  Use false only if you know the duplicates
-           are harmless and you are running on a large data set and
-           you want to reduce the log size.
+           docs match the specified keys.  The default is False.
 
         :return: handle to query return
         :rtype:  MondoDB Cursor object of query result.
@@ -5788,9 +5782,10 @@ class Database(pymongo.database.Database):
         to TimeSeries objects when it reads the data from the files
         indexed by this function.
 
-        :param dfile:  file name of data to be indexed.  Asssumed to be
-          the leaf node of the path - i.e. it contains no directory information
-          but just the file name.
+        :param dfile: file name or path of data to be indexed.  Strings and
+          :class:`pathlib.Path` objects are accepted.  An absolute path takes
+          precedence over ``dir``; a relative path is resolved beneath
+          ``dir`` or the current working directory when ``dir`` is None.
         :param dir:  directory name.  This can be a relative path from the
           current directory be be advised it will always be converted to an
           fully qualified path.  If it is undefined (the default) the function
@@ -5843,18 +5838,18 @@ class Database(pymongo.database.Database):
           generic handler to avoid aborts in a large job.
         """
         dbh = self[collection]
-        # If dir is not define assume current directory.  Otherwise
-        # use realpath to make sure the directory is the full path
-        # We store the full path in mongodb
-        if dir is None:
-            odir = os.getcwd()
-        else:
-            odir = os.path.abspath(dir)
         if dfile is None:
             dfile = self._get_dfile_uuid("mseed")
-        fname = os.path.join(odir, dfile)
-        # TODO:  should have a way to pass verbose to this function
-        # present verbose is not appropriate.
+        dfile_path = pathlib.Path(dfile)
+        if dfile_path.is_absolute():
+            file_path = dfile_path
+        else:
+            base_dir = pathlib.Path.cwd() if dir is None else pathlib.Path(dir)
+            file_path = base_dir / dfile_path
+        file_path = file_path.resolve()
+        odir = str(file_path.parent)
+        dfile = file_path.name
+        fname = str(file_path)
         ind, elog = _mseed_file_indexer(fname, segment_time_tears)
         if len(elog.get_error_log()) > 0 and "No such file or directory" in str(
             elog.get_error_log()
@@ -5881,11 +5876,11 @@ class Database(pymongo.database.Database):
             if "loc" in doc:
                 loc = doc["loc"]
                 chandoc = self.get_seed_channel(
-                    net, sta, chan, loc, time=stime, verbose=False
+                    net, sta, chan, loc, time=stime, verbose=verbose
                 )
             else:
                 chandoc = self.get_seed_channel(
-                    net, sta, chan, time=stime, verbose=False
+                    net, sta, chan, time=stime, verbose=verbose
                 )
             if chandoc != None:
                 doc["channel_id"] = chandoc["_id"]

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3379,7 +3379,15 @@ def normalize(
     find_output = matcher.find_one(mspass_object)
     # api of BasicMatcher specified a pair return we handle here
     if find_output[0] is None:
-        mspass_object.kill()
+        if kill_on_failure:
+            if find_output[1] is None or find_output[1].size() == 0:
+                message = "{} found no matching metadata for this datum".format(
+                    type(matcher).__name__
+                )
+                mspass_object.elog.log_error(
+                    "normalize", message, ErrorSeverity.Invalid
+                )
+            mspass_object.kill()
     else:
         # this could be done with operator+= in C++ with appropriate
         # casting but I think this is the only solution here

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -1370,4 +1370,5 @@ class LargeEnsemblePlotter(SeismicPlotter):
         handles = self.get_3Censemble_gcf()
         if handles:
             for gcf in handles:
-                gcf.clear()
+                if gcf:
+                    gcf.clear()

--- a/python/mspasspy/preprocessing/css30/datascope.py
+++ b/python/mspasspy/preprocessing/css30/datascope.py
@@ -268,7 +268,7 @@ class DatascopeDatabase:
             right_suffix = "_" + table
         df_right = self.get_table(table)
         if join_keys == "right_primary":
-            right_jkeys = self.get_keys(table)
+            right_jkeys = self.get_primary_keys(table)
             left_jkeys = right_jkeys
         elif isinstance(join_keys, list):
             right_jkeys = join_keys

--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -18,6 +18,7 @@ def sliding_window_pipeline(
     a_args=None,
     a_kwargs=None,
     verbose=False,
+    progress_report_interval=10000,
 ):
     """
     Run a processing function and optional completion function on an
@@ -185,8 +186,10 @@ def sliding_window_pipeline(
        require kwargs.
     :param verbose:  boolean controlling output.  When False (default)
        the function itself is totally silent.  When set True it
-       prints a message for each submit and each return.  Not recommended for workflows
-       that use a large number of submits as the output can easily get huge.
+       prints periodic progress reports.
+    :param progress_report_interval: positive integer defining how many
+       completed items elapse between reports when ``verbose`` is True.
+       The default is 10000.  The final item is always reported.
 
     :return:   When the completion_function is not defined (default)
        this function will return a list of return values from each
@@ -218,6 +221,12 @@ def sliding_window_pipeline(
             alg
         )
         raise ValueError(message)
+    if (
+        isinstance(progress_report_interval, bool)
+        or not isinstance(progress_report_interval, int)
+        or progress_report_interval <= 0
+    ):
+        raise ValueError("progress_report_interval must be a positive integer")
     if pfunc_args is None:
         # this and the comparable logic with kwargs is needed or a type error will be thrown when we use it
         # this is how python accepts a null args
@@ -320,8 +329,6 @@ def sliding_window_pipeline(
         swsize = N
     i_d = 0
     for d in dlist:
-        if verbose:
-            print("Submitting item number ", i_d)
         f = dask_client.submit(processing_function, d, *pfunc_args, **pfunc_kwargs)
         futures_list.append(f)
         i_d += 1
@@ -334,8 +341,6 @@ def sliding_window_pipeline(
     seq = ddist.as_completed(futures_list)
     for f in seq:
         f_result = f.result()
-        if verbose:
-            print("Handling result number ", number_handled)
         if run_completion_function:
             f_result = completion_function(f_result, *cfunc_args, **cfunc_kwargs)
             if accumulator is None:
@@ -348,9 +353,12 @@ def sliding_window_pipeline(
         # found to be necessary to assure dask doesn't hog memory held by f
         dask_client.cancel(f)
         del f
+        number_handled += 1
+        if verbose and (
+            number_handled % progress_report_interval == 0 or number_handled == N
+        ):
+            print(f"Handled {number_handled} of {N} items")
         if i_d < N:
-            if verbose:
-                print("Submitting item number ", i_d)
             f = dask_client.submit(
                 processing_function, dlist[i_d], *pfunc_args, **pfunc_kwargs
             )

--- a/python/tests/algorithms/test_snr.py
+++ b/python/tests/algorithms/test_snr.py
@@ -258,6 +258,19 @@ def test_FD_snr_estimator():
     assert sigspec.nf() == 6002
     assert nspec.nf() == 15002
 
+    # Spectra are diagnostic output and should remain available even when
+    # the estimated bandwidth is below the requested detection threshold.
+    low_bandwidth_output = FD_snr_estimator(
+        TimeSeries(ts0),
+        noise_window=nwin,
+        signal_window=swin,
+        signal_detection_minimum_bandwidth=1000.0,
+        save_spectra=True,
+    )
+    assert low_bandwidth_output[1].size() == 1
+    assert pickle.loads(low_bandwidth_output[0]["signal_spectrum"]).nf() == 6002
+    assert pickle.loads(low_bandwidth_output[0]["noise_spectrum"]).nf() == 15002
+
 
 def test_FD_snr_estimator_error_handlers():
     """

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -29,7 +29,7 @@ from mspasspy.ccore.algorithms.amplitudes import (
 )
 from mspasspy.ccore.algorithms.basic import TimeWindow
 from mspasspy.algorithms.window import scale
-from mspasspy.algorithms.window import WindowData, TopMute, WindowData_autopad
+from mspasspy.algorithms.window import WindowData, TopMute, WindowData_autopad, merge
 
 
 # Build a simple _CoreTimeSeries and _CoreSeismogram with
@@ -45,6 +45,31 @@ def setbasics(d, n):
     d.t0 = 0.0
     d.tref = TimeReferenceType.Relative
     d.live = True
+
+
+def test_merge_sorts_segments_by_start_time():
+    first = TimeSeries(3)
+    first.set_dt(1.0)
+    first.t0 = 0.0
+    first.set_live()
+    first.data[0] = 0.0
+    first.data[1] = 1.0
+    first.data[2] = 2.0
+
+    second = TimeSeries(3)
+    second.set_dt(1.0)
+    second.t0 = 3.0
+    second.set_live()
+    second.data[0] = 3.0
+    second.data[1] = 4.0
+    second.data[2] = 5.0
+
+    result = merge([second, first])
+
+    assert result.live
+    assert result.t0 == 0.0
+    assert result.npts == 6
+    assert np.array_equal(np.asarray(result.data), np.arange(6.0))
 
 
 def test_scale():

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -56,8 +56,7 @@ from mspasspy.db.collection import Collection
 
 def test_seed_lookup_verbose_defaults():
     assert (
-        inspect.signature(Database.get_seed_site).parameters["verbose"].default
-        is False
+        inspect.signature(Database.get_seed_site).parameters["verbose"].default is False
     )
     assert (
         inspect.signature(Database.get_seed_channel).parameters["verbose"].default
@@ -314,9 +313,7 @@ class TestDatabase:
                 inconsistent_ts, dir, dfile, foff, nbytes, format="mseed"
             )
         assert inconsistent_ts.dead()
-        assert "Inconsistent endtimes" in str(
-            inconsistent_ts.elog.get_error_log()
-        )
+        assert "Inconsistent endtimes" in str(inconsistent_ts.elog.get_error_log())
 
     def test_save_and_read_gridfs(self):
         tmp_seis = get_live_seismogram()
@@ -361,9 +358,7 @@ class TestDatabase:
         inconsistent_ts.set_live()
         self.db._read_data_from_gridfs(inconsistent_ts, gridfs_id)
         assert inconsistent_ts.dead()
-        assert "Metadata value for npts" in str(
-            inconsistent_ts.elog.get_error_log()
-        )
+        assert "Metadata value for npts" in str(inconsistent_ts.elog.get_error_log())
 
         gfsh = gridfs.GridFS(self.db)
         assert gfsh.exists(gridfs_id)

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -1,7 +1,9 @@
 import copy
+import inspect
 import io
 import os
 import pickle
+from pathlib import Path
 
 import gridfs
 import numpy as np
@@ -50,6 +52,17 @@ import datetime
 from mspasspy.db.database import Database, geoJSON_doc
 from mspasspy.db.client import DBClient
 from mspasspy.db.collection import Collection
+
+
+def test_seed_lookup_verbose_defaults():
+    assert (
+        inspect.signature(Database.get_seed_site).parameters["verbose"].default
+        is False
+    )
+    assert (
+        inspect.signature(Database.get_seed_channel).parameters["verbose"].default
+        is False
+    )
 
 
 class TestDatabase:
@@ -283,6 +296,28 @@ class TestDatabase:
         )
         assert all(a == b for a, b in zip(tmp_ts.data, tmp_ts_2.data))
 
+        # A fatal end-time inconsistency must not be undone by the later
+        # nonempty-data check.
+        bad_trace = Mock()
+        bad_trace.stats = Mock()
+        bad_trace.stats.npts = 3
+        bad_trace.stats.starttime = obspy.UTCDateTime(0)
+        bad_trace.stats.endtime = obspy.UTCDateTime(99)
+        bad_trace.stats.delta = 1.0
+        bad_trace.data = np.array([1.0, 2.0, 3.0])
+        inconsistent_ts = TimeSeries()
+        inconsistent_ts.npts = 3
+        inconsistent_ts.t0 = 0.0
+        inconsistent_ts.dt = 1.0
+        with patch("mspasspy.db.database.obspy.read", return_value=[bad_trace]):
+            self.db._read_data_from_dfile(
+                inconsistent_ts, dir, dfile, foff, nbytes, format="mseed"
+            )
+        assert inconsistent_ts.dead()
+        assert "Inconsistent endtimes" in str(
+            inconsistent_ts.elog.get_error_log()
+        )
+
     def test_save_and_read_gridfs(self):
         tmp_seis = get_live_seismogram()
         seis_return = self.db._save_sample_data_to_gridfs(tmp_seis)
@@ -319,6 +354,16 @@ class TestDatabase:
         tmp_ts_2.npts = 255
         self.db._read_data_from_gridfs(tmp_ts_2, gridfs_id)
         assert np.isclose(tmp_ts.data, tmp_ts_2.data).all()
+
+        inconsistent_ts = TimeSeries()
+        inconsistent_ts.npts = 255
+        inconsistent_ts["npts"] = 254
+        inconsistent_ts.set_live()
+        self.db._read_data_from_gridfs(inconsistent_ts, gridfs_id)
+        assert inconsistent_ts.dead()
+        assert "Metadata value for npts" in str(
+            inconsistent_ts.elog.get_error_log()
+        )
 
         gfsh = gridfs.GridFS(self.db)
         assert gfsh.exists(gridfs_id)
@@ -1586,13 +1631,15 @@ class TestDatabase:
         self.db.drop_collection("abortions")
 
     def test_index_mseed_file(self):
-        dir = "python/tests/data/"
+        dir = Path("python/tests/data/").resolve()
         dfile = "3channels.mseed"
-        fname = os.path.join(dir, dfile)
-        self.db.index_mseed_file(fname, collection="wf_miniseed")
+        fname = dir / dfile
+        self.db.index_mseed_file(fname, dir=dir, collection="wf_miniseed")
         assert self.db["wf_miniseed"].count_documents({}) == 3
 
         for doc in self.db["wf_miniseed"].find():
+            assert doc["dir"] == str(dir)
+            assert doc["dfile"] == dfile
             ts = self.db.read_data(doc, collection="wf_miniseed")
             assert ts.npts == len(ts.data)
 
@@ -2598,7 +2645,7 @@ class TestDatabase:
         # assert res['tst'] == time
         # assert res['starttime'] == time_new
 
-    def test_save_ensemble_data(self):
+    def test_save_ensemble_data(self, tmp_path):
         """
         Tests writer for ensembles.   In v1 this was done with
         different methods.  From v2 forward the recommended use is
@@ -2629,6 +2676,25 @@ class TestDatabase:
         # data being tested - avoids confusing dependencies that
         # were present in earlier versions of this test script
         ts_ensemble0 = copy.deepcopy(ts_ensemble)
+
+        # An explicit output directory must win over stale ensemble metadata,
+        # both for the sample file and the waveform documents.
+        conflicting_ensemble = copy.deepcopy(ts_ensemble0)
+        conflicting_ensemble["dir"] = str(tmp_path / "stale")
+        output_dir = tmp_path / "requested"
+        conflicting_ensemble = self.db.save_data(
+            conflicting_ensemble,
+            storage_mode="file",
+            dir=output_dir,
+            dfile="ensemble.bin",
+            return_data=True,
+        )
+        assert (output_dir / "ensemble.bin").is_file()
+        assert not (tmp_path / "stale").exists()
+        for member in conflicting_ensemble.member:
+            assert member["dir"] == str(output_dir.resolve())
+            doc = self.db["wf_TimeSeries"].find_one({"_id": member["_id"]})
+            assert doc["dir"] == str(output_dir.resolve())
         # First test save in backward compatibility with
         # save_ensemble_data using directory list and dfile list.
         # Note this function may be deprecated in future releases

--- a/python/tests/db/test_normalize.py
+++ b/python/tests/db/test_normalize.py
@@ -88,6 +88,28 @@ def Metadata_cmp(a, b):
     return True
 
 
+class _NoMatchWithoutLog:
+    def find_one(self, _datum):
+        return [None, None]
+
+
+def test_normalize_logs_every_kill_and_honors_kill_on_failure():
+    datum = TimeSeries(1)
+    datum.set_live()
+    result = normalize(datum, _NoMatchWithoutLog())
+    assert result.dead()
+    assert result.elog.size() == 1
+    assert "_NoMatchWithoutLog found no matching metadata" in str(
+        result.elog.get_error_log()
+    )
+
+    datum = TimeSeries(1)
+    datum.set_live()
+    result = normalize(datum, _NoMatchWithoutLog(), kill_on_failure=False)
+    assert result.live
+    assert result.elog.size() == 0
+
+
 class TestNormalize:
     def setup_class(self):
         client = DBClient("localhost")

--- a/python/tests/preprocessing/test_datascope.py
+++ b/python/tests/preprocessing/test_datascope.py
@@ -75,6 +75,12 @@ def test_DatascopeDatabase():
     # because it is a key.  Probably needs a test for suffix option
     # of join
     assert len(dfj.columns) == 37
+    # Default join_keys requests a natural join using the right table's
+    # declared primary keys.
+    event_df = db.get_table("event")
+    natural_join = db.join(event_df, "event")
+    assert len(natural_join) == len(event_df)
+    assert "evid" in natural_join.columns
     # test get_nulls method.   expected to return a dict of
     # the size in the assert after the call
     nulls = db.get_nulls("site")

--- a/python/tests/test_graphics.py
+++ b/python/tests/test_graphics.py
@@ -1,0 +1,16 @@
+from unittest.mock import Mock
+
+from mspasspy.graphics import LargeEnsemblePlotter
+
+
+def test_large_ensemble_plotter_ignores_empty_figure_handles(monkeypatch):
+    plotter = LargeEnsemblePlotter()
+    active_figure = Mock()
+    monkeypatch.setattr(plotter, "get_plot_gcf", lambda: None)
+    monkeypatch.setattr(
+        plotter, "get_3Censemble_gcf", lambda: [None, active_figure, None]
+    )
+
+    plotter._clear_figure_canvases()
+
+    active_figure.clear.assert_called_once_with()

--- a/python/tests/test_workflow.py
+++ b/python/tests/test_workflow.py
@@ -62,7 +62,7 @@ cluster = ddist.LocalCluster(
 dask_client = cluster.get_client()
 
 
-def test_sliding_window_pipeline():
+def test_sliding_window_pipeline(capsys):
     """
     Test function for `sliding_window_pipeline` function.
 
@@ -94,10 +94,19 @@ def test_sliding_window_pipeline():
         assert x in expected_out
     # repeat with verbose on and sliding_window_size set auto
     result = sliding_window_pipeline(
-        dlist, simple_no_args, dask_client, sliding_window_size="auto", verbose=True
+        dlist,
+        simple_no_args,
+        dask_client,
+        sliding_window_size="auto",
+        verbose=True,
+        progress_report_interval=3,
     )
     for x in result:
         assert x in expected_out
+    progress = capsys.readouterr().out
+    for handled in (3, 6, 9, 10):
+        assert f"Handled {handled} of 10 items" in progress
+    assert "Submitting item" not in progress
 
     # run function with an arg to pfunc_args
     result = sliding_window_pipeline(
@@ -251,6 +260,10 @@ def test_swp_error_handlers():
     # test arg0 handling
     with pytest.raises(ValueError, match="Illegal value for arg0"):
         result = sliding_window_pipeline(42, simple_no_args, dask_client)
+    with pytest.raises(ValueError, match="progress_report_interval"):
+        sliding_window_pipeline(
+            [], simple_no_args, dask_client, progress_report_interval=0
+        )
     # test arg1 handling
     with pytest.raises(
         ValueError,

--- a/scripts/dependency_map.toml
+++ b/scripts/dependency_map.toml
@@ -19,6 +19,7 @@ packages = ["earthscope-sdk"]
 # Only list packages where conda names differ from pip, or that expand to multiple packages.
 [conda_name_map]
 "dask[complete]" = ["dask", "distributed", "cloudpickle"]
+"graphviz" = ["python-graphviz", "graphviz"]
 
 # Conda-only runtime dependencies (C libraries, etc.) with no pip equivalent.
 # These are appended to the generated meta.yaml run: section.


### PR DESCRIPTION
## Summary

This consolidates small, longstanding fixes discovered while reviewing the open issue backlog.

- Database and I/O: make SEED lookup quiet by default, preserve fatal file-read failures, handle GridFS metadata mismatches through the datum error log, synchronize ensemble metadata before writing samples, and normalize miniSEED paths.
- Algorithms and utilities: sort merge inputs, preserve low-bandwidth SNR spectra, honor normalization failure policy, skip empty plot handles, use Datascope primary keys for natural joins, and return metadata-aware RF diagnostic time series.
- Workflow, dependencies, and docs: throttle sliding-window progress output, install Graphviz consistently, and document bind-mount requirements for symlink targets.

Addresses #284, #288, #335, #476, #549, #570, #649, #661, #671, #681, #686, #696, #723, and #757.

## Why

The affected paths had small, independent defects: defaults that produced excessive output, state transitions that could overwrite fatal failures, metadata synchronized after sample storage, assumptions about input ordering and paths, and optional outputs that were discarded on an otherwise valid diagnostic failure. Packaging and container documentation also omitted Graphviz and symlink-target mount requirements.

## Impact

Users get quieter metadata lookup, deterministic segment merging, safer file/GridFS reads, correct ensemble file destinations, reliable miniSEED path handling, retained diagnostic spectra, bounded workflow logging, usable RF diagnostics, and complete Graphviz/container setup.

## Validation

- Targeted regression suite: 14 passed.
- Full SNR module: 4 passed.
- Dependency manifests: `python3 scripts/sync_dependencies.py --check`.
- Changed Python files: `python3 -m py_compile ...`.
- Documentation: Sphinx HTML build completed successfully with `NUMBA_DISABLE_JIT=1`; the strict offline build only reported unavailable external inventories and a local multitaper/numba cache import warning.
- Diff hygiene: `git diff --check`.
