### PR TITLE
Fix Database.create_collection on PyMongo 4

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -306,6 +306,7 @@ class Database(pymongo.database.Database):
         write_concern=None,
         read_concern=None,
         session=None,
+        check_exists=True,
         **kwargs,
     ):
         """
@@ -337,6 +338,8 @@ class Database(pymongo.database.Database):
             :class:`~pymongo.collation.Collation`.
           :param session: (optional): a
             :class:`~pymongo.client_session.ClientSession`.
+          :param check_exists: (optional): if ``True`` (the default), check
+            whether the collection already exists before creating it.
           :param kwargs: (optional): additional keyword arguments will
             be passed as options for the ``createCollection`` command.
 
@@ -354,27 +357,25 @@ class Database(pymongo.database.Database):
         - ``expireAfterSeconds``: the number of seconds after which a
           document in a timeseries collection expires.
         """
-        with self.__client._tmp_session(session) as s:
-            # Skip this check in a transaction where listCollections is not
-            # supported.
-            if (not s or not s.in_transaction) and name in self.list_collection_names(
-                filter={"name": name}, session=s
-            ):
-                raise pymongo.errors.CollectionInvalid(
-                    "collection %s already exists" % name
-                )
-
-            return Collection(
-                self,
-                name,
-                True,
-                codec_options,
-                read_preference,
-                write_concern,
-                read_concern,
-                session=s,
-                **kwargs,
-            )
+        collection = super().create_collection(
+            name,
+            codec_options=codec_options,
+            read_preference=read_preference,
+            write_concern=write_concern,
+            read_concern=read_concern,
+            session=session,
+            check_exists=check_exists,
+            **kwargs,
+        )
+        return Collection(
+            self,
+            collection.name,
+            False,
+            collection.codec_options,
+            collection.read_preference,
+            collection.write_concern,
+            collection.read_concern,
+        )
 
     def set_metadata_schema(self, schema):
         """

--- a/python/tests/db/test_create_collection.py
+++ b/python/tests/db/test_create_collection.py
@@ -1,0 +1,132 @@
+import uuid
+from unittest.mock import patch
+
+import pymongo
+import pytest
+from bson.codec_options import CodecOptions
+from bson.son import SON
+from pymongo import ReadPreference
+from pymongo.errors import CollectionInvalid, OperationFailure
+from pymongo.read_concern import ReadConcern
+from pymongo.write_concern import WriteConcern
+
+from mspasspy.db.client import DBClient
+from mspasspy.db.collection import Collection
+from mspasspy.db.database import Database
+
+
+def test_create_collection_forwards_to_pymongo():
+    with DBClient("mongodb://localhost", connect=False) as client:
+        database = Database(client, "create_collection_unit_test")
+        codec_options = CodecOptions(document_class=SON)
+        read_preference = ReadPreference.SECONDARY
+        write_concern = WriteConcern(w=2)
+        read_concern = ReadConcern("majority")
+        session = object()
+        parent_collection = pymongo.collection.Collection(
+            database,
+            "created",
+            codec_options=codec_options,
+            read_preference=read_preference,
+            write_concern=write_concern,
+            read_concern=read_concern,
+        )
+
+        with patch.object(
+            pymongo.database.Database,
+            "create_collection",
+            autospec=True,
+            return_value=parent_collection,
+        ) as parent_create:
+            result = database.create_collection(
+                "created",
+                codec_options=codec_options,
+                read_preference=read_preference,
+                write_concern=write_concern,
+                read_concern=read_concern,
+                session=session,
+                check_exists=False,
+                capped=True,
+                size=4096,
+            )
+
+        parent_create.assert_called_once_with(
+            database,
+            "created",
+            codec_options=codec_options,
+            read_preference=read_preference,
+            write_concern=write_concern,
+            read_concern=read_concern,
+            session=session,
+            check_exists=False,
+            capped=True,
+            size=4096,
+        )
+        assert isinstance(result, Collection)
+        assert result.name == "created"
+        assert result.codec_options == codec_options
+        assert result.read_preference == read_preference
+        assert result.write_concern == write_concern
+        assert result.read_concern == read_concern
+
+
+def test_create_collection_propagates_pymongo_error():
+    with DBClient("mongodb://localhost", connect=False) as client:
+        database = Database(client, "create_collection_error_test")
+        error = OperationFailure("create failed", code=123)
+
+        with patch.object(
+            pymongo.database.Database,
+            "create_collection",
+            autospec=True,
+            side_effect=error,
+        ) as parent_create:
+            with pytest.raises(OperationFailure) as exc_info:
+                database.create_collection("created")
+
+        assert exc_info.value is error
+        parent_create.assert_called_once_with(
+            database,
+            "created",
+            codec_options=None,
+            read_preference=None,
+            write_concern=None,
+            read_concern=None,
+            session=None,
+            check_exists=True,
+        )
+
+
+def test_create_collection_with_mongodb():
+    with DBClient("mongodb://localhost", serverSelectionTimeoutMS=5000) as client:
+        client.admin.command("ping")
+        database_name = f"create_collection_{uuid.uuid4().hex}"
+        database = Database(client, database_name)
+        validator = {"value": {"$type": "int"}}
+
+        try:
+            collection = database.create_collection(
+                "configured",
+                validator=validator,
+                validationLevel="strict",
+            )
+            assert isinstance(collection, Collection)
+            assert collection.name == "configured"
+
+            collection_info = database.command(
+                {"listCollections": 1, "filter": {"name": "configured"}}
+            )["cursor"]["firstBatch"][0]
+            assert collection_info["options"]["validator"] == validator
+            assert collection_info["options"]["validationLevel"] == "strict"
+
+            with pytest.raises(CollectionInvalid):
+                database.create_collection("configured")
+
+            with client.start_session() as session:
+                session_collection = database.create_collection(
+                    "with_session", session=session
+                )
+            assert isinstance(session_collection, Collection)
+            assert "with_session" in database.list_collection_names()
+        finally:
+            client.drop_database(database_name)


### PR DESCRIPTION
## Summary

- delegate collection creation to the supported PyMongo 4 parent implementation
- forward codec/read/write concerns, session, `check_exists`, and command options unchanged
- wrap the created handle as an MsPASS `Collection` without a second write
- preserve PyMongo exception identity

## Root cause

The override copied an obsolete PyMongo private implementation and accessed a nonexistent `self.__client` attribute.

## Validation

- focused mock/unit tests: **2 passed**
- adjacent cursor tests: **2 passed**
- real MongoDB 8.0.29 integration: create, validator/validationLevel, duplicate `CollectionInvalid`, and session creation all passed
- Black, Python byte compilation, and `git diff --check`
- independent agent review: **REVIEW PASS** against PyMongo 4.15.3 signatures and live Mongo

Fixes #809