### PR TITLE
Fix sliding-window pipeline result and resource contracts

### DIFF
--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -1,6 +1,8 @@
-import dask.distributed as ddist
-
+import math
 from collections.abc import Mapping, Iterable
+from numbers import Integral, Real
+
+import dask.distributed as ddist
 
 
 def sliding_window_pipeline(
@@ -63,7 +65,7 @@ def sliding_window_pipeline(
     The function uses dask Futures (note Futures are supported only in dask
     so this function cannot be used with a pyspark workflow) and submits
     and runs only sliding_window_size instances of the task defined by
-    the "completion_function" argument.  The default behavior runs
+    the "processing_function" argument.  The default behavior runs
     approximately 2 instances of the function per worker.  The number is
     "approximate" because the scheduler algorithm often queues up more
     instances on startup and the load is unbalanced until all workers are
@@ -81,10 +83,12 @@ def sliding_window_pipeline(
 
     The other element of this function is the optional "completion_function"
     argument.  That function is run on the output of every instance of
-    the function returned by workers.  By default the output of the
-    completion function replaces that of the processing function yielding
-    a list of the same size as the input `dlist`.   For large numbers of
-    inputs such a giant list can be problematic for a variety of reasons.
+    the function returned by workers.  When defined, its output replaces
+    that of the processing function in the returned list.  Without a
+    completion function, processing results are returned directly.  Either
+    list has the same size as `dlist` and follows Future completion order,
+    which is not necessarily input order.  For large numbers of inputs such
+    a giant list can be problematic for a variety of reasons.
     For that reason this function has an optional `accumulator`
     argument.  As the name implies it should be an accumulation function
     that creates a summary of the output or some useful combination of
@@ -104,14 +108,6 @@ def sliding_window_pipeline(
     accumulator to be stateless.   Optional ``*args`` and ``**kwargs``
     values can be passed by the optional a_args and
     a_kwargs parameters.
-
-    The function supports two types of completion functions controlled
-    by the boolean argument "completion_is_accumulator".  When True
-    the completion function is expected to be an accumulator. In that
-    mode the completion function should still return it's current
-    result but the result will overwritten as each Future completes.
-    The function then returns the final value.
-
 
     The function is made generic at the cost of having a rather complicated
     API.   That is summarized here, but the reader is advised to consult
@@ -142,16 +138,17 @@ def sliding_window_pipeline(
        MsPASS normal use is to fetch this with the MsPASS client
        `get_scheduler` method.
     :param sliding_window_size:   size of the sliding window submit buffer.
-    :type sliding_window_size:  must be either the unique string "auto" or
-      an integer.  If set to "auto" (default) the sliding window size is set to
+    :type sliding_window_size:  must be either the literal string "auto" or
+      a positive integer other than a boolean.  If set to "auto" (default)
+      the sliding window size is set to
       the value of `tasks_per_worker` times the number of workers
       dask_client responds are running when this function is first called.
       Note that works perfectly on HPC systems but can fail in cloud
       environment if dask is runnign with dynamic scheduling.  This can
       also be a integer value that manually sets the sliding window size.
-    :param task_per_worker: determines the size of the sliding window
-      when `sliding_window_size="auto"`.  Ignored if the sliding window
-      size is set manually with an integer value.
+    :param task_per_worker: positive finite real number that determines the
+      size of the sliding window when `sliding_window_size="auto"`.  It is
+      ignored after validation if the sliding window size is set manually.
     :param completion_function:   if defined the result returned by each submit
        will be processed with this function.   When defined the function
        output will be the single output of this function.
@@ -191,9 +188,11 @@ def sliding_window_pipeline(
        completed items elapse between reports when ``verbose`` is True.
        The default is 10000.  The final item is always reported.
 
-    :return:   When the completion_function is not defined (default)
-       this function will return a list of return values from each
-       component of dlist passed through the processing function.
+    :return:   When the completion_function is not defined (default), return
+       a list of processing results.  With a completion function and no
+       accumulator, return a list of completion results.  With both, return
+       the final accumulator value.  Results are handled in Future completion
+       order and do not preserve input order.
        Be warned this list can get huge if the data set is large
        and anything but a tiny datum is returned by processing_function.
        The definitive use of this function in MsPASS is a function
@@ -202,20 +201,17 @@ def sliding_window_pipeline(
        boolean values.  If, however, the same function is run with
        `return_data=True` a memory overflow in the caller is likely
        unless the entire output of the processing fits in the memory
-       space of the caller.  When a completion function is used the
-       return is the return of the completion function.
-       A complexity is that if the `accumulator` function is defined
-       the return is NOT a list but the accumulated output of
-       that function.
+       space of the caller.
     """
-    # check args for validity and set integer run_mode for combinations of
-    # logic for processing_function and completion_function arguments
+    # Materialize once so generators and other one-shot iterables have the same
+    # behavior as lists throughout validation and submission.
     alg = "sliding_window_pipeline"
     if not isinstance(dlist, Iterable):
         message = "{}:  Illegal value for arg0 - must be an interable container (usually a list)".format(
             alg
         )
         raise ValueError(message)
+    data_items = list(dlist)
     if not callable(processing_function):
         message = "{}:  Illegal value for arg1 - must be the name of a processing function to be submitted".format(
             alg
@@ -245,11 +241,10 @@ def sliding_window_pipeline(
                 alg
             )
             raise ValueError(message)
-    # handle cfunc slightly differently because it may be used at all
-    # this conditional couod be used directly below but to me this
-    # makes logic clearer
     if completion_function is None:
         run_completion_function = False
+        if accumulator is not None:
+            raise ValueError("accumulator requires a completion_function")
     else:
         run_completion_function = True
         if not callable(completion_function):
@@ -296,75 +291,116 @@ def sliding_window_pipeline(
                     )
                     raise ValueError(message)
 
-    swsize = 0  # initialization - set in block below
-    if isinstance(dask_client, ddist.Client):
-        active_workers = dask_client.nthreads()
-        num_workers = len(active_workers)
-        del active_workers
-        if sliding_window_size == "auto":
-            swsize = round(num_workers * task_per_worker)
-            if swsize < num_workers:
-                print(
-                    f"{alg}:  WARNING set sliding window size to {swsize} which smaller than the number of workers={num_workers}"
-                )
-                print(
-                    "This will not use the dask cluster if you are running this job on HPC"
-                )
-                print(
-                    "This setting makes sense only if you are running on a cluster service being used by multiple applications"
-                )
-        else:
-            swsize = sliding_window_size
-    else:
+    automatic_window = (
+        isinstance(sliding_window_size, str) and sliding_window_size == "auto"
+    )
+    if not automatic_window and (
+        isinstance(sliding_window_size, bool)
+        or not isinstance(sliding_window_size, Integral)
+        or sliding_window_size <= 0
+    ):
+        raise ValueError('sliding_window_size must be "auto" or a positive integer')
+    if (
+        isinstance(task_per_worker, bool)
+        or not isinstance(task_per_worker, Real)
+        or not math.isfinite(task_per_worker)
+        or task_per_worker <= 0
+    ):
+        raise ValueError("task_per_worker must be a positive finite real number")
 
+    if not isinstance(dask_client, ddist.Client):
         message = "{}: Illegal value for arg2.  Must be an instance of dask.distributed.Client".format(
             alg
         )
         raise ValueError(message)
-    futures_list = list()
-    N = len(dlist)
+
+    if automatic_window:
+        num_workers = len(dask_client.nthreads())
+        if num_workers == 0:
+            raise ValueError("cannot calculate an automatic window with zero workers")
+        swsize = round(num_workers * task_per_worker)
+        if swsize < 1:
+            raise ValueError("automatic sliding window size rounded below one")
+        if swsize < num_workers:
+            print(
+                f"{alg}:  WARNING set sliding window size to {swsize} which smaller than the number of workers={num_workers}"
+            )
+            print(
+                "This will not use the dask cluster if you are running this job on HPC"
+            )
+            print(
+                "This setting makes sense only if you are running on a cluster service being used by multiple applications"
+            )
+    else:
+        swsize = int(sliding_window_size)
+
+    N = len(data_items)
     if verbose:
         print(f"Processing {N} items")
-    if N < swsize:
-        swsize = N
-    i_d = 0
-    for d in dlist:
-        f = dask_client.submit(processing_function, d, *pfunc_args, **pfunc_kwargs)
-        futures_list.append(f)
-        i_d += 1
-        if i_d >= swsize:
-            break
-    # initialize both of these although one or the other is returned
-    results = list()
+    swsize = min(swsize, N)
+    results = []
     accumulated_output = None
     number_handled = 0
-    seq = ddist.as_completed(futures_list)
-    for f in seq:
-        f_result = f.result()
-        if run_completion_function:
-            f_result = completion_function(f_result, *cfunc_args, **cfunc_kwargs)
-            if accumulator is None:
-                results.append(f_result)
-            else:
-                # accumulator MUST handle None for arg0 - see docstring
-                accumulated_output = accumulator(
-                    accumulated_output, f_result, *a_args, **a_kwargs
-                )
-        # found to be necessary to assure dask doesn't hog memory held by f
-        dask_client.cancel(f)
-        del f
-        number_handled += 1
-        if verbose and (
-            number_handled % progress_report_interval == 0 or number_handled == N
-        ):
-            print(f"Handled {number_handled} of {N} items")
-        if i_d < N:
-            f = dask_client.submit(
-                processing_function, dlist[i_d], *pfunc_args, **pfunc_kwargs
+    next_item = 0
+    outstanding = []
+    completed_futures = ddist.as_completed(loop=dask_client.loop)
+
+    try:
+        while next_item < swsize:
+            future = dask_client.submit(
+                processing_function,
+                data_items[next_item],
+                *pfunc_args,
+                pure=False,
+                **pfunc_kwargs,
             )
-            seq.add(f)
-            i_d += 1
+            outstanding.append(future)
+            completed_futures.add(future)
+            next_item += 1
+
+        for future in completed_futures:
+            result = future.result()
+            if run_completion_function:
+                result = completion_function(result, *cfunc_args, **cfunc_kwargs)
+                if accumulator is None:
+                    results.append(result)
+                else:
+                    accumulated_output = accumulator(
+                        accumulated_output, result, *a_args, **a_kwargs
+                    )
+            else:
+                results.append(result)
+
+            # Release scheduler/client references as soon as each result has
+            # been handled.
+            dask_client.cancel(future)
+            outstanding.remove(future)
+            number_handled += 1
+            if verbose and (
+                number_handled % progress_report_interval == 0 or number_handled == N
+            ):
+                print(f"Handled {number_handled} of {N} items")
+
+            if next_item < N:
+                future = dask_client.submit(
+                    processing_function,
+                    data_items[next_item],
+                    *pfunc_args,
+                    pure=False,
+                    **pfunc_kwargs,
+                )
+                outstanding.append(future)
+                completed_futures.add(future)
+                next_item += 1
+    except BaseException:
+        if outstanding:
+            try:
+                dask_client.cancel(outstanding)
+            except BaseException:
+                # Preserve the processing/completion/accumulation exception.
+                pass
+        raise
+
     if accumulator is None:
         return results
-    else:
-        return accumulated_output
+    return accumulated_output

--- a/python/tests/test_workflow.py
+++ b/python/tests/test_workflow.py
@@ -1,7 +1,9 @@
+from collections import Counter
 from contextlib import contextmanager
 from pathlib import Path
 import subprocess
 import sys
+import time
 
 import dask
 import pytest
@@ -62,17 +64,62 @@ def accumulator_full(old, x, a, b=30):
         return old + x + a + b
 
 
+def delayed_value(item):
+    value, delay = item
+    time.sleep(delay)
+    return value
+
+
+def times_ten(value):
+    return value * 10
+
+
+def append_accumulator(old, value):
+    if old is None:
+        return [value]
+    return old + [value]
+
+
+def fail_or_delay(item):
+    should_fail, delay = item
+    time.sleep(delay)
+    if should_fail:
+        raise RuntimeError("processing failed")
+    return should_fail
+
+
+def fail_completion(value):
+    if value == "fail":
+        raise RuntimeError("completion failed")
+    return value
+
+
+def fail_accumulator(old, value):
+    raise RuntimeError("accumulator failed")
+
+
+class OneShotIterable:
+    def __init__(self, values):
+        self.values = values
+        self.iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        if self.iterations > 1:
+            raise AssertionError("iterable was consumed more than once")
+        return iter(self.values)
+
+
 @contextmanager
 def _local_dask_client():
-    cluster = ddist.LocalCluster(processes=False, dashboard_address=None)
-    try:
-        client = cluster.get_client()
-        try:
+    with ddist.LocalCluster(
+        n_workers=1,
+        threads_per_worker=4,
+        processes=False,
+        dashboard_address=None,
+    ) as cluster:
+        with ddist.Client(cluster) as client:
             yield client
-        finally:
-            client.close()
-    finally:
-        cluster.close()
 
 
 @pytest.fixture
@@ -105,6 +152,33 @@ def test_local_dask_client_cleanup_preserves_unrelated_compute():
     assert dask.delayed(simple_no_args)(2).compute() == 3
 
 
+def test_pipeline_uses_the_supplied_non_default_client(dask_client, monkeypatch):
+    observed_loops = []
+    as_completed = ddist.as_completed
+
+    def record_loop(*args, **kwargs):
+        observed_loops.append(kwargs.get("loop"))
+        return as_completed(*args, **kwargs)
+
+    monkeypatch.setattr(ddist, "as_completed", record_loop)
+    with ddist.LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+    ) as cluster:
+        with ddist.Client(cluster, set_as_default=False) as supplied_client:
+            assert ddist.default_client() is dask_client
+            assert supplied_client is not dask_client
+            assert sliding_window_pipeline(
+                [1],
+                simple_no_args,
+                supplied_client,
+                sliding_window_size=1,
+            ) == [2]
+            assert observed_loops == [supplied_client.loop]
+
+
 def test_sliding_window_pipeline(dask_client, capsys):
     """
     Test function for `sliding_window_pipeline` function.
@@ -133,8 +207,7 @@ def test_sliding_window_pipeline(dask_client, capsys):
         dlist + 1
     )  # numpy vector overload makes this a simple way to create this
 
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
     # repeat with verbose on and sliding_window_size set auto
     result = sliding_window_pipeline(
         dlist,
@@ -144,8 +217,7 @@ def test_sliding_window_pipeline(dask_client, capsys):
         verbose=True,
         progress_report_interval=3,
     )
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
     progress = capsys.readouterr().out
     for handled in (3, 6, 9, 10):
         assert f"Handled {handled} of 10 items" in progress
@@ -156,8 +228,7 @@ def test_sliding_window_pipeline(dask_client, capsys):
         dlist, simple_warg, dask_client, sliding_window_size=4, pfunc_args=[2]
     )
     expected_out = dlist + 2
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
 
     # same with pfun_kwarg
     kwa = {"b": 3}
@@ -165,16 +236,14 @@ def test_sliding_window_pipeline(dask_client, capsys):
         dlist, simple_wkwarg, dask_client, sliding_window_size=4, pfunc_kwargs=kwa
     )
     expected_out = dlist + 3
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
 
     # similar but let kwargs default
     result = sliding_window_pipeline(
         dlist, simple_wkwarg, dask_client, sliding_window_size=4
     )
     expected_out = dlist + 2  # note 2 must match default of function
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
 
     # run function with multiple args
     kwa = {"d": 4}
@@ -187,8 +256,7 @@ def test_sliding_window_pipeline(dask_client, capsys):
         pfunc_kwargs=kwa,
     )
     expected_out = dlist + 7  # sum of all 3 args passed
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
 
     # run same with a completion that just adds 1 with no args
     result = sliding_window_pipeline(
@@ -201,8 +269,7 @@ def test_sliding_window_pipeline(dask_client, capsys):
         completion_function=simple_completion,
     )
     expected_out = dlist + 7 + 1  # sum of all 3 args passed + completion add 1
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
 
     # now run with arg and default kwarg
     result = sliding_window_pipeline(
@@ -217,8 +284,7 @@ def test_sliding_window_pipeline(dask_client, capsys):
     )
     addamount = 7 + 20 + 10
     expected_out = dlist + addamount
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
 
     # now add cfunc kwarg
     result = sliding_window_pipeline(
@@ -234,8 +300,7 @@ def test_sliding_window_pipeline(dask_client, capsys):
     )
     addamount = 7 + 20 + 30
     expected_out = dlist + addamount
-    for x in result:
-        assert x in expected_out
+    assert Counter(result) == Counter(expected_out.tolist())
 
     # finally test accmulator feature
     # change the input in this case as all we care about this the summed output
@@ -294,7 +359,204 @@ def test_sliding_window_pipeline(dask_client, capsys):
     assert result == expected_result
 
 
-def test_swp_error_handlers():
+def test_completion_order_and_return_modes(dask_client):
+    items = [(0, 0.3), (1, 0.15), (2, 0.01)]
+
+    result = sliding_window_pipeline(
+        items, delayed_value, dask_client, sliding_window_size=3
+    )
+    assert result == [2, 1, 0]
+
+    result = sliding_window_pipeline(
+        items,
+        delayed_value,
+        dask_client,
+        sliding_window_size=3,
+        completion_function=times_ten,
+    )
+    assert result == [20, 10, 0]
+
+    result = sliding_window_pipeline(
+        items,
+        delayed_value,
+        dask_client,
+        sliding_window_size=3,
+        completion_function=times_ten,
+        accumulator=append_accumulator,
+    )
+    assert result == [20, 10, 0]
+
+
+def test_empty_input_in_all_return_modes(dask_client):
+    assert (
+        sliding_window_pipeline([], simple_no_args, dask_client, sliding_window_size=1)
+        == []
+    )
+    assert (
+        sliding_window_pipeline(
+            [],
+            simple_no_args,
+            dask_client,
+            sliding_window_size=1,
+            completion_function=simple_completion,
+        )
+        == []
+    )
+    assert (
+        sliding_window_pipeline(
+            [],
+            simple_no_args,
+            dask_client,
+            sliding_window_size=1,
+            completion_function=simple_completion,
+            accumulator=simple_accumulator,
+        )
+        is None
+    )
+
+
+def test_one_shot_iterable_is_materialized_once(dask_client):
+    source = OneShotIterable([1, 1, 2, 3])
+    result = sliding_window_pipeline(
+        source, simple_no_args, dask_client, sliding_window_size=4
+    )
+
+    assert source.iterations == 1
+    assert Counter(result) == Counter([2, 2, 3, 4])
+
+
+def test_accumulator_without_completion_is_rejected_before_submit(
+    dask_client, monkeypatch
+):
+    source = OneShotIterable([1])
+    submit_calls = 0
+    original_submit = dask_client.submit
+
+    def record_submit(*args, **kwargs):
+        nonlocal submit_calls
+        submit_calls += 1
+        return original_submit(*args, **kwargs)
+
+    monkeypatch.setattr(dask_client, "submit", record_submit)
+
+    with pytest.raises(ValueError, match="requires a completion_function"):
+        sliding_window_pipeline(
+            source,
+            simple_no_args,
+            dask_client,
+            sliding_window_size=1,
+            accumulator=simple_accumulator,
+        )
+
+    assert source.iterations == 1
+    assert submit_calls == 0
+
+
+@pytest.mark.parametrize(
+    "window_size",
+    [True, False, 0, -1, 1.0, "AUTO", "1", None, float("nan"), float("inf")],
+)
+def test_invalid_sliding_window_size(window_size, dask_client):
+    with pytest.raises(ValueError, match="sliding_window_size"):
+        sliding_window_pipeline(
+            [], simple_no_args, dask_client, sliding_window_size=window_size
+        )
+
+
+@pytest.mark.parametrize(
+    "tasks_per_worker",
+    [True, False, 0, -1, float("nan"), float("inf"), float("-inf"), "2"],
+)
+def test_invalid_tasks_per_worker(tasks_per_worker, dask_client):
+    with pytest.raises(ValueError, match="task_per_worker"):
+        sliding_window_pipeline(
+            [],
+            simple_no_args,
+            dask_client,
+            sliding_window_size=1,
+            task_per_worker=tasks_per_worker,
+        )
+
+
+def test_invalid_automatic_window_size(dask_client, monkeypatch):
+    monkeypatch.setattr(dask_client, "nthreads", lambda: {})
+    with pytest.raises(ValueError, match="zero workers"):
+        sliding_window_pipeline([], simple_no_args, dask_client)
+
+    monkeypatch.setattr(dask_client, "nthreads", lambda: {"worker": 1})
+    with pytest.raises(ValueError, match="rounded below one"):
+        sliding_window_pipeline([], simple_no_args, dask_client, task_per_worker=0.25)
+
+
+def _assert_all_cancelled(futures):
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and any(
+        future.status != "cancelled" for future in futures
+    ):
+        time.sleep(0.01)
+    assert futures
+    assert all(future.status == "cancelled" for future in futures)
+
+
+@pytest.mark.parametrize(
+    ("failure_stage", "expected_message"),
+    [
+        ("submit", "submit failed"),
+        ("processing", "processing failed"),
+        ("completion", "completion failed"),
+        ("accumulator", "accumulator failed"),
+    ],
+)
+def test_failures_cancel_all_outstanding_futures(
+    failure_stage, expected_message, dask_client, monkeypatch
+):
+    submitted = []
+    submit_calls = 0
+    original_submit = dask_client.submit
+
+    def record_or_fail_submit(*args, **kwargs):
+        nonlocal submit_calls
+        submit_calls += 1
+        if failure_stage == "submit" and submit_calls == 2:
+            raise RuntimeError("submit failed")
+        future = original_submit(*args, **kwargs)
+        submitted.append(future)
+        return future
+
+    monkeypatch.setattr(dask_client, "submit", record_or_fail_submit)
+
+    kwargs = {}
+    if failure_stage == "submit":
+        items = [(False, 0.3)] * 3
+        processing_function = fail_or_delay
+    elif failure_stage == "processing":
+        items = [(True, 0), (False, 0.3), (False, 0.3)]
+        processing_function = fail_or_delay
+    else:
+        items = [("fail", 0), ("slow-1", 0.3), ("slow-2", 0.3)]
+        processing_function = delayed_value
+        kwargs["completion_function"] = (
+            fail_completion if failure_stage == "completion" else lambda value: value
+        )
+        if failure_stage == "accumulator":
+            kwargs["accumulator"] = fail_accumulator
+
+    with pytest.raises(RuntimeError, match=expected_message):
+        sliding_window_pipeline(
+            items,
+            processing_function,
+            dask_client,
+            sliding_window_size=3,
+            **kwargs,
+        )
+
+    _assert_all_cancelled(submitted)
+    # Cancellation cannot interrupt a running Python function.  Let those
+    # short tasks leave the shared worker threads before the next case starts.
+    time.sleep(0.35)
+
+
+def test_swp_error_handlers(dask_client):
     """
     pytest function to exercise all error handlers that can be raised by
     the function `sliding_window_pipeline`.  Uses the set of function


### PR DESCRIPTION
## Summary

- Materialize each input iterable exactly once and preserve duplicate inputs.
- Return processing or completion results in actual Future completion order.
- Bind as_completed to the explicitly supplied Dask client loop, including when another client is the process default.
- Validate window settings before submission and cancel every outstanding Future on failures.
- Preserve the function-scoped Dask client lifecycle introduced by #1004.

## Validation

- python/tests/test_workflow.py: 32 passed
- Black, Python byte compilation, and git diff --check

Closes #783