### PR TITLE
Wait for MongoDB shards before configuring databases

### DIFF
--- a/data/yaml/docker-compose_sharding.yaml
+++ b/data/yaml/docker-compose_sharding.yaml
@@ -13,7 +13,7 @@ services:
       - mspass-shard-1
     environment:
       MSPASS_ROLE: dbmanager
-      MSPASS_SHARD_LIST: mspass-shard-0/mspass-shard-0:27017 mspass-shard-1/mspass-shard-1:27017
+      MSPASS_SHARD_LIST: rs0/mspass-shard-0:27017 rs1/mspass-shard-1:27017
       MONGODB_PORT: 27017
     healthcheck:
       test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet 

--- a/python/tests/test_start_mspass_sharding.py
+++ b/python/tests/test_start_mspass_sharding.py
@@ -1,0 +1,96 @@
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+START_MSPASS = REPOSITORY_ROOT / "scripts" / "start-mspass.sh"
+SHARDING_COMPOSE = REPOSITORY_ROOT / "data" / "yaml" / "docker-compose_sharding.yaml"
+
+
+def _write_executable(path, content):
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def _run_dbmanager(tmp_path, successful_add_shard_attempt):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "mongosh.log"
+
+    for command in ("mongod", "mongos", "tail"):
+        _write_executable(fake_bin / command, "#!/bin/bash\nexit 0\n")
+
+    _write_executable(
+        fake_bin / "mongosh",
+        """#!/bin/bash
+printf '%s\n' "$*" >> "$MONGOSH_LOG"
+if [[ "$*" == *'sh.addShard'* ]]; then
+  attempts=$(grep -c 'sh.addShard' "$MONGOSH_LOG")
+  if ((attempts < SUCCESSFUL_ADD_SHARD_ATTEMPT)); then
+    exit 1
+  fi
+fi
+exit 0
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "MONGODB_PORT": "27017",
+            "MONGOSH_LOG": str(command_log),
+            "MSPASS_DB_DIR": str(tmp_path / "db"),
+            "MSPASS_LOG_DIR": str(tmp_path / "logs"),
+            "MSPASS_ROLE": "dbmanager",
+            "MSPASS_SHARD_COLLECTIONS": "wf_miniseed:_id",
+            "MSPASS_SHARD_DATABASE": "usarray2012",
+            "MSPASS_SHARD_LIST": "rs0/shard0:27017",
+            "MSPASS_SLEEP_TIME": "0",
+            "MSPASS_WORK_DIR": str(tmp_path / "work"),
+            "SUCCESSFUL_ADD_SHARD_ATTEMPT": str(successful_add_shard_attempt),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(START_MSPASS)],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=10,
+    )
+    commands = command_log.read_text().splitlines()
+    return result, commands
+
+
+def test_dbmanager_waits_for_shard_before_enabling_sharding(tmp_path):
+    result, commands = _run_dbmanager(tmp_path, successful_add_shard_attempt=3)
+
+    assert result.returncode == 0, result.stderr
+    add_shard_commands = [line for line in commands if "sh.addShard" in line]
+    assert len(add_shard_commands) == 3
+    assert next(
+        i for i, line in enumerate(commands) if "sh.enableSharding" in line
+    ) > max(i for i, line in enumerate(commands) if "sh.addShard" in line)
+
+
+def test_dbmanager_stops_when_no_shard_becomes_ready(tmp_path):
+    result, commands = _run_dbmanager(tmp_path, successful_add_shard_attempt=21)
+
+    assert result.returncode != 0
+    assert sum("sh.addShard" in line for line in commands) == 20
+    assert all("sh.enableSharding" not in line for line in commands)
+    assert "failed after 20 attempts" in result.stderr
+
+
+def test_sharding_compose_uses_the_initialized_replica_set_names():
+    compose = yaml.safe_load(SHARDING_COMPOSE.read_text())
+    shard_list = compose["services"]["mspass-dbmanager"]["environment"][
+        "MSPASS_SHARD_LIST"
+    ]
+
+    assert shard_list.split() == [
+        "rs0/mspass-shard-0:27017",
+        "rs1/mspass-shard-1:27017",
+    ]

--- a/python/tests/test_start_mspass_sharding.py
+++ b/python/tests/test_start_mspass_sharding.py
@@ -7,6 +7,7 @@ import yaml
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 START_MSPASS = REPOSITORY_ROOT / "scripts" / "start-mspass.sh"
 SHARDING_COMPOSE = REPOSITORY_ROOT / "data" / "yaml" / "docker-compose_sharding.yaml"
+DISTRIBUTED_NODE = REPOSITORY_ROOT / "scripts" / "tacc_examples" / "distributed_node.sh"
 
 
 def _write_executable(path, content):
@@ -14,10 +15,14 @@ def _write_executable(path, content):
     path.chmod(0o755)
 
 
-def _run_dbmanager(tmp_path, successful_add_shard_attempt):
+def _run_dbmanager(tmp_path, successful_add_shard_attempt, restore=False):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     command_log = tmp_path / "mongosh.log"
+    ready_file = tmp_path / "db-ready"
+
+    if restore:
+        (tmp_path / "db" / "data_config").mkdir(parents=True)
 
     for command in ("mongod", "mongos", "tail"):
         _write_executable(fake_bin / command, "#!/bin/bash\nexit 0\n")
@@ -43,6 +48,7 @@ exit 0
             "MONGODB_PORT": "27017",
             "MONGOSH_LOG": str(command_log),
             "MSPASS_DB_DIR": str(tmp_path / "db"),
+            "MSPASS_DB_READY_FILE": str(ready_file),
             "MSPASS_LOG_DIR": str(tmp_path / "logs"),
             "MSPASS_ROLE": "dbmanager",
             "MSPASS_SHARD_COLLECTIONS": "wf_miniseed:_id",
@@ -61,11 +67,13 @@ exit 0
         timeout=10,
     )
     commands = command_log.read_text().splitlines()
-    return result, commands
+    return result, commands, ready_file
 
 
 def test_dbmanager_waits_for_shard_before_enabling_sharding(tmp_path):
-    result, commands = _run_dbmanager(tmp_path, successful_add_shard_attempt=3)
+    result, commands, ready_file = _run_dbmanager(
+        tmp_path, successful_add_shard_attempt=3
+    )
 
     assert result.returncode == 0, result.stderr
     add_shard_commands = [line for line in commands if "sh.addShard" in line]
@@ -73,15 +81,32 @@ def test_dbmanager_waits_for_shard_before_enabling_sharding(tmp_path):
     assert next(
         i for i, line in enumerate(commands) if "sh.enableSharding" in line
     ) > max(i for i, line in enumerate(commands) if "sh.addShard" in line)
+    assert ready_file.is_file()
 
 
 def test_dbmanager_stops_when_no_shard_becomes_ready(tmp_path):
-    result, commands = _run_dbmanager(tmp_path, successful_add_shard_attempt=21)
+    result, commands, ready_file = _run_dbmanager(
+        tmp_path, successful_add_shard_attempt=21
+    )
 
     assert result.returncode != 0
     assert sum("sh.addShard" in line for line in commands) == 20
     assert all("sh.enableSharding" not in line for line in commands)
     assert "failed after 20 attempts" in result.stderr
+    assert not ready_file.exists()
+
+
+def test_restored_dbmanager_repairs_missing_shard_registration(tmp_path):
+    result, commands, ready_file = _run_dbmanager(
+        tmp_path, successful_add_shard_attempt=2, restore=True
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert sum("sh.addShard" in line for line in commands) == 2
+    assert next(
+        i for i, line in enumerate(commands) if "sh.enableSharding" in line
+    ) > max(i for i, line in enumerate(commands) if "sh.addShard" in line)
+    assert ready_file.is_file()
 
 
 def test_sharding_compose_uses_the_initialized_replica_set_names():
@@ -94,3 +119,19 @@ def test_sharding_compose_uses_the_initialized_replica_set_names():
         "rs0/mspass-shard-0:27017",
         "rs1/mspass-shard-1:27017",
     ]
+
+
+def test_frontera_frontend_waits_for_dbmanager_readiness():
+    script = DISTRIBUTED_NODE.read_text()
+    dbmanager_launch = script.index("APPTAINERENV_MSPASS_ROLE=dbmanager")
+    shard_launch = script.index("APPTAINERENV_MSPASS_ROLE=shard", dbmanager_launch)
+    readiness_wait = script.index('while [[ ! -f "$DB_READY_FILE" ]]', shard_launch)
+    frontend_launches = [
+        index
+        for index in range(len(script))
+        if script.startswith("APPTAINERENV_MSPASS_ROLE=frontend", index)
+    ]
+
+    assert frontend_launches
+    assert dbmanager_launch < shard_launch < readiness_wait < min(frontend_launches)
+    assert "DBMANAGER_PID=$!" in script[dbmanager_launch:readiness_wait]

--- a/scripts/start-mspass.sh
+++ b/scripts/start-mspass.sh
@@ -127,6 +127,26 @@ if [[ -z $MSPASS_SLEEP_TIME ]]; then
   MSPASS_SLEEP_TIME=15
 fi
 
+function retry_mongosh_command {
+  local description="$1"
+  shift
+  local attempt
+  local max_attempts=20
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if mongosh "$@"; then
+      return 0
+    fi
+    if ((attempt < max_attempts)); then
+      echo "$description is not ready (attempt $attempt/$max_attempts); retrying in ${MSPASS_SLEEP_TIME}s"
+      sleep "$MSPASS_SLEEP_TIME"
+    fi
+  done
+
+  echo "ERROR: $description failed after $max_attempts attempts" >&2
+  return 1
+}
+
 # This sets defaults for this set of env variables
 if [[ -z ${MSPASS_DB_DIR} ]]; then
   MSPASS_DB_DIR=${MSPASS_WORKDIR}/db
@@ -475,8 +495,10 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
       # add shard clusters
       for i in ${MSPASS_SHARD_LIST[@]}; do
         echo "add shard with host ${i}"
-        sleep ${MSPASS_SLEEP_TIME}
-        mongosh --host $HOSTNAME --port $MONGODB_PORT --eval "sh.addShard(\"${i}\")"
+        if ! retry_mongosh_command "add shard ${i}" \
+          --host "$HOSTNAME" --port "$MONGODB_PORT" --eval "sh.addShard(\"${i}\")"; then
+          exit 1
+        fi
       done
     fi
 

--- a/scripts/start-mspass.sh
+++ b/scripts/start-mspass.sh
@@ -147,6 +147,36 @@ function retry_mongosh_command {
   return 1
 }
 
+function ensure_shard_registered {
+  local shard_connection="$1"
+  local shard_name="${shard_connection%%/*}"
+  local ensure_script
+
+  if ! retry_mongosh_command "shard ${shard_name} primary" \
+    --host "$shard_connection" --quiet --eval \
+    'const hello = db.adminCommand({hello: 1}); if (!(hello.isWritablePrimary || hello.ismaster)) { quit(1); }'; then
+    return 1
+  fi
+
+  ensure_script="
+    const connection = \"${shard_connection}\";
+    const name = \"${shard_name}\";
+    const listed = db.adminCommand({listShards: 1});
+    if (!listed.ok) { quit(1); }
+    const existing = listed.shards.find((shard) => shard._id === name);
+    if (existing && existing.host !== connection) {
+      print(\"Shard \" + name + \" is registered as \" + existing.host + \" instead of \" + connection);
+      quit(1);
+    }
+    if (!existing) {
+      const added = sh.addShard(connection);
+      if (!added.ok) { quit(1); }
+    }
+  "
+  retry_mongosh_command "register shard ${shard_name}" \
+    --host "$HOSTNAME" --port "$MONGODB_PORT" --eval "$ensure_script"
+}
+
 # This sets defaults for this set of env variables
 if [[ -z ${MSPASS_DB_DIR} ]]; then
   MSPASS_DB_DIR=${MSPASS_WORKDIR}/db
@@ -444,6 +474,9 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
       start_db_scratch
     fi
   elif [ "$MSPASS_ROLE" = "dbmanager" ]; then
+    if [[ -n ${MSPASS_DB_READY_FILE:-} ]]; then
+      rm -f -- "$MSPASS_DB_READY_FILE"
+    fi
     # config server configuration
     MONGODB_CONFIG_PORT=$(($MONGODB_PORT+1))
     if [ -d ${MONGO_DATA}_config ]; then
@@ -492,26 +525,40 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
 
       # start a mongos router server
       mongos --port $MONGODB_PORT --configdb configserver/$HOSTNAME:$MONGODB_CONFIG_PORT --logpath ${MONGO_LOG}_router --bind_ip_all &
-      # add shard clusters
-      for i in ${MSPASS_SHARD_LIST[@]}; do
-        echo "add shard with host ${i}"
-        if ! retry_mongosh_command "add shard ${i}" \
-          --host "$HOSTNAME" --port "$MONGODB_PORT" --eval "sh.addShard(\"${i}\")"; then
+    fi
+
+    if [[ -z ${MSPASS_SHARD_LIST:-} ]]; then
+      echo "ERROR: MSPASS_SHARD_LIST must contain at least one shard" >&2
+      exit 1
+    fi
+    for i in ${MSPASS_SHARD_LIST[@]}; do
+      echo "ensure shard ${i} is reachable and registered"
+      if ! ensure_shard_registered "$i"; then
+        exit 1
+      fi
+    done
+
+    if [[ -n ${MSPASS_SHARD_DATABASE:-} ]]; then
+      # enable database sharding
+      echo "enable database $MSPASS_SHARD_DATABASE sharding"
+      if ! retry_mongosh_command "enable database $MSPASS_SHARD_DATABASE sharding" \
+        --host "$HOSTNAME" --port "$MONGODB_PORT" --eval "sh.enableSharding(\"${MSPASS_SHARD_DATABASE}\")"; then
+        exit 1
+      fi
+      # shard collection(using hashed)
+      for i in ${MSPASS_SHARD_COLLECTIONS[@]}; do
+        echo "shard collection $MSPASS_SHARD_DATABASE.${i%%:*} and shard key is ${i##*:}"
+        if ! retry_mongosh_command "shard collection $MSPASS_SHARD_DATABASE.${i%%:*}" \
+          --host "$HOSTNAME" --port "$MONGODB_PORT" --eval "sh.shardCollection(\"$MSPASS_SHARD_DATABASE.${i%%:*}\", {${i##*:}: \"hashed\"})"; then
           exit 1
         fi
       done
     fi
 
-    # enable database sharding
-    echo "enable database $MSPASS_SHARD_DATABASE sharding"
-    mongosh --host $HOSTNAME --port $MONGODB_PORT --eval "sh.enableSharding(\"${MSPASS_SHARD_DATABASE}\")"
-    sleep ${MSPASS_SLEEP_TIME}
-    # shard collection(using hashed)
-    for i in ${MSPASS_SHARD_COLLECTIONS[@]}; do
-      echo "shard collection $MSPASS_SHARD_DATABASE.${i%%:*} and shard key is ${i##*:}"
-      mongosh --host $HOSTNAME --port $MONGODB_PORT --eval "sh.shardCollection(\"$MSPASS_SHARD_DATABASE.${i%%:*}\", {${i##*:}: \"hashed\"})"
-      sleep ${MSPASS_SLEEP_TIME}
-    done
+    if [[ -n ${MSPASS_DB_READY_FILE:-} ]] && ! touch "$MSPASS_DB_READY_FILE"; then
+      echo "ERROR: could not create database readiness file $MSPASS_DB_READY_FILE" >&2
+      exit 1
+    fi
     tail -f /dev/null
   elif [ "$MSPASS_ROLE" = "shard" ]; then
     [[ -n $MSPASS_SHARD_ID ]] || MSPASS_SHARD_ID=$MY_ID

--- a/scripts/tacc_examples/distributed_node.sh
+++ b/scripts/tacc_examples/distributed_node.sh
@@ -108,15 +108,17 @@ if [ "$DB_SHARDING" = true ] ; then
         SHARD_LOGS_PATH[$i]="$username@${WORKER_LIST_ARR[$i]}.${HOSTNAME_BASE}:/tmp/logs/mongo_log_shard_$i"
     done
 
+    DB_READY_FILE="$WORK_DIR/.mspass-db-ready-${SLURM_JOB_ID:-$$}"
+    rm -f -- "$DB_READY_FILE"
+
     APPTAINERENV_MSPASS_WORK_DIR=$WORK_DIR \
+    APPTAINERENV_MSPASS_DB_READY_FILE=$DB_READY_FILE \
     APPTAINERENV_MSPASS_SHARD_DATABASE=${SHARD_DATABASE} \
     APPTAINERENV_MSPASS_SHARD_COLLECTIONS=${SHARD_COLLECTIONS[@]} \
     APPTAINERENV_MSPASS_SHARD_LIST=${SHARD_LIST[@]} \
     APPTAINERENV_MSPASS_SLEEP_TIME=$SLEEP_TIME \
     APPTAINERENV_MSPASS_ROLE=dbmanager $APP_COM &
-
-    # ensure enough time for dbmanager to finish
-    sleep 30
+    DBMANAGER_PID=$!
 
     # start a shard container in each worker node
     # mipexec could be cleaner while ssh would induce more complexity
@@ -129,6 +131,27 @@ if [ "$DB_SHARDING" = true ] ; then
         APPTAINERENV_MSPASS_ROLE=shard \
         mpiexec.hydra -n 1 -ppn 1 -hosts ${WORKER_LIST_ARR[i]} $APP_COM &
     done
+
+    DB_READY_TIMEOUT=900
+    DB_READY_WAITED=0
+    while [[ ! -f "$DB_READY_FILE" ]]; do
+        if ! kill -0 "$DBMANAGER_PID" 2>/dev/null; then
+            wait "$DBMANAGER_PID"
+            DBMANAGER_STATUS=$?
+            if ((DBMANAGER_STATUS == 0)); then
+                DBMANAGER_STATUS=1
+            fi
+            echo "dbmanager exited before MongoDB sharding was ready" >&2
+            exit "$DBMANAGER_STATUS"
+        fi
+        if ((DB_READY_WAITED >= DB_READY_TIMEOUT)); then
+            echo "timed out waiting for MongoDB sharding readiness" >&2
+            exit 1
+        fi
+        sleep 2
+        DB_READY_WAITED=$((DB_READY_WAITED + 2))
+    done
+    rm -f -- "$DB_READY_FILE"
 
     # Launch the jupyter notebook frontend in the primary node.
     # Run in batch mode if the script was


### PR DESCRIPTION
## Summary

- wait for each shard replica-set primary and register missing shards through one idempotent path shared by fresh and restored config servers
- retry MongoDB topology, database, and collection setup with a bounded attempt count; stop cleanly instead of continuing with zero shards
- publish an explicit readiness marker only after all shard/database/collection steps succeed
- make the Frontera launcher start shards immediately, wait for that marker, propagate dbmanager failure/timeout, and only then start either interactive or batch frontend
- align the Docker Compose shard connection strings with the replica-set IDs initialized by `start-mspass.sh` (`rs0` and `rs1`)
- add regression coverage for delayed readiness, exhausted retries, restore repair, readiness marker ordering, Frontera frontend ordering, and Compose replica-set names

This addresses both failure modes from #453: partial initialization can recover on restart, and no frontend can begin database work before the sharded topology and requested database/collections are ready.

## Verification

- `bash -n scripts/start-mspass.sh`
- `bash -n scripts/tacc_examples/distributed_node.sh`
- `pytest -q python/tests/test_start_mspass_sharding.py`: 5 passed
- Black check passed
- `docker compose -f data/yaml/docker-compose_sharding.yaml config --quiet` passed
- `git diff --check` passed
- real sharded MongoDB fresh-start integration with dbmanager deliberately started before both shards:
  - observed real DNS/primary-selection failures
  - dbmanager recovered when the shards became ready
  - `rs0` and `rs1` were registered
  - `usarray2012.wf_miniseed` was sharded and writable
  - readiness marker appeared only after configuration completed
- real in-place dbmanager restart using the existing config data:
  - restore path revalidated both shard primaries
  - existing registrations were handled idempotently
  - database and collection setup remained idempotent
  - readiness marker was recreated and a post-restore insert succeeded
- disposable integration containers and network were removed after verification

Fixes #453