### PR TITLE
Preserve ensemble read failure diagnostics

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -988,8 +988,17 @@ class Database(pymongo.database.Database):
             # kind of data returned in the "abortions" list.
             # See Undertaker docstring or User Manual for concepts
             if len(abortions) > 0:
-                for md in abortions:
-                    self.stedronsky.handle_abortion(md)
+                for doc, abortion_elog in abortions:
+                    if object_type is TimeSeries:
+                        abortion = TimeSeries()
+                    else:
+                        abortion = Seismogram()
+                    for key in doc:
+                        abortion[key] = doc[key]
+                    abortion.elog += abortion_elog
+                    abortion["is_abortion"] = True
+                    abortion.kill()
+                    self.stedronsky.handle_abortion(abortion)
             if live and len(mdlist) > 0:
                 # note this function returns a clean ensemble with
                 # no dead data.  It will be considered bad only if is empty
@@ -1062,7 +1071,7 @@ class Database(pymongo.database.Database):
                     ensemble = SeismogramEnsemble()
             # elog referenced here comes from doclist2mdlist - a bit confusing
             # but delayed to here to construct ensemble first
-            if elog.size() < 0:
+            if elog.size() > 0:
                 ensemble.elog += elog
 
             # We post this even to dead ensmebles
@@ -8197,14 +8206,17 @@ def doclist2mdlist(
     a document to md is problematic.  The issues are defined in the
     related `doc2md` function that is used here for the atomic operation of
     converting a given document to a Metadata object.   The issue we have to
-    face is what to do with warning message and documents that have
+    face is what to do with warning messages and documents that have
     fatal flaws (marked dead when passed through doc2md).  Warning
-    messages are passed to the ErrorLogger component of the returned tuple.
+    messages from retained documents are passed to the ErrorLogger component
+    of the returned tuple.
     Callers should either print those messages or post them to the
     ensemble metadata that is expected to be constructed after calling
-    this function.   In "cautious" and "pedantic" mode doc2md may mark
+    this function.  In "cautious" and "pedantic" mode doc2md may mark
     a datum as bad with a kill return.  When a document is "killed"
-    by doc2md it is dropped and two thi
+    by doc2md it is dropped from the Metadata list and returned with its
+    corresponding ErrorLogger so the caller can preserve the reason for the
+    failed read.
 
     :param doclist:  list of documents to be converted to Metadata with schema
       constraints
@@ -8216,30 +8228,31 @@ def doclist2mdlist(
         0. filtered array of Metadata containers.
         1. live boolean.   Set False only if conversion of all the documents
            in doclist failed.
-        2. ErrorLogger where warning and kill messages are posted (see above).
-        3. an array of documents that could not be converted (i.e. marked
-           bad when processed with doc2md.)
+        2. ErrorLogger containing warnings from documents retained in the
+           Metadata list.
+        3. an array of ``(document, ErrorLogger)`` tuples for documents that
+           could not be converted (i.e. were marked bad by ``doc2md``).
 
     """
     mdlist = []
     ensemble_elog = ErrorLogger()
-    bodies = []
+    abortions = []
     for doc in doclist:
-        md, live, elog = doc2md(
+        md, datum_is_live, elog = doc2md(
             doc, database_schema, metadata_schema, wfcol, exclude_keys, mode
         )
-        if live:
+        if datum_is_live:
             mdlist.append(md)
+            if elog.size() > 0:
+                ensemble_elog += elog
         else:
-            bodies.append(doc)
-        if elog.size() > 0:
-            ensemble_elog += elog
+            abortions.append((doc, elog))
 
     if len(mdlist) == 0:
         live = False
     else:
         live = True
-    return [mdlist, live, ensemble_elog, bodies]
+    return [mdlist, live, ensemble_elog, abortions]
 
 
 def parse_normlist(input_nlist, db) -> list:

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -3092,6 +3092,74 @@ class TestDatabase:
             and seis_ensemble_metadata["key2"] == "value2"
         )
 
+    def test_read_ensemble_data_preserves_read_errors(self):
+        """Read failures retain their logs and are saved as abortions."""
+        cases = [
+            ("wf_TimeSeries", TimeSeries, TimeSeriesEnsemble, self.test_ts),
+            ("wf_Seismogram", Seismogram, SeismogramEnsemble, self.test_seis),
+        ]
+        warning_key = "issue_670_live_warning"
+        abortion_key = "issue_670_abortion"
+
+        for collection, object_type, ensemble_type, template in cases:
+            self.db.drop_collection(collection)
+            self.db.drop_collection("abortions")
+            self.db.drop_collection("cemetery")
+            try:
+                saved_ids = []
+                for _ in range(3):
+                    datum = copy.deepcopy(template)
+                    saved = self.db.save_data(
+                        datum,
+                        collection=collection,
+                        storage_mode="gridfs",
+                        return_data=True,
+                    )
+                    saved_ids.append(saved["_id"])
+
+                self.db[collection].update_one(
+                    {"_id": saved_ids[0]}, {"$set": {warning_key: True}}
+                )
+                self.db[collection].update_one(
+                    {"_id": saved_ids[2]},
+                    {"$set": {"npts": "not-an-integer", abortion_key: True}},
+                )
+
+                cursor = self.db[collection].find({"_id": {"$in": saved_ids}})
+                ensemble = self.db.read_data(
+                    cursor,
+                    collection=collection,
+                    mode="cautious",
+                )
+
+                assert isinstance(ensemble, ensemble_type)
+                assert ensemble.live
+                assert len(ensemble.member) == 2
+                ensemble_messages = [
+                    error.message for error in ensemble.elog.get_error_log()
+                ]
+                assert any(warning_key in message for message in ensemble_messages)
+                assert not any(
+                    "will be killed" in message for message in ensemble_messages
+                )
+
+                assert self.db.abortions.count_documents({}) == 1
+                assert self.db.cemetery.count_documents({}) == 0
+                abortion_doc = self.db.abortions.find_one({})
+                assert abortion_doc["type"] == str(object_type)
+                assert abortion_doc["tombstone"]["_id"] == saved_ids[2]
+                assert abortion_doc["tombstone"][abortion_key]
+                assert abortion_doc["tombstone"]["is_abortion"]
+                abortion_messages = [
+                    entry["error_message"] for entry in abortion_doc["logdata"]
+                ]
+                assert any("npts" in message for message in abortion_messages)
+                assert any("will be killed" in message for message in abortion_messages)
+            finally:
+                self.db.drop_collection(collection)
+                self.db.drop_collection("abortions")
+                self.db.drop_collection("cemetery")
+
     def test_get_response(self):
         inv = obspy.read_inventory("python/tests/data/TA.035A.xml")
         net = "TA"


### PR DESCRIPTION
## Summary
- keep each schema-rejected waveform document paired with its own `ErrorLogger`
- save rejected TimeSeries and Seismogram documents as typed abortions with `is_abortion` and their read diagnostics intact
- retain warnings from accepted documents on the returned ensemble and fix the unreachable error-log guard
- add a MongoDB-backed regression test covering both waveform types, warning retention, error-log isolation, abortions, and cemetery behavior

## Validation
- `python/tests/db/test_database.py::TestDatabase`: **42 passed**
- directed TimeSeries/Seismogram regression after final assertion: **1 passed**
- Black checks for the changed test and production-code ranges
- Python syntax compilation and `git diff --check`

Fixes #670