### PR TITLE
Fix ParameterGTree keyed pruning

### DIFF
--- a/python/mspasspy/global_history/ParameterGTree.py
+++ b/python/mspasspy/global_history/ParameterGTree.py
@@ -274,17 +274,13 @@ class ParameterGTree(collections.OrderedDict):
 
     def prune(self, key):
         """
-        Remove a branch or leaf defined by key from self. Return a copy of the
-        branch/leaf pruned in the process (like get_branch/get_leaf but self is altered)
+        Remove a branch or leaf defined by key from self and return its value.
+
+        :raises MsPASSError: if ``key`` is not present at this tree level.
         """
         if key not in self:
             raise MsPASSError("[Error] Wrong Key, Please check your input key again.")
-        if key in self.get_leaf_keys():
-            ret_val = self.get_leaf(key)
-        if key in self.get_branch_keys():
-            ret_val = self.get_branch(key)
-        collections.OrderedDict.popitem(self, key)
-        return ret_val
+        return collections.OrderedDict.pop(self, key)
 
     def get(self, key, seperator="."):
         """

--- a/python/tests/global_history/test_gtree.py
+++ b/python/tests/global_history/test_gtree.py
@@ -6,6 +6,7 @@ import json
 import os
 import yaml
 import collections
+import copy
 from mspasspy.ccore.utility import MsPASSError, AntelopePf
 from mspasspy.util.converter import AntelopePf2dict
 
@@ -55,15 +56,68 @@ def test_get_branch_keys():
     assert keys == ["pf"]
 
 
-def test_prune():
-    gTree = build_helper()
-    leaf_key, leaf_val = leaf_helper()
-    pruned_leaf_val = gTree.prune(leaf_key)
-    assert pruned_leaf_val == leaf_val
-    #   Test to prune a branch
-    branch_key, branch_val = branch_helper()
-    pruned_branch_val = gTree.prune(branch_key)
-    assert pruned_branch_val == branch_val
+def build_prune_tree():
+    return ParameterGTree(
+        collections.OrderedDict(
+            [
+                ("first_leaf", ["first"]),
+                (
+                    "middle_branch",
+                    collections.OrderedDict(
+                        [
+                            ("nested_leaf", ["nested"]),
+                            (
+                                "nested_branch",
+                                collections.OrderedDict([("deep_leaf", "deep")]),
+                            ),
+                        ]
+                    ),
+                ),
+                ("middle_leaf", ["middle"]),
+                (
+                    "final_branch",
+                    collections.OrderedDict([("final_leaf", ["final"])]),
+                ),
+            ]
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "key", ["first_leaf", "middle_branch", "middle_leaf", "final_branch"]
+)
+def test_prune_removes_only_requested_key(key):
+    gTree = build_prune_tree()
+    before = copy.deepcopy(gTree.asdict())
+    expected_tree = copy.deepcopy(before)
+    del expected_tree[key]
+
+    pruned_value = gTree.prune(key)
+
+    assert pruned_value == before[key]
+    assert gTree.asdict() == expected_tree
+
+
+def test_prune_nested_leaf_preserves_full_tree():
+    gTree = build_prune_tree()
+    before = copy.deepcopy(gTree.asdict())
+    expected_tree = copy.deepcopy(before)
+    del expected_tree["middle_branch"]["nested_leaf"]
+
+    pruned_value = gTree["middle_branch"].prune("nested_leaf")
+
+    assert pruned_value == before["middle_branch"]["nested_leaf"]
+    assert gTree.asdict() == expected_tree
+
+
+def test_prune_missing_key_preserves_full_tree():
+    gTree = build_prune_tree()
+    before = copy.deepcopy(gTree.asdict())
+
+    with pytest.raises(MsPASSError, match="Wrong Key"):
+        gTree.prune("missing")
+
+    assert gTree.asdict() == before
 
 
 def test_get_leaf():


### PR DESCRIPTION
## Summary

- Remove exactly the requested branch or leaf from ParameterGTree.prune.
- Return the removed value without changing neighboring entries.
- Preserve the established MsPASSError contract and the complete tree when the key is missing.
- Add structural regressions for root, nested, first, middle, and final keys.

## Validation

- python/tests/global_history/test_gtree.py: 13 passed
- Black, Python byte compilation, and git diff --check

Closes #836