### PR TITLE
Fix normalize_mseed wfquery parsing

### DIFF
--- a/python/mspasspy/db/script/normalize_mseed.py
+++ b/python/mspasspy/db/script/normalize_mseed.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 import argparse
 import sys
+from bson import json_util
+from bson.errors import BSONError
 from mspasspy.db.database import Database
 from mspasspy.db.client import DBClient
 from mspasspy.db.normalize import normalize_mseed
@@ -68,6 +70,16 @@ def main(args=None):
     )
 
     args = parser.parse_args(args)
+    if args.wfquery:
+        try:
+            query = json_util.loads(args.wfquery)
+        except (ValueError, BSONError):
+            parser.error("--wfquery must be valid BSON Extended JSON")
+        if not isinstance(query, dict):
+            parser.error("--wfquery must decode to a JSON object")
+    else:
+        query = {}
+
     dbname = args.dbname
     print("Normalizing database with name=", dbname)
 
@@ -79,10 +91,6 @@ def main(args=None):
     else:
         print("Will normalize all matching wf_miniseed documents with channel_id")
     blocksize = args.blocksize
-    if len(args.wfquery) > 0:
-        query = eval(args.query)
-    else:
-        query = {}
 
     dbclient = DBClient()
     db = Database(dbclient, dbname)
@@ -91,8 +99,8 @@ def main(args=None):
         db, wfquery=query, blocksize=blocksize, normalize_site=normalize_site
     )
     print("Normalization completed for wf_miniseed collection of database = ", dbname)
-    if len(args.wfquery) > 0:
-        print("Applied with this query to wf_miniseed:  ", args.query)
+    if args.wfquery:
+        print("Applied with this query to wf_miniseed:  ", args.wfquery)
     print("Number of documents processed=", ret_tuple[0])
     print("Number of channel_ids set=", ret_tuple[1])
     print("Number of site_ids set=", ret_tuple[2])

--- a/python/tests/db/test_normalize_mseed_cli.py
+++ b/python/tests/db/test_normalize_mseed_cli.py
@@ -1,0 +1,113 @@
+import builtins
+
+import pytest
+from bson import ObjectId
+
+from mspasspy.db.script import normalize_mseed as normalize_mseed_cli
+
+
+@pytest.fixture
+def successful_cli(monkeypatch):
+    dbclient = object()
+    database = object()
+    calls = {"dbclient": 0, "database": [], "normalize": []}
+
+    def make_dbclient():
+        calls["dbclient"] += 1
+        return dbclient
+
+    def make_database(client, name):
+        calls["database"].append((client, name))
+        return database
+
+    def run_normalize(db, **kwargs):
+        calls["normalize"].append((db, kwargs))
+        return (0, 0, 0)
+
+    monkeypatch.setattr(normalize_mseed_cli, "DBClient", make_dbclient)
+    monkeypatch.setattr(normalize_mseed_cli, "Database", make_database)
+    monkeypatch.setattr(normalize_mseed_cli, "normalize_mseed", run_normalize)
+    return dbclient, database, calls
+
+
+@pytest.mark.parametrize(
+    ("query_args", "expected_query"),
+    [
+        ([], {}),
+        (["--wfquery", ""], {}),
+        (
+            ["--wfquery", '{"net":"IU","npts":{"$gte":100}}'],
+            {"net": "IU", "npts": {"$gte": 100}},
+        ),
+        (
+            [
+                "--wfquery",
+                '{"_id":{"$oid":"64b000000000000000000001"}}',
+            ],
+            {"_id": ObjectId("64b000000000000000000001")},
+        ),
+    ],
+)
+def test_wfquery_is_parsed_before_normalization(
+    query_args, expected_query, successful_cli
+):
+    dbclient, database, calls = successful_cli
+
+    normalize_mseed_cli.main(["testdb", *query_args])
+
+    assert calls["dbclient"] == 1
+    assert calls["database"] == [(dbclient, "testdb")]
+    assert calls["normalize"] == [
+        (
+            database,
+            {
+                "wfquery": expected_query,
+                "blocksize": 1000,
+                "normalize_site": False,
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("query_text", "diagnostic"),
+    [
+        (
+            "{'net': __import__('os').getcwd()}",
+            "--wfquery must be valid BSON Extended JSON",
+        ),
+        (
+            '{"_id":{"$oid":"not-an-object-id"}}',
+            "--wfquery must be valid BSON Extended JSON",
+        ),
+        ("42", "--wfquery must decode to a JSON object"),
+        ('["IU"]', "--wfquery must decode to a JSON object"),
+    ],
+)
+def test_invalid_wfquery_exits_before_database_construction(
+    query_text, diagnostic, monkeypatch, capsys
+):
+    eval_calls = []
+    constructor_calls = []
+
+    def record_eval(*args, **kwargs):
+        eval_calls.append((args, kwargs))
+        return {}
+
+    def record_construction(*args, **kwargs):
+        constructor_calls.append((args, kwargs))
+        return object()
+
+    monkeypatch.setattr(builtins, "eval", record_eval)
+    monkeypatch.setattr(normalize_mseed_cli, "DBClient", record_construction)
+    monkeypatch.setattr(normalize_mseed_cli, "Database", record_construction)
+
+    with pytest.raises(SystemExit) as excinfo:
+        normalize_mseed_cli.main(["testdb", "--wfquery", query_text])
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 2
+    assert captured.out == ""
+    assert captured.err.endswith(f"normalize_mseed: error: {diagnostic}\n")
+    assert eval_calls == []
+    assert constructor_calls == []


### PR DESCRIPTION
## Summary

- read the declared `--wfquery` argument consistently
- parse nonempty input with BSON Extended JSON and require a dictionary
- treat omitted and explicit empty input as `{}`
- reject invalid/non-dictionary input with stderr and exit status 2 before database construction
- remove Python `eval` from the query boundary

## Root cause

The CLI declared `args.wfquery` but read `args.query`, then attempted to evaluate external text as Python.

## Validation

- focused CLI tests: **8 passed**
- normal JSON, Extended JSON/ObjectId, omitted/empty, list/scalar, malicious expression, and malformed BSON
- verified DBClient/Database are never constructed on invalid input and `eval` is never invoked
- Black, Python byte compilation, and `git diff --check`
- independent agent review: **REVIEW PASS**; reviewer added malformed `$oid` coverage

Fixes #839