### PR TITLE
Resolve packaged data without MSPASS_HOME

### DIFF
--- a/cxx/include/mspass/utility/AntelopePf.h
+++ b/cxx/include/mspass/utility/AntelopePf.h
@@ -65,13 +65,14 @@ public:
   /*! \brief Construct from a base pf name.
 
   This constructor acts like the antelope pfread function for
-  parameter files constructed in plain C.  A relative base name is first
-  read from the MsPASS data directory: MSPASS_HOME/data when MSPASS_HOME is
-  set, or the installed mspasspy package data otherwise.  The constructor
-  then follows the chain of directories defined by PFPATH; if PFPATH is not
-  defined, that path defaults to ".".  As with the antelope pfread procedure,
-  the last file read takes precedence, so PFPATH or the current directory can
-  override the MsPASS data file.
+  parameter files constructed in plain C.  A relative base name is first read
+  from the MsPASS data directory when available: MSPASS_HOME/data when
+  MSPASS_HOME is set, or the installed mspasspy package data after the Python
+  extension registers it.  A standalone caller without MSPASS_HOME instead
+  starts with the directories defined by PFPATH; if PFPATH is not defined,
+  that path defaults to ".".  As with the antelope pfread procedure, the last
+  file read takes precedence, so PFPATH or the current directory can override
+  the MsPASS data file.
   Further if pfbase begins with a slash (i.e. "/") it is assumed to be
   the actual file name to read and the PFPATH feature is disabled.
 

--- a/cxx/include/mspass/utility/AntelopePf.h
+++ b/cxx/include/mspass/utility/AntelopePf.h
@@ -65,15 +65,18 @@ public:
   /*! \brief Construct from a base pf name.
 
   This constructor acts like the antelope pfread function for
-  parameter files constructed in plain C.   That is, the argument is
-  a base name sans the .pf extension.   Like antelope's pfread it
-  will follow the chain of directories defined by PFPATH.   As with
-  the antelope pfread procedure the last file read takes precendence.
-  Note if PFPATH is not defined the path defaults to ".".
+  parameter files constructed in plain C.  A relative base name is first
+  read from the MsPASS data directory: MSPASS_HOME/data when MSPASS_HOME is
+  set, or the installed mspasspy package data otherwise.  The constructor
+  then follows the chain of directories defined by PFPATH; if PFPATH is not
+  defined, that path defaults to ".".  As with the antelope pfread procedure,
+  the last file read takes precedence, so PFPATH or the current directory can
+  override the MsPASS data file.
   Further if pfbase begins with a slash (i.e. "/") it is assumed to be
   the actual file name to read and the PFPATH feature is disabled.
 
-    \param pfbase is a the base pf name (always adds .pf to each name in PFPATH)
+    \param pfbase is the base pf name.  Relative names may include or omit
+      the .pf suffix; it is added when absent.
 
     \exception - throws a MsPASSError object with an informative message if
       constuctor fails for any reason.

--- a/cxx/include/mspass/utility/utility.h
+++ b/cxx/include/mspass/utility/utility.h
@@ -10,9 +10,11 @@ namespace utility {
 mspass.
 
 Programs often need a standard set of initialization files.  In mspass we
-group these under a "data" directory.  This procedure returns the top of the
-chain of data directories.  Note this is the top of a directory chain and
-most application will need to add a subdirectory.   e.g.
+group these under a "data" directory.  This procedure first uses the data
+directory under MSPASS_HOME when that environment variable is defined.  When
+called from the Python extension without MSPASS_HOME, it uses the data
+directory installed with the mspasspy package.  Note this is the top of a
+directory chain and most applications will need to add a subdirectory.  e.g.
 
 string datadir=mspass::utility::data_directory();
 string mydatafile=datadir+"/pf";

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -16,6 +16,7 @@
 
 #include "python/utility/Publicdmatrix_py.h"
 #include "python/utility/boost_any_converter_py.h"
+#include "src/lib/utility/data_directory.h"
 
 namespace mspass {
 namespace mspasspy {
@@ -25,6 +26,19 @@ using namespace std;
 using namespace mspass::utility;
 
 namespace {
+void register_python_package_data_directory() {
+  py::object package_file = py::module_::import("mspasspy").attr("__file__");
+  if (package_file.is_none())
+    return;
+
+  py::module_ path = py::module_::import("os.path");
+  py::object package_directory =
+      path.attr("dirname")(path.attr("abspath")(package_file));
+  const std::string data_directory =
+      path.attr("join")(package_directory, "data").cast<std::string>();
+  mspass::utility::detail::set_python_package_data_directory(data_directory);
+}
+
 bool is_expected_python_conversion_error(py::error_already_set &err) {
   return err.matches(PyExc_TypeError) || err.matches(PyExc_ValueError) ||
          err.matches(PyExc_OverflowError);
@@ -230,6 +244,7 @@ static PyGetSetDef MsPASSError_getsetters[] = {
 };
 
 PYBIND11_MODULE(utility, m) {
+  register_python_package_data_directory();
   m.attr("__name__") = "mspasspy.ccore.utility";
   m.doc() = "A submodule for utility namespace of ccore";
 

--- a/cxx/src/lib/utility/AntelopePf.cc
+++ b/cxx/src/lib/utility/AntelopePf.cc
@@ -325,23 +325,32 @@ list<string> split_pfpath(string pfbase, char *s) {
 AntelopePf::AntelopePf(std::string pfbase) {
   try {
     list<string> pffiles;
-    try {
-      pffiles.push_back(data_directory() + "/pf/" + pfbase);
-    } catch (const MsPASSError &) {
-      /* A standalone C++ caller without MSPASS_HOME has no package data
-       * directory.  Preserve the existing PFPATH/current-directory search. */
+    const bool is_absolute = !pfbase.empty() && pfbase[0] == '/';
+    string pfname(pfbase);
+    if (!is_absolute && (pfname.size() < 3 ||
+                         pfname.compare(pfname.size() - 3, 3, ".pf") != 0)) {
+      pfname += ".pf";
+    }
+    if (!is_absolute) {
+      try {
+        pffiles.push_back(data_directory() + "/pf/" + pfname);
+      } catch (const MsPASSError &) {
+        /* A standalone C++ caller without MSPASS_HOME has no package data
+         * directory.  Preserve the existing PFPATH/current-directory search.
+         */
+      }
     }
     const string envname("PFPATH");
     char *s = getenv(envname.c_str());
-    if (s == NULL) {
-      pffiles.push_back(pfbase);
-    }
     /* Test to see if pfbase is an absolute path - if so just use
      * it and ignore the pfpath feature */
-    else if (pfbase[0] == '/') {
+    if (is_absolute) {
       pffiles.push_back(pfbase);
+    } else if (s == NULL) {
+      pffiles.push_back(pfname);
     } else {
-      pffiles = split_pfpath(pfbase, s);
+      list<string> pfpath_files = split_pfpath(pfname, s);
+      pffiles.splice(pffiles.end(), pfpath_files);
     }
     list<string>::iterator pfptr;
     int nread;

--- a/cxx/src/lib/utility/AntelopePf.cc
+++ b/cxx/src/lib/utility/AntelopePf.cc
@@ -325,13 +325,11 @@ list<string> split_pfpath(string pfbase, char *s) {
 AntelopePf::AntelopePf(std::string pfbase) {
   try {
     list<string> pffiles;
-    const std::string mspass_home_envname("MSPASS_HOME");
-    char *base;
-    /* Note man page for getenv says explicitly the return of getenv should not
-            be touched - i.e. don't free it*/
-    base = getenv(mspass_home_envname.c_str());
-    if (base != NULL) {
+    try {
       pffiles.push_back(data_directory() + "/pf/" + pfbase);
+    } catch (const MsPASSError &) {
+      /* A standalone C++ caller without MSPASS_HOME has no package data
+       * directory.  Preserve the existing PFPATH/current-directory search. */
     }
     const string envname("PFPATH");
     char *s = getenv(envname.c_str());

--- a/cxx/src/lib/utility/data_directory.cc
+++ b/cxx/src/lib/utility/data_directory.cc
@@ -1,44 +1,26 @@
+#include "data_directory.h"
 #include "mspass/utility/MsPASSError.h"
-#include <Python.h>
 #include <cstdlib>
 #include <string>
 
 namespace {
-std::string python_package_data_directory() {
-  if (!Py_IsInitialized())
-    return std::string();
-
-  const PyGILState_STATE gil_state = PyGILState_Ensure();
-  std::string datadir;
-  PyObject *modules = PyImport_GetModuleDict();
-  PyObject *package = PyDict_GetItemString(modules, "mspasspy");
-  if (package != nullptr) {
-    PyObject *package_file = PyObject_GetAttrString(package, "__file__");
-    if (package_file != nullptr && package_file != Py_None) {
-      const char *path = PyUnicode_AsUTF8(package_file);
-      if (path != nullptr) {
-        const std::string filename(path);
-        const std::size_t separator = filename.find_last_of("/\\");
-        if (separator != std::string::npos)
-          datadir = filename.substr(0, separator) + "/data";
-      }
-    }
-    Py_XDECREF(package_file);
-  }
-  if (PyErr_Occurred())
-    PyErr_Clear();
-  PyGILState_Release(gil_state);
-  return datadir;
+std::string &python_package_data_directory() {
+  static std::string directory;
+  return directory;
 }
 } // namespace
 
 namespace mspass::utility {
+void detail::set_python_package_data_directory(const std::string &directory) {
+  python_package_data_directory() = directory;
+}
+
 /* Standardizes top level directory for mspass */
 std::string data_directory() {
   const std::string mspass_home_envname("MSPASS_HOME");
   /* Note man page for getenv says explicitly the return of getenv should not
                   be touched - i.e. don't free it*/
-  const char *base = getenv(mspass_home_envname.c_str());
+  const char *base = std::getenv(mspass_home_envname.c_str());
   if (base != nullptr)
     return std::string(base) + "/data";
 

--- a/cxx/src/lib/utility/data_directory.cc
+++ b/cxx/src/lib/utility/data_directory.cc
@@ -1,19 +1,53 @@
 #include "mspass/utility/MsPASSError.h"
+#include <Python.h>
+#include <cstdlib>
 #include <string>
+
+namespace {
+std::string python_package_data_directory() {
+  if (!Py_IsInitialized())
+    return std::string();
+
+  const PyGILState_STATE gil_state = PyGILState_Ensure();
+  std::string datadir;
+  PyObject *modules = PyImport_GetModuleDict();
+  PyObject *package = PyDict_GetItemString(modules, "mspasspy");
+  if (package != nullptr) {
+    PyObject *package_file = PyObject_GetAttrString(package, "__file__");
+    if (package_file != nullptr && package_file != Py_None) {
+      const char *path = PyUnicode_AsUTF8(package_file);
+      if (path != nullptr) {
+        const std::string filename(path);
+        const std::size_t separator = filename.find_last_of("/\\");
+        if (separator != std::string::npos)
+          datadir = filename.substr(0, separator) + "/data";
+      }
+    }
+    Py_XDECREF(package_file);
+  }
+  if (PyErr_Occurred())
+    PyErr_Clear();
+  PyGILState_Release(gil_state);
+  return datadir;
+}
+} // namespace
+
 namespace mspass::utility {
 /* Standardizes top level directory for mspass */
 std::string data_directory() {
   const std::string mspass_home_envname("MSPASS_HOME");
-  char *base;
   /* Note man page for getenv says explicitly the return of getenv should not
                   be touched - i.e. don't free it*/
-  base = getenv(mspass_home_envname.c_str());
-  if (base == NULL)
-    throw MsPASSError(std::string("maspass_data_directory procedure:  ") +
-                      "required environmental variable=" + mspass_home_envname +
-                      " is not set");
-  std::string datadir;
-  datadir = std::string(base) + "/data";
-  return datadir;
+  const char *base = getenv(mspass_home_envname.c_str());
+  if (base != nullptr)
+    return std::string(base) + "/data";
+
+  const std::string package_datadir = python_package_data_directory();
+  if (!package_datadir.empty())
+    return package_datadir;
+
+  throw MsPASSError(
+      "mspass::utility::data_directory:  MSPASS_HOME is not set and the "
+      "mspasspy package data directory is unavailable");
 }
 } // namespace mspass::utility

--- a/cxx/src/lib/utility/data_directory.h
+++ b/cxx/src/lib/utility/data_directory.h
@@ -1,0 +1,10 @@
+#ifndef MSPASS_DATA_DIRECTORY_H
+#define MSPASS_DATA_DIRECTORY_H
+
+#include <string>
+
+namespace mspass::utility::detail {
+void set_python_package_data_directory(const std::string &directory);
+}
+
+#endif

--- a/cxx/test/CMakeLists.txt
+++ b/cxx/test/CMakeLists.txt
@@ -2,6 +2,7 @@ include(CTest)
 if(BUILD_TESTING)
   add_subdirectory(amap)
   add_subdirectory(decon_serialization)
+  add_subdirectory(data_directory)
   add_subdirectory(dmatrix)
   add_subdirectory(gid_penalty)
   add_subdirectory(md)
@@ -18,6 +19,10 @@ if(BUILD_TESTING)
 # note this test needs to access a data file in the run directory. 
 # we set that with WORKING_DIRECTORY and the special symbol after the keyword
   add_test(NAME test_decon_serialization COMMAND ${PROJECT_BINARY_DIR}/test/decon_serialization/test_decon_serialization WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/decon_serialization)
+  add_test(NAME test_data_directory
+    COMMAND ${PROJECT_BINARY_DIR}/test/data_directory/test_data_directory)
+  set_tests_properties(test_data_directory PROPERTIES
+    ENVIRONMENT "MSPASS_HOME=${PROJECT_BINARY_DIR}/test/data_directory/home")
   add_test(NAME test_dmatrix COMMAND ${PROJECT_BINARY_DIR}/test/dmatrix/test_dmatrix)
   add_test(NAME test_gid_penalty COMMAND ${PROJECT_BINARY_DIR}/test/gid_penalty/test_gid_penalty)
   add_test(NAME test_Metadata COMMAND ${PROJECT_BINARY_DIR}/test/md/test_md WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/md)

--- a/cxx/test/data_directory/CMakeLists.txt
+++ b/cxx/test/data_directory/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_data_directory test_data_directory.cc)
+include_directories(${Boost_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/include/)
+target_link_libraries(test_data_directory PRIVATE mspass)

--- a/cxx/test/data_directory/test_data_directory.cc
+++ b/cxx/test/data_directory/test_data_directory.cc
@@ -1,0 +1,21 @@
+#include "mspass/utility/utility.h"
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main() {
+  const char *home = std::getenv("MSPASS_HOME");
+  if (home == nullptr) {
+    std::cerr << "MSPASS_HOME was not set for the test" << std::endl;
+    return 1;
+  }
+
+  const std::string expected = std::string(home) + "/data";
+  const std::string actual = mspass::utility::data_directory();
+  if (actual != expected) {
+    std::cerr << "data_directory returned " << actual << ", expected "
+              << expected << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/docs/source/getting_started/deploy_mspass_with_conda.rst
+++ b/docs/source/getting_started/deploy_mspass_with_conda.rst
@@ -69,14 +69,14 @@ About ``MSPASS_HOME``
 The Conda package includes the standard MsPASS schema and parameter files, so
 you do not normally need to clone the repository or set ``MSPASS_HOME``.
 
-Some older C++-backed interfaces still look for defaults below
-``$MSPASS_HOME/data``.  If one of those interfaces reports that a data file is
-missing, set ``MSPASS_HOME`` to the installed package directory for that
-shell:
+Python and C++-backed interfaces locate those files in the installed package
+when ``MSPASS_HOME`` is unset.  Set ``MSPASS_HOME`` only when you want to
+override the packaged files with a custom data directory.  Its value must be
+the parent of that custom ``data`` directory:
 
 .. code-block:: bash
 
-   export MSPASS_HOME="$(python -c 'from pathlib import Path; import mspasspy; print(Path(mspasspy.__file__).resolve().parent)')"
+   export MSPASS_HOME=/path/to/custom/mspass
 
 MongoDB and other services
 --------------------------

--- a/docs/source/user_manual/importing_tabular_data.rst
+++ b/docs/source/user_manual/importing_tabular_data.rst
@@ -175,7 +175,8 @@ can be created with a variant of the following code fragment:
 where ``usarray`` is the database name (and file-name prefix).  The constructor
 also accepts an optional ``pffile`` argument defining the table layouts; when
 it is omitted, MsPASS loads the bundled ``DatascopeDatabase.pf`` through
-``$MSPASS_HOME``.
+``$MSPASS_HOME/data/pf`` when ``MSPASS_HOME`` is set, or from the installed
+``mspasspy`` package data otherwise.
 
 Experienced Datascope users will know that Datascope has a useful,
 albeit confusing, feature that allows the collection of

--- a/python/mspasspy/preprocessing/css30/datascope.py
+++ b/python/mspasspy/preprocessing/css30/datascope.py
@@ -71,8 +71,8 @@ class DatascopeDatabase:
 
     :param dbname: root database name used by Datascope flat files.
     :param pffile: optional parameter file defining table layouts; when
-        omitted the constructor searches ``$MSPASS_HOME/data/pf`` for the
-        bundled ``DatascopeDatabase.pf`` file.
+        omitted the constructor uses ``$MSPASS_HOME/data/pf`` if MSPASS_HOME
+        is defined, or the data directory installed with mspasspy otherwise.
     """
 
     def __init__(self, dbname, pffile=None):
@@ -94,19 +94,20 @@ class DatascopeDatabase:
 
         :param pffile:  parameter file name used to create the data structure
         used internally by this class.   If None (the default)
-        the constructor looks for a master file called DatascopeDatabase.pf
-        that it will attempt to read from $MsPASS_HOME/data/pf.
+        the constructor looks for a master file called DatascopeDatabase.pf.
+        It uses $MSPASS_HOME/data/pf when MSPASS_HOME is defined and the
+        package data directory otherwise.
 
         """
         self.dbname = dbname
         if pffile == None:
             home = os.getenv("MSPASS_HOME")
             if home == None:
-                raise MsPASSError(
-                    "AntelopeDatabase constructor: "
-                    + "MSPASS_HOME not defined.  Needed for default constructor\n"
-                    + "Specify a full path for pf file name or set MsPASS_HOME",
-                    "Fatal",
+                path = os.path.abspath(
+                    os.path.join(
+                        os.path.dirname(__file__),
+                        "../../data/pf/DatascopeDatabase.pf",
+                    )
                 )
             else:
                 path = os.path.join(home, "data/pf", "DatascopeDatabase.pf")

--- a/python/tests/preprocessing/test_datascope.py
+++ b/python/tests/preprocessing/test_datascope.py
@@ -16,6 +16,15 @@ def compare_selected(A, B, key):
         return False
 
 
+def test_default_parameter_file_uses_packaged_data(tmp_path, monkeypatch):
+    monkeypatch.delenv("MSPASS_HOME", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    db = DatascopeDatabase("unused")
+
+    assert db.get_primary_keys("event") == ["evid"]
+
+
 # testing section - pytest prototype
 def test_DatascopeDatabase():
     """

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -1784,24 +1784,42 @@ def test_ProcessingHistoryBase(ProcessingHistoryBase):
     assert str(phred.get_nodes()) == str(phred_copy.get_nodes())
 
 
-def test_antelope_pf_uses_packaged_data_without_mspass_home(tmp_path, monkeypatch):
+@pytest.mark.parametrize("pfbase", ["attribute_maps", "attribute_maps.pf"])
+def test_antelope_pf_uses_packaged_data_without_mspass_home(
+    pfbase, tmp_path, monkeypatch
+):
     monkeypatch.delenv("MSPASS_HOME", raising=False)
-    monkeypatch.delenv("PFPATH", raising=False)
     monkeypatch.chdir(tmp_path)
 
-    packaged = AntelopePf("attribute_maps.pf")
+    custom_pfpath = tmp_path / "pfpath"
+    custom_pfpath.mkdir()
+    (custom_pfpath / "attribute_maps.pf").write_text(
+        "source_marker pfpath\n" "pfpath_only &Arr{\nmarker sentinel\n}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PFPATH", str(custom_pfpath))
+
+    packaged = AntelopePf(pfbase)
 
     assert "css3.0" in packaged.arr_keys()
+    assert "pfpath_only" in packaged.arr_keys()
+    assert packaged.get_string("source_marker") == "pfpath"
 
     custom_home = tmp_path / "custom"
     custom_pf = custom_home / "data" / "pf" / "attribute_maps.pf"
     custom_pf.parent.mkdir(parents=True)
-    custom_pf.write_text("override &Arr{\nmarker sentinel\n}\n", encoding="utf-8")
+    custom_pf.write_text(
+        "source_marker mspass_home\n" "override &Arr{\nmarker sentinel\n}\n",
+        encoding="utf-8",
+    )
     monkeypatch.setenv("MSPASS_HOME", str(custom_home))
 
-    overridden = AntelopePf("attribute_maps.pf")
+    overridden = AntelopePf(pfbase)
 
     assert "override" in overridden.arr_keys()
+    assert "pfpath_only" in overridden.arr_keys()
+    assert "css3.0" not in overridden.arr_keys()
+    assert overridden.get_string("source_marker") == "pfpath"
 
 
 def test_MsPASSError():

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -19,6 +19,7 @@ from mspasspy.ccore.seismic import (
     TimeReferenceType,
 )
 from mspasspy.ccore.utility import (
+    AntelopePf,
     AtomicType,
     copy_selected_metadata,
     dmatrix,
@@ -1781,6 +1782,26 @@ def test_ProcessingHistoryBase(ProcessingHistoryBase):
 
     phred_copy = pickle.loads(pickle.dumps(phred))
     assert str(phred.get_nodes()) == str(phred_copy.get_nodes())
+
+
+def test_antelope_pf_uses_packaged_data_without_mspass_home(tmp_path, monkeypatch):
+    monkeypatch.delenv("MSPASS_HOME", raising=False)
+    monkeypatch.delenv("PFPATH", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    packaged = AntelopePf("attribute_maps.pf")
+
+    assert "css3.0" in packaged.arr_keys()
+
+    custom_home = tmp_path / "custom"
+    custom_pf = custom_home / "data" / "pf" / "attribute_maps.pf"
+    custom_pf.parent.mkdir(parents=True)
+    custom_pf.write_text("override &Arr{\nmarker sentinel\n}\n", encoding="utf-8")
+    monkeypatch.setenv("MSPASS_HOME", str(custom_home))
+
+    overridden = AntelopePf("attribute_maps.pf")
+
+    assert "override" in overridden.arr_keys()
 
 
 def test_MsPASSError():


### PR DESCRIPTION
## Summary

- Keep the standalone C++ core free of Python runtime/link dependencies.  The Python `utility` binding registers the installed `mspasspy/data` path when the module initializes; `MSPASS_HOME/data` remains the core override when the environment variable is set.
- Let `AntelopePf` load the MsPASS base parameter file before its existing `PFPATH`/current-directory chain, preserving last-file-wins overrides.
- Accept relative parameter-file base names with or without the documented `.pf` suffix.
- Make `DatascopeDatabase` use installed package data when `MSPASS_HOME` is absent, and update the C++/Python/Conda/user-manual documentation.
- Add Python regression coverage plus a standalone CMake test that deliberately links without Python.

Fixes #550

## Validation

- Built all C++ libraries, tests, and Python extension modules from the implementation in `mspass/mspass:latest` (Python 3.12); exact HEAD `83d5d9ddd04d61570b13d45f35602823bbdeaa7f` adds only the independently requested API-documentation clarification.
- Passed the new standalone `test_data_directory` CTest; its dynamic dependencies contain no `libpython`.
- From an unrelated temporary directory, verified packaged `AntelopePf` loading with both `attribute_maps` and `attribute_maps.pf`, `PFPATH` merging/last-file-wins, and `MSPASS_HOME` replacing the packaged base.
- Verified `DatascopeDatabase` loads bundled `DatascopeDatabase.pf` with both `MSPASS_HOME` and `PFPATH` unset.
- Black, clang-format checks on changed C++ ranges/files, Python syntax compilation, a direct standalone no-Python compile/link/run, and `git diff --check` passed.