### PR TITLE
Keep long MongoDB scans alive

### DIFF
--- a/docs/source/user_manual/mongodb_and_mspass.rst
+++ b/docs/source/user_manual/mongodb_and_mspass.rst
@@ -391,7 +391,7 @@ long.  A direct PyMongo loop should use a ``with`` statement so the cursor is
 always closed, although that context manager does not prevent expiry.
 Setting ``no_cursor_timeout=True`` alone is not sufficient for an indefinitely
 long scan because MongoDB's logical session timeout still applies.  The MsPASS
-``clean_collection`` method and the
+``clean_collection`` and ``read_inventory`` methods and the
 ``dbclean`` and ``dbverify`` commands provide an opt-in
 ``no_cursor_timeout``/``--no-cursor-timeout`` mode for large data sets.  That
 mode opens an explicit session, refreshes it periodically, and closes both the

--- a/docs/source/user_manual/mongodb_and_mspass.rst
+++ b/docs/source/user_manual/mongodb_and_mspass.rst
@@ -386,6 +386,20 @@ The examples above show the most common, simple usage.
 Both accept a required-or-defaulted filter and an optional projection;
 additional behavior is controlled by documented keyword arguments.
 
+MongoDB can expire a cursor when processing one returned batch takes too
+long.  A direct PyMongo loop should use a ``with`` statement so the cursor is
+always closed, although that context manager does not prevent expiry.
+Setting ``no_cursor_timeout=True`` alone is not sufficient for an indefinitely
+long scan because MongoDB's logical session timeout still applies.  The MsPASS
+``clean_collection`` method and the
+``dbclean`` and ``dbverify`` commands provide an opt-in
+``no_cursor_timeout``/``--no-cursor-timeout`` mode for large data sets.  That
+mode opens an explicit session, refreshes it periodically, and closes both the
+cursor and session when the scan ends.  See MongoDB's `cursor timeout
+documentation
+<https://www.mongodb.com/docs/manual/reference/method/cursor.nocursortimeout/#session-idle-timeout-overrides-nocursortimeout>`__
+for the server-side details.
+
 1.  The first argument defines the query filter.  The default is an empty dictionary
     that is interpreted as "all".
 2.  The second argument defines a "projection".  It is a list of field names

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3,8 +3,10 @@ import io
 import copy
 import pathlib
 import pickle
+import time
 import urllib.request
 from array import array
+from contextlib import contextmanager
 import pandas as pd
 
 # WARNING fcntl is unix specific.
@@ -57,6 +59,39 @@ from mspasspy.ccore.utility import (
 from mspasspy.db.collection import Collection
 from mspasspy.db.schema import DatabaseSchema, MetadataSchema
 from mspasspy.util.converter import Textfile2Dataframe
+
+_CURSOR_SESSION_REFRESH_INTERVAL_SECONDS = 300.0
+
+
+@contextmanager
+def _managed_collection_cursor(collection, query, no_cursor_timeout=False):
+    """Yield a cursor that is closed reliably after a collection scan.
+
+    Long-running scans use an explicit session because MongoDB's session idle
+    timeout can otherwise close a cursor even when ``no_cursor_timeout`` is
+    enabled.  Refreshing the session every five minutes keeps it well below
+    the server's default 30-minute session timeout.
+    """
+    if not no_cursor_timeout:
+        with collection.find(query) as cursor:
+            yield cursor
+        return
+
+    client = collection.database.client
+    with client.start_session() as session:
+        with collection.find(query, no_cursor_timeout=True, session=session) as cursor:
+            last_refresh = time.monotonic()
+
+            def refreshing_documents():
+                nonlocal last_refresh
+                for document in cursor:
+                    yield document
+                    now = time.monotonic()
+                    if now - last_refresh >= _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS:
+                        client.admin.command({"refreshSessions": [session.session_id]})
+                        last_refresh = now
+
+            yield refreshing_documents()
 
 
 class Database(pymongo.database.Database):
@@ -1619,6 +1654,7 @@ class Database(pymongo.database.Database):
         delete_missing_required=False,
         verbose=False,
         verbose_keys=None,
+        no_cursor_timeout=False,
     ):
         """
         This method can be used to fix a subset of common database problems
@@ -1670,6 +1706,12 @@ class Database(pymongo.database.Database):
         :param verbose: Set to ``True`` to print all the operations. Default is ``False``.
         :param verbose_keys: a list of keys you want to added to better identify problems when error happens. It's used in the print messages.
         :type verbose_keys: :class:`list` of :class:`str`
+        :param no_cursor_timeout: Set to ``True`` for a collection scan that
+          may run long enough for MongoDB to expire an idle cursor.  MsPASS
+          then uses an explicit session, refreshes it periodically, and closes
+          both the cursor and session when processing ends.  Default is
+          ``False``.
+        :type no_cursor_timeout: :class:`bool`
         """
         if query is None:
             query = {}
@@ -1688,25 +1730,25 @@ class Database(pymongo.database.Database):
         if matchsize == 0:
             return fixed_cnt
         else:
-            docs = col.find(query)
-            for doc in docs:
-                if "_id" in doc:
-                    fixed_attr_cnt = self.clean(
-                        doc["_id"],
-                        collection,
-                        rename_undefined,
-                        delete_undefined,
-                        required_xref_list,
-                        delete_missing_xref,
-                        delete_missing_required,
-                        verbose,
-                        verbose_keys,
-                    )
-                    for k, v in fixed_attr_cnt.items():
-                        if k not in fixed_cnt:
-                            fixed_cnt[k] = 1
-                        else:
-                            fixed_cnt[k] += v
+            with _managed_collection_cursor(col, query, no_cursor_timeout) as documents:
+                for doc in documents:
+                    if "_id" in doc:
+                        fixed_attr_cnt = self.clean(
+                            doc["_id"],
+                            collection,
+                            rename_undefined,
+                            delete_undefined,
+                            required_xref_list,
+                            delete_missing_xref,
+                            delete_missing_required,
+                            verbose,
+                            verbose_keys,
+                        )
+                        for k, v in fixed_attr_cnt.items():
+                            if k not in fixed_cnt:
+                                fixed_cnt[k] = 1
+                            else:
+                                fixed_cnt[k] += v
 
         return fixed_cnt
 
@@ -2123,7 +2165,14 @@ class Database(pymongo.database.Database):
 
         return is_mismatch_key
 
-    def _delete_attributes(self, collection, keylist, query=None, verbose=False):
+    def _delete_attributes(
+        self,
+        collection,
+        keylist,
+        query=None,
+        verbose=False,
+        no_cursor_timeout=False,
+    ):
         """
         Deletes all occurrences of attributes linked to keys defined
         in a list of keywords passed as (required) keylist argument.
@@ -2139,20 +2188,21 @@ class Database(pymongo.database.Database):
         :param verbose:  when ``True`` edit will produce a line of printed
           output describing what was deleted.  Use this option only if
           you know from dbverify the number of changes to be made are small.
+        :param no_cursor_timeout: when ``True`` keep the scan cursor's explicit
+          MongoDB session alive until processing is complete.
 
         :return:  dict keyed by the keys of all deleted entries.  The value
           of each entry is the number of documents the key was deleted from.
         :rtype: :class:`dict`
         """
         dbcol = self[collection]
-        cursor = dbcol.find(query)
         counts = dict()
         # preload counts to 0 so we get a return saying 0 when no changes
         # are made
         for k in keylist:
             counts[k] = 0
-        try:
-            for doc in cursor:
+        with _managed_collection_cursor(dbcol, query, no_cursor_timeout) as documents:
+            for doc in documents:
                 id = doc.pop("_id")
                 n = 0
                 todel = dict()
@@ -2173,11 +2223,16 @@ class Database(pymongo.database.Database):
                         n += 1
                 if n > 0:
                     dbcol.update_one({"_id": id}, {"$unset": todel})
-        finally:
-            cursor.close()
         return counts
 
-    def _rename_attributes(self, collection, rename_map, query=None, verbose=False):
+    def _rename_attributes(
+        self,
+        collection,
+        rename_map,
+        query=None,
+        verbose=False,
+        no_cursor_timeout=False,
+    ):
         """
         Renames specified keys for all or a subset of documents in a
         MongoDB collection.   The updates are driven by an input python
@@ -2195,6 +2250,8 @@ class Database(pymongo.database.Database):
           output describing what was deleted.  Use this option only if
           you know from dbverify the number of changes to be made are small.
           When false the function runs silently.
+        :param no_cursor_timeout: when ``True`` keep the scan cursor's explicit
+          MongoDB session alive until processing is complete.
 
         :return:  dict keyed by the keys of all changed entries.  The value
           of each entry is the number of documents changed.  The keys are the
@@ -2202,14 +2259,13 @@ class Database(pymongo.database.Database):
           the rename_map.
         """
         dbcol = self[collection]
-        cursor = dbcol.find(query)
         counts = dict()
         # preload counts to 0 so we get a return saying 0 when no changes
         # are made
         for k in rename_map:
             counts[k] = 0
-        try:
-            for doc in cursor:
+        with _managed_collection_cursor(dbcol, query, no_cursor_timeout) as documents:
+            for doc in documents:
                 id = doc.pop("_id")
                 n = 0
                 for k in rename_map:
@@ -2230,11 +2286,11 @@ class Database(pymongo.database.Database):
                         counts[k] += 1
                         n += 1
                 dbcol.replace_one({"_id": id}, doc)
-        finally:
-            cursor.close()
         return counts
 
-    def _fix_attribute_types(self, collection, query=None, verbose=False):
+    def _fix_attribute_types(
+        self, collection, query=None, verbose=False, no_cursor_timeout=False
+    ):
         """
         This function attempts to fix type collisions in the schema defined
         for the specified database and collection.  It tries to fix any
@@ -2260,14 +2316,15 @@ class Database(pymongo.database.Database):
           printed output for each change it makes.  The default is false.
           Needless verbose should be avoided unless you are certain the
           number of changes it will make are small.
+        :param no_cursor_timeout: when ``True`` keep the scan cursor's explicit
+          MongoDB session alive until processing is complete.
         """
         dbcol = self[collection]
         schema = self.database_schema
         col_schema = schema[collection]
         counts = dict()
-        cursor = dbcol.find(query)
-        try:
-            for doc in cursor:
+        with _managed_collection_cursor(dbcol, query, no_cursor_timeout) as documents:
+            for doc in documents:
                 n = 0
                 id = doc.pop("_id")
                 if verbose:
@@ -2320,9 +2377,6 @@ class Database(pymongo.database.Database):
 
                 if n > 0:
                     dbcol.update_one({"_id": id}, {"$set": up_d})
-        finally:
-            cursor.close()
-
         return counts
 
     def _check_links(
@@ -2332,6 +2386,7 @@ class Database(pymongo.database.Database):
         wfquery=None,
         verbose=False,
         error_limit=1000,
+        no_cursor_timeout=False,
     ):
         """
         This function checks for missing cross-referencing ids in a
@@ -2364,6 +2419,8 @@ class Database(pymongo.database.Database):
           The number should be large enough to catch all condition but
           not so huge it become cumbersome.  With no limit or a memory
           fault is even possible on a huge dataset.
+        :param no_cursor_timeout: when ``True`` keep each scan cursor's explicit
+          MongoDB session alive until processing is complete.
         :return:  returns a tuple with two lists.  Both lists are ObjectIds
           of the scanned wf collection that have errors.  component 0
           of the tuple contains ids of wf entries that have the normalization
@@ -2447,9 +2504,10 @@ class Database(pymongo.database.Database):
                 )
                 print("This should resolve links to ", normalize, " collection")
 
-            cursor = dbwf.find(wfquery)
-            try:
-                for doc in cursor:
+            with _managed_collection_cursor(
+                dbwf, wfquery, no_cursor_timeout
+            ) as documents:
+                for doc in documents:
                     wfid = doc["_id"]
                     is_bad_xref_key, is_bad_wf = self._check_xref_key(
                         doc, wf_collection, xref_key
@@ -2479,13 +2537,15 @@ class Database(pymongo.database.Database):
                         or len(missing_id_list) >= error_limit
                     ):
                         break
-            finally:
-                cursor.close()
-
         return tuple([bad_id_list, missing_id_list])
 
     def _check_attribute_types(
-        self, collection, query=None, verbose=False, error_limit=1000
+        self,
+        collection,
+        query=None,
+        verbose=False,
+        error_limit=1000,
+        no_cursor_timeout=False,
     ):
         """
         This function checks the integrity of all attributes
@@ -2520,6 +2580,8 @@ class Database(pymongo.database.Database):
           The number should be large enough to catch all condition but
           not so huge it become cumbersome.  With no limit or a memory
           fault is even possible on a huge dataset.
+        :param no_cursor_timeout: when ``True`` keep the scan cursor's explicit
+          MongoDB session alive until processing is complete.
         :return:  returns a tuple with two python dict containers.
           The component 0 python dict contains details of type mismatch errors.
           Component 1 contains details for data with undefined keys.
@@ -2547,11 +2609,10 @@ class Database(pymongo.database.Database):
                 + " yields zero matching documents",
                 "Fatal",
             )
-        cursor = dbcol.find(query)
         bad_type_docs = dict()
         undefined_key_docs = dict()
-        try:
-            for doc in cursor:
+        with _managed_collection_cursor(dbcol, query, no_cursor_timeout) as documents:
+            for doc in documents:
                 bad_types = dict()
                 undefined_keys = dict()
                 id = doc["_id"]
@@ -2588,9 +2649,6 @@ class Database(pymongo.database.Database):
                     or len(bad_type_docs) >= error_limit
                 ):
                     break
-        finally:
-            cursor.close()
-
         return tuple([bad_type_docs, undefined_key_docs])
 
     def _check_required(
@@ -2600,6 +2658,7 @@ class Database(pymongo.database.Database):
         query=None,
         verbose=False,
         error_limit=100,
+        no_cursor_timeout=False,
     ):
         """
         This function applies a test to assure a list of attributes
@@ -2638,6 +2697,8 @@ class Database(pymongo.database.Database):
           The number should be large enough to catch all condition but
           not so huge it become cumbersome.  With no limit or a memory
           fault is even possible on a huge dataset.
+        :param no_cursor_timeout: when ``True`` keep the scan cursor's explicit
+          MongoDB session alive until processing is complete.
         :return:  tuple with two components. Both components contain a
           python dict container keyed by ObjectId of problem documents.
           The values in the component 0 dict are themselves python dict
@@ -2679,9 +2740,8 @@ class Database(pymongo.database.Database):
             )
         undef = dict()
         wrong_types = dict()
-        cursor = dbcol.find(query)
-        try:
-            for doc in cursor:
+        with _managed_collection_cursor(dbcol, query, no_cursor_timeout) as documents:
+            for doc in documents:
                 id = doc["_id"]
                 undef_this = list()
                 wrong_this = dict()
@@ -2698,8 +2758,6 @@ class Database(pymongo.database.Database):
                     wrong_types[id] = wrong_this
                 if len(wrong_types) >= error_limit or len(undef) >= error_limit:
                     break
-        finally:
-            cursor.close()
         return tuple([wrong_types, undef])
 
     def update_metadata(

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -4956,7 +4956,6 @@ class Database(pymongo.database.Database):
         queryrecord["net"] = record_to_test["net"]
         queryrecord["sta"] = record_to_test["sta"]
         queryrecord["loc"] = record_to_test["loc"]
-        matches = dbsite.find(queryrecord)
         # this returns a warning that count is depricated but
         # I'm getting confusing results from google search on the
         # topic so will use this for now
@@ -4972,11 +4971,12 @@ class Database(pymongo.database.Database):
             stm = st0 - time_fudge_factor
             etp = et0 + time_fudge_factor
             etm = et0 - time_fudge_factor
-            for x in matches:
-                sttest = x["starttime"]
-                ettest = x["endtime"]
-                if sttest > stm and sttest < stp and ettest > etm and ettest < etp:
-                    return False
+            with _managed_collection_cursor(dbsite, queryrecord) as matches:
+                for x in matches:
+                    sttest = x["starttime"]
+                    ettest = x["endtime"]
+                    if sttest > stm and sttest < stp and ettest > etm and ettest < etp:
+                        return False
             return True
 
     def _channel_is_not_in_db(self, record_to_test):
@@ -4996,7 +4996,6 @@ class Database(pymongo.database.Database):
         queryrecord["sta"] = record_to_test["sta"]
         queryrecord["loc"] = record_to_test["loc"]
         queryrecord["chan"] = record_to_test["chan"]
-        matches = dbchannel.find(queryrecord)
         # this returns a warning that count is depricated but
         # I'm getting confusing results from google search on the
         # topic so will use this for now
@@ -5012,11 +5011,12 @@ class Database(pymongo.database.Database):
             stm = st0 - time_fudge_factor
             etp = et0 + time_fudge_factor
             etm = et0 - time_fudge_factor
-            for x in matches:
-                sttest = x["starttime"]
-                ettest = x["endtime"]
-                if sttest > stm and sttest < stp and ettest > etm and ettest < etp:
-                    return False
+            with _managed_collection_cursor(dbchannel, queryrecord) as matches:
+                for x in matches:
+                    sttest = x["starttime"]
+                    ettest = x["endtime"]
+                    if sttest > stm and sttest < stp and ettest > etm and ettest < etp:
+                        return False
             return True
 
     def _handle_null_starttime(self, t):
@@ -5343,7 +5343,9 @@ class Database(pymongo.database.Database):
         print("number of channel records saved=", n_chan_saved)
         return tuple([n_site_saved, n_chan_saved, n_site_processed, n_chan_processed])
 
-    def read_inventory(self, net=None, sta=None, loc=None, time=None):
+    def read_inventory(
+        self, net=None, sta=None, loc=None, time=None, no_cursor_timeout=False
+    ):
         """
         Loads an obspy inventory object limited by one or more
         keys.   Default is to load the entire contents of the
@@ -5362,6 +5364,12 @@ class Database(pymongo.database.Database):
           startime<time<endtime.  Input is assumed an
           epoch time NOT an obspy UTCDateTime. Use a conversion
           to epoch time if necessary.
+        :param no_cursor_timeout: Set to ``True`` when reading an inventory
+          large enough that processing a cursor batch may exceed MongoDB's
+          idle timeout.  MsPASS then uses an explicit session, refreshes it
+          periodically, and closes both the cursor and session when the scan
+          ends.  Default is ``False``.
+        :type no_cursor_timeout: :class:`bool`
         :return:  obspy Inventory of all stations matching the
           query parameters
         :rtype:  obspy Inventory
@@ -5382,15 +5390,17 @@ class Database(pymongo.database.Database):
         if matchsize == 0:
             return None
         else:
-            stations = dbsite.find(query)
-            for s in stations:
-                serialized = s["serialized_inventory"]
-                netw = pickle.loads(serialized)
-                # It might be more efficient to build a list of
-                # Network objects but here we add them one
-                # station at a time.  Note the extend method
-                # if poorly documented in obspy
-                result.extend([netw])
+            with _managed_collection_cursor(
+                dbsite, query, no_cursor_timeout
+            ) as stations:
+                for s in stations:
+                    serialized = s["serialized_inventory"]
+                    netw = pickle.loads(serialized)
+                    # It might be more efficient to build a list of
+                    # Network objects but here we add them one
+                    # station at a time.  Note the extend method
+                    # if poorly documented in obspy
+                    result.extend([netw])
         return result
 
     def get_seed_site(self, net, sta, loc="NONE", time=-1.0, verbose=False):

--- a/python/mspasspy/db/script/dbclean.py
+++ b/python/mspasspy/db/script/dbclean.py
@@ -43,7 +43,10 @@ def main(args=None):
         args = sys.argv[1:]
     parser = argparse.ArgumentParser(
         prog="dbclean",
-        usage="%(prog)s dbname collection [-ft] [-d k1 ...] [-r kold:knew ... ] [-v] [-h]",
+        usage=(
+            "%(prog)s dbname collection [-ft] [-d k1 ...] "
+            "[-r kold:knew ... ] [-v] [--no-cursor-timeout] [-h]"
+        ),
         description="MsPASS program to fix most errors detected by dbverify",
     )
     parser.add_argument(
@@ -81,6 +84,14 @@ def main(args=None):
         action="store_true",
         help="When used be echo each fix - default works silently",
     )
+    parser.add_argument(
+        "--no-cursor-timeout",
+        action="store_true",
+        help=(
+            "Keep the collection scan cursor alive with a periodically "
+            "refreshed MongoDB session"
+        ),
+    )
 
     args = parser.parse_args(args)
     dbname = args.dbname
@@ -89,6 +100,7 @@ def main(args=None):
     delete = args.delete
     rename = args.rename
     verbose = args.verbose
+    no_cursor_timeout = args.no_cursor_timeout
 
     # not a very robust way to detect this condition but it should work
     # it is not robust because it assumes a behavior in argparse for
@@ -120,19 +132,33 @@ def main(args=None):
     # accumulate counts of edits for each key
 
     if enable_deletion:
-        delcounts = db._delete_attributes(collection, delete, verbose=verbose)
+        delcounts = db._delete_attributes(
+            collection,
+            delete,
+            verbose=verbose,
+            no_cursor_timeout=no_cursor_timeout,
+        )
         print("delete processing compeleted on collection=", collection)
         print("Number of documents changed for each key requested follow:")
         print(json_util.dumps(delcounts, indent=4))
     if enable_rename:
-        repcounts = db._rename_attributes(collection, rename_map, verbose=verbose)
+        repcounts = db._rename_attributes(
+            collection,
+            rename_map,
+            verbose=verbose,
+            no_cursor_timeout=no_cursor_timeout,
+        )
         print("rename processing compeleted on collection=", collection)
         print("Here is the set of changes requested:")
         print(json_util.dumps(rename_map))
         print("Number of documents changed for each key requested follow:")
         print(json_util.dumps(repcounts, indent=4))
     if fixtypes:
-        fixcounts = db._fix_attribute_types(collection, verbose=verbose)
+        fixcounts = db._fix_attribute_types(
+            collection,
+            verbose=verbose,
+            no_cursor_timeout=no_cursor_timeout,
+        )
         print("fixtype processing compeleted on collection=", collection)
         print("Keys of documents changed and number changed follow:")
         print(json_util.dumps(fixcounts, indent=4))

--- a/python/mspasspy/db/script/dbverify.py
+++ b/python/mspasspy/db/script/dbverify.py
@@ -7,7 +7,8 @@ dbverify - MsPASS database verify command line tool
 .. topic:: Usage
 
     dbverify dbname [-t testname] [-c col ... ]
-            [-n n1 ...] [-r k1 ...][-e n] [-v] [-h | --help]
+            [-n n1 ...] [-r k1 ...][-e n] [-v]
+            [--no-cursor-timeout] [-h | --help]
 
 .. topic:: Description
 
@@ -103,6 +104,11 @@ argument attached to the -t flag:
     1000.  Smaller numbers are often useful in verbose mode and larger numbers
     may be needed for data sets assembled from multiple sources with different
     problems.
+
+* --no-cursor-timeout:
+    Keeps each collection scan cursor alive with an explicit MongoDB session
+    that MsPASS refreshes periodically.  Use this for large data sets when
+    processing one cursor batch could exceed MongoDB's idle timeout.
 
 .. topic:: EXAMPLES
 
@@ -243,7 +249,9 @@ def print_bad_wf_docs(dbcol, idlist):
         print("////////////////////////////////////////////////////////")
 
 
-def run_check_links(db, wfcollection, nrmlist, elimit, verbose):
+def run_check_links(
+    db, wfcollection, nrmlist, elimit, verbose, no_cursor_timeout=False
+):
     """
     Run the verify function called check_links and produces a reasonable
     summary or readable (verbose) printed output of the results.
@@ -276,7 +284,10 @@ def run_check_links(db, wfcollection, nrmlist, elimit, verbose):
 
     for nrmcol in nrmlist:
         errs = db._check_links(
-            xref_key=nrmcol, collection=wfcollection, error_limit=elimit
+            xref_key=nrmcol,
+            collection=wfcollection,
+            error_limit=elimit,
+            no_cursor_timeout=no_cursor_timeout,
         )
         broken = errs[0]
         undef = errs[1]
@@ -321,7 +332,7 @@ def run_check_links(db, wfcollection, nrmlist, elimit, verbose):
                 )
 
 
-def run_check_attribute_types(db, col, elimit, verbose):
+def run_check_attribute_types(db, col, elimit, verbose, no_cursor_timeout=False):
     """
     Run the verify function called check_attribute_types and produces
     a reasonable summary or readable (verbose) printed output of the results.
@@ -352,7 +363,11 @@ def run_check_attribute_types(db, col, elimit, verbose):
     # definitions for each collection listed.  Verbose is
     # also always off.  Note the solution to enter one from
     # an input is to use json.loads
-    errs = db._check_attribute_types(col, error_limit=elimit)
+    errs = db._check_attribute_types(
+        col,
+        error_limit=elimit,
+        no_cursor_timeout=no_cursor_timeout,
+    )
     mismatch = errs[0]
     undef = errs[1]
     print("check_attribute_types result for collection=", col)
@@ -426,7 +441,9 @@ def run_check_attribute_types(db, col, elimit, verbose):
             print(json_util.dumps(mmkeys, indent=2))
 
 
-def run_check_required(db, col, required_list, elimit, verbose):
+def run_check_required(
+    db, col, required_list, elimit, verbose, no_cursor_timeout=False
+):
     """
     Each standard collection in mspass has some key attributes that
     are essential to be useful.   This test should be run to verify
@@ -439,7 +456,12 @@ def run_check_required(db, col, required_list, elimit, verbose):
     readable layout with json_util.dumps.
 
     """
-    errs = db._check_required(col, required_list, error_limit=elimit)
+    errs = db._check_required(
+        col,
+        required_list,
+        error_limit=elimit,
+        no_cursor_timeout=no_cursor_timeout,
+    )
     mismatch = errs[0]
     undef = errs[1]
     print("////Results from run_check_required on collection=", col)
@@ -532,7 +554,10 @@ def main(args=None):
         args = sys.argv[1:]
     parser = argparse.ArgumentParser(
         prog="dbverify",
-        usage="%(prog)s dbname [-t TEST -c [collection ...] -n [normalize ... ] -error_limit n -v]",
+        usage=(
+            "%(prog)s dbname [-t TEST -c [collection ...] "
+            "-n [normalize ... ] -error_limit n -v --no-cursor-timeout]"
+        ),
         description="MsPASS database verify program",
     )
     parser.add_argument(
@@ -589,6 +614,14 @@ def main(args=None):
         action="store_true",
         help="When used print offending values.  Otherwise just return a summary",
     )
+    parser.add_argument(
+        "--no-cursor-timeout",
+        action="store_true",
+        help=(
+            "Keep collection scan cursors alive with periodically refreshed "
+            "MongoDB sessions"
+        ),
+    )
 
     args = parser.parse_args(args)
     test_to_run = args.test
@@ -600,6 +633,7 @@ def main(args=None):
     reqlist = args.require
     verbose = args.verbose
     elimit = args.error_limit
+    no_cursor_timeout = args.no_cursor_timeout
 
     # If python had a switch case it would be used here.  this
     # is the list of known tests.  the program can only run one
@@ -615,7 +649,7 @@ def main(args=None):
         if not isinstance(col, str):
             print("Invalid value parsed for -c option=", col)
             exit(-1)
-        run_check_links(db, col, normalize, elimit, verbose)
+        run_check_links(db, col, normalize, elimit, verbose, no_cursor_timeout)
     elif test_to_run == "required":
         if len(col_to_test) > 1:
             print("WARNING:  required test can only be run on one collection at a time")
@@ -634,10 +668,10 @@ def main(args=None):
             required_list = get_required(col)
         else:
             required_list = reqlist
-        run_check_required(db, col, required_list, elimit, verbose)
+        run_check_required(db, col, required_list, elimit, verbose, no_cursor_timeout)
     elif test_to_run == "schema_check":
         for col in col_to_test:
-            run_check_attribute_types(db, col, elimit, verbose)
+            run_check_attribute_types(db, col, elimit, verbose, no_cursor_timeout)
     else:
         print("Unrecognized value for --test value parsed=", test_to_run)
         print("Must be one of:  normalization, required, or schema_check")

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -219,6 +219,28 @@ class TestDatabase:
         with pytest.raises(MsPASSError, match="not defined"):
             dummy = db.database_schema["source"]
 
+    def test_read_inventory_with_managed_cursor(self):
+        source_inventory = obspy.read_inventory("python/tests/data/TA.035A.xml")
+        document_id = self.db.site.insert_one(
+            {
+                "net": "CURSOR_TEST",
+                "sta": "CURSOR_TEST",
+                "serialized_inventory": pickle.dumps(source_inventory.networks[0]),
+            }
+        ).inserted_id
+        try:
+            inventory = self.db.read_inventory(
+                net="CURSOR_TEST",
+                sta="CURSOR_TEST",
+                no_cursor_timeout=True,
+            )
+
+            assert inventory is not None
+            assert len(inventory.networks) == 1
+            assert inventory.networks[0].code == "TA"
+        finally:
+            self.db.site.delete_one({"_id": document_id})
+
     def test_save_elogs(self):
         tmp_ts = get_live_timeseries()
         tmp_ts.elog.log_error("alg", str("message"), ErrorSeverity.Informational)

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -49,7 +49,11 @@ from mspasspy.db.schema import DatabaseSchema, MetadataSchema
 from mspasspy.util import logging_helper
 from bson.objectid import ObjectId
 import datetime
-from mspasspy.db.database import Database, geoJSON_doc
+from mspasspy.db.database import (
+    Database,
+    _managed_collection_cursor,
+    geoJSON_doc,
+)
 from mspasspy.db.client import DBClient
 from mspasspy.db.collection import Collection
 
@@ -62,6 +66,48 @@ def test_seed_lookup_verbose_defaults():
         inspect.signature(Database.get_seed_channel).parameters["verbose"].default
         is False
     )
+
+
+def test_managed_collection_cursor_default_mode():
+    cursor = mock.MagicMock()
+    cursor.__enter__.return_value = cursor
+    cursor.__iter__.return_value = iter([{"_id": 1}])
+    collection = mock.MagicMock()
+    collection.find.return_value = cursor
+
+    with _managed_collection_cursor(collection, {"key": "value"}) as documents:
+        assert list(documents) == [{"_id": 1}]
+
+    collection.find.assert_called_once_with({"key": "value"})
+    collection.database.client.start_session.assert_not_called()
+    cursor.__exit__.assert_called_once()
+
+
+def test_managed_collection_cursor_refreshes_explicit_session():
+    cursor = mock.MagicMock()
+    cursor.__enter__.return_value = cursor
+    cursor.__iter__.return_value = iter([{"_id": 1}, {"_id": 2}])
+    session = mock.MagicMock()
+    session.__enter__.return_value = session
+    session.session_id = {"id": "session-id"}
+    client = mock.MagicMock()
+    client.start_session.return_value = session
+    collection = mock.MagicMock()
+    collection.database.client = client
+    collection.find.return_value = cursor
+
+    with patch("mspasspy.db.database.time.monotonic", side_effect=[0.0, 301.0, 302.0]):
+        with _managed_collection_cursor(
+            collection, {}, no_cursor_timeout=True
+        ) as documents:
+            assert list(documents) == [{"_id": 1}, {"_id": 2}]
+
+    collection.find.assert_called_once_with({}, no_cursor_timeout=True, session=session)
+    client.admin.command.assert_called_once_with(
+        {"refreshSessions": [session.session_id]}
+    )
+    cursor.__exit__.assert_called_once()
+    session.__exit__.assert_called_once()
 
 
 class TestDatabase:
@@ -1793,7 +1839,7 @@ class TestDatabase:
         )
         assert save_res.live
 
-        fixed_cnt = self.db.clean_collection("wf_TimeSeries")
+        fixed_cnt = self.db.clean_collection("wf_TimeSeries", no_cursor_timeout=True)
         assert fixed_cnt == {"npts": 1, "delta": 1}
 
     def test_clean(self, capfd):

--- a/python/tests/db/test_dbclean.py
+++ b/python/tests/db/test_dbclean.py
@@ -146,6 +146,7 @@ class TestDBClean:
                 "starttime",
                 "-r",
                 "calib:rename_calib",
+                "--no-cursor-timeout",
             ]
         )
 

--- a/python/tests/db/test_dbverify.py
+++ b/python/tests/db/test_dbverify.py
@@ -124,7 +124,14 @@ class TestDBVerify:
         doc3_str = json_util.dumps(doc3, indent=2)
 
         # default normalization test
-        dbverify.main(["test_dbverify", "-t", "normalization"])
+        dbverify.main(
+            [
+                "test_dbverify",
+                "-t",
+                "normalization",
+                "--no-cursor-timeout",
+            ]
+        )
         out, err = capfd.readouterr()
         assert (
             out


### PR DESCRIPTION
## Summary

- add one managed cursor path for every cursor created inside `Database`
- opt in to `no_cursor_timeout` with an explicit MongoDB session, refresh that session between documents before the next cursor fetch, and close both cursor and session reliably
- expose the option through `clean_collection`, collection-wide maintenance/verification helpers, and `read_inventory`
- expose `--no-cursor-timeout` in `dbclean` and `dbverify`, with API and user-guide documentation
- make the remaining small inventory lookup cursors deterministically close on normal and early-return paths
- cover default and long-running cursor behavior plus the affected database and CLI paths

MongoDB logical session expiry can invalidate a cursor even when PyMongo's `no_cursor_timeout=True` is used on its own. This implementation follows MongoDB's documented pattern of pairing the option with an explicit, periodically refreshed session.

## Verification

- `48 passed` across `test_database.py`, `test_dbclean.py`, and `test_dbverify.py` against MongoDB 4.4
- focused managed-cursor unit tests: `2 passed`
- Sphinx HTML build completed with exit code 0 (only existing offline intersphinx warnings)
- Black, Python byte-compilation, and `git diff --check` passed

Fixes #293