### PR TITLE
Fix TimeIntervalReader final group handling

### DIFF
--- a/python/mspasspy/db/ensembles.py
+++ b/python/mspasspy/db/ensembles.py
@@ -207,131 +207,58 @@ def TimeIntervalReader(
     ]
     cursor = db[collection].find(query).sort(sortlist)
 
-    ndocs = db[collection].count_documents(query)
-
     # We create an array of ensembles - one for each unique combination of
     # chan and loc.
-    count = 0
     ensemble_list = list()
-    for doc in cursor:
-        if count == 0:
-            current_keys = seed_keys(doc)
-            current = _initialize_ensemble(doc, tstart, tend)
-            segments = TimeSeriesVector()
-            datum = db.read_data(doc, collection=collection)
-            if datum.dead():
-                count += 1
-                continue
-            else:
-                segments.append(datum)
+    current_keys = None
+    current = None
+    segments = TimeSeriesVector()
+
+    def append_current_segments():
+        if len(segments) == 0:
+            return
+        if len(segments) == 1:
+            datum = WindowData(segments[0], tstart, tend)
         else:
-            test_keys = seed_keys(doc)
-            # Handle the last item specially.
-            if count >= ndocs - 1:
-                datum = db.read_data(doc, collection=collection)
-                if test_keys == current_keys:
-                    segments.append(datum)
-                    if len(segments) == 1:
-                        # I don't think this will ever be executed but
-                        # it makes the logic more robust
-                        datum = WindowData(segments[0], tstart, tend)
-                    else:
-                        datum = merge(
-                            segments,
-                            starttime=tstart,
-                            endtime=tend,
-                            fix_overlaps=fix_overlaps,
-                            zero_gaps=zero_gaps,
-                            object_history=object_history,
-                        )
+            datum = merge(
+                segments,
+                starttime=tstart,
+                endtime=tend,
+                fix_overlaps=fix_overlaps,
+                zero_gaps=zero_gaps,
+                object_history=object_history,
+            )
+        if datum.live or save_zombies:
+            current.member.append(datum)
 
-                    if datum.live or save_zombies:
-                        current.member.append(datum)
-                else:
-                    # This is special cleanup code to handle
-                    # the case when the last doc defines a new segment
-                    # May be confusing because here we break the
-                    # loop while if we are gluing segments we
-                    # continue through the next block.   Because of
-                    # the ordering of the data this block will only
-                    # be entered if the last doc is a new net:sta:chan:loc
-                    # that would otherwise initiate creation and appending
-                    # of a new segments vector.
-                    datum = db.read_data(doc, collection=collection)
-                    datum = WindowData(datum, tstart, tend)
-                    if datum.live:  # do nothing further if dead
-                        if current_keys.same_channel(test_keys):
-                            current.member.append(datum)
-                        else:
-                            ensemble_list.append(current)
-                            current = _initialize_ensemble(doc, tstart, tend)
-                            current.member.append(datum)
+    def append_current_ensemble():
+        if len(current.member) > 0:
+            # set_live refuses to revive an ensemble containing only zombies.
+            current.set_live()
+        else:
+            current.kill()
+        ensemble_list.append(current)
 
-                # All cases for this cleanup have to push the latest
-                # ensemble to the output that is returned after exiting
-                # the loop
-                if len(current.member) > 0:
-                    # if all the contents of current are zombies this
-                    # method will refuse to set current as live
-                    current.set_live()
-                else:
-                    # due to a feature of the C++ ensemble templates
-                    # this is not currently required but better to
-                    # be explicit in this kill
-                    current.kill()
-                ensemble_list.append(current)
+    for doc in cursor:
+        test_keys = seed_keys(doc)
+        if current_keys is None:
+            current_keys = test_keys
+            current = _initialize_ensemble(doc, tstart, tend)
+        elif test_keys != current_keys:
+            append_current_segments()
+            if not current_keys.same_channel(test_keys):
+                append_current_ensemble()
+                current = _initialize_ensemble(doc, tstart, tend)
+            current_keys = test_keys
+            segments = TimeSeriesVector()
 
-            elif test_keys != current_keys:
-                if len(segments) == 1:
-                    datum = WindowData(segments[0], tstart, tend)
-                else:
-                    datum = merge(
-                        segments,
-                        starttime=tstart,
-                        endtime=tend,
-                        fix_overlaps=fix_overlaps,
-                        zero_gaps=zero_gaps,
-                        object_history=object_history,
-                    )
-                # Merge can kill data for a variety of reasons
-                # The cutsy boolean name controls if the dead are retained
-                if datum.live or save_zombies:
-                    current.member.append(datum)
-                # Decide if we need to start a new ensemble.  That
-                # happens here when the channel names do not match
-                # If they match we assume one of the other codes changed
-                # so we initialize the segments vector
-                if current_keys.same_channel(test_keys):
-                    current_keys = test_keys
-                    segments = TimeSeriesVector()
-                    datum = db.read_data(doc, collection=collection)
-                    if datum.live:
-                        segments.append(datum)
-                else:
-                    if len(current.member) > 0:
-                        current.set_live()
-                    else:
-                        # due to a feature of the C++ ensemble templates
-                        # this is not currently required but better to
-                        # be explicit in this kill
-                        current.kill()
-                    # We always post current even if dead and empty
-                    # caller needs to handle null returns.
-                    ensemble_list.append(current)
-                    if count < ndocs - 1:
-                        current = _initialize_ensemble(doc, tstart, tend)
-                        current_keys = test_keys
-                        segments = TimeSeriesVector()
-                        datum = db.read_data(doc, collection=collection)
-                        if datum.live:
-                            segments.append(datum)
+        datum = db.read_data(doc, collection=collection)
+        if datum.live:
+            segments.append(datum)
 
-            else:
-                datum = db.read_data(doc, collection=collection)
-                segments.append(datum)
-                current_keys = test_keys
-
-        count += 1
+    if current is not None:
+        append_current_segments()
+        append_current_ensemble()
 
     return ensemble_list
 

--- a/python/tests/db/test_ensembles.py
+++ b/python/tests/db/test_ensembles.py
@@ -285,3 +285,67 @@ def test_ensembles():
     assert enslist[1]["chan"] == "BHZ"
     assert len(enslist[0].member) == 3
     assert len(enslist[1].member) == 3
+
+
+def test_time_interval_reader_single_segment_groups():
+    """Every matching single-segment station is returned exactly once."""
+    dbclient = DBClient("localhost")
+    database_name = "test_time_interval_reader_single_segments"
+    dbclient.drop_database(database_name)
+    db = Database(
+        dbclient,
+        database_name,
+        db_schema="mspass_lite.yaml",
+        md_schema="mspass_lite.yaml",
+    )
+    starttime = 10000.0
+    endtime = 10020.0
+    stations = ["SINGLE01", "SINGLE02"]
+    channels = ["BH1", "BH2", "BHZ"]
+
+    try:
+        for channel in channels:
+            for station in stations:
+                datum = make_one_ts(
+                    starttime - 10.0,
+                    endtime + 10.0,
+                    sta=station,
+                    chan=channel,
+                )
+                datum["segment_id"] = f"{channel}-{station}"
+                db.save_data(datum, collection="wf_TimeSeries")
+
+        ensembles = TimeIntervalReader(
+            db,
+            starttime,
+            endtime,
+            collection="wf_TimeSeries",
+        )
+        assert [ensemble["chan"] for ensemble in ensembles] == channels
+        for ensemble in ensembles:
+            channel = ensemble["chan"]
+            segment_ids = [datum["segment_id"] for datum in ensemble.member]
+            assert segment_ids == [f"{channel}-{station}" for station in stations]
+            assert len(segment_ids) == len(set(segment_ids))
+
+        single = TimeIntervalReader(
+            db,
+            starttime,
+            endtime,
+            collection="wf_TimeSeries",
+            base_query={"segment_id": "BHZ-SINGLE01"},
+        )
+        assert len(single) == 1
+        assert len(single[0].member) == 1
+        assert single[0].member[0]["segment_id"] == "BHZ-SINGLE01"
+
+        empty = TimeIntervalReader(
+            db,
+            starttime,
+            endtime,
+            collection="wf_TimeSeries",
+            base_query={"segment_id": "missing"},
+        )
+        assert empty == []
+    finally:
+        dbclient.drop_database(database_name)

--- a/python/tests/db/test_ensembles.py
+++ b/python/tests/db/test_ensembles.py
@@ -3,6 +3,8 @@ from mspasspy.db.ensembles import TimeIntervalReader
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
 import numpy as np
+from bson import ObjectId
+from unittest.mock import patch
 
 
 def make_one_ts(
@@ -292,12 +294,7 @@ def test_time_interval_reader_single_segment_groups():
     dbclient = DBClient("localhost")
     database_name = "test_time_interval_reader_single_segments"
     dbclient.drop_database(database_name)
-    db = Database(
-        dbclient,
-        database_name,
-        db_schema="mspass_lite.yaml",
-        md_schema="mspass_lite.yaml",
-    )
+    db = Database(dbclient, database_name)
     starttime = 10000.0
     endtime = 10020.0
     stations = ["SINGLE01", "SINGLE02"]
@@ -313,14 +310,18 @@ def test_time_interval_reader_single_segment_groups():
                     chan=channel,
                 )
                 datum["segment_id"] = f"{channel}-{station}"
-                db.save_data(datum, collection="wf_TimeSeries")
+                db.save_data(datum, collection="wf_miniseed")
 
-        ensembles = TimeIntervalReader(
-            db,
-            starttime,
-            endtime,
-            collection="wf_TimeSeries",
-        )
+        with patch.object(db, "read_data", wraps=db.read_data) as read_data:
+            ensembles = TimeIntervalReader(
+                db,
+                starttime,
+                endtime,
+            )
+        read_ids = [call.args[0]["_id"] for call in read_data.call_args_list]
+        assert len(read_ids) == len(channels) * len(stations)
+        assert len(read_ids) == len(set(read_ids))
+
         assert [ensemble["chan"] for ensemble in ensembles] == channels
         for ensemble in ensembles:
             channel = ensemble["chan"]
@@ -332,18 +333,43 @@ def test_time_interval_reader_single_segment_groups():
             db,
             starttime,
             endtime,
-            collection="wf_TimeSeries",
             base_query={"segment_id": "BHZ-SINGLE01"},
         )
         assert len(single) == 1
         assert len(single[0].member) == 1
         assert single[0].member[0]["segment_id"] == "BHZ-SINGLE01"
 
+        source_ids = [ObjectId(), ObjectId()]
+        output_tag = "time_interval_reader_test"
+        for source_id in source_ids:
+            for ensemble in TimeIntervalReader(db, starttime, endtime):
+                ensemble["source_id"] = source_id
+                db.save_data(
+                    ensemble,
+                    storage_mode="gridfs",
+                    data_tag=output_tag,
+                )
+
+        expected_ids = [
+            f"{channel}-{station}" for channel in channels for station in stations
+        ]
+        assert db.wf_TimeSeries.count_documents({"data_tag": output_tag}) == len(
+            source_ids
+        ) * len(expected_ids)
+        for source_id in source_ids:
+            saved_ids = sorted(
+                doc["segment_id"]
+                for doc in db.wf_TimeSeries.find(
+                    {"source_id": source_id, "data_tag": output_tag}
+                )
+            )
+            assert saved_ids == expected_ids
+            assert len(saved_ids) == len(set(saved_ids))
+
         empty = TimeIntervalReader(
             db,
             starttime,
             endtime,
-            collection="wf_TimeSeries",
             base_query={"segment_id": "missing"},
         )
         assert empty == []


### PR DESCRIPTION
## Summary
- replace the count/last-document special case with one streaming group finalization path
- flush each station's pending segments before changing SEED keys and flush the final station/ensemble after cursor exhaustion
- read each matching document exactly once, including single-document and final-new-station queries
- add a real-MongoDB regression for the reported 2/2/1 analogue, empty/single inputs, and exact-once reads
- mirror the issue's multi-source workflow with actual `wf_miniseed` inputs and `Database.save_data`, proving each source gets the complete six unique outputs

The original documentation gap was addressed by merged PR #682 plus later API/user-manual fixes (#744 and #754); the current public API and Continuous Data pages both expose `TimeIntervalReader`. This PR addresses the functional reports added later to the issue.

## Validation
- current `master` regression reproduced as BH1=2, BH2=2, BHZ=1 (missing `BHZ-SINGLE01`) and a double read of the final document
- exact-once read assertion: 6 distinct MongoDB `_id` values, 6 `read_data` calls
- actual save workflow: 2 ObjectId sources × 6 unique outputs = 12 `wf_TimeSeries` documents
- `python/tests/db/test_ensembles.py`: **2 passed**
- Black checks for both changed files
- Python syntax compilation and `git diff --check`

Fixes #679