### PR TITLE
Complete the documentation update roadmap

### DIFF
--- a/docs/source/_static/figures/snr_windows_and_bandwidth.svg
+++ b/docs/source/_static/figures/snr_windows_and_bandwidth.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
+  <title id="title">Signal-to-noise windows and frequency-domain bandwidth</title>
+  <desc id="desc">The upper panel shows a small-amplitude noise window before an arrival and a larger-amplitude signal window after it. The lower panel shows an amplitude signal-to-noise curve crossing a cutoff at low and high frequency edges around a starting frequency.</desc>
+  <defs>
+    <style>
+      .panel { fill: #ffffff; stroke: #cbd5e1; stroke-width: 2; }
+      .axis { stroke: #334155; stroke-width: 2; }
+      .tick { stroke: #64748b; stroke-width: 1.5; }
+      .wave { fill: none; stroke: #172554; stroke-width: 3; stroke-linejoin: round; stroke-linecap: round; }
+      .ratio { fill: none; stroke: #7c3aed; stroke-width: 4; stroke-linejoin: round; stroke-linecap: round; }
+      .guide { stroke: #64748b; stroke-width: 2; stroke-dasharray: 8 7; }
+      .edge { stroke: #0369a1; stroke-width: 2; stroke-dasharray: 5 5; }
+      .label { fill: #0f172a; font: 20px sans-serif; }
+      .small { fill: #334155; font: 17px sans-serif; }
+      .panel-title { fill: #0f172a; font: 600 22px sans-serif; }
+    </style>
+  </defs>
+
+  <rect class="panel" x="30" y="25" width="1140" height="270" rx="10"/>
+  <text class="panel-title" x="60" y="62">Time-domain windows</text>
+  <rect x="115" y="82" width="360" height="165" fill="#dbeafe" opacity="0.8"/>
+  <rect x="690" y="82" width="350" height="165" fill="#ffedd5" opacity="0.9"/>
+  <line class="axis" x1="80" y1="205" x2="1120" y2="205"/>
+  <line class="guide" x1="655" y1="82" x2="655" y2="252"/>
+  <path class="wave" d="M80 204 L95 199 L110 208 L125 203 L140 211 L155 196 L170 207 L185 201 L200 210 L215 198 L230 204 L245 209 L260 194 L275 207 L290 201 L305 211 L320 197 L335 206 L350 202 L365 209 L380 196 L395 205 L410 200 L425 208 L440 198 L455 204 L470 205 L485 201 L500 207 L515 199 L530 205 L545 202 L560 208 L575 197 L590 204 L605 202 L620 207 L635 199 L650 204 L665 201 L680 207 L695 190 L710 218 L725 162 L740 240 L755 128 L770 257 L785 150 L800 231 L815 168 L830 222 L845 181 L860 214 L875 187 L890 211 L905 192 L920 208 L935 195 L950 206 L965 198 L980 205 L995 200 L1010 207 L1025 199 L1040 205 L1055 201 L1070 207 L1085 200 L1100 204 L1120 203"/>
+  <text class="label" x="225" y="112">Noise window</text>
+  <text class="label" x="800" y="112">Signal window</text>
+  <text class="small" x="610" y="76">arrival, t = 0</text>
+  <text class="small" x="96" y="276">noise start</text>
+  <text class="small" x="420" y="276">noise end</text>
+  <text class="small" x="670" y="276">signal start</text>
+  <text class="small" x="986" y="276">signal end</text>
+  <text class="label" x="1065" y="235">time</text>
+
+  <rect class="panel" x="30" y="320" width="1140" height="275" rx="10"/>
+  <text class="panel-title" x="60" y="357">Frequency-domain usable bandwidth</text>
+  <rect x="390" y="378" width="480" height="155" fill="#dcfce7" opacity="0.85"/>
+  <line class="axis" x1="95" y1="535" x2="1120" y2="535"/>
+  <line class="axis" x1="95" y1="535" x2="95" y2="380"/>
+  <line class="guide" x1="95" y1="465" x2="1120" y2="465"/>
+  <line class="edge" x1="390" y1="395" x2="390" y2="548"/>
+  <line class="edge" x1="870" y1="395" x2="870" y2="548"/>
+  <line class="guide" x1="630" y1="395" x2="630" y2="548"/>
+  <path class="ratio" d="M105 517 C165 515 220 510 275 497 C325 486 355 474 390 465 C440 442 480 420 535 411 C585 402 615 404 630 407 C690 414 735 427 780 442 C825 454 850 461 870 465 C930 480 995 501 1110 518"/>
+  <text class="small" x="105" y="455">band_cutoff_snr</text>
+  <text class="small" x="495" y="405">accepted passband</text>
+  <text class="small" x="365" y="574">f_low</text>
+  <text class="small" x="615" y="574">f0</text>
+  <text class="small" x="845" y="574">f_high</text>
+  <text class="label" x="1035" y="568">frequency</text>
+  <text class="label" transform="translate(64 520) rotate(-90)">amplitude SNR</text>
+</svg>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -89,8 +89,8 @@ Choose your path
 
    user_manual/database_concepts
    user_manual/schema_choices
-   user_manual/mongodb_and_mspass
-   user_manual/CRUD_operations
+   MongoDB and PyMongo primer <user_manual/mongodb_and_mspass>
+   MsPASS Database CRUD API <user_manual/CRUD_operations>
    user_manual/normalization
    user_manual/importing_data
    user_manual/importing_tabular_data

--- a/docs/source/python_api/mspasspy.util.rst
+++ b/docs/source/python_api/mspasspy.util.rst
@@ -7,7 +7,7 @@ Common utility entry points
 ``mspasspy.util`` contains adapters and workflow helpers that are easy to miss
 when browsing by algorithm name.  Start with the entries below before writing
 a project-specific conversion or ensemble loop; the generated module reference
-that follows lists every public member.
+that follows provides the remaining module-level API reference.
 
 .. list-table:: Common utility entry points
    :widths: 22 48 30
@@ -39,8 +39,10 @@ that follows lists every public member.
        :py:func:`~mspasspy.util.seismic.ensemble_time_range`, and
        :py:func:`~mspasspy.util.seismic.sort_ensemble`
      - :ref:`Seismic data object concepts <data_object_design_concepts>`
-   * - Regularize sampling before ensemble processing
-     - :py:func:`~mspasspy.util.seismic.regularize_sampling`
+   * - Validate ensemble sampling
+     - :py:func:`~mspasspy.util.seismic.regularize_sampling` checks sample
+       intervals and, by default, kills mismatched members; it does not
+       resample data
      - :ref:`Arrival-time processing <arrival_time_measurement>`
    * - Clean Metadata and manage dead data
      - :py:class:`~mspasspy.util.Janitor.Janitor`,
@@ -49,9 +51,9 @@ that follows lists every public member.
      - :ref:`Cleaning Metadata <cleaning_metadata>` and
        :ref:`handling errors <handling_errors>`
    * - Adapt an external function to MsPASS objects
-     - :mod:`mspasspy.util.decorators`, especially
-       ``mspass_func_wrapper``, ``mspass_method_wrapper``, and the ObsPy
-       conversion decorators
+     - :py:func:`~mspasspy.util.decorators.mspass_func_wrapper`,
+       :py:func:`~mspasspy.util.decorators.mspass_method_wrapper`, and the
+       ObsPy conversion decorators documented below
      - :ref:`Adapting algorithms <adapting_algorithms>`
 
 converter
@@ -72,6 +74,26 @@ db_utils
 
 decorators
 ----------
+
+The principal decorators are listed explicitly because their signature-
+preserving implementation prevents Sphinx from discovering them as functions
+defined by this module.
+
+.. autofunction:: mspasspy.util.decorators.mspass_func_wrapper
+
+.. autofunction:: mspasspy.util.decorators.mspass_func_wrapper_multi
+
+.. autofunction:: mspasspy.util.decorators.mspass_method_wrapper
+
+.. autofunction:: mspasspy.util.decorators.mspass_reduce_func_wrapper
+
+.. autofunction:: mspasspy.util.decorators.timeseries_as_trace
+
+.. autofunction:: mspasspy.util.decorators.seismogram_as_stream
+
+.. autofunction:: mspasspy.util.decorators.timeseries_ensemble_as_stream
+
+.. autofunction:: mspasspy.util.decorators.seismogram_ensemble_as_stream
 
 .. automodule:: mspasspy.util.decorators
     :members:

--- a/docs/source/python_api/mspasspy.util.rst
+++ b/docs/source/python_api/mspasspy.util.rst
@@ -1,6 +1,59 @@
 mspasspy.util
 =============
 
+Common utility entry points
+---------------------------
+
+``mspasspy.util`` contains adapters and workflow helpers that are easy to miss
+when browsing by algorithm name.  Start with the entries below before writing
+a project-specific conversion or ensemble loop; the generated module reference
+that follows lists every public member.
+
+.. list-table:: Common utility entry points
+   :widths: 22 48 30
+   :header-rows: 1
+
+   * - Task
+     - Useful APIs
+     - Related guide
+   * - Convert between ObsPy and MsPASS
+     - :py:func:`~mspasspy.util.converter.Trace2TimeSeries`,
+       :py:func:`~mspasspy.util.converter.TimeSeries2Trace`,
+       :py:func:`~mspasspy.util.converter.Stream2Seismogram`, and
+       :py:func:`~mspasspy.util.converter.Seismogram2Stream`
+     - :ref:`ObsPy interfaces <obspy_interface>`
+   * - Convert ensembles and streams
+     - :py:func:`~mspasspy.util.converter.Stream2TimeSeriesEnsemble`,
+       :py:func:`~mspasspy.util.converter.TimeSeriesEnsemble2Stream`,
+       :py:func:`~mspasspy.util.converter.Stream2SeismogramEnsemble`, and
+       :py:func:`~mspasspy.util.converter.SeismogramEnsemble2Stream`
+     - :ref:`Continuous data handling <continuous_data>`
+   * - Move between dictionaries, Metadata, and tabular data
+     - :py:func:`~mspasspy.util.converter.dict2Metadata`,
+       :py:func:`~mspasspy.util.converter.Metadata2dict`, and
+       :py:func:`~mspasspy.util.converter.Textfile2Dataframe`
+     - :ref:`Importing tabular data <importing_tabular_data>`
+   * - Inspect and organize ensembles
+     - :py:func:`~mspasspy.util.seismic.number_live`,
+       :py:func:`~mspasspy.util.seismic.has_live_data`,
+       :py:func:`~mspasspy.util.seismic.ensemble_time_range`, and
+       :py:func:`~mspasspy.util.seismic.sort_ensemble`
+     - :ref:`Seismic data object concepts <data_object_design_concepts>`
+   * - Regularize sampling before ensemble processing
+     - :py:func:`~mspasspy.util.seismic.regularize_sampling`
+     - :ref:`Arrival-time processing <arrival_time_measurement>`
+   * - Clean Metadata and manage dead data
+     - :py:class:`~mspasspy.util.Janitor.Janitor`,
+       :py:class:`~mspasspy.util.Janitor.MiniseedJanitor`, and
+       :py:class:`~mspasspy.util.Undertaker.Undertaker`
+     - :ref:`Cleaning Metadata <cleaning_metadata>` and
+       :ref:`handling errors <handling_errors>`
+   * - Adapt an external function to MsPASS objects
+     - :mod:`mspasspy.util.decorators`, especially
+       ``mspass_func_wrapper``, ``mspass_method_wrapper``, and the ObsPy
+       conversion decorators
+     - :ref:`Adapting algorithms <adapting_algorithms>`
+
 converter
 ---------
 

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -12,8 +12,15 @@ must accomplish cleanly.  This section is organized into subsections on
 each of the topics defined by CRUD.  At the end of this section we
 summarize some common options in CRUD operations.
 
+This chapter covers the supported :class:`~mspasspy.db.database.Database`
+interface.  When a task requires a direct collection query, aggregation,
+index, or PyMongo update, first read the lower-level
+:ref:`MongoDB and PyMongo primer <mongodb_and_mspass>`.  Keeping the two
+abstraction levels explicit helps avoid bypassing MsPASS waveform, error-log,
+and processing-history handling accidentally.
+
 The most common database operations are defined as methods in a class
-we give the obvious name Database.  Most MsPASS jobs need to the have following
+we give the obvious name Database.  Most MsPASS jobs need the following
 incantation at the top of the python job script:
 
 .. code-block:: python

--- a/docs/source/user_manual/algorithms.rst
+++ b/docs/source/user_manual/algorithms.rst
@@ -250,7 +250,7 @@ map-style functions above:
      - Prepare a teleseismic P-wave ensemble and choose an initial beam for
        multichannel correlation.
      - TimeSeriesEnsemble and noise window
-     - Prepared ensemble and beam
+     - Prepares the input ensemble in place; returns it with the initial beam
    * - :py:func:`align_and_stack<mspasspy.algorithms.MCXcorStacking.align_and_stack>`
      - Iteratively align an ensemble by cross-correlation and compute a robust
        stack.
@@ -260,8 +260,8 @@ map-style functions above:
      - Run a supplied SeisBench model, or the default pretrained PhaseNet model,
        and retain candidate P arrivals above a probability threshold.
      - TimeSeries
-     - Calls ``rtoa()`` to ensure UTC time, then writes ``p_wave_picks``
-       Metadata in place
+     - Converts the input to UTC, may adjust a supplied ``TimeWindow`` in
+       place, and writes ``p_wave_picks`` Metadata in place
 
 See :ref:`Arrival Time Measurement Techniques <arrival_time_measurement>` for
 the complete workflow, preprocessing requirements, robust-stack controls, and

--- a/docs/source/user_manual/algorithms.rst
+++ b/docs/source/user_manual/algorithms.rst
@@ -255,7 +255,7 @@ map-style functions above:
      - Iteratively align an ensemble by cross-correlation and compute a robust
        stack.
      - TimeSeriesEnsemble and initial beam
-     - Aligned ensemble and final stack
+     - Aligns the input ensemble in place; returns it with the final stack
    * - :py:func:`annotate_arrival_time<mspasspy.algorithms.ml.arrival.annotate_arrival_time>`
      - Run a supplied SeisBench model, or the default pretrained PhaseNet model,
        and retain candidate P arrivals above a probability threshold.

--- a/docs/source/user_manual/algorithms.rst
+++ b/docs/source/user_manual/algorithms.rst
@@ -228,6 +228,44 @@ utility for writing custom functions that use them inside another algorithm.
      - TimeSeries or Seismogram
      - float
 
+Arrival-time and multichannel-correlation workflows
+----------------------------------------------------
+
+The :py:mod:`mspasspy.algorithms.MCXcorStacking` module contains the
+multichannel cross-correlation and robust-stacking workflow.  The
+:py:mod:`mspasspy.algorithms.ml.arrival` module provides the optional
+SeisBench/PhaseNet arrival annotator.  These entry points have nonstandard
+multi-object or in-place contracts, so they are summarized separately from the
+map-style functions above:
+
+.. list-table:: Arrival-time workflow entry points
+   :widths: 25 45 15 15
+   :header-rows: 1
+
+   * - Name
+     - Purpose
+     - Inputs
+     - Output or side effect
+   * - :py:func:`MCXcorPrepP<mspasspy.algorithms.MCXcorStacking.MCXcorPrepP>`
+     - Prepare a teleseismic P-wave ensemble and choose an initial beam for
+       multichannel correlation.
+     - TimeSeriesEnsemble and noise window
+     - Prepared ensemble and beam
+   * - :py:func:`align_and_stack<mspasspy.algorithms.MCXcorStacking.align_and_stack>`
+     - Iteratively align an ensemble by cross-correlation and compute a robust
+       stack.
+     - TimeSeriesEnsemble and initial beam
+     - Aligned ensemble and final stack
+   * - :py:func:`annotate_arrival_time<mspasspy.algorithms.ml.arrival.annotate_arrival_time>`
+     - Run a supplied SeisBench model, or the default pretrained PhaseNet model,
+       and retain candidate P arrivals above a probability threshold.
+     - TimeSeries
+     - Writes ``p_wave_picks`` Metadata in place
+
+See :ref:`Arrival Time Measurement Techniques <arrival_time_measurement>` for
+the complete workflow, preprocessing requirements, robust-stack controls, and
+the distinction between candidate picks and event association.
+
 Processing Objects
 -------------------------------------
 This collection of things are "processing objects" meaning they implement

--- a/docs/source/user_manual/algorithms.rst
+++ b/docs/source/user_manual/algorithms.rst
@@ -260,7 +260,8 @@ map-style functions above:
      - Run a supplied SeisBench model, or the default pretrained PhaseNet model,
        and retain candidate P arrivals above a probability threshold.
      - TimeSeries
-     - Writes ``p_wave_picks`` Metadata in place
+     - Calls ``rtoa()`` to ensure UTC time, then writes ``p_wave_picks``
+       Metadata in place
 
 See :ref:`Arrival Time Measurement Techniques <arrival_time_measurement>` for
 the complete workflow, preprocessing requirements, robust-stack controls, and

--- a/docs/source/user_manual/arrival_time_measurement.rst
+++ b/docs/source/user_manual/arrival_time_measurement.rst
@@ -327,7 +327,7 @@ function called
 It provides a top-level interface for automatically preparing the filtered
 ensemble and initial beam required by
 :py:func:`align_and_stack <mspasspy.algorithms.MCXcorStacking.align_and_stack>`.
-It returns those two objects as ``(ensemble, beam)``.
+It returns a two-element list that can be unpacked as ``ensemble, beam``.
 The parameters this function defines are discussed in the section above.
 See the docstring for the function for guidance on use and examples
 below and in the mspass tutorial repository.
@@ -364,7 +364,7 @@ show the full function signature for ``align_and_stack``:
     checks_arg0_type=True,
     handles_dead_data=True,
     **kwargs,
-    ) -> tuple:
+    ) -> list:
 
 .. note::
 
@@ -636,8 +636,10 @@ timestamps to probabilities.  An optional absolute-time
 restrict the annotation interval.  The function mutates the input datum and
 does not return a separate picks object.  It first calls ``rtoa()`` on the
 input, so a relative-time datum is converted to UTC in place before annotation.
-If a supplied ``TimeWindow`` extends beyond the datum, its bounds are also
-clipped in place to the datum's UTC time range.
+If a supplied ``TimeWindow`` partially overlaps the datum, bounds outside the
+datum are clipped in place to its UTC time range.  If the window has no
+overlap, both bounds are reset in place to the full datum range and the whole
+datum is annotated.
 
 SeisBench is an optional dependency.  Install MsPASS with the ``seisbench``
 extra when this feature is needed, for example ``pip install 'mspass[seisbench]'``.

--- a/docs/source/user_manual/arrival_time_measurement.rst
+++ b/docs/source/user_manual/arrival_time_measurement.rst
@@ -636,6 +636,8 @@ timestamps to probabilities.  An optional absolute-time
 restrict the annotation interval.  The function mutates the input datum and
 does not return a separate picks object.  It first calls ``rtoa()`` on the
 input, so a relative-time datum is converted to UTC in place before annotation.
+If a supplied ``TimeWindow`` extends beyond the datum, its bounds are also
+clipped in place to the datum's UTC time range.
 
 SeisBench is an optional dependency.  Install MsPASS with the ``seisbench``
 extra when this feature is needed, for example ``pip install 'mspass[seisbench]'``.

--- a/docs/source/user_manual/arrival_time_measurement.rst
+++ b/docs/source/user_manual/arrival_time_measurement.rst
@@ -634,7 +634,8 @@ the P-wave probabilities that meet the requested threshold to the datum's
 timestamps to probabilities.  An optional absolute-time
 :py:class:`TimeWindow <mspasspy.ccore.algorithms.basic.TimeWindow>` can
 restrict the annotation interval.  The function mutates the input datum and
-does not return a separate picks object.
+does not return a separate picks object.  It first calls ``rtoa()`` on the
+input, so a relative-time datum is converted to UTC in place before annotation.
 
 SeisBench is an optional dependency.  Install MsPASS with the ``seisbench``
 extra when this feature is needed, for example ``pip install 'mspass[seisbench]'``.

--- a/docs/source/user_manual/introduction.rst
+++ b/docs/source/user_manual/introduction.rst
@@ -15,10 +15,11 @@ Some key features of MsPASS are the following:
     needs to work with data that match the data models described in this
     manual.
 
--   It is essential that all users or potential user understand that MsPASS
-    was designed as a package to support *research* in seismology NOT
-    a *mission* like seismic network operations.  As a result MsPASS design
-    was shaped by several key axioms:
+-   MsPASS is a *research framework*: it supplies reusable data objects,
+    database interfaces, processing algorithms, and parallel-workflow tools
+    that researchers can assemble into project-specific methods.  It is not a
+    fixed application or an operational system for a mission such as seismic
+    network monitoring.  That distinction shaped several key design axioms:
 
     *  It must be as generic as possible.   That is essential to support basic research
        that is open-ended and wildly variable.

--- a/docs/source/user_manual/mongodb_and_mspass.rst
+++ b/docs/source/user_manual/mongodb_and_mspass.rst
@@ -26,6 +26,12 @@ although not that order for pedagogic reasons.
 The final section covers an auxiliary issue of MongoDB: indexes.
 Indexes are critical for query performance, but are not required.
 
+This chapter teaches MongoDB concepts and direct PyMongo operations.  For
+normal waveform create, read, update, and delete operations, use the higher
+level :ref:`MsPASS Database CRUD API <CRUD_operations>`.  The two guides are
+kept as separate layers so that users who only need the MsPASS API do not have
+to work through the lower-level query language first.
+
 Concepts
 -------------
 MongoDB for RDBMS Users

--- a/docs/source/user_manual/signal_to_noise.rst
+++ b/docs/source/user_manual/signal_to_noise.rst
@@ -50,10 +50,25 @@ to define a signal window if the data had been converted to "relative time"
 (see section :ref:`time_standard_constraints`)
 with zero defined as a measured or predicted phase arrival time.
 
+.. _snr_time_windows_figure:
+
+.. figure:: ../_static/figures/snr_windows_and_bandwidth.svg
+   :alt: A waveform with separate noise and signal windows above a frequency-domain SNR passband diagram.
+   :align: center
+   :width: 92%
+
+   Time-domain metrics compare amplitudes measured in the noise and signal
+   windows (top).  ``FD_snr_estimator`` estimates spectra from the same windows
+   and finds a contiguous usable band with a search initialized at ``f0`` where
+   amplitude SNR exceeds ``band_cutoff_snr`` (bottom).  The illustrated case has
+   ``f0`` inside the band; the curves are schematic, not measured data.
+
 All algorithms to estimate *snr* require a `TimeWindow` defining what section of
 data should be used for computing some metric for signal and noise to
 compute the ratio.  The metric applied to each window may or may not always
-be the same.
+be the same.  The windows may have different lengths, but both must lie inside
+the datum.  Keep the noise window clear of the target arrival and choose a
+signal window long enough to contain the signal whose quality is being tested.
 
 Time Window Amplitude Metrics
 ______________________________
@@ -176,6 +191,15 @@ of the signal power spectral density to the estimated noise power spectral
 density.  The high-frequency search is bounded by 80% of Nyquist.  The
 ``band_cutoff_snr`` parameter therefore defines the minimum SNR at which the
 algorithm considers a signal to be present.
+
+The bottom panel of :numref:`snr_time_windows_figure` shows the resulting
+quantities.  ``low_f_band_edge`` and ``high_f_band_edge`` are the cutoff
+crossings that bound the accepted band.  ``bandwidth`` is reported in decibels
+as :math:`20\log_{10}(f_h/f_l)` when the low edge is nonzero, rather than as the
+linear difference :math:`f_h-f_l`.  ``bandwidth_fraction`` describes the usable
+fraction of the analyzed frequency range.  If no sufficiently wide band is
+found, the estimator returns no bandwidth metrics and records an ``Invalid``
+diagnostic; callers should not interpret that outcome as an SNR of zero.
 
 The signal and noise spectra are estimated with a multitaper method.  Its
 smoothing scale is controlled by the time-bandwidth product, ``tbp``, through

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -619,8 +619,9 @@ def dbxcor_weights(ensemble, stack, residual_norm_floor=0.1):
     Returns a numpy vector of weights.  Any dead data will have a weight of
     -1.0 (test for negative is sufficient).  In addition the function has a
     safety to handle receiving a vector of all zeros.  If the function detects
-    all 0s for a datum marked live it will silently return a weight of 0
-    for that datum.
+    an all-zero stack, every live member receives a weight of 0.  If an
+    individual live datum is all zeros, that datum likewise receives a weight
+    of 0.
 
     :param ensemble:  `TimeSeriesEnsemble` of data from which weights are to
       be computed.
@@ -645,6 +646,11 @@ def dbxcor_weights(ensemble, stack, residual_norm_floor=0.1):
     # Scale the scack vector to be a unit vector
     s_unit = np.array(stack.data)
     nrm_s = np.linalg.norm(stack.data)
+    if nrm_s == 0.0:
+        for i in range(N):
+            if ensemble.member[i].dead():
+                wts[i] = -1.0
+        return wts
     s_unit /= nrm_s
     N_s = len(s_unit)
     for i in range(N):

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -1052,9 +1052,9 @@ def beam_align(ensemble, beam, window=None, time_shift_limit=10.0):
     :type time_shift_limit: float (may abort if you use an int
         because the value can to sent to a C++ method that it type
         sensitive)
-    :return:   copy of ensemble with the members time shifted to align with
-        the time base of beam.   Note if a window is defined it is not
-        applied to the ensemble members.
+    :return: the input ensemble with its members time shifted in place to align
+        with the time base of beam.  If a window is defined it is used only for
+        correlation and is not applied to the ensemble members.
 
     """
     # this may not be necessary for internal use but if used
@@ -1129,11 +1129,11 @@ def align_and_stack(
     align all the data in the input ensemble by cross-correlation with
     the beam, apply a robust stack to the aligned signals, update the
     beam with the robust stack, and repeat until the changes to the
-    beam signal are small.   Returns a copy of the ensemble time
-    shifted to be aligned with beam time base and an updated beam
-    estimate crated by the robust stack.  The shifts and the weights
-    of each input signal are stored in the Metadata of each live ensemble
-    member returned with keys defined by `robust_weight_key` and
+    beam signal are small.  The input ensemble is modified in place to align
+    its members with the beam time base, and the function returns that ensemble
+    with an updated beam estimate created by the robust stack.  The shifts and
+    weights of each input signal are stored in the Metadata of each live
+    ensemble member returned with keys defined by `robust_weight_key` and
     `time_shift_key`.
 
     This function is a python implementation of the same basic
@@ -1374,9 +1374,9 @@ def align_and_stack(
         means the set of all time shifts computed by this function will
         have zero mean.
 
-    :return: tuple with 0 containing the original ensemble but time
-        shifted by cross-correlation.   Failed/discarded signals for the
-        stack are not killed but can be detected by testing the
+    :return: tuple with component 0 containing the input ensemble, modified in
+        place by cross-correlation time shifts.  Failed/discarded signals for
+        the stack are not killed but can be detected by testing the
         key defined by the "time_shift_key" argument
         (default is 'arrival_time_correction') being set.
         i.e. that value will not be set for components dropped from

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -59,20 +59,24 @@ def extract_initial_beam_estimate(
     fetched with a single key.  That key can be changed from
     the default "Parrival" (default of `broadband_snr_QC`) to
     something else via the "subdoc_key" argument.  This list of
-    keys inside that subdocument that can be used to set what metric
-    will be used are:  bandwidth, filtered_envelope, filtered_L2,
-    filtered_Linf, or filtered_perc.  See the docstring for
-    `broadband_snr_QC` for an explanation of each metric.
+    metric names accepted here map to the following keys produced by
+    `broadband_snr_QC`:
+
+    - ``bandwidth`` -> ``bandwidth``
+    - ``filtered_envelope`` -> ``snr_filtered_envelope_peak``
+    - ``filtered_L2`` -> ``snr_filtered_rms``
+    - ``filtered_MAD`` -> ``snr_filtered_mad``
+    - ``filtered_Linf`` -> ``snr_filtered_peak``
+    - ``filtered_perc`` -> ``snr_filtered_perc``
 
     :param ensemble:   ensemble to be scanned
     :type ensemble:  `TimeSeriesEnsemble`
     :param metric:   quality metric to use for selecting member to use
       as return.  Always scans for the maximum of specified value as it
       assume the value is some norm measure.   Accepted values at present
-      are all those computed by `broadband_snr_QC`:  bandwidth,
-      filtered_envelope, filtered_L2, filtered_Linf, or filtered_perc.
-      Default is "bandwidth".   A ValueError exception will be thrown
-      if not one of those values.
+      are ``bandwidth``, ``filtered_envelope``, ``filtered_L2``,
+      ``filtered_MAD``, ``filtered_Linf``, and ``filtered_perc``.  Default is
+      ``bandwidth``.  A `ValueError` is raised for any other value.
     :type metric:  string
     :param subdoc_key:   `broadband_snr_QC` normally posts output to
       a subdocument (dictionary).  This is the key that is used to
@@ -85,31 +89,33 @@ def extract_initial_beam_estimate(
     """
     if ensemble.dead():
         return TimeSeries()
-    if metric == "bandwidth":
-        key2use = "bandwidth"
-    elif metric == "filtered_envelope":
-        key2use = "filtered_envelope"
-    elif metric == "filtered_L2":
-        key2use = "filtered_L2"
-    elif metric == "filtered_perc":
-        key2use = "filtered_perc"
-    else:
+    metric_keys = {
+        "bandwidth": "bandwidth",
+        "filtered_envelope": "snr_filtered_envelope_peak",
+        "filtered_L2": "snr_filtered_rms",
+        "filtered_MAD": "snr_filtered_mad",
+        "filtered_Linf": "snr_filtered_peak",
+        "filtered_perc": "snr_filtered_perc",
+    }
+    if metric not in metric_keys:
         message = "extract_initial_beam_estimate:  illegal value for argument metric={}".format(
             metric
         )
-        message += "Must one of:  bandwidth, filtered_envelope, filtered_L2, filtered_MAD, filtered_Linf, or filtered_perc"
+        message += "\nMust be one of: " + ", ".join(metric_keys)
         raise ValueError(message)
+    key2use = metric_keys[metric]
     N = len(ensemble.member)
-    # this holds metric values - use the index of to associate with correct member
-    # works because zero is never the maximum unless none are defined
-    mvals = np.zeros(N)
+    # Use the index to associate each metric value with its ensemble member.
+    # Missing metrics must never outrank a defined value, including zero.
+    mvals = np.full(N, -np.inf)
     n_set = 0
     for i in range(len(ensemble.member)):
         d = ensemble.member[i]
         if d.live and d.is_defined(subdoc_key):
             subdoc = d[subdoc_key]
-            mvals[i] = subdoc[key2use]
-            n_set += 1
+            if key2use in subdoc:
+                mvals[i] = subdoc[key2use]
+                n_set += 1
     if n_set > 0:
         imax = np.argmax(mvals)
         return TimeSeries(ensemble.member[imax])
@@ -120,7 +126,7 @@ def extract_initial_beam_estimate(
 def estimate_ensemble_bandwidth(
     ensemble,
     snr_doc_key="Parrival",
-):
+) -> list:
     """
     Estimate average bandwidth of an ensemble of data using the output of
     broadband_snr_QC.
@@ -138,14 +144,14 @@ def estimate_ensemble_bandwidth(
     The verbose names should make their definition obvious.   This
     function returns the median of the values of all values of those
     two attributes extracted from all live members of the input ensemble.
-    The result is returned as a tuple with the low frequency edge as 0
-    and the high frequency edge as 1.    The expectation is that the
-    data will be bandpass filtered between the low and high edges before
-    running the `align_and_stack` function.
+    The result is returned as a three-element list containing the low
+    frequency edge, high frequency edge, and number of live members used.
+    The expectation is that the data will be bandpass filtered between the
+    low and high edges before running the `align_and_stack` function.
 
     :param ensemble:  ensemble of data to be scanned
     :type ensemble:  `TimeSeriesEnsemble`
-    :param srn_doc_key:  subdocument key of attributes computed by
+    :param snr_doc_key:  subdocument key of attributes computed by
       `broadband_snr_QC` to fetch as estimates of low and high frequency
       edges.
     :type snr_doc_key:  string (default "Parrival" = default of
@@ -221,9 +227,9 @@ def MCXcorPrepP(
     checks_arg0_type=True,
     handles_dead_data=True,
     **kwargs,
-) -> tuple:
+) -> list:
     """
-    Function used to preprocess an ensemble  to prepare input for
+    Function used to preprocess an ensemble to prepare input for
     running multichannel cross-correlation and stacking method
     (automated dbxcor algorithm) of P phase data.  This function should
     not be used for anything but teleseismic P data.
@@ -231,7 +237,7 @@ def MCXcorPrepP(
     The multichannel correlation and stacking function in this module called
     `align_and_stack` requires one to define a number of parameters that
     in the original dbxcor implementation were input through a graphical
-    user interface.   This function can be thought of a robot that will
+    user interface.   This function can be thought of as a robot that will
     attempt to set all the required parameters automatically using signal processing.
     It will attempt to produce two inputs required by the `align_and_stack`:
     1.  What I call a "correlation window".
@@ -286,24 +292,23 @@ def MCXcorPrepP(
         to the `Metadata` of that `TimeSeries` where `align_and_stack`
         can parse them to set the correlation time window.
 
-    The function returns a copy of the input ensemble filtered to the
-    average bandwidth as component 0 of a tuple.  Component 1 of that
-    tuple contains an the initial beam estimate that should be used
-    as the input to align_and_stack.
+    The function filters and prepares the input ensemble in place.  Component 0
+    of the returned list is that same ensemble, and component 1 is the initial
+    beam estimate that should be passed to `align_and_stack`.
     Callers should verify the beam signal is marked live.  A dead
     beam signal indicates the algorithm failed in one way or another.
     Errors at that level will result in messages being posted to the
     `ErrorLogger` container of the beam output (elog attribute).  Note also this
-    algorithm can kill some ensemble members in the output that
-    were marked live in the input.
+    algorithm can kill ensemble members that were marked live on input.
 
     :param ensemble:   input ensemble of data to use.  As noted above it
       must have been processed with `broadband_snr_QC` or this function will
       return a null result.  The function makes a tacit assumption that all
       the members of this ensemble are in relative time with 0 of each member
       being an estimate of the P wave arrival time.  It does no tests to
-      validate this assumption so the assumption is wrong you will, at best,
-      get junk as output.
+      validate this assumption, so if the assumption is wrong you will, at best,
+      get junk as output.  This ensemble is filtered and prepared in place;
+      members can be modified or killed.
     :type ensemble: `TimeSeriesEnsemble`  Note for most uses this is the
       output of ExtractComponent of a `SeismogramEnsemble` processed with
       `broadband_snr_QC` that is the longitudinal component for the P phase.
@@ -315,14 +320,14 @@ def MCXcorPrepP(
     :param noise_metric:  vector norm metric to use for measuring the
       amplitude of the noise extracted from the data in the range defined by
       noise_window.
-    :type noise_metric: string (Must be one of:  "mad" (default), "rms",
-      or "peak").  Any other string will cause the function to throw a ValueError
-      exception.
+    :type noise_metric: string.  ``"rms"`` and ``"peak"`` select those
+      metrics; every other value, including the default ``"mad"``, uses median
+      absolute deviation.
     :param initial_beam_metric:  key of attribute to extract from the
       output of `broadband_snr_QC` used to select initial beam signal.
-      This argument is passed to the `extract_initial_beam_estimate` function for
-      as the "metric" argument of that function.
-    :param initial_beam_metric:  string (default "bandwidth").  For a list of
+      This argument is passed to `extract_initial_beam_estimate` as its
+      ``metric`` argument.
+    :type initial_beam_metric:  string (default "bandwidth").  For a list of
       allowed values see the docstring of `extract_initial_beam_estimate`.
     :param snr_doc_key:  key to use to fetch the subdocument containing the
       output of `broadband_snr_QC`.
@@ -342,12 +347,19 @@ def MCXcorPrepP(
       scan ensemble to estimate the frequency range)
     :param npoles:  number of poles to use for the Butterworth bandpass filter.
     :type npoles:  integer (default 4)
-    :param set_phases: boolean that if set True (default) the P phase time s
+    :param filter_parameter_keys: three Metadata keys used to record the low
+      corner, high corner, and number of poles of the filter applied in place.
+    :type filter_parameter_keys: list of three strings (default
+      ``["MCXcor_f_low", "MCXcor_f_high", "MCXcor_npoles"]``)
+    :param coda_level_factor: multiplier applied to each member's measured
+      background-noise amplitude to define the coda-detection threshold.
+    :type coda_level_factor: float (default 4.0)
+    :param set_phases: boolean that if set True (default) the arrival times for
       P, pP (if defined), and PP (if defined) are computed and posted to the
-      output of each ensemble member.  If False the algorith assumes the
+      output of each ensemble member.  If False the algorithm assumes the
       same quantities were previously calculated and can be fetched from the
       member TimeSeries Metadata container using keys defined by Ptime_key,
-      pPtimme_key, and PPtime_key.
+      pPtime_key, and PPtime_key.
     :param Ptime_key:
     :param pPtime_key:
     :param PPtime_key:  These three arguments define alternative keys that
@@ -356,7 +368,11 @@ def MCXcorPrepP(
       Changing any of these values is not really advised when set_phases is True.
       These are most useful if the phase arrival times were previously
       computed or measured and posted with different keys.
-    :param station_collection:   MonogDB collection name used to fetch
+    :param model: travel-time model used to compute P, pP, and PP arrivals when
+      ``set_phases`` is True.  A default ``TauPyModel("iasp91")`` is created
+      when this argument is None.
+    :type model: ``obspy.taup.TauPyModel`` or None
+    :param station_collection: MongoDB collection name used to fetch
       receiver coordinate data.   Normal practice in MsPASS is to save
       receiver Metadata in two channels called "channel" and "site" and
       to load the coordinate data through normalization when the data are
@@ -374,27 +390,26 @@ def MCXcorPrepP(
       correlation window is determined by running the internal
       `_coda_duration` function on each ensemble member and computing the
       range from the median of the ranges computed from all the ensemble
-      members.  Each coda search, however, is constrained by the time so f
+      members.  Each coda search, however, is constrained by the times of
       pP and/or PP.   As noted above the function uses the pP time for
       events with depths greater than 100 km but PP for shallow sources.
       To allow for hypocenter errors  the duration defined by
       P to pP or P to PP is multiplied by this factor to define the
       search start for the coda estimation.
     :type search_window_fraction: float (default 0.9)
-    :param minimum_coda_duration:   if the estimate of coda duration
-      computed internally is less than this value the correlation window
-      is set to this value - relative time from P.
-      :type minimum_coda_duration:  float (5.0 seconds)
+    :param minimum_coda_duration: minimum accepted coda-duration estimate.
+      Shorter estimates are excluded.  If no estimate exceeds this floor, the
+      ensemble is killed and returned with a dead beam.
+    :type minimum_coda_duration:  float (default 5.0 seconds)
     :param correlation_window_start:  the time of the correlation window
       set in the output "beam" is fixed as this value.   It is normally
       a negative number defining a time before P that no signal is likely to
       have an arrival before this relative time.
     :type correlation_window_start:  float (default -3.0)
-    :return:  tuple with two components.  Component 0 holds a copy of the
-      input ensembled filtered with bandwidth range estimated by the
-      algorithm but NOT time shifted. Component 1 is an best guess of
-      a suitable initial beam estimate for running the robust stacking
-      algorithm of dbxcor (it requires an initial bean estiamte).
+    :return: two-element list.  Component 0 is the input ensemble
+      after in-place filtering, phase-time conversion, Metadata updates, and
+      any member kills.  Component 1 is an initial beam estimate suitable for
+      the dbxcor robust-stacking algorithm.
     """
     alg = "MCXcorPrepP"
     if not isinstance(ensemble, TimeSeriesEnsemble):
@@ -532,7 +547,7 @@ def MCXcorPrepP(
             else:
                 # silently default to MAD - maybe should log an error to ensemble or throw an exception
                 namp = MADAmplitude(nd)
-            coda_window = _coda_duration(d, coda_level_factor, search_start=sr)
+            coda_window = _coda_duration(d, namp * coda_level_factor, search_start=sr)
             # silently drop any retun value less than the floor defined
             # by minimum_coda_duration
             duration = coda_window.end - coda_window.start
@@ -540,10 +555,10 @@ def MCXcorPrepP(
                 coda_duration.append(duration)
     if len(coda_duration) == 0:
         message = "Calculation of correlation window from the envelop of filtered ensemble members failed\n"
-        message += "No data detected with signal level in the passband above the floor value={}\n".format(
+        message += "No data detected with signal level in the passband above {} times the measured noise level\n".format(
             coda_level_factor
         )
-        message += "noise_window range or value of floor value are likely inconsistent with the data\n"
+        message += "noise_window range or coda_level_factor are likely inconsistent with the data\n"
         message += "Killing this ensemble"
         enswork.elog.log_error(alg, message, ErrorSeverity.Invalid)
         enswork.kill()
@@ -665,9 +680,14 @@ def dbxcor_weights(ensemble, stack, residual_norm_floor=0.1):
                 # denom.  Not needed her because of conditional chain here
                 wts[i] = abs(d_dot_stack) / denom
 
-    # rescale weights so largest is 1 - easier to understand
-    maxwt = np.max(wts)
-    wts /= maxwt
+    # Rescale live-member weights so the largest is 1.  Leave the negative
+    # sentinel for dead members unchanged, and avoid dividing an all-zero
+    # live subset by zero.
+    live_weight_indices = wts >= 0.0
+    if np.any(live_weight_indices):
+        maxwt = np.max(wts[live_weight_indices])
+        if maxwt > 0.0:
+            wts[live_weight_indices] /= maxwt
     return wts
 
 
@@ -721,10 +741,10 @@ def robust_stack(
     timespan_method="ensemble_inner",
     pad_fraction_cutoff=0.05,
     residual_norm_floor=0.01,
-) -> tuple:
+) -> list:
     """
     Generic function for robust stacking live members of a `TimeSeriesEnsemble`.
-    An optional initial stack estimate can be used via tha stack0 argument.
+    An optional initial stack estimate can be used via the stack0 argument.
     The function currently supports two methods:  "median" for a median
     stack and "dbxcor" to implement the robust loss function
     used in the dbxcor program defined in Pavlis and Vernon (2010).
@@ -736,25 +756,24 @@ def robust_stack(
     an initial estimator for the stack.  They do that because the
     penalty function is defined from a metric of residuals relative to
     the current estimate of center.   The median, however, does not
-    require an initial estimator which complicates the API for this function.
-    For the current options understand that stack0 is required for
-    the dbxcor algorithm but will be ignored if median is requested.
+    require an initial estimator.  For the dbxcor method, ``stack0`` can
+    supply that estimate; when it is omitted, this function computes a median
+    stack for the initial estimate.  The median method always computes the
+    sample median and ignores ``stack0`` values.
 
     The other complication of this function is handling of potential
     irregular time ranges of the ensemble input and how to set the
     time range for the output.   The problem is further complicated by
     use in an algorithm like `align_and_stack` in this module where
     the data can get shifted to have undefined data within the
-    time range the data aims to utilize.   The behavior of the
-    algorithm for this issue is controlled by the kwarg values
-    with the keys "timespan_method" and "pad_fraction_cutoff".
-    As the name imply "timespan_method" defines how the time span
+    time range the data aims to utilize.  The ``timespan_method`` argument
+    defines how the time span
     for the stack should be defined.   The following options
     are supported:
 
     "stack0" - sets the time span to that of the input
     `TimeSeries` passed as stack0.  i.e. the range is set to
-    stack0.dt to stack0.endtime().
+    stack0.t0 to stack0.endtime().
 
     "ensemble_inner" - (default) use the range defined by the "inner" method
     for computing the range with the function `ensemble_time_range`.
@@ -768,13 +787,10 @@ def robust_stack(
     for computing the range with the function `ensemble_time_range`.
     (see `ensemble_time_range` docstring for the definition).
 
-    These interact with the value passed via "fractional_mismatch_level".
-    When the time range computed is larger than the range of a particular
-    member of the input ensemble this parameter determines whether or not
-    the member will be used in the stack.  If the fraction of
-    undefined samples (i.e. N_undefined/Nsamp) is greater than this cutoff
-    that datum will be ignored.   Otherwise if there are undefined
-    values they will be zero padded.
+    When the selected range extends beyond a live ensemble member, that
+    member is zero padded; the current implementation does not reject members
+    based on the padded fraction.  ``pad_fraction_cutoff`` applies only when a
+    dbxcor ``stack0`` must be padded to the selected range.
 
     :param ensemble:   input data to be stacked.   Should all be in
         relative time with all members having the same relative time span.
@@ -793,34 +809,43 @@ def robust_stack(
         uses the median as the starting point, but this can be used to
         input something else.   Note the function will silently ignore this
         argument if method == "median".
-    :type stack0:  TimeSeries.   Note the time span of this optional input
-        must be the same or wider than the ensemble member range defined by
-        the (internal to this module) validate_ensemble function or the
-        return will be return as a copy of this TimeSeries marked dead.
-        Default for this argument is None which means the median will be
-        used for the initial stack for dbxcor
+    :type stack0: TimeSeries or None.  For dbxcor, the seed is windowed or
+        padded to the selected time span and is returned dead when the missing
+        fraction exceeds ``pad_fraction_cutoff``.  A value is also required
+        when ``timespan_method="stack0"`` even if ``method="median"``, because
+        it defines the output range.  The default None uses a median initial
+        estimate for dbxcor.
     :param stack_md:   optional Metadata container to define the
         content of the stack output.  By default the output will have only
         Metadata that duplicate required internal attributes (e.g. t0 and npts).
-        An exception is if stack0 is used the Metadata of that container will
-        be copied and this argument will be ignored.
-    :type stack_md:  Metadata container or None.  If stack0 is defined
-        this argument is ignored.   Otherwise it should be used to add
+        An exception is when dbxcor uses ``stack0``: that seed's Metadata is
+        copied and this argument is ignored.
+    :type stack_md: Metadata container or None.  When dbxcor uses ``stack0``
+        this argument is ignored.  Otherwise it should be used to add
         whatever Metadata is required to provide a tag that can be used to
         identify the output.  If not specified the stack Metadata
         will be only those produce from default construction of a
         TimeSeries.  That is almost never what you want.   Reiterate,
-        however, that if stack0 is defined the output stack will be a
+        however, that if dbxcor uses stack0 the output stack will be a
         clone of stack0 with possible modifications of time and data
         range attributes and anything the stack algorithm posts.
+    :param timespan_method: method used to select the output time range.
+        Accepted values are ``"ensemble_inner"`` (default),
+        ``"ensemble_outer"``, ``"ensemble_median"``, and ``"stack0"`` as
+        described above.
+    :type timespan_method: string
+    :param pad_fraction_cutoff: maximum fraction of missing samples that may
+        be zero padded when a dbxcor ``stack0`` is adjusted to the selected
+        time range.  This value does not control padding of ensemble members.
+    :type pad_fraction_cutoff: float (default 0.05)
     :param residual_norm_floor: floor on residuals used to compute dbxcor weight
         function.  See docstring for `dbxcor_weights` for details.  Ignored
         unless method is "dbxcor"
     :type residual_norm_floor:   float (default 0.01)
-    :return:  tuple containing the requested stack as component 0.  The
+    :return: two-element list containing the requested stack as component 0.  The
         stack is returned as a `TimeSeries`  with optional Metadata copied
         from the (optional) stack_md argument.   Component 1 is defined only
-        for the dbxcor method in which case it a numpy array containing th e
+        for the dbxcor method in which case it is a numpy array containing the
         robust weights returned by the dbxcor algorithm.  If the method is
         set to "median" component 1 will be returned as a None type.
     """
@@ -879,7 +904,7 @@ def robust_stack(
     dt = ensemble.member[0].dt
     N = int((timespan.end - timespan.start) / dt) + 1
 
-    if stack0:
+    if stack0 and method == "dbxcor":
         stack = WindowData_autopad(
             stack0,
             timespan.start,
@@ -906,9 +931,9 @@ def robust_stack(
         stack = TimeSeries(N)
         if stack_md:
             stack = TimeSeries(stack, stack_md)
-            stack.t0 = timespan.start
-            # this works because we can assume ensemble is not empty and clean
-            stack.dt = ensemble.member[0].dt
+        stack.t0 = timespan.start
+        # this works because we can assume ensemble is not empty and clean
+        stack.dt = ensemble.member[0].dt
         # Make sure the stack has the same time base as the input
         stack.tref = ensemble.member[0].tref
         # Always compute the median stack as a starting point
@@ -936,7 +961,7 @@ def robust_stack(
     else:
         # since method can only be median or dbxcor at this point this
         # block is exectuted only when method=="dbxcor"
-        # this works because _dbxcor returns a tuple of the right form
+        # this works because _dbxcor_stacker returns a two-element list
         return _dbxcor_stacker(
             ensemble,
             stack,
@@ -950,15 +975,15 @@ def _dbxcor_stacker(
     eps=0.001,
     maxiterations=20,
     residual_norm_floor=0.1,
-) -> tuple:
+) -> list:
     """
     Runs the dbxcor robust stacking algorithm on `enemble` with initial
     stack estimate stack0.
-    Returns a tuple with the stack as component 0 and a numpy vector
+    Returns a two-element list with the stack as component 0 and a numpy vector
     of the final robust weights as component 1.
 
     This function is intended to be used only internally in this module
-    as it has no safties and assumes ensemble and stack0 are what it expects.
+    as it has no safeguards and assumes ensemble and stack0 are what it expects.
 
     :param ensemble:  TimeSeriesEnsemble assumed to have constant data
       range and sample interval and not contain any dead data.
@@ -969,7 +994,7 @@ def _dbxcor_stacker(
     :param maxiterations:  maximum number of iterations (default 20)
     :param residual_norm_floor: floor on residuals used to compute dbxcor weight
       function.  See docstring for `dbxcor_weights` for details.
-    :type residual_norm_floor:   float (default 0.01)
+    :type residual_norm_floor:   float (default 0.1)
     """
     stack = TimeSeries(stack0)
     # useful shorthands
@@ -1122,7 +1147,7 @@ def align_and_stack(
     checks_arg0_type=True,
     handles_dead_data=True,
     **kwargs,
-) -> tuple:
+) -> list:
     """
     This function uses an initial estimate of the array stack passed as
     the `beam` argument as a seed to a robust algorithm that will
@@ -1149,53 +1174,41 @@ def align_and_stack(
     to be run in batch without user intervention.  The original dbxcor
     algorithm required four interactive picks to set the input.
     The way we set them for this automated algorithm is described in the
-    following four itemize paragraphs:
+    following four numbered items:
 
-        1.  The "correlation window", which is the waveform segment
-            used to compute cross-correlations between the beam and all
-            ensmebled members, is set one of three ways.  The default
-            uses the time window defined by the starttime and endtime of
-            the `beam` signal as the cross-correlation window.
-            Alternative, this window can be specified either by
-            fetching values from the `Metadata` container of beam
-            or via the `correlation_window` argument.   The algorithm
-            first tests if `correlation_window` is set and is an
-            instance of a `TimeWindow` object.   If the type of
-            the argument is not a `TimeWindow` object an error is logged
-            and the program reverts to using the span of the beam
-            signal as the correlation window.   If `correlation_window`
-            is a None (default) the algorithm then checks for a valid
-            input via the `correlation_window_keys` argument.  If
-            defined that argument is assumed to contain a pair of strings
-            that can be used as keys to fetch start (component 0)
-            and end times (component 1) from the Metadata container of
-            the TimeSeries objct passed via beam. For example,
+        1.  The "correlation window", which is the waveform segment used to
+            compute cross-correlations between the beam and all ensemble
+            members, is set one of three ways.  An explicit `TimeWindow`
+            passed as `correlation_window` takes precedence; a truthy value of
+            any other type raises `TypeError`, while a falsy value is treated
+            as unset.  In the unset case, the algorithm checks the pair of beam
+            Metadata keys supplied through `correlation_window_keys`.  For example,
 
                correlation_window_keys = ['correlation_start','correlation_end']
 
-            would cause the function to attempt to fetch the
-            start time with "correlation_start" and end time with
-            "correlation_end".  In the default both `correlation_window`
-            and `correlation_window_keys` are None which cause the
-            function to silently use the window defined as
-            [beam.t0, beam.endtime()] as the correlation winow.
-            If the optional boolean `window_beam` argument is set True
-            the function will attempt to window the beam using a range
-            input via either of the optional methods of setting the
-            correlation window.  An error is logged and nothing happens if
-            `window_beam` is set True and the default use of the beam
-            window is being used.
+            would cause the function to fetch the start time with
+            "correlation_start" and end time with "correlation_end".  By
+            default, `correlation_window_keys` is
+            ["correlation_window_start", "correlation_window_end"].  The
+            function first tries those beam Metadata keys and logs a complaint
+            before falling back to the corresponding beam bound for each
+            missing key.  Passing `correlation_window_keys=None` skips the
+            Metadata lookup and silently uses [beam.t0, beam.endtime()] as the
+            correlation window.  When `window_beam` is True, an explicit or
+            Metadata-derived window is also applied to the beam.  With
+            `correlation_window_keys=None`, the beam already defines the
+            window and is left unchanged without an error.
         2.  The "robust window" is a concept used in dbxcor to
             implement a special robust stacking algorithm that is a novel
-            feature of the dbxcor algorithm.   It uses a very aggresssive
+            feature of the dbxcor algorithm.   It uses a very aggressive
             weighting scheme to downweight signals that do not match the
             beam.  The Pavlis and Vernon paper shows examples of how this
             algorithm can cleanly handle ensembles with a mix of high
             signal-to-noise data with pure junk and produce a clean
             stack that is defined.   Note recent experience has shown
             that with large, consistent ensembles the dbxcor robust
-            estimate tends to converge to the focus on the signal closestbeam_correlation
-            to the median stack.  The reason is that the median stack
+            estimate tends to focus on the signal closest to the median
+            stack.  The reason is that the median stack
             is always used as the initial estimator.   Hence, it can
             be thought of as a median stack that uses the full data
             set more completely.
@@ -1207,7 +1220,7 @@ def align_and_stack(
             running this function and select the initial seed (beam) from
             one or more of the computed snr metrics.   In addition,
             with this approach I envision a two-stage computation where
-            the some initial seed is used for a first pass.   The
+            an initial seed is used for a first pass.   The
             return is then used to revise the correlation window by
             examining stack coherence metrics and then rerunning the
             algorithm.   The point is it is a research problem for
@@ -1223,53 +1236,31 @@ def align_and_stack(
             to manually or automatically pick an arrival time from the
             beam output.
 
-    This function does some consistency checking of arguments to handle
-    the different modes for handling the correlation and robust windows
-    noted above.  It also applies a series of validation tests on the
-    input ensemble before attempting to run.  Any of the following will
-    cause the return to be a dead ensemble with an explanation in the
-    elog container of the ensemble (in these situation the stack is an
-    empty `TimeSeries` container):
+    This function checks the window arguments and input ensemble before the
+    iterative stack.  The resulting state changes are reported through the
+    ensemble or beam error log:
 
-        1.  Irregular sample intervals of live data.
-        2.  Any live data with the time reference set to UTC
-        3.  Inconsistency of the time range of the data and the
-            time windows parsed for the correlation and robust windows.
-            That is, it checks the time span of all member functions and
-            if the time range of all members (min of start time and maximum end times).
-            is not outside (inclusive) the range of the correlation and robust
-            windows it is viewed as invalid.
-        4.  What we called the "robust window" in the dbxcor paper isextract_input_beam_estimate
-            required to be inside (inclusive of endpoints) the cross-correlation window
-            time window.   That could be relaxed but is a useful constraint because
-            in my (glp) experience the most coherent part of phase arrivals is the
-            first few cycles of the phase that is also the part cross-correlation
-            needs to contain if it is to be stable.   The "robust window" should
-            be set to focus on the section of the signal that will have the most
-            coherent stack.
+        1.  Members with irregular sample intervals are killed.  The ensemble
+            is killed only when no live members remain.
+        2.  All members are required to use relative time, but the function
+            does not explicitly validate every member's time reference.  The
+            caller must convert UTC data before calling this function.
+        3.  If the correlation window lies outside the estimated median time
+            span of the ensemble, the beam is marked dead and returned with the
+            input ensemble.
+        4.  If the robust window extends beyond the cross-correlation window,
+            it is clipped to those bounds, a Complaint is logged on the beam,
+            and processing continues.
 
-    There is a further complexity in the iteration sequence used by this algorithm
-    for any robust stack method.  That is, time shifts computed by cross-correlation
-    can potentially move the correlation window outside the bounds of the
-    data received as input.   To reduce the impact of that potential problem
-    the function has an optional argument called `time_shift_limit`
-    that is validated against other inputs.   In particular, the function
-    computes the average start and end time (keep in mind the assumption is the
-    time base is time relative to the arrival time a particular phase)
-    of the input ensemble.   If the difference between the average start time
-    and the correlation window start time is less than `time_shift_limit`
-    the input is viewed as problematic.   How that is handled depends on how
-    the correlation window is set.  If it is received as constant
-    (`correlation_window` argument) an exception will be thrown to abort
-    the entire job.   It that window is extracted from the beam TimeSeries
-    Metadata container a complaint is logged to the outputs.  An
-    endtime inconsistency is treated the same way.  i.e. it is treated as
-    a problem if the average ensemble endtime - the correlation window
-    endtime is less than the `time_shift_limit`.
+    Cross-correlation can estimate a shift larger than the useful range of the
+    input.  The `time_shift_limit` argument is an absolute ceiling applied to
+    each estimate: a larger positive or negative lag is clipped to the limit
+    with its sign preserved.  It does not validate the correlation-window
+    margins against the ensemble time span.
 
     A related issue is that arrival times estimated by this algorithm
     will be biased by the model mismatch with whatever signal was used
-    as the initial beam estimae.  In dbxcor that was handled by forcing
+    as the initial beam estimate.  In dbxcor that was handled by forcing
     the user to manually pick the first arrival of the computed stack.
     That could be done if desired but would require you to devise a scheme
     to do that picking.   The default here is handled by the boolean
@@ -1284,12 +1275,11 @@ def align_and_stack(
     by the `output_stack_window` argument.  See below for details.
 
     :param ensemble:   ensemble of data to be aligned and stacked.
-        This function requires all data to be on a relative time base.
-        It will throw a MsPASSError exception if any live datum has a UTC time base.
-        The assumption is all data have a time span that have the correlation
-        and robust windows inside the data time range.   Both windows are
-        carved from the inputs using the WindowData function which will kill
-        any members that do not satisfy this requirement.
+        This function requires all data to be on a relative time base, but it
+        does not explicitly validate every member's time reference.  The caller
+        must convert UTC data before use.  The correlation and robust windows
+        are expected to lie within the ensemble's usable time range; validation
+        outcomes are described above.
     :type ensemble:  `TimeSeriesEnsemble` with some fairly rigid requirements.
         (see above)
     :param beam:  Estimate of stack (may be just one representative member)
@@ -1305,42 +1295,43 @@ def align_and_stack(
         extract cross-correlation window attributes from beam Metadata container.
         If defined component 0 is taken as the key for the start time of the window and
         component 1 the key for the end time.
-    :type correlation_window_key:  iterable list containing two strings.
-        Default is None which is taken to mean the span of the beam signal defines
-        the cross-correlation window.
+    :type correlation_window_keys: iterable list containing two strings.  The
+        default is ["correlation_window_start", "correlation_window_end"].
+        Passing None uses the span of the beam signal without a Metadata lookup.
     :param window_beam:  if True (default) the parsed cross-correlation window attributes
         are applied to the beam signal as well as the data before starting
         processing.   If False the beam signal is used directly in all cross-correlations.
         Set False only if you can be sure secondary phases are not present in the
         unwindowed input.
-    :param robust_stack_window: Provide an explicity `TimeWindow` used for
+    :param robust_stack_window: Provide an explicit `TimeWindow` used for
         extracting the robust window for this algorithm.   Interacts with the
         robust_stack_window_keys argument as described above.
     :type robust_stack_window:  If defined must be a `TimeWindow` object.
         If a None type (default) use the logic defined above to set this time window.
     :param robust_stack_window_keys: specifies a pair of strings to be used
-        as keys to extract the strart time (component 0) and end time (component 1)
+        as keys to extract the start time (component 0) and end time (component 1)
         of the robust time window to use from the beam `TimeSeries`.
     :type robust_stack_window_keys: iterable list of two strings
     :param output_stack_window:  optional `TimeWindow` to apply to the
         computed robust stack output.   Default returns a stack spanning the
-        inner range of all live members of the ensemble.
+        median start and end times of the live ensemble members.
     :type output_stack_window:  `TimeWindow` object.  If None (default) the range
-        is derived from the ensemble member time ranges.
+        is derived from the median ensemble member time range.
     :param robust_weight_key:  The robust weight used for each member to
         compute the robust stack output is posted to the Metadata container of
         each live member with this key.
     :type robust_weight_key:  string
-    :param robust_stack_method:   keyword defining the method textract_input_beam_estimateo use for
+    :param robust_stack_method: keyword defining the method to use for
         computing the robust stack.  Currently accepted value are:
         "dbxcor" (default) and "median".
     :type robust_stack_method:  string  - must be one of options listed above.
-    :param use_median_initial_stack:  If True (default) use the median stack as the initial
-        estimate of the stack in the first iterative pass.  When False the signal in the
-        `TimeSeries` passed via the "beam" argument is used for the initial estimate.
+    :param use_median_initial_stack: currently has no effect.  The implementation
+        always uses a median stack as the initial estimate, including when this
+        value is False.
+    :type use_median_initial_stack: boolean (default True)
     :param time_shift_key:  the time shift applied relative to the starting
         point is posted to each live member with this key.  It is
-        IMPORTANT to realize this is the time for this pass.  If thisextract_input_beam_estimatefunctions
+        IMPORTANT to realize this is the time for this pass.  If this function
         is applied more than once and you reuse this key the shift from the
         previous run will be overwritten.  If you need to accumulate shifts
         it needs to be handled outside this function.
@@ -1348,40 +1339,37 @@ def align_and_stack(
     :param convergence:   fractional change in robust stack estimates in
         iterative loop to define convergence.  This should not be changed
         unless you deeply understand the algorithm.
-    :type convergence:  real number (default 0.001)
+    :type convergence:  real number (default 0.01)
     :param time_shift_limit: when time shifting data with the cross
         correlation algorithm any estimated time shift larger than
         this value will be truncated to this value with the sign
-        of th shift preserved.
+        of the shift preserved.
     :type time_shift_limit:  float
-    :param  abort_irregular_sampling: boolean that controls error
-        handling of data with irregular sample rates.  This function uses
+    :param abort_irregular_sampling: currently has no effect.  This function uses
         a generous test for sample rate mismatch.  A mismatch is
         detected only if the computed time skew over the time span of
-        the input beam signal is more than 1/2 of the beam sample interval
-        (beam.dt).  When set true the function will
-        abort with a ValueError exception if any ensemble member fails the
-        sample interval test.  If False (the default) offending ensemble
-        members are killed and a message is posted.  Note the actual
-        ensemble is modified so the return may have fewer data live
-        than the input when this mode is enabled.
-    :type abort_irregular_sampling:  boolean
+        the input beam signal is more than half of the beam sample interval
+        (``beam.dt``).  Offending ensemble members are always killed and a
+        message is posted; setting this value to True does not currently raise
+        ``ValueError``.  The input ensemble can therefore return with fewer
+        live members.
+    :type abort_irregular_sampling: boolean (default False)
     :param residual_norm_floor: floor on residuals used to compute dbxcor weight
         function.  See docstring for `dbxcor_weights` for details.
-    :type residual_norm_floor:   float (default 0.01)
+    :type residual_norm_floor:   float (default 0.1)
     :param demean_residuals: boolean controlling if the computed shifts
         are corrected with a demean operation.   Default is True which
         means the set of all time shifts computed by this function will
         have zero mean.
 
-    :return: tuple with component 0 containing the input ensemble, modified in
-        place by cross-correlation time shifts.  Failed/discarded signals for
-        the stack are not killed but can be detected by testing the
-        key defined by the "time_shift_key" argument
-        (default is 'arrival_time_correction') being set.
-        i.e. that value will not be set for components dropped from
-        the stack.   Component 1 of return tuple is the computed
-        stack windowed to the range defined by `stack_time_window`.
+    :return: two-element list with component 0 containing the input ensemble,
+        modified in place by cross-correlation time shifts and member kills.
+        On a successful return, every member still live has the key defined by
+        ``time_shift_key``.  With the ``dbxcor`` stack method, live members
+        with positive final weight also have ``robust_weight_key``; members
+        killed by sampling or windowing failures are marked dead.  Component 1
+        is the computed stack windowed to the range defined by
+        ``output_stack_window``.
     """
     alg = "align_and_stack"
     # xcor ensemble has the initial start time posted to each
@@ -1660,7 +1648,7 @@ def align_and_stack(
             tshift = ensemble.member[i].t0 - initial_starttime
             ensemble.member[i].put_double(time_shift_key, tshift)
     if output_stack_window:
-        # this will clone the beam trace metadata automaticallyextract_input_beam_estimate
+        # this will clone the beam trace metadata automatically
         # using pad option assures t0 will be output_stack_window.start
         # and npts is consistent with window requested
         output_stack = WindowData(

--- a/python/mspasspy/algorithms/ml/arrival.py
+++ b/python/mspasspy/algorithms/ml/arrival.py
@@ -21,13 +21,15 @@ def annotate_arrival_time(
     Predict the arrival time of the P wave using the provided seisbench WaveformModel.
     The arrival time will be saved as a dictionary in the input TimeSeries object and can be accessed using
     the key ``p_wave_picks``. In the dictionary, the key is the arrival time in the UTC timestamp format,
-    and the value is the probability of the pick.
+    and the value is the probability of the pick.  The input is converted to
+    UTC in place with ``rtoa()`` before prediction.
 
     :param timeseries: The time series data to predict the arrival time.
     :param threshold: The probability threshold (0-1) to filter p-wave picks.
         Any picks with probability less than the threshold will be removed. Default value is 0.2.
     :param time_window: The time window (in utc timestamp) to filter the predicted arrival time.
-        If not provided, the whole time series will be used.
+        If not provided, the whole time series will be used.  Bounds outside
+        the input data range are clipped in place on this object.
     :param model: The model used to predict the arrival time.
     :param model_args: arguments to initialize a new model if not provided
     :type timeseries: mspasspy.ccore.seismic.TimeSeries

--- a/python/mspasspy/algorithms/ml/arrival.py
+++ b/python/mspasspy/algorithms/ml/arrival.py
@@ -28,10 +28,15 @@ def annotate_arrival_time(
     :param threshold: The probability threshold (0-1) to filter p-wave picks.
         Any picks with probability less than the threshold will be removed. Default value is 0.2.
     :param time_window: The time window (in utc timestamp) to filter the predicted arrival time.
-        If not provided, the whole time series will be used.  Bounds outside
-        the input data range are clipped in place on this object.
+        If not provided, the whole time series will be used.  A partially
+        overlapping window is clipped in place to the input data range.  A
+        window with no overlap is reset in place to the full input range, so
+        the whole time series is annotated.
     :param model: The model used to predict the arrival time.
-    :param model_args: arguments to initialize a new model if not provided
+    :param model_args: optional dictionary used when ``model`` is not
+        provided.  Its ``name`` value selects the pretrained PhaseNet model;
+        other keys are currently ignored.  The default model name is
+        ``"stead"``.
     :type timeseries: mspasspy.ccore.seismic.TimeSeries
     :type threshold: float
     :type time_window: mspasspy.ccore.algorithms.basic.TimeWindow defined as absolute time in UTC
@@ -44,7 +49,7 @@ def annotate_arrival_time(
     # Check the input arguments
     if not 0 <= threshold <= 1:
         logging.warning(
-            "Threshold should be in the range of [0, 1]. Using default threshold {}}".format(
+            "Threshold should be in the range of [0, 1]. Using default threshold {}".format(
                 default_threshold
             )
         )

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -65,6 +65,7 @@ def mspass_func_wrapper(
     This decorator can be used to adapt a processing function to the
     mspass framework.  It can be used to handle the following nonstandard
     functionality that would not appear in a function outside of mspass:
+
         1.  This decorator can make a function dogmatic about the type of arg0.
             A processing function in mspass normally requires arg0 to be a
             seismic data type.   If the function being decorated handles
@@ -507,7 +508,7 @@ def mspass_method_wrapper(
        is taken to mean any return of the wrapped function will be ignored.  Note
        that when function_return_key is anything but None, it is assumed the
        returned object is the (usually modified) data object.
-     :param handles_ensembles:  set True (default) if the function this is applied to
+    :param handles_ensembles:  set True (default) if the function this is applied to
        can hangle ensemble objects directly.   When False this decorator
        applies the atomic function to each ensemble member in
        a loop over members.
@@ -759,7 +760,8 @@ def timeseries_ensemble_copy_helper(es1, es2):
 @decorator
 def timeseries_as_trace(func, *args, **kwargs):
     """
-    This decorator converts all the mspasspy TimeSeries objects in user inputs (*args and **kargs)
+    This decorator converts all the mspasspy TimeSeries objects in user inputs
+    (``*args`` and ``**kwargs``)
     to trace objects (defined in Obspy), and execute the func with the converted user inputs. After the execution,
     the trace objects will be converted back by overriding the data and metadata of the origin mspasspy objects. This
     wrapper makes it easy to process mspasspy objects using Obspy methods.
@@ -843,7 +845,8 @@ def seismogram_ensemble_copy_helper(es1, es2):
 @decorator
 def seismogram_as_stream(func, *args, **kwargs):
     """
-    This decorator converts all the mspasspy Seismogram objects in user inputs (*args and **kargs)
+    This decorator converts all the mspasspy Seismogram objects in user inputs
+    (``*args`` and ``**kwargs``)
     to stream objects (defined in Obspy), and execute the func with the converted user inputs. After the execution,
     the stream objects will be converted back by overriding the data and metadata of the origin mspasspy objects.
 
@@ -895,7 +898,8 @@ def seismogram_as_stream(func, *args, **kwargs):
 @decorator
 def timeseries_ensemble_as_stream(func, *args, **kwargs):
     """
-    This decorator converts all the mspasspy TimeSeries ensemble objects in user inputs (*args and **kargs)
+    This decorator converts all the mspasspy TimeSeries ensemble objects in user inputs
+    (``*args`` and ``**kwargs``)
     to stream objects (defined in Obspy), and execute the func with the converted user inputs. After the execution,
     the stream objects will be converted back by overriding the data and metadata of each member in the ensemble.
 
@@ -939,7 +943,8 @@ def timeseries_ensemble_as_stream(func, *args, **kwargs):
 @decorator
 def seismogram_ensemble_as_stream(func, *args, **kwargs):
     """
-    This decorator converts all the mspasspy Seismogram ensemble objects in user inputs (*args and **kargs)
+    This decorator converts all the mspasspy Seismogram ensemble objects in user inputs
+    (``*args`` and ``**kwargs``)
     to stream objects (defined in Obspy), and execute the func with the converted user inputs. After the execution,
     the stream objects will be converted back by overriding the data and metadata of each member in the ensemble.
 

--- a/python/tests/algorithms/ml/test_arrival.py
+++ b/python/tests/algorithms/ml/test_arrival.py
@@ -95,6 +95,17 @@ def test_annotate_arrival_time_threshold():
     assert len(mspass_picks) < len(seis_picks)
 
 
+def test_annotate_arrival_time_invalid_threshold_uses_default():
+    stream = get_trace_for_test()
+    expected = Trace2TimeSeries(stream[0])
+    annotate_arrival_time(expected, 0.2, model=pn_model)
+
+    for invalid_threshold in (-0.1, 1.1):
+        timeseries = Trace2TimeSeries(stream[0])
+        annotate_arrival_time(timeseries, invalid_threshold, model=pn_model)
+        assert timeseries["p_wave_picks"] == expected["p_wave_picks"]
+
+
 def test_annotate_arrival_time_window():
     """
     Test the annotate_arrival_time function with a time window.
@@ -163,6 +174,36 @@ def test_annotate_arrival_time_filters_trimmed_boundary_samples():
     picks = timeseries["p_wave_picks"]
     assert set(picks.keys()) == {1.0, 2.0, 3.0}
     assert all(window_start <= pick_time <= window_end for pick_time in picks)
+
+
+def test_annotate_arrival_time_adjusts_window_in_place():
+    trace = Trace(np.zeros(10))
+    trace.stats.starttime = UTCDateTime(0)
+    trace.stats.delta = 1.0
+
+    timeseries = Trace2TimeSeries(trace)
+    partial_window = TimeWindow(-2.0, 3.0)
+    annotate_arrival_time(
+        timeseries,
+        threshold=0,
+        time_window=partial_window,
+        model=_BoundaryPredictionModel(),
+    )
+    assert partial_window.start == 0.0
+    assert partial_window.end == 3.0
+    assert set(timeseries["p_wave_picks"]) == {0.0, 1.0, 2.0, 3.0}
+
+    timeseries = Trace2TimeSeries(trace)
+    disjoint_window = TimeWindow(20.0, 30.0)
+    annotate_arrival_time(
+        timeseries,
+        threshold=0,
+        time_window=disjoint_window,
+        model=_BoundaryPredictionModel(),
+    )
+    assert disjoint_window.start == 0.0
+    assert disjoint_window.end == 9.0
+    assert set(timeseries["p_wave_picks"]) == set(np.arange(10, dtype=float))
 
 
 class _NoPPhasePredictionModel(_BoundaryPredictionModel):

--- a/python/tests/algorithms/test_MCXcorStacking.py
+++ b/python/tests/algorithms/test_MCXcorStacking.py
@@ -204,6 +204,12 @@ def test_dbxcor_weights_preserves_zero_and_dead_sentinels():
     assert np.all(np.isfinite(weights))
     assert np.array_equal(weights, np.array([0.0, 1.0, -1.0]))
 
+    zero_stack_weights = dbxcor_weights(
+        ensemble, _make_live_timeseries([0.0, 0.0])
+    )
+    assert np.all(np.isfinite(zero_stack_weights))
+    assert np.array_equal(zero_stack_weights, np.array([0.0, 0.0, -1.0]))
+
 
 def test_robust_stack_median_ignores_stack0_values():
     ensemble = TimeSeriesEnsemble()

--- a/python/tests/algorithms/test_MCXcorStacking.py
+++ b/python/tests/algorithms/test_MCXcorStacking.py
@@ -10,6 +10,8 @@ functions.
 """
 
 import pickle
+from unittest.mock import patch
+
 import numpy as np
 from scipy import signal
 from numpy.random import randn
@@ -21,6 +23,7 @@ from mspasspy.ccore.seismic import (
     DoubleVector,
 )
 from mspasspy.ccore.algorithms.basic import TimeWindow
+from mspasspy.ccore.algorithms.amplitudes import MADAmplitude
 from mspasspy.algorithms.window import WindowData
 from mspasspy.algorithms.basic import ExtractComponent
 from mspasspy.algorithms.window import scale
@@ -29,8 +32,11 @@ from obspy.taup import TauPyModel
 from mspasspy.algorithms.MCXcorStacking import (
     align_and_stack,
     _coda_duration,
+    dbxcor_weights,
+    extract_initial_beam_estimate,
     MCXcorPrepP,
     number_live,
+    robust_stack,
     _set_phases,
     regularize_sampling,
     ensemble_time_range,
@@ -131,6 +137,95 @@ def print_elog(mspass_object):
             print("Error Message:  ", log.message)
             print("Badness:  ", log.badness)
         print(separator)
+
+
+@pytest.mark.parametrize(
+    ("metric", "stored_key"),
+    [
+        ("bandwidth", "bandwidth"),
+        ("filtered_envelope", "snr_filtered_envelope_peak"),
+        ("filtered_L2", "snr_filtered_rms"),
+        ("filtered_MAD", "snr_filtered_mad"),
+        ("filtered_Linf", "snr_filtered_peak"),
+        ("filtered_perc", "snr_filtered_perc"),
+    ],
+)
+def test_extract_initial_beam_estimate_metric_mapping(metric, stored_key):
+    ensemble = TimeSeriesEnsemble()
+    for candidate_index, value in enumerate((None, 1.0, 3.0)):
+        datum = TimeSeries()
+        datum.set_npts(1)
+        datum.set_live()
+        datum["candidate_index"] = candidate_index
+        datum["Parrival"] = {} if value is None else {stored_key: value}
+        ensemble.member.append(datum)
+    ensemble.set_live()
+
+    beam = extract_initial_beam_estimate(ensemble, metric=metric)
+
+    assert beam.live
+    assert beam["candidate_index"] == 2
+    assert beam is not ensemble.member[2]
+
+
+def test_extract_initial_beam_estimate_rejects_unknown_metric():
+    ensemble = TimeSeriesEnsemble()
+    datum = TimeSeries()
+    datum.set_npts(1)
+    datum.set_live()
+    ensemble.member.append(datum)
+    ensemble.set_live()
+    with pytest.raises(ValueError, match="Must be one of"):
+        extract_initial_beam_estimate(ensemble, metric="not-a-metric")
+
+
+def _make_live_timeseries(data, t0=0.0, dt=1.0):
+    datum = TimeSeries()
+    datum.dt = dt
+    datum.t0 = t0
+    datum.set_npts(len(data))
+    datum.data = DoubleVector(data)
+    datum.set_live()
+    return datum
+
+
+def test_dbxcor_weights_preserves_zero_and_dead_sentinels():
+    stack = _make_live_timeseries([1.0, 1.0])
+    ensemble = TimeSeriesEnsemble()
+    ensemble.member.append(_make_live_timeseries([0.0, 0.0]))
+    ensemble.member.append(_make_live_timeseries([1.0, 1.0]))
+    dead_member = _make_live_timeseries([1.0, 1.0])
+    dead_member.kill()
+    ensemble.member.append(dead_member)
+    ensemble.set_live()
+
+    weights = dbxcor_weights(ensemble, stack)
+
+    assert np.all(np.isfinite(weights))
+    assert np.array_equal(weights, np.array([0.0, 1.0, -1.0]))
+
+
+def test_robust_stack_median_ignores_stack0_values():
+    ensemble = TimeSeriesEnsemble()
+    ensemble.member.append(_make_live_timeseries([1.0, 3.0], t0=10.0, dt=0.5))
+    ensemble.member.append(_make_live_timeseries([3.0, 5.0], t0=10.0, dt=0.5))
+    ensemble.set_live()
+    stack0 = _make_live_timeseries([100.0, 100.0], t0=10.0, dt=0.5)
+
+    stack, weights = robust_stack(ensemble, method="median", stack0=stack0)
+
+    assert stack.live
+    assert np.allclose(stack.data, np.array([2.0, 4.0]))
+    assert stack.t0 == 10.0
+    assert stack.dt == 0.5
+    assert stack.npts == 2
+    assert weights is None
+
+    dbxcor_stack, dbxcor_weights_output = robust_stack(
+        ensemble, method="dbxcor", stack0=stack0
+    )
+    assert dbxcor_stack.live
+    assert np.all(np.isfinite(dbxcor_weights_output))
 
 
 def test_align_and_stack():
@@ -575,9 +670,30 @@ def test_MCXcorPrepP():
     # the test data are the output of an ExtractComponent ensemble an the
     # member were normalized by the site collection.   Hence we have to
     # change the station_collection argument to site - default is channel
-    [e, beam] = MCXcorPrepP(
-        e, nw, station_collection="site", correlation_window_start=-2.0
-    )
+    coda_levels = []
+
+    def record_coda_level(datum, level, *args, **kwargs):
+        noise_start = datum.t0 if datum.t0 < nw.start else nw.start
+        noise_data = WindowData(
+            datum, noise_start, nw.end, short_segment_handling="truncate"
+        )
+        coda_levels.append((level, 4.0 * MADAmplitude(noise_data)))
+        return _coda_duration(datum, level, *args, **kwargs)
+
+    with patch(
+        "mspasspy.algorithms.MCXcorStacking._coda_duration",
+        side_effect=record_coda_level,
+    ):
+        [e, beam] = MCXcorPrepP(
+            e,
+            nw,
+            station_collection="site",
+            correlation_window_start=-2.0,
+            coda_level_factor=4.0,
+        )
+    assert coda_levels
+    for observed, expected in coda_levels:
+        assert np.isclose(observed, expected)
     assert number_live(e) == N
     assert np.isclose(beam["correlation_window_start"], -2.0)
     assert np.isclose(beam["correlation_window_end"], 154.65957854747774)
@@ -629,10 +745,12 @@ def test_MCXcorPrepP():
     [eo, beam] = MCXcorPrepP(e, nw, station_collection="site")
     assert eo.dead()
     assert beam.dead()
-    # no signals present.
+    # No signals present.  Use zeros instead of random noise: a threshold
+    # scaled to a random record's own MAD can legitimately be crossed by
+    # excursions in a sufficiently long record.
     e = TimeSeriesEnsemble(e0)
     for i in range(len(e.member)):
-        e.member[i].data = DoubleVector(np.random.normal(size=e.member[i].npts))
+        e.member[i].data = DoubleVector(np.zeros(e.member[i].npts))
     [eo, beam] = MCXcorPrepP(e, nw, station_collection="site")
     assert eo.dead()
     assert eo.elog.size() == 1


### PR DESCRIPTION
## Summary

- define what MsPASS means by a research framework and clarify the two database-documentation layers
- add MCXcor/robust-stacking and SeisBench/PhaseNet entry points to the algorithm quick reference
- add an accessible SNR time-window/bandwidth figure and explain the returned band metrics
- add a curated guide to commonly reused `mspasspy.util` converters, ensemble helpers, cleanup tools, and adapters
- align the published MCXcor and PhaseNet contracts with runtime behavior, with regressions for SNR metric selection, noise-relative coda detection, robust-stack return/state semantics, PhaseNet threshold fallback, and in-place window adjustment

## Relationship to #718

Merged PRs #727, #748, and #754 already supplied the deconvolution chapter, client/worker and schema guidance, updated arrival-time/ML material, cloud/GeoLab deployment pages, expanded FAQ, and the broad proofreading/link repair requested in the issue. This PR closes the remaining discoverability and SNR-explanation gaps.

The issue proposed physically merging the MongoDB and CRUD chapters. The later maintainer-reviewed information architecture in #754 retained them as two deliberately different abstraction levels. This PR makes that distinction explicit in the navigation and with reciprocal links instead of creating one roughly 1,900-line page. The unfinished research-computing essay was likewise deliberately removed during #754 review.

While validating the newly exposed API documentation, the tests also found and fixed small contract bugs: QC metric aliases now map to the keys emitted by `broadband_snr_QC`; coda thresholds use the measured noise amplitude; median stacking ignores dbxcor seeds and preserves its output time axis; zero/dead robust weights retain their documented sentinels; and invalid PhaseNet thresholds correctly fall back to 0.2.

## Validation

- `git diff --check`
- Black and Python syntax checks for the changed Python sources/tests
- candidate-source `python/tests/algorithms/test_MCXcorStacking.py`: 16 passed
- candidate-source `python/tests/algorithms/ml/test_arrival.py`: 8 passed
- `xmllint --noout docs/source/_static/figures/snr_windows_and_bandwidth.svg`
- clean 64-page Sphinx HTML build with `-E -a -W --keep-going`; only the same three environment warnings remained (two unreachable external inventories and one optional local import), with no new RST, reference, system-message, or asset warnings
- rendered the SVG directly and inspected the generated SNR, algorithm, and utility-reference HTML layouts

Fixes #718