### PR TITLE
Normalize percentile amplitude semantics

### DIFF
--- a/cxx/include/mspass/algorithms/amplitudes.h
+++ b/cxx/include/mspass/algorithms/amplitudes.h
@@ -15,10 +15,18 @@ double PeakAmplitude(const mspass::seismic::CoreTimeSeries &d);
 double PeakAmplitude(const mspass::seismic::CoreSeismogram &d);
 double RMSAmplitude(const mspass::seismic::CoreTimeSeries &d);
 double RMSAmplitude(const mspass::seismic::CoreSeismogram &d);
+/*! Compute a lower-quantile absolute amplitude.
+
+The percentile can be supplied either as a fraction in ``(0, 1]`` or as a
+percentage in ``(1, 100]``.  For ``n`` sorted amplitudes the selected index is
+``floor(p * (n - 1))``, where ``p`` is the normalized fraction.  Dead or empty
+data return 0.0; invalid percentiles on live, nonempty data throw
+MsPASSError with Invalid severity.
+*/
 double PercAmplitude(const mspass::seismic::CoreTimeSeries &d,
-                     const double perf);
+                     const double percentile);
 double PercAmplitude(const mspass::seismic::CoreSeismogram &d,
-                     const double perf);
+                     const double percentile);
 double MADAmplitude(const mspass::seismic::CoreTimeSeries &d);
 double MADAmplitude(const mspass::seismic::CoreSeismogram &d);
 enum class ScalingMethod {

--- a/cxx/src/lib/algorithms/amplitudes.cc
+++ b/cxx/src/lib/algorithms/amplitudes.cc
@@ -4,11 +4,31 @@
 #include "mspass/seismic/TimeSeries.h"
 #include "mspass/utility/MsPASSError.h"
 #include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+namespace {
+double normalize_percentile(const double percentile) {
+  if (!std::isfinite(percentile) || percentile <= 0.0 || percentile > 100.0) {
+    std::stringstream ss;
+    ss << "PercAmplitude: received percentile value=" << percentile << '\n'
+       << "Must be a fraction in (0, 1] or a percentage in (1, 100]";
+    throw mspass::utility::MsPASSError(ss.str(),
+                                       mspass::utility::ErrorSeverity::Invalid);
+  }
+  return percentile > 1.0 ? percentile / 100.0 : percentile;
+}
+
+std::size_t percentile_index(const std::size_t sample_count,
+                             const double percentile) {
+  return static_cast<std::size_t>(
+      std::floor(percentile * static_cast<double>(sample_count - 1)));
+}
+} // namespace
+
 namespace mspass::algorithms::amplitudes {
 using namespace std;
 using namespace mspass::seismic;
-using mspass::utility::ErrorSeverity;
-using mspass::utility::MsPASSError;
 
 /* Series of overloaded functions to measure peak amplitudes for
 different types of seismic data objects.  These are used in
@@ -70,21 +90,10 @@ double RMSAmplitude(const CoreSeismogram &d) {
     sumsq += (*ptr) * (*ptr);
   return sqrt(sumsq / d.npts());
 }
-double PercAmplitude(const CoreTimeSeries &d, const double perc) {
-  double percfrac;
-  if (perc > 100.0 || perc <= 0.0) {
-    stringstream ss;
-    ss << "PercAmplitude:  received perc value=" << perc << endl
-       << "Must be a nonzero percentage from 1 to 100 or a fraction value less "
-          "than 1"
-       << endl;
-    throw MsPASSError(ss.str(), ErrorSeverity::Invalid);
-  } else if (perc <= 1.0) {
-    percfrac = perc;
-  } else {
-    // Land her for actual percentage values
-    percfrac = perc / 100.0;
-  }
+double PercAmplitude(const CoreTimeSeries &d, const double percentile) {
+  if (d.dead() || d.npts() == 0)
+    return 0.0;
+  const double percentile_fraction = normalize_percentile(percentile);
   vector<double> amps;
   amps = d.s;
   vector<double>::iterator ptr;
@@ -92,23 +101,22 @@ double PercAmplitude(const CoreTimeSeries &d, const double perc) {
     *ptr = fabs(*ptr);
   sort(amps.begin(), amps.end());
   size_t n = amps.size();
-  size_t iperc = static_cast<size_t>(percfrac * static_cast<double>(n));
+  size_t iperc = percentile_index(n, percentile_fraction);
   return amps[iperc];
 }
-double PercAmplitude(const CoreSeismogram &d, const double perc) {
+double PercAmplitude(const CoreSeismogram &d, const double percentile) {
+  if (d.dead() || d.npts() == 0)
+    return 0.0;
+  const double percentile_fraction = normalize_percentile(percentile);
   vector<double> amps;
   amps.reserve(d.npts());
-  for (int i = 0; i < d.npts(); ++i) {
+  for (size_t i = 0; i < d.npts(); ++i) {
     double thisamp = dnrm2(3, d.u.get_address(0, i), 1);
     amps.push_back(thisamp);
   }
   sort(amps.begin(), amps.end());
   size_t n = amps.size();
-  /* n-1 because C arrays start at 0 */
-  size_t iperc = static_cast<size_t>(perc * static_cast<double>(n));
-  /* Silently return 100% if iperc exceeds the range of amps*/
-  if (iperc >= amps.size())
-    iperc = amps.size() - 1;
+  size_t iperc = percentile_index(n, percentile_fraction);
   return amps[iperc];
 }
 /* This pair could be made a template, but they are so simple

--- a/cxx/test/CMakeLists.txt
+++ b/cxx/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(CTest)
 if(BUILD_TESTING)
   add_subdirectory(amap)
+  add_subdirectory(amplitudes)
   add_subdirectory(decon_serialization)
   add_subdirectory(data_directory)
   add_subdirectory(dmatrix)
@@ -19,6 +20,7 @@ if(BUILD_TESTING)
 # note this test needs to access a data file in the run directory. 
 # we set that with WORKING_DIRECTORY and the special symbol after the keyword
   add_test(NAME test_decon_serialization COMMAND ${PROJECT_BINARY_DIR}/test/decon_serialization/test_decon_serialization WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/decon_serialization)
+  add_test(NAME test_amplitudes COMMAND ${PROJECT_BINARY_DIR}/test/amplitudes/test_amplitudes)
   add_test(NAME test_data_directory
     COMMAND ${PROJECT_BINARY_DIR}/test/data_directory/test_data_directory)
   set_tests_properties(test_data_directory PROPERTIES

--- a/cxx/test/amplitudes/CMakeLists.txt
+++ b/cxx/test/amplitudes/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(test_amplitudes test_amplitudes.cc)
+include_directories(
+  ${Boost_INCLUDE_DIRS}
+  ${pybind11_INCLUDE_DIR}
+  ${Python_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/include/)
+
+target_link_libraries(test_amplitudes PRIVATE mspass ${Boost_LIBRARIES} ${Python_LIBRARIES})

--- a/cxx/test/amplitudes/test_amplitudes.cc
+++ b/cxx/test/amplitudes/test_amplitudes.cc
@@ -1,0 +1,88 @@
+#include "mspass/algorithms/amplitudes.h"
+#include "mspass/seismic/CoreSeismogram.h"
+#include "mspass/seismic/CoreTimeSeries.h"
+#include "mspass/utility/MsPASSError.h"
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using mspass::algorithms::amplitudes::PercAmplitude;
+using mspass::seismic::CoreSeismogram;
+using mspass::seismic::CoreTimeSeries;
+using mspass::utility::ErrorSeverity;
+using mspass::utility::MsPASSError;
+
+void check(const bool condition, const std::string &message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
+
+template <typename Waveform>
+void assert_invalid_percentile(const Waveform &waveform,
+                               const double percentile) {
+  bool threw_invalid_error = false;
+  try {
+    PercAmplitude(waveform, percentile);
+  } catch (const MsPASSError &error) {
+    check(error.severity() == ErrorSeverity::Invalid,
+          "invalid percentile raised the wrong error severity");
+    threw_invalid_error = true;
+  }
+  check(threw_invalid_error, "invalid percentile did not throw MsPASSError");
+}
+
+template <typename Waveform> void verify_percentiles(const Waveform &waveform) {
+  check(PercAmplitude(waveform, 0.01) == 1.0, "0.01 percentile mismatch");
+  check(PercAmplitude(waveform, 0.5) == 4.0, "0.5 percentile mismatch");
+  check(PercAmplitude(waveform, 50.0) == 4.0, "50 percentile mismatch");
+  check(PercAmplitude(waveform, 0.95) == 16.0, "0.95 percentile mismatch");
+  check(PercAmplitude(waveform, 95.0) == 16.0, "95 percentile mismatch");
+  check(PercAmplitude(waveform, 1.0) == 32.0, "1.0 percentile mismatch");
+  check(PercAmplitude(waveform, 100.0) == 32.0, "100 percentile mismatch");
+
+  const std::vector<double> invalid_percentiles{
+      0.0,
+      -1.0,
+      100.1,
+      std::numeric_limits<double>::infinity(),
+      -std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::quiet_NaN(),
+  };
+  for (const double percentile : invalid_percentiles)
+    assert_invalid_percentile(waveform, percentile);
+}
+
+int main() {
+  const std::vector<double> samples{-16.0, 1.0, -32.0, 4.0, -2.0, 8.0};
+
+  CoreTimeSeries timeseries(samples.size());
+  timeseries.set_live();
+  timeseries.s = samples;
+
+  CoreSeismogram seismogram(samples.size());
+  seismogram.set_live();
+  for (size_t sample = 0; sample < samples.size(); ++sample)
+    seismogram.u(0, sample) = samples[sample];
+
+  verify_percentiles(timeseries);
+  verify_percentiles(seismogram);
+
+  CoreTimeSeries dead_timeseries(timeseries);
+  dead_timeseries.kill();
+  CoreSeismogram dead_seismogram(seismogram);
+  dead_seismogram.kill();
+  check(PercAmplitude(dead_timeseries, 0.0) == 0.0,
+        "dead TimeSeries did not return zero");
+  check(PercAmplitude(dead_seismogram, 0.0) == 0.0,
+        "dead Seismogram did not return zero");
+
+  CoreTimeSeries empty_timeseries;
+  empty_timeseries.set_live();
+  CoreSeismogram empty_seismogram;
+  empty_seismogram.set_live();
+  check(PercAmplitude(empty_timeseries, 0.0) == 0.0,
+        "empty TimeSeries did not return zero");
+  check(PercAmplitude(empty_seismogram, 0.0) == 0.0,
+        "empty Seismogram did not return zero");
+}

--- a/python/tests/algorithms/test_amplitudes_pickle.py
+++ b/python/tests/algorithms/test_amplitudes_pickle.py
@@ -33,7 +33,7 @@ def _make_timeseries_5():
 
 
 def _make_timeseries_window():
-    """CoreTimeSeries from test_window: Peak=100, RMS≈33.49, Perc(0.8)=6."""
+    """CoreTimeSeries from test_window: Peak=100, RMS≈33.49, Perc(0.8)=5."""
     d = _CoreTimeSeries(9)
     d.npts = 9
     d.set_dt(0.01)
@@ -101,8 +101,8 @@ def test_PercAmplitude_captured_in_closure_picklable():
 
     def _compute():
         d = _make_timeseries_window()
-        return PercAmplitude(d, 0.8)  # 80% clip = 6.0
+        return PercAmplitude(d, 0.8)  # lower 80th percentile = 5.0
 
     pickled = cloudpickle.dumps(_compute)
     fn_restored = cloudpickle.loads(pickled)
-    assert fn_restored() == 6.0, f"Round-trip pickle: expected 6.0, got {fn_restored()}"
+    assert fn_restored() == 5.0, f"Round-trip pickle: expected 5.0, got {fn_restored()}"

--- a/python/tests/algorithms/test_percentile_amplitude.py
+++ b/python/tests/algorithms/test_percentile_amplitude.py
@@ -1,0 +1,61 @@
+import math
+
+import pytest
+
+from mspasspy.ccore.algorithms.amplitudes import PercAmplitude
+from mspasspy.ccore.seismic import _CoreSeismogram, _CoreTimeSeries
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+
+SAMPLES = (-16.0, 1.0, -32.0, 4.0, -2.0, 8.0)
+
+
+def _timeseries():
+    waveform = _CoreTimeSeries(len(SAMPLES))
+    waveform.set_live()
+    for index, sample in enumerate(SAMPLES):
+        waveform.data[index] = sample
+    return waveform
+
+
+def _seismogram():
+    waveform = _CoreSeismogram(len(SAMPLES))
+    waveform.set_live()
+    for index, sample in enumerate(SAMPLES):
+        waveform.data[0, index] = sample
+    return waveform
+
+
+@pytest.mark.parametrize("factory", [_timeseries, _seismogram])
+def test_percentile_amplitude_uses_lower_quantile(factory):
+    waveform = factory()
+    sorted_amplitudes = sorted(abs(sample) for sample in SAMPLES)
+
+    for percentile in (0.01, 0.5, 50.0, 0.95, 95.0, 1.0, 100.0):
+        fraction = percentile / 100.0 if percentile > 1.0 else percentile
+        expected = sorted_amplitudes[math.floor(fraction * (len(SAMPLES) - 1))]
+        assert PercAmplitude(waveform, percentile) == expected
+
+    assert PercAmplitude(waveform, 0.5) == PercAmplitude(waveform, 50.0)
+    assert PercAmplitude(waveform, 0.95) == PercAmplitude(waveform, 95.0)
+    assert PercAmplitude(waveform, 1.0) == PercAmplitude(waveform, 100.0)
+
+
+@pytest.mark.parametrize("factory", [_timeseries, _seismogram])
+@pytest.mark.parametrize(
+    "percentile", [0.0, -1.0, 100.1, float("inf"), float("-inf"), float("nan")]
+)
+def test_percentile_amplitude_rejects_invalid_live_input(factory, percentile):
+    with pytest.raises(MsPASSError) as exc_info:
+        PercAmplitude(factory(), percentile)
+    assert exc_info.value.severity == ErrorSeverity.Invalid
+
+
+@pytest.mark.parametrize("factory", [_timeseries, _seismogram])
+def test_percentile_amplitude_returns_zero_for_dead_or_empty_input(factory):
+    dead = factory()
+    dead.kill()
+    assert PercAmplitude(dead, 0.0) == 0.0
+
+    empty = type(dead)(0)
+    empty.set_live()
+    assert PercAmplitude(empty, 0.0) == 0.0

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -86,8 +86,8 @@ def test_scale():
     dts.data[6] = 5.0
     dts.data[7] = 1.0
     dts.data[8] = -6.0
-    # MAD o=f above should be 2
-    # perf of 0.8 should be 4
+    # MAD of the absolute amplitudes above is 3
+    # p=0.8 uses floor(p*(n-1)), yielding 5 for this 9-sample vector
     # rms should be just over 10=10.010993957
     print("Starting tests for time series data of amplitude functions")
     ampmad = MADAmplitude(dts)
@@ -101,7 +101,7 @@ def test_scale():
     print("Peak amplitude=", amppeak)
     print("80% clip level amplitude=", ampperf80)
     assert amppeak == 100.0
-    assert ampperf80 == 6.0
+    assert ampperf80 == 5.0
     print("Starting comparable tests for 3c data")
     d3c.data[0, 0] = 3.0
     d3c.data[0, 1] = 2.0
@@ -118,7 +118,7 @@ def test_scale():
     print("Peak amplitude=", amppeak)
     print("60% clip level amplitude=", ampperf60)
     assert amppeak == 200.0
-    assert ampperf60 == 4.0
+    assert ampperf60 == 3.0
     assert ampmad == 3.0
     amptest = round(amprms, 2)
     assert amptest == 89.48


### PR DESCRIPTION
## Summary

- normalize percentage and fractional percentile inputs identically for TimeSeries and Seismogram
- select `floor(p * (n - 1))` without a terminal out-of-range access
- reject invalid live/nonempty percentile inputs with `MsPASSError(Invalid)`
- retain the dead/empty zero result and existing Python overloads
- add Release-safe native and Python binding regressions

## Root cause

The overloads interpreted 0–1 and 1–100 inputs inconsistently and indexed `p*n`, so the 100th percentile could access beyond the sorted vector.

## Validation

- Release full native build: passed
- CTest: **13/13 passed**
- Python binding and directed regressions: **26 passed**
- clang-format, Python byte compilation, Black, and `git diff --check`
- independent agent review: **REVIEW PASS**; reviewer replaced Release-disabled `assert` checks with runtime checks and removed unrelated formatting

Fixes #844