### PR TITLE
Correct DEPMIN and DEPMAX schema descriptions

### DIFF
--- a/data/yaml/mspass.yaml
+++ b/data/yaml/mspass.yaml
@@ -721,12 +721,12 @@ Metadata:
         aliases: [idep, IDEP]
       DEPMIN:
         type: double
-        concept: Maximum amplitude of a signal
+        concept: Minimum amplitude of a signal
         readonly: false
         aliases: [depmin]
       DEPMAX:
         type: double
-        concept: Minimum amplitude of a signal
+        concept: Maximum amplitude of a signal
         readonly: false
         aliases: [depmax]
       DEPMEN:

--- a/data/yaml/mspass_fdsn.yaml
+++ b/data/yaml/mspass_fdsn.yaml
@@ -644,12 +644,12 @@ Metadata:
         aliases: [idep, IDEP]
       DEPMIN:
         type: double
-        concept: Maximum amplitude of a signal
+        concept: Minimum amplitude of a signal
         readonly: false
         aliases: [depmin]
       DEPMAX:
         type: double
-        concept: Minimum amplitude of a signal
+        concept: Maximum amplitude of a signal
         readonly: false
         aliases: [depmax]
       DEPMEN:

--- a/data/yaml/mspass_s3.yaml
+++ b/data/yaml/mspass_s3.yaml
@@ -639,12 +639,12 @@ Metadata:
         aliases: [idep, IDEP]
       DEPMIN:
         type: double
-        concept: Maximum amplitude of a signal
+        concept: Minimum amplitude of a signal
         readonly: false
         aliases: [depmin]
       DEPMAX:
         type: double
-        concept: Minimum amplitude of a signal
+        concept: Maximum amplitude of a signal
         readonly: false
         aliases: [depmax]
       DEPMEN:

--- a/python/tests/test_schema_documentation.py
+++ b/python/tests/test_schema_documentation.py
@@ -1,0 +1,47 @@
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_FILES = (
+    REPO_ROOT / "data" / "yaml" / "mspass.yaml",
+    REPO_ROOT / "data" / "yaml" / "mspass_fdsn.yaml",
+    REPO_ROOT / "data" / "yaml" / "mspass_s3.yaml",
+)
+EXPECTED_CONCEPTS = {
+    "DEPMIN": "Minimum amplitude of a signal",
+    "DEPMAX": "Maximum amplitude of a signal",
+}
+
+
+def test_depmin_depmax_schema_descriptions():
+    for schema_file in SCHEMA_FILES:
+        with schema_file.open(encoding="utf-8") as stream:
+            schema = yaml.safe_load(stream)
+        attributes = schema["Metadata"]["Other"]["schema"]
+
+        assert {
+            key: attributes[key]["concept"] for key in EXPECTED_CONCEPTS
+        } == EXPECTED_CONCEPTS
+
+
+def test_generated_depmin_depmax_descriptions(tmp_path, monkeypatch):
+    generator_file = (
+        REPO_ROOT / "docs" / "source" / "mspass_schema" / "build_metadata_tbls.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "mspass_schema_table_generator", generator_file
+    )
+    generator = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, generator)
+    spec.loader.exec_module(generator)
+    monkeypatch.setattr(generator, "SCRIPT_DIR", tmp_path)
+
+    generator.main()
+
+    with (tmp_path / "all.csv").open(encoding="utf-8", newline="") as stream:
+        rows = {row["key"]: row for row in csv.DictReader(stream)}
+    assert {key: rows[key]["concept"] for key in EXPECTED_CONCEPTS} == EXPECTED_CONCEPTS


### PR DESCRIPTION
## Summary

- describe DEPMIN as minimum amplitude and DEPMAX as maximum amplitude
- apply the correction to the default, FDSN, and S3 schemas
- verify both source YAML and the real generated metadata table output

## Root cause

The two field descriptions were reversed in all three schema sources.

## Validation

- focused schema/generator tests: **2 passed**
- real `build_metadata_tbls.py` execution with generated `all.csv` assertions
- verified the generator does not pollute the documentation tree
- Black, Python byte compilation, and `git diff --check`
- independent agent review: **REVIEW PASS**; reviewer strengthened module/path isolation

Fixes #805