### PR TITLE
Install requested dataframe dtypes during text conversion

### DIFF
--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -716,9 +716,8 @@ def Textfile2Dataframe(
 
     #   Convert data in each column to the type given in type_dict
     if type_dict is not None:
-        for field, type in type_dict.items():
-            if field in df:
-                df[field].astype(type)
+        for field, dtype in type_dict.items():
+            df[field] = df[field].astype(dtype)
 
     if attributes_to_use is not None:
         df = df[attributes_to_use]

--- a/python/tests/util/test_textfile_dtype.py
+++ b/python/tests/util/test_textfile_dtype.py
@@ -1,0 +1,66 @@
+import importlib
+
+import pandas as pd
+import pytest
+
+from mspasspy.util import converter
+
+
+def _converter(parallel):
+    if parallel:
+        pytest.importorskip("dask.dataframe")
+        importlib.reload(converter)
+        assert converter.__mspasspy_has_dask
+    return converter.Textfile2Dataframe
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_textfile2dataframe_installs_requested_dtypes(tmp_path, parallel):
+    convert = _converter(parallel)
+
+    input_file = tmp_path / "typed.csv"
+    input_file.write_text(
+        "integer,float,text,unused\n"
+        "1,1.5,10,first\n"
+        "1,1.5,10,duplicate\n"
+        "2,2.5,20,second\n",
+        encoding="utf-8",
+    )
+
+    result = convert(
+        input_file,
+        separator=",",
+        type_dict={"integer": "int16", "float": "float32", "text": "string"},
+        attributes_to_use=["integer", "float", "text"],
+        one_to_one=False,
+        rename_attributes={"integer": "renamed_integer"},
+        parallel=parallel,
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["renamed_integer", "float", "text"]
+    assert str(result["renamed_integer"].dtype) == "int16"
+    assert str(result["float"].dtype) == "float32"
+    assert pd.api.types.is_string_dtype(result["text"].dtype)
+    assert result.to_dict("records") == [
+        {"renamed_integer": 1, "float": 1.5, "text": "10"},
+        {"renamed_integer": 2, "float": 2.5, "text": "20"},
+    ]
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_textfile2dataframe_rejects_missing_typed_field(tmp_path, parallel):
+    convert = _converter(parallel)
+
+    input_file = tmp_path / "typed.csv"
+    input_file.write_text("present\n1\n", encoding="utf-8")
+
+    with pytest.raises(KeyError, match="missing"):
+        convert(
+            input_file,
+            separator=",",
+            type_dict={"missing": "int64"},
+            attributes_to_use=["present"],
+            rename_attributes={"present": "renamed"},
+            parallel=parallel,
+        )


### PR DESCRIPTION
Fixes #862

## Summary

- assign each `Series.astype` result back to its dataframe column
- let a missing requested field raise `KeyError` before selection, deduplication, rename, insertion, or return
- verify integer, float, and string dtypes survive selection, deduplication, rename, and Dask materialization

## Validation

- focused pandas and real Dask contract tests: 4/4 passed
- focused tests plus existing converter regressions: 16/16 passed
- baseline red proof against unmodified `master`: all 4 new tests failed for the expected dtype/missing-field reasons
- Black single-process check, `py_compile`, and `git diff --check`: passed

## Independent agent review

A separate agent that did not implement this change fetched and re-read #862, confirmed the loaded module came from this isolated worktree, reran the pandas/Dask and legacy tests, repeated the baseline-red proof, and returned **REVIEW PASS** with no blocker. No merge was performed.