### PR TITLE
Fix MsPASS client PySpark compatibility

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,10 +26,10 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   # Keep BuildKit cache out of GitHub Actions cache entries.
   CACHE_IMAGE: ghcr.io/${{ github.repository }}
-  SPARK_VERSION: 3.0.0
-  SPARK_ARCHIVE: spark-3.0.0-bin-hadoop2.7.tgz
-  SPARK_URL: https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
-  SPARK_SHA512: f5652835094d9f69eb3260e20ca9c2d58e8bdf85a8ed15797549a518b23c862b75a329b38d4248f8427e4310718238c60fae0f9d1afb3c70fb390d3e9cce2e49
+  SPARK_VERSION: 3.5.8
+  SPARK_ARCHIVE: spark-3.5.8-bin-hadoop3.tgz
+  SPARK_URL: https://archive.apache.org/dist/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz
+  SPARK_SHA512: 5d5d2e6e111182ee1210d4a46a17ae27107c7ccc70433da0ded3d8197e027f949b00445bb5678ed0c1d5c59f12993d9b9ed12e43686d5aad89a9ec570e93a083
 
 jobs:
   download-spark:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,12 @@ ARG MSPASS_BASE_IMAGE=ghcr.io/seisscoped/container-base:ubuntu22.04_jupyterlab
 ARG GEOLAB_BASE_IMAGE=ghcr.io/mspass-team/geolab-base-mirror@sha256:7aa0b713de225288188163c13519efce1ac5248ea386e734d88ad7c54b0abe27
 ARG PYTHON_VERSION=3.12
 ARG DASK_LABEXTENSION_VERSION=7.0.0
-ARG SPARK_VERSION=3.0.0
-ARG SPARK_PACKAGE=spark-${SPARK_VERSION}-bin-hadoop2.7
+ARG SPARK_VERSION=3.5.8
+ARG SPARK_PACKAGE=spark-${SPARK_VERSION}-bin-hadoop3
 ARG SPARK_ARCHIVE=${SPARK_PACKAGE}.tgz
 ARG APACHE_MIRROR=https://archive.apache.org/dist
 ARG SPARK_URL=${APACHE_MIRROR}/spark/spark-${SPARK_VERSION}/${SPARK_ARCHIVE}
-ARG SPARK_SHA512=f5652835094d9f69eb3260e20ca9c2d58e8bdf85a8ed15797549a518b23c862b75a329b38d4248f8427e4310718238c60fae0f9d1afb3c70fb390d3e9cce2e49
+ARG SPARK_SHA512=5d5d2e6e111182ee1210d4a46a17ae27107c7ccc70433da0ded3d8197e027f949b00445bb5678ed0c1d5c59f12993d9b9ed12e43686d5aad89a9ec570e93a083
 
 FROM scratch AS spark-build-assets
 
@@ -174,7 +174,7 @@ ARG TARGETARCH
 
 # Prepare the environment
 ARG SPARK_VERSION
-ARG SPARK_PACKAGE=spark-${SPARK_VERSION}-bin-hadoop2.7
+ARG SPARK_PACKAGE=spark-${SPARK_VERSION}-bin-hadoop3
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-${TARGETARCH}
 ENV SPARK_HOME=/usr/local/spark
@@ -191,7 +191,7 @@ RUN ln -s /usr/local/spark/bin/pyspark /usr/bin/pyspark
 RUN python -c "import site; print(site.getsitepackages()[0])" > site_packages_path.txt && \
 	PYTHON_SITE_PACKAGES_PATH=$(cat site_packages_path.txt) && \
 	ln -s /usr/local/spark/python/pyspark ${PYTHON_SITE_PACKAGES_PATH}/pyspark && \
-	unzip /usr/local/spark/python/lib/py4j-0.10.9-src.zip -d ${PYTHON_SITE_PACKAGES_PATH}/  \
+	unzip /usr/local/spark/python/lib/py4j-*-src.zip -d ${PYTHON_SITE_PACKAGES_PATH}/  \
 	&& docker-clean
 
 # Patch pyspark for machines don't have localhost defined in /etc/hosts
@@ -201,6 +201,7 @@ RUN unzip /usr/local/spark/python/lib/pyspark.zip \
     && zip /usr/local/spark/python/lib/pyspark.zip pyspark/accumulators.py \
     && rm -r ./pyspark \
 	&& docker-clean
+RUN python -c "import pyspark; expected='${SPARK_VERSION}'; assert pyspark.__version__ == expected, (pyspark.__version__, expected)"
 
 # Install Python tooling
 RUN pip3 --no-cache-dir install --upgrade pip \

--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -9,15 +9,16 @@ from mspasspy.global_history.manager import GlobalHistoryManager
 
 try:
     from pyspark import SparkConf, SparkContext
-
-    _mspasspy_has_pyspark = True
-except ImportError:
-    _mspasspy_has_pyspark = False
-
-try:
     from pyspark.sql import SparkSession
-except ImportError:
+except Exception as err:
+    SparkConf = None
+    SparkContext = None
+    SparkSession = None
     _mspasspy_has_pyspark = False
+    _mspasspy_pyspark_import_error = err
+else:
+    _mspasspy_has_pyspark = True
+    _mspasspy_pyspark_import_error = None
 
 try:
     from dask.distributed import Client as DaskClient
@@ -27,6 +28,16 @@ except ImportError:
     _mspasspy_has_dask_distributed = False
 
 from mspasspy.ccore.utility import MsPASSError
+
+
+def _require_pyspark():
+    if _mspasspy_has_pyspark:
+        return
+
+    message = "Spark scheduler was requested, but PySpark could not be imported"
+    if _mspasspy_pyspark_import_error is not None:
+        message += ": " + str(_mspasspy_pyspark_import_error)
+    raise MsPASSError(message + ".", "Fatal")
 
 
 def _address_has_port(address):
@@ -147,6 +158,16 @@ class Client:
         MSPASS_SCHEDULER_ADDRESS = os.environ.get("MSPASS_SCHEDULER_ADDRESS")
         DASK_SCHEDULER_PORT = os.environ.get("DASK_SCHEDULER_PORT")
         SPARK_MASTER_PORT = os.environ.get("SPARK_MASTER_PORT")
+
+        if (
+            dask_client is None
+            and not _mspasspy_has_pyspark
+            and (
+                scheduler == "spark"
+                or (scheduler is None and MSPASS_SCHEDULER == "spark")
+            )
+        ):
+            _require_pyspark()
 
         # create a database client
         # priority: parameter -> env -> default
@@ -427,6 +448,8 @@ class Client:
                 + " is found.",
                 "Fatal",
             )
+        if scheduler == "spark":
+            _require_pyspark()
 
         prev_scheduler = self._scheduler
         self._scheduler = scheduler

--- a/python/mspasspy/global_history/manager.py
+++ b/python/mspasspy/global_history/manager.py
@@ -10,8 +10,8 @@ except ImportError:
     pass
 try:
     import pyspark
-except ImportError:
-    pass
+except Exception:
+    pyspark = None
 from bson.objectid import ObjectId
 from mspasspy.ccore.utility import MsPASSError, AntelopePf
 from mspasspy.util.converter import AntelopePf2dict
@@ -562,10 +562,8 @@ class GlobalHistoryManager:
         except NameError:
             pass
 
-        try:
+        if pyspark is not None:
             pyspark.RDD.mspass_map = mspass_spark_map
-        except NameError:
-            pass
 
         # modify pyspark/dask reduce to our defined reduce
         try:
@@ -573,10 +571,8 @@ class GlobalHistoryManager:
         except NameError:
             pass
 
-        try:
+        if pyspark is not None:
             pyspark.RDD.mspass_reduce = mspass_spark_reduce
-        except NameError:
-            pass
 
     def logging(self, alg_id, alg_name, parameters):
         """

--- a/python/tests/test_client_broken_optional_pyspark.py
+++ b/python/tests/test_client_broken_optional_pyspark.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+import sys
+
+
+def _run_with_broken_pyspark(tmp_path, code):
+    pyspark_package = tmp_path / "pyspark"
+    pyspark_package.mkdir()
+    (pyspark_package / "__init__.py").write_text(
+        'raise TypeError("broken pyspark import")\n', encoding="utf-8"
+    )
+
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(tmp_path)
+    if pythonpath:
+        env["PYTHONPATH"] += os.pathsep + pythonpath
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_client_import_survives_broken_optional_pyspark(tmp_path):
+    result = _run_with_broken_pyspark(
+        tmp_path,
+        "from mspasspy.client import Client",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_explicit_spark_reports_broken_optional_pyspark(tmp_path):
+    result = _run_with_broken_pyspark(
+        tmp_path,
+        """
+from mspasspy.client import Client
+from mspasspy.ccore.utility import MsPASSError
+
+try:
+    Client(scheduler="spark")
+except MsPASSError as err:
+    message = str(err)
+    assert "PySpark could not be imported" in message, message
+    assert "broken pyspark import" in message, message
+else:
+    raise AssertionError("Client(scheduler='spark') should fail when PySpark is broken")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- treat PySpark import-time failures as an unavailable optional backend instead of breaking `mspasspy.client` imports
- raise a clear `MsPASSError` when Spark is explicitly requested but PySpark cannot be imported
- upgrade the container Spark runtime from 3.0.0/Hadoop 2.7 to 3.5.8/Hadoop 3 and remove the hard-coded Py4J archive version
- validate the bundled PySpark version directly after the Spark installation step
- add regression coverage for a PySpark package that is installed but raises `TypeError` during import
- align the Docker publish workflow's cached Spark build asset with the container version

## Root cause

The container Python runtime was moved to Python 3.12 while the runtime image still injected the PySpark bundled with Spark 3.0.0 into `site-packages`. That old PySpark/cloudpickle code fails while importing on Python 3.12 with a `TypeError`. The optional dependency guards in `client.py` and `global_history/manager.py` only caught `ImportError`, so the exception escaped before `Client()` could be constructed.

## Validation

- added subprocess regression tests that emulate an installed-but-broken PySpark package and verify `mspasspy.client` remains importable
- keep application behavior checks in pytest rather than the Docker package-build layers
- keep a narrow container installation check that imports PySpark and verifies its version matches Spark 3.5.8
- pinned the Spark 3.5.8 Hadoop 3 archive and matching Apache SHA512 in both the Dockerfile and Docker workflow
- branch is a single commit on top of current `master`; GitHub Actions exercise the full Python and Docker builds

Fixes #778