### PR TITLE
Allow forcing a PIC-safe bundled Boost

### DIFF
--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -48,12 +48,16 @@ message (STATUS "YAML_CPP_INCLUDE_DIR = ${YAML_CPP_INCLUDE_DIR}")
 
 # Boost.Serialization archives are shared across MsPASS builds, so the Boost
 # version is a compatibility constraint rather than a minimum dependency.
+option (MSPASS_FORCE_BUNDLED_BOOST
+  "Ignore installed Boost libraries and build the pinned bundled Boost" OFF)
 set (Boost_USE_STATIC_LIBS ON)
 if (DEFINED ENV{MSPASS_BOOST_ROOT} AND NOT "$ENV{MSPASS_BOOST_ROOT}" STREQUAL "")
   set (BOOST_ROOT "$ENV{MSPASS_BOOST_ROOT}")
 endif ()
-find_package (Boost 1.86.0 EXACT COMPONENTS serialization)
-if (NOT Boost_FOUND)
+if (NOT MSPASS_FORCE_BUNDLED_BOOST)
+  find_package (Boost 1.86.0 EXACT COMPONENTS serialization)
+endif ()
+if (MSPASS_FORCE_BUNDLED_BOOST OR NOT Boost_FOUND)
   message (STATUS "Building Boost")
   include (cmake/boost.cmake)
   fetch_boost (

--- a/cxx/cmake/boost.cmake
+++ b/cxx/cmake/boost.cmake
@@ -33,9 +33,34 @@ macro(fetch_boost _download_module_path _download_root)
     endif()
 
     set (BOOST_ROOT ${BOOST_INSTALL_ROOT})
+    set (BOOST_INCLUDEDIR ${BOOST_INSTALL_ROOT}/include)
+    set (BOOST_LIBRARYDIR ${BOOST_INSTALL_ROOT}/lib)
     set (Boost_NO_BOOST_CMAKE ON)
+    set (Boost_NO_SYSTEM_PATHS ON)
     set (Boost_USE_STATIC_LIBS ON)
-    set (Boost_INCLUDE_DIR ${BOOST_ROOT}/include)
 
+    # A failed initial find_package call can leave usable headers or libraries
+    # from a different prefix in CMake's cache.  Clear those results so the
+    # bundled build cannot mix its headers with an incompatible installed
+    # Boost library.
+    foreach (_boost_cache_var IN ITEMS
+        Boost_DIR
+        Boost_FOUND
+        Boost_INCLUDE_DIR
+        Boost_INCLUDE_DIRS
+        Boost_LIBRARIES
+        Boost_LIBRARY_DIRS
+        Boost_LIBRARY_DIR_DEBUG
+        Boost_LIBRARY_DIR_RELEASE
+        Boost_SERIALIZATION_LIBRARY_DEBUG
+        Boost_SERIALIZATION_LIBRARY_RELEASE)
+        unset (${_boost_cache_var})
+        unset (${_boost_cache_var} CACHE)
+    endforeach ()
+
+    set (_MSPASS_SAVED_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+    set (CMAKE_PREFIX_PATH "${BOOST_INSTALL_ROOT}")
     find_package (Boost 1.86.0 EXACT REQUIRED COMPONENTS serialization)
+    set (CMAKE_PREFIX_PATH "${_MSPASS_SAVED_CMAKE_PREFIX_PATH}")
+    unset (_MSPASS_SAVED_CMAKE_PREFIX_PATH)
 endmacro()

--- a/cxx/cmake/boost.cmake
+++ b/cxx/cmake/boost.cmake
@@ -49,6 +49,7 @@ macro(fetch_boost _download_module_path _download_root)
         Boost_INCLUDE_DIR
         Boost_INCLUDE_DIRS
         Boost_LIBRARIES
+        Boost_LIBRARY_DIR
         Boost_LIBRARY_DIRS
         Boost_LIBRARY_DIR_DEBUG
         Boost_LIBRARY_DIR_RELEASE

--- a/docs/source/getting_started/advanced_setup_considerations.rst
+++ b/docs/source/getting_started/advanced_setup_considerations.rst
@@ -45,6 +45,24 @@ Do not add ``--user`` inside a Conda or virtual environment: it can install a
 second copy outside the environment.  Also avoid ``sudo pip``, which can
 modify files managed by the operating system.
 
+Force the bundled Boost build
+-----------------------------
+
+MsPASS links the static Boost.Serialization library into its Python extension,
+so that library must be compiled as position-independent code.  If CMake finds
+an incompatible Boost library in a Conda or system prefix, configure the C++
+build with ``MSPASS_FORCE_BUNDLED_BOOST`` enabled:
+
+.. code-block:: bash
+
+   cmake -S cxx -B build -DMSPASS_FORCE_BUNDLED_BOOST=ON
+   cmake --build build
+
+The option is also available in ``ccmake``.  It skips installed Boost
+libraries and builds the project's pinned Boost version as a static ``-fPIC``
+library.  Leave the option off to retain the normal behavior of using a
+compatible installed Boost first.
+
 Check which copy is imported
 ----------------------------
 

--- a/docs/source/getting_started/advanced_setup_considerations.rst
+++ b/docs/source/getting_started/advanced_setup_considerations.rst
@@ -55,8 +55,10 @@ build with ``MSPASS_FORCE_BUNDLED_BOOST`` enabled:
 
 .. code-block:: bash
 
-   cmake -S cxx -B build -DMSPASS_FORCE_BUNDLED_BOOST=ON
-   cmake --build build
+   mkdir -p build
+   cd build
+   cmake ../cxx -DMSPASS_FORCE_BUNDLED_BOOST=ON
+   cmake --build .
 
 The option is also available in ``ccmake``.  It skips installed Boost
 libraries and builds the project's pinned Boost version as a static ``-fPIC``


### PR DESCRIPTION
## Summary

- add a default-off `MSPASS_FORCE_BUNDLED_BOOST` CMake option that bypasses Conda/system Boost discovery
- after building the pinned Boost 1.86 dependency, clear stale Boost cache entries (including CMake 3.11's `Boost_LIBRARY_DIR`) and restrict the final lookup to the bundled install prefix
- prevent mixed Boost headers/libraries from separate prefixes
- document a CMake 3.11-compatible `cmake` and `ccmake` workflow for source builds

The bundled Boost path already builds static Boost.Serialization with `-fPIC`. This change gives developers an explicit escape hatch when an installed static Boost is incompatible with the Python extension link.

## Verification

- adversarial forced configure with both a different complete Boost 1.86 prefix and an explicit external `Boost_LIBRARY_DIR` still resolved headers, library directories, and `libboost_serialization.a` exclusively from the bundled build
- full forced C++ build completed successfully, including all Python extension link steps
- CTest: 11/11 passed
- default-off configure continued to select the compatible installed Boost
- Sphinx HTML build completed with exit code 0 (only existing offline intersphinx warnings)
- `git diff --check` passed

Fixes #446