### PR TITLE
Fix AGC window indexing and gain-function state

### DIFF
--- a/cxx/include/mspass/algorithms/algorithms.h
+++ b/cxx/include/mspass/algorithms/algorithms.h
@@ -13,16 +13,10 @@ namespace mspass::algorithms {
 /* \brief Apply agc operator to three component seismogram data.
 
    Automatic gain control (agc) is a standard operation in seismic
-reflection processing.  The algorithm used her is a variant of that in
-seismic unix but applied to vector data.   That is scaling is no
-determined by absolute value of each sample but th vector amplitude of
-each sample.  Scaling is determined by the average vector amplitude
-over a specified time window length.  There isa  ramp in and ramp off
-range of size equal to the window length.   agc was notorious in the
-early days of seismic processing for making it impossible to recover
-true amplitude.   We remove that problem here by returning a TimeSeries
-object whose contents contain the gain applied to each sample of the
-original data.
+reflection processing.  Each three-component sample is scaled by the inverse
+RMS amplitude in a centered, inclusive window.  Windows are truncated at data
+boundaries.  A zero-energy window has zero gain.  The gain applied at every
+sample is returned so callers can inspect the operation.
 
 \param d - data to apply the operator to.  Note it is altered.
 \param twin - length of the agc operator in seconds
@@ -30,8 +24,9 @@ original data.
 \return TimeSeries object with the same number of samples as d. The
   value of each sample is the gain applied at the comparable sample in d.
 
-This function does not throw an exception, but can post errors to the
-ErrorLogger object that is a member of Seismogram.
+\exception MsPASSError with Invalid severity if twin or the input sample
+interval is nonfinite or nonpositive, or if the input contains no samples.
+Rejected inputs are not modified.
 */
 mspass::seismic::TimeSeries agc(mspass::seismic::Seismogram &d,
                                 const double twin);

--- a/cxx/src/lib/algorithms/agc.cc
+++ b/cxx/src/lib/algorithms/agc.cc
@@ -1,142 +1,69 @@
 #include "mspass/algorithms/algorithms.h"
 #include "mspass/seismic/Seismogram.h"
-#include <math.h>
-#include <stdlib.h>
-#include <string>
-namespace mspass::algorithms {
-using namespace std;
-using namespace mspass::seismic;
-using namespace mspass::utility;
+#include "mspass/utility/MsPASSError.h"
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <sstream>
 
-/* This uses the same algorithm as seismic unix BUT with a vector ssq
- * instead of the scalar form.   Returns a gain function a the same sample
- * rate as teh original data with the gain factor applied to each 3c sample.
- * The gain is averaged over scale twin ramping on and off using the same
- * cumulative approach used in seismic unix algorithm. */
-/* This function uses the same algorith as seismic unix BUT with a vector ssq
-   instead of the scalar form used for a simple time series.  Returns a
-   gain function at the same sample rate as the original data.  The original
-   data can then be restored by scaling each vector sample by 1/gain at
-   each sample.   */
+namespace mspass::algorithms {
+using mspass::seismic::BasicTimeSeries;
+using mspass::seismic::Seismogram;
+using mspass::seismic::TimeSeries;
+using mspass::utility::dmatrix;
+using mspass::utility::ErrorSeverity;
+using mspass::utility::Metadata;
+using mspass::utility::MsPASSError;
+
 TimeSeries agc(Seismogram &d, const double twin) {
-  try {
-    /* First deal with the processing history */
-    dmatrix agcdata(3, d.npts());
-    double val, rms, ssq, gain, lastgain;
-    size_t i, k;
-    CoreTimeSeries gf(dynamic_cast<BasicTimeSeries &>(d),
-                      dynamic_cast<Metadata &>(d));
-    gf.set_t0(d.t0() + gf.dt());
-    gf.set_npts(d.npts());
-    /* this is inefficient but needed to mesh with older push_back algorithm. */
-    gf.s.clear();
-    int nwin, iwagc;
-    nwin = round(twin / (d.dt()));
-    iwagc = nwin / 2;
-    if (iwagc <= 0) {
-      d.elog.log_error(
-          "agc", "Illegal gain time window - resolves to less than one sample",
-          ErrorSeverity::Invalid);
-      return TimeSeries();
-    }
-    if (iwagc > d.npts())
-      iwagc = d.npts();
-    /* First compute sum of squares in initial wondow to establish the
-     * initial scale */
-    for (i = 0, ssq = 0.0; i < iwagc; ++i) {
-      for (k = 0; k < 3; ++k) {
-        val = d.u(k, i);
-        ssq += val * val;
-      }
-    }
-    int normalization;
-    normalization = 3 * iwagc;
-    rms = ssq / ((double)normalization);
-    if (rms > 0.0) {
-      gain = 1.0 / sqrt(rms);
-      for (k = 0; k < 3; ++k) {
-        agcdata(k, 0) = gain * d.u(k, 0);
-      }
-      gf.s.push_back(gain);
-    } else {
-      gf.s.push_back(0.0);
-      lastgain = 0.0;
-    }
-    for (i = 1; i <= iwagc; ++i) {
-      for (k = 0; k < 3; ++k) {
-        val = d.u(k, i + iwagc);
-        ssq += val * val;
-        ++normalization;
-      }
-      rms = ssq / ((double)normalization);
-      if (rms > 0.0) {
-        lastgain = gain;
-        gain = 1.0 / sqrt(rms);
-      } else {
-        if (lastgain == 0.0)
-          gain = 0.0;
-        else
-          gain = lastgain;
-      }
-      gf.s.push_back(gain);
-      lastgain = gain;
-      for (k = 0; k < 3; ++k)
-        agcdata(k, i) = gain * d.u(k, i);
-    }
-    int isave;
-    for (i = iwagc + 1, isave = iwagc + 1; i < d.npts() - iwagc; ++i, ++isave) {
-      for (k = 0; k < 3; ++k) {
-        val = d.u(k, i + iwagc);
-        ssq += val * val;
-        val = d.u(k, i - iwagc);
-        ssq -= val * val;
-      }
-      rms = ssq / ((double)normalization);
-      if (rms > 0.0) {
-        lastgain = gain;
-        gain = 1.0 / sqrt(rms);
-      } else {
-        if (lastgain == 0.0)
-          gain = 0.0;
-        else
-          gain = lastgain;
-      }
-      gf.s.push_back(gain);
-      lastgain = gain;
-      for (k = 0; k < 3; ++k)
-        agcdata(k, i) = gain * d.u(k, i);
-    }
-    /* ramping off */
-    for (i = isave; i < d.npts(); ++i) {
-      for (k = 0; k < 3; ++k) {
-        val = d.u(k, i - iwagc);
-        ssq -= val * val;
-        --normalization;
-      }
-      rms = ssq / ((double)normalization);
-      if (rms > 0.0) {
-        lastgain = gain;
-        gain = 1.0 / sqrt(rms);
-      } else {
-        if (lastgain == 0.0)
-          gain = 0.0;
-        else
-          gain = lastgain;
-      }
-      gf.s.push_back(gain);
-      lastgain = gain;
-      for (k = 0; k < 3; ++k)
-        agcdata(k, i) = gain * d.u(k, i);
-    }
-    d.u = agcdata;
-    gf.set_live();
-    gf.set_npts(gf.s.size());
-    return gf;
-  } catch (...) {
-    string uxperr("Something threw an unexpected exception");
-    d.elog.log_error("agc", uxperr, ErrorSeverity::Invalid);
-    /* Return an empty TimeSeries object in this case. */
-    return TimeSeries();
+  if (!std::isfinite(twin) || twin <= 0.0) {
+    std::ostringstream message;
+    message << "agc: twin must be finite and positive; received " << twin;
+    throw MsPASSError(message.str(), ErrorSeverity::Invalid);
   }
+  if (!std::isfinite(d.dt()) || d.dt() <= 0.0) {
+    std::ostringstream message;
+    message << "agc: input dt must be finite and positive; received " << d.dt();
+    throw MsPASSError(message.str(), ErrorSeverity::Invalid);
+  }
+  const std::size_t sample_count = d.npts();
+  if (sample_count == 0)
+    throw MsPASSError("agc: input must contain at least one sample",
+                      ErrorSeverity::Invalid);
+
+  const double requested_half_window =
+      std::floor(std::round(twin / d.dt()) / 2.0);
+  const std::size_t maximum_half_window = (sample_count - 1) / 2;
+  const std::size_t half_window = static_cast<std::size_t>(std::min(
+      requested_half_window, static_cast<double>(maximum_half_window)));
+
+  TimeSeries gain_function(dynamic_cast<BasicTimeSeries &>(d),
+                           dynamic_cast<Metadata &>(d));
+  dmatrix output(3, sample_count);
+
+  for (std::size_t i = 0; i < sample_count; ++i) {
+    const std::size_t first = i > half_window ? i - half_window : 0;
+    const std::size_t last = std::min(sample_count - 1, i + half_window);
+    const std::size_t window_sample_count = last - first + 1;
+
+    double energy = 0.0;
+    for (std::size_t j = first; j <= last; ++j) {
+      for (std::size_t component = 0; component < 3; ++component) {
+        const double sample = d.u(component, j);
+        energy += sample * sample;
+      }
+    }
+
+    const double gain =
+        energy > 0.0 ? 1.0 / std::sqrt(energy / (3.0 * window_sample_count))
+                     : 0.0;
+    gain_function.s[i] = gain;
+    for (std::size_t component = 0; component < 3; ++component)
+      output(component, i) = gain * d.u(component, i);
+  }
+
+  d.u = output;
+  gain_function.set_live();
+  return gain_function;
 }
 } // namespace mspass::algorithms

--- a/cxx/test/CMakeLists.txt
+++ b/cxx/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(CTest)
 if(BUILD_TESTING)
+  add_subdirectory(agc)
   add_subdirectory(amap)
   add_subdirectory(decon_serialization)
   add_subdirectory(data_directory)
@@ -18,6 +19,7 @@ if(BUILD_TESTING)
 
 # note this test needs to access a data file in the run directory. 
 # we set that with WORKING_DIRECTORY and the special symbol after the keyword
+  add_test(NAME test_agc COMMAND ${PROJECT_BINARY_DIR}/test/agc/test_agc)
   add_test(NAME test_decon_serialization COMMAND ${PROJECT_BINARY_DIR}/test/decon_serialization/test_decon_serialization WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/decon_serialization)
   add_test(NAME test_data_directory
     COMMAND ${PROJECT_BINARY_DIR}/test/data_directory/test_data_directory)

--- a/cxx/test/agc/CMakeLists.txt
+++ b/cxx/test/agc/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(test_agc test_agc.cc)
+include_directories(
+  ${Boost_INCLUDE_DIRS}
+  ${pybind11_INCLUDE_DIR}
+  ${Python_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/include/)
+
+target_link_libraries(test_agc PRIVATE mspass ${Boost_LIBRARIES} ${Python_LIBRARIES})

--- a/cxx/test/agc/test_agc.cc
+++ b/cxx/test/agc/test_agc.cc
@@ -1,0 +1,158 @@
+#include "mspass/algorithms/algorithms.h"
+#include "mspass/seismic/Seismogram.h"
+#include "mspass/utility/MsPASSError.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using mspass::algorithms::agc;
+using mspass::seismic::Seismogram;
+using mspass::utility::ErrorSeverity;
+using mspass::utility::MsPASSError;
+
+void check(const bool condition, const std::string &message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
+
+void check_close(const double actual, const double expected,
+                 const std::string &message) {
+  const double scale = std::max({1.0, std::abs(actual), std::abs(expected)});
+  check(std::abs(actual - expected) <= 1.0e-12 * scale, message);
+}
+
+Seismogram make_data(const std::size_t sample_count, const double dt = 0.5,
+                     const double t0 = 0.0) {
+  Seismogram data(sample_count);
+  data.set_dt(dt);
+  data.set_t0(t0);
+  data.set_live();
+  return data;
+}
+
+std::size_t expected_half_window(const Seismogram &data, const double twin) {
+  const double requested = std::floor(std::round(twin / data.dt()) / 2.0);
+  return static_cast<std::size_t>(
+      std::min(requested, static_cast<double>((data.npts() - 1) / 2)));
+}
+
+void verify_against_formula(Seismogram data, const double twin) {
+  const Seismogram original(data);
+  const auto gain_function = agc(data, twin);
+  const std::size_t half_window = expected_half_window(original, twin);
+
+  check(gain_function.live(), "gain function is not live");
+  check(gain_function.npts() == original.npts(),
+        "gain function sample count mismatch");
+  check(gain_function.s.size() == original.npts(),
+        "gain function vector size mismatch");
+  check_close(gain_function.t0(), original.t0(),
+              "gain function start time mismatch");
+  check_close(gain_function.dt(), original.dt(),
+              "gain function sample interval mismatch");
+
+  for (std::size_t i = 0; i < original.npts(); ++i) {
+    const std::size_t first = i > half_window ? i - half_window : 0;
+    const std::size_t last = std::min(original.npts() - 1, i + half_window);
+    const std::size_t window_sample_count = last - first + 1;
+    double energy = 0.0;
+    for (std::size_t j = first; j <= last; ++j)
+      for (std::size_t component = 0; component < 3; ++component)
+        energy += original.u(component, j) * original.u(component, j);
+    const double expected_gain =
+        energy > 0.0 ? 1.0 / std::sqrt(energy / (3.0 * window_sample_count))
+                     : 0.0;
+    check_close(gain_function.s[i], expected_gain, "gain sample mismatch");
+    for (std::size_t component = 0; component < 3; ++component)
+      check_close(data.u(component, i),
+                  expected_gain * original.u(component, i),
+                  "output sample mismatch");
+  }
+}
+
+void verify_rejected_without_mutation(Seismogram data, const double twin) {
+  const Seismogram original(data);
+  bool threw_invalid = false;
+  try {
+    agc(data, twin);
+  } catch (const MsPASSError &error) {
+    check(error.severity() == ErrorSeverity::Invalid,
+          "AGC rejection used the wrong severity");
+    threw_invalid = true;
+  }
+  check(threw_invalid, "AGC invalid input did not throw MsPASSError");
+  check(data.npts() == original.npts(), "rejection changed npts");
+  check(data.live() == original.live(), "rejection changed live state");
+  if (std::isnan(original.dt()))
+    check(std::isnan(data.dt()), "rejection changed NaN dt");
+  else
+    check(data.dt() == original.dt(), "rejection changed dt");
+  check(data.t0() == original.t0(), "rejection changed t0");
+  check(data.elog.size() == original.elog.size(), "rejection changed elog");
+  for (std::size_t i = 0; i < original.npts(); ++i)
+    for (std::size_t component = 0; component < 3; ++component)
+      check(data.u(component, i) == original.u(component, i),
+            "rejection changed a data sample");
+}
+
+int main() {
+  auto constant = make_data(7, 0.5, 12.25);
+  for (std::size_t i = 0; i < constant.npts(); ++i)
+    for (std::size_t component = 0; component < 3; ++component)
+      constant.u(component, i) = 1.0;
+  verify_against_formula(constant, 2.6);
+
+  auto all_zero = make_data(6);
+  verify_against_formula(all_zero, 1.5);
+
+  for (const std::size_t impulse_position : {std::size_t{0}, std::size_t{3}}) {
+    auto impulse = make_data(7);
+    impulse.u(1, impulse_position) = 3.0;
+    verify_against_formula(impulse, 2.0);
+  }
+
+  auto signal_and_silence = make_data(9);
+  signal_and_silence.u(0, 0) = 2.0;
+  signal_and_silence.u(2, 1) = -1.0;
+  verify_against_formula(signal_and_silence, 1.0);
+
+  verify_against_formula(make_data(1, 0.25, -4.0), 0.01);
+  auto two_samples = make_data(2, 0.25, 3.5);
+  two_samples.u(0, 0) = 2.0;
+  two_samples.u(1, 1) = 4.0;
+  verify_against_formula(two_samples, 0.5);
+
+  auto equal_window = make_data(5, 0.2);
+  equal_window.u(0, 2) = 5.0;
+  verify_against_formula(equal_window, equal_window.npts() * equal_window.dt());
+  verify_against_formula(equal_window, 1000.0);
+
+  auto valid = make_data(4);
+  valid.u(0, 1) = 7.0;
+  const std::vector<double> invalid_twin{
+      0.0,
+      -1.0,
+      std::numeric_limits<double>::infinity(),
+      -std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::quiet_NaN(),
+  };
+  for (const double twin : invalid_twin)
+    verify_rejected_without_mutation(valid, twin);
+
+  const std::vector<double> invalid_dt{
+      0.0,
+      -1.0,
+      std::numeric_limits<double>::infinity(),
+      -std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::quiet_NaN(),
+  };
+  for (const double dt : invalid_dt) {
+    auto invalid = valid;
+    invalid.set_dt(dt);
+    verify_rejected_without_mutation(invalid, 1.0);
+  }
+  verify_rejected_without_mutation(make_data(0), 1.0);
+}

--- a/python/tests/algorithms/test_agc.py
+++ b/python/tests/algorithms/test_agc.py
@@ -1,0 +1,122 @@
+import math
+
+import numpy as np
+import pytest
+
+from mspasspy.ccore.algorithms.basic import agc
+from mspasspy.ccore.seismic import Seismogram
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+
+
+def _make_data(samples, dt=0.5, t0=0.0):
+    data = Seismogram(len(samples))
+    data.dt = dt
+    data.t0 = t0
+    data.set_live()
+    for index, vector in enumerate(samples):
+        data.data[:, index] = vector
+    return data
+
+
+def _expected(samples, twin, dt):
+    sample_count = len(samples)
+    rounded_window_samples = math.floor(twin / dt + 0.5)
+    half_window = min(
+        math.floor(rounded_window_samples / 2), math.floor((sample_count - 1) / 2)
+    )
+    gains = []
+    output = np.zeros((3, sample_count))
+    for index in range(sample_count):
+        first = max(0, index - half_window)
+        last = min(sample_count - 1, index + half_window)
+        window = np.asarray(samples[first : last + 1])
+        energy = np.square(window).sum()
+        gain = 1.0 / math.sqrt(energy / (3 * len(window))) if energy > 0 else 0.0
+        gains.append(gain)
+        output[:, index] = gain * np.asarray(samples[index])
+    return gains, output
+
+
+@pytest.mark.parametrize(
+    ("samples", "twin", "dt", "t0"),
+    [
+        ([[1.0, 1.0, 1.0]] * 5, 1.5, 0.5, 9.25),
+        ([[0.0, 0.0, 0.0]] * 5, 1.5, 0.5, 0.0),
+        ([[3.0, 0.0, 0.0]] + [[0.0, 0.0, 0.0]] * 4, 1.0, 0.5, 0.0),
+        (
+            [[0.0, 0.0, 0.0]] * 2 + [[0.0, -3.0, 0.0]] + [[0.0, 0.0, 0.0]] * 2,
+            1.0,
+            0.5,
+            0.0,
+        ),
+        (
+            [[2.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+            0.5,
+            0.5,
+            -2.0,
+        ),
+        ([[2.0, 0.0, 0.0]], 0.01, 0.5, 4.0),
+        (
+            [[0.0, 0.0, 0.0]] * 2 + [[0.0, 5.0, 0.0]] + [[0.0, 0.0, 0.0]] * 2,
+            2.5,
+            0.5,
+            0.0,
+        ),
+        ([[2.0, 0.0, 0.0], [0.0, 4.0, 0.0]], 100.0, 0.5, 4.0),
+    ],
+)
+def test_agc_binding_matches_formula(samples, twin, dt, t0):
+    data = _make_data(samples, dt=dt, t0=t0)
+    expected_gain, expected_output = _expected(samples, twin, dt)
+
+    gain = agc(data, twin)
+
+    assert gain.npts == len(samples)
+    assert len(gain.data) == len(samples)
+    assert gain.t0 == t0
+    assert gain.dt == dt
+    np.testing.assert_allclose(gain.data, expected_gain, rtol=1.0e-12, atol=1.0e-12)
+    np.testing.assert_allclose(data.data, expected_output, rtol=1.0e-12, atol=1.0e-12)
+
+
+@pytest.mark.parametrize("twin", [0.0, -1.0, float("inf"), float("-inf"), float("nan")])
+def test_agc_binding_rejects_invalid_twin_without_mutation(twin):
+    data = _make_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    original = np.array(data.data, copy=True)
+
+    with pytest.raises(MsPASSError) as exc_info:
+        agc(data, twin)
+
+    assert exc_info.value.severity == ErrorSeverity.Invalid
+    np.testing.assert_array_equal(data.data, original)
+
+
+@pytest.mark.parametrize("dt", [0.0, -1.0, float("inf"), float("-inf"), float("nan")])
+def test_agc_binding_rejects_invalid_dt_without_mutation(dt):
+    data = _make_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dt=dt, t0=3.25)
+    original = np.array(data.data, copy=True)
+
+    with pytest.raises(MsPASSError) as exc_info:
+        agc(data, 1.0)
+
+    assert exc_info.value.severity == ErrorSeverity.Invalid
+    assert data.npts == 2
+    assert data.t0 == 3.25
+    if math.isnan(dt):
+        assert math.isnan(data.dt)
+    else:
+        assert data.dt == dt
+    np.testing.assert_array_equal(data.data, original)
+
+
+def test_agc_binding_rejects_empty_without_mutation():
+    data = _make_data([], dt=0.5, t0=-8.0)
+
+    with pytest.raises(MsPASSError) as exc_info:
+        agc(data, 1.0)
+
+    assert exc_info.value.severity == ErrorSeverity.Invalid
+    assert data.npts == 0
+    assert data.t0 == -8.0
+    assert data.dt == 0.5
+    assert data.live


### PR DESCRIPTION
Fixes #843

## Summary

- validate `twin`, `dt`, and empty inputs before mutating the waveform
- derive the bounded half-window from `round(twin/dt)` and compute each inclusive three-component RMS window exactly once
- define zero-energy gain as zero and apply each gain to the matching sample only
- preserve the gain function time grid and commit the output only after a successful full computation
- add Release-safe native contract tests and Python binding regressions

## Validation

- Release full native build: passed
- CTest: 13/13 passed (`test_agc` 1/1)
- rebuilt Python bindings, confirmed loaded from the isolated build tree: 19/19 passed
- `clang-format --dry-run --Werror`: passed
- Black check: passed
- `py_compile`: passed
- `git diff --check`: passed

## Independent agent review

A separate agent that did not implement this change re-read #843, audited the mutation/error/window/gain/time-axis contracts, rebuilt the Release target and bindings, reran the native and Python tests, and returned **REVIEW PASS** with no blocker. No merge was performed.