### PR TITLE
Post ensemble metadata from the first live member

### DIFF
--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -843,42 +843,6 @@ def Stream2SeismogramEnsemble(stream):
 obspy.core.Stream.toSeismogramEnsemble = Stream2SeismogramEnsemble
 
 
-def _all_members_match(ens, key):
-    """
-    This is a helper function for below.  I scans ens to assure all members
-    of the ensemble have the same value for the requested key. It uses
-    the python operator == for testing.  That can fail for a variety of
-    reasons the "match" may be overly restrictive for some types of data
-    linked to key.
-
-    :param ens:  ensemble data to scan.  Function will throw a MsPASS error if
-      the data this symbol is associated with is not a mspass ensemble object.
-    :param key:  key whose values are to be tested for all members of ens.
-    :return:  True of all members match, false if there are any differences.
-      Note if a key is not defined in a live member the result will be false.
-      Dead data are ignored.
-    """
-    if isinstance(ens, TimeSeriesEnsemble) or isinstance(ens, SeismogramEnsemble):
-        nlive = 0
-        for d in ens.member:
-            if d.live:
-                if nlive == 0:
-                    val0 = d[key]
-                    nlive += 1
-                else:
-                    if not key in d:
-                        return False
-                    val = d[key]
-                    if val0 != val:
-                        return False
-                    nlive += 1
-        return True
-    else:
-        raise MsPASSError(
-            "_all_members_match:  input is not a mspass ensemble object", "Invalid"
-        )
-
-
 def post_ensemble_metadata(ens, keys=[], check_all_members=False, clean_members=False):
     """
     It may be necessary to call this function after conversion from
@@ -893,7 +857,7 @@ def post_ensemble_metadata(ens, keys=[], check_all_members=False, clean_members=
 
     Two different approaches can be used to do this copy.  The faster,
     but least reliable method is to simply copy the values from the first
-    member of the ensemble.  That approach is enabled by default.
+    live member of the ensemble.  That approach is enabled by default.
     It is completely reliable when used after a conversion from an obspy
     Stream but ONLY if the data began life as a mspass ensemble with
     exactly the same keys set as global.   The type example of that
@@ -901,12 +865,12 @@ def post_ensemble_metadata(ens, keys=[], check_all_members=False, clean_members=
     via the mspass decorators.
 
     A more cautious algorithm can be enabled by setting check_all_members
-    True. In that mode the list of keys received is tested with a
-    not equal test for against each member.  Note we do not do anything
-    fancy with floating point data to allow for finite precision.
+    True. In that mode each requested key is required in every live member,
+    and values are compared with the Python ``==`` operator.  Note we do not
+    do anything fancy with floating point data to allow for finite precision.
     The reason is Metadata float values are normally expected to be
-    constant data.  In that case an != test will yield false when the
-    comparison is between two copies.  The not equal test may fail, however,
+    constant data.  In that case an equality test will yield true when the
+    comparison is between two copies.  The equality test may fail, however,
     if used with computed floating point numbers.   An example where
     that is possible would be spatial gathers like PP data assembled by
     midpoint coordinates.  If you need to build gathers in such a context
@@ -914,7 +878,7 @@ def post_ensemble_metadata(ens, keys=[], check_all_members=False, clean_members=
     document collection in MongoDB that defines the geometry of that
     point.  There may be other examples, but the point is don't trust
     computed floating point values to work.  It will also not work if
-    the values of a key-value pair don't support an != comparison.
+    the values of a key-value pair don't support an ``==`` comparison.
     That could be common if the value request for copy was a python object.
 
     :param ens:  ensemble data to be processed.  The function will throw
@@ -929,43 +893,59 @@ def post_ensemble_metadata(ens, keys=[], check_all_members=False, clean_members=
       will be removed from all members.  This option is only allowed
       if check_all_members is set True.  It will be silently ignored if
       check_all_members is False.
+    :return: None.  The input ensemble is modified in place.
     """
+
     alg = "post_ensemble_metadata"
 
     if isinstance(ens, TimeSeriesEnsemble) or isinstance(ens, SeismogramEnsemble):
+        live_members = [d for d in ens.member if d.live]
+        if not live_members:
+            return
+
         md = Metadata()
-        for d in ens.member:
-            if d.live:
-                for k in keys:
-                    if not k in d:
+        source = live_members[0]
+        for k in keys:
+            if k not in source:
+                raise MsPASSError(
+                    alg
+                    + ":  no data matching requested key="
+                    + k
+                    + " in the first live member.  Cannot post to ensemble",
+                    ErrorSeverity.Invalid,
+                )
+            md[k] = source[k]
+
+            if check_all_members:
+                for d in live_members[1:]:
+                    if k not in d:
                         raise MsPASSError(
                             alg
                             + ":  no data matching requested key="
                             + k
-                            + " Cannot post to ensemble",
-                            "Invalid",
+                            + " in a live member.  Cannot post to ensemble",
+                            ErrorSeverity.Invalid,
                         )
-                    md[k] = d[k]
-        if check_all_members:
-            for d in ens.member:
-                for k in keys:
-                    if not _all_members_match(ens, k):
+                    if not d[k] == md[k]:
                         raise MsPASSError(
                             alg
                             + ":  Data mismatch data members with key="
                             + k
                             + "\n  In check_all_members mode all values associated with this key must match",
-                            "Invalid",
+                            ErrorSeverity.Invalid,
                         )
+
+        ens.update_metadata(md)
+        if check_all_members:
             if clean_members:
                 for d in ens.member:
                     for k in keys:
-                        d.erase(k)
-        ens.update_metadata(md)
+                        if k in d:
+                            d.erase(k)
 
     else:
         raise MsPASSError(
             alg
             + ":  Illegal data received.  This function runs only on mspass ensemble objects",
-            "Invalid",
+            ErrorSeverity.Invalid,
         )

--- a/python/tests/util/test_post_ensemble_metadata.py
+++ b/python/tests/util/test_post_ensemble_metadata.py
@@ -1,0 +1,168 @@
+import pytest
+
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+from mspasspy.util.converter import post_ensemble_metadata
+
+
+@pytest.fixture(
+    params=[
+        (TimeSeries, TimeSeriesEnsemble),
+        (Seismogram, SeismogramEnsemble),
+    ],
+    ids=["TimeSeriesEnsemble", "SeismogramEnsemble"],
+)
+def ensemble_types(request):
+    return request.param
+
+
+def _member(datum_type, live=True, **metadata):
+    datum = datum_type(2)
+    if live:
+        datum.set_live()
+    else:
+        datum.kill()
+    for key, value in metadata.items():
+        datum[key] = value
+    return datum
+
+
+def _ensemble(ensemble_type, *members, **metadata):
+    result = ensemble_type()
+    for key, value in metadata.items():
+        result[key] = value
+    for member in members:
+        result.member.append(member)
+    return result
+
+
+def _snapshot(ensemble):
+    return dict(ensemble), [(datum.live, dict(datum)) for datum in ensemble.member]
+
+
+@pytest.mark.parametrize("clean_members", [False, True])
+def test_post_ensemble_metadata_uses_first_live_member_only(
+    ensemble_types, clean_members
+):
+    datum_type, ensemble_type = ensemble_types
+    ensemble = _ensemble(
+        ensemble_type,
+        _member(datum_type, False, shared="dead"),
+        _member(datum_type, True, shared="first"),
+        _member(datum_type, True, shared="last"),
+    )
+
+    result = post_ensemble_metadata(ensemble, ["shared"], clean_members=clean_members)
+
+    assert result is None
+    assert ensemble["shared"] == "first"
+    assert [datum["shared"] for datum in ensemble.member] == [
+        "dead",
+        "first",
+        "last",
+    ]
+
+
+def test_post_ensemble_metadata_leaves_all_dead_ensemble_unchanged(ensemble_types):
+    datum_type, ensemble_type = ensemble_types
+    ensemble = _ensemble(
+        ensemble_type,
+        _member(datum_type, False, shared="one"),
+        _member(datum_type, False, shared="two"),
+        original="metadata",
+    )
+    before = _snapshot(ensemble)
+
+    result = post_ensemble_metadata(
+        ensemble, ["shared"], check_all_members=True, clean_members=True
+    )
+
+    assert result is None
+    assert _snapshot(ensemble) == before
+
+
+@pytest.mark.parametrize("check_all_members", [False, True])
+def test_post_ensemble_metadata_missing_key_is_atomic(
+    ensemble_types, check_all_members
+):
+    datum_type, ensemble_type = ensemble_types
+    members = [
+        _member(datum_type, False, stable="dead", shared="dead"),
+        _member(datum_type, True, stable="common"),
+    ]
+    if check_all_members:
+        members = [
+            _member(datum_type, False, stable="dead", shared="dead"),
+            _member(datum_type, True, stable="common", shared="first"),
+            _member(datum_type, True, stable="common"),
+        ]
+    ensemble = _ensemble(ensemble_type, *members, original="metadata")
+    before = _snapshot(ensemble)
+
+    with pytest.raises(MsPASSError) as excinfo:
+        post_ensemble_metadata(
+            ensemble,
+            ["stable", "shared"],
+            check_all_members=check_all_members,
+            clean_members=True,
+        )
+
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+    assert "shared" in str(excinfo.value)
+    assert _snapshot(ensemble) == before
+
+
+def test_post_ensemble_metadata_mismatch_is_atomic(ensemble_types):
+    datum_type, ensemble_type = ensemble_types
+    ensemble = _ensemble(
+        ensemble_type,
+        _member(datum_type, False, stable="dead", shared="dead"),
+        _member(datum_type, True, stable="common", shared="first"),
+        _member(datum_type, True, stable="common", shared="last"),
+        original="metadata",
+    )
+    before = _snapshot(ensemble)
+
+    with pytest.raises(MsPASSError) as excinfo:
+        post_ensemble_metadata(
+            ensemble,
+            ["stable", "shared"],
+            check_all_members=True,
+            clean_members=True,
+        )
+
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+    assert "shared" in str(excinfo.value)
+    assert _snapshot(ensemble) == before
+
+
+@pytest.mark.parametrize("clean_members", [False, True])
+def test_post_ensemble_metadata_all_member_success(ensemble_types, clean_members):
+    datum_type, ensemble_type = ensemble_types
+    ensemble = _ensemble(
+        ensemble_type,
+        _member(datum_type, False),
+        _member(datum_type, False, shared="dead"),
+        _member(datum_type, True, shared="common"),
+        _member(datum_type, True, shared="common"),
+    )
+    member_key_presence = ["shared" in member for member in ensemble.member]
+
+    result = post_ensemble_metadata(
+        ensemble,
+        ["shared"],
+        check_all_members=True,
+        clean_members=clean_members,
+    )
+
+    assert result is None
+    assert ensemble["shared"] == "common"
+    expected_presence = (
+        [False] * len(ensemble.member) if clean_members else member_key_presence
+    )
+    assert ["shared" in member for member in ensemble.member] == expected_presence


### PR DESCRIPTION
Fixes #865

## Summary

- select the first live member once for the fast metadata-posting path
- return an all-dead ensemble unchanged
- prevalidate every requested key and every live-member equality before updating ensemble metadata or cleaning members
- use `ErrorSeverity.Invalid` consistently and remove the obsolete comparison helper
- clean member copies only after successful all-member validation and only when requested

## Validation

- focused TimeSeriesEnsemble/SeismogramEnsemble contract matrix: 16/16 passed
- existing converter regressions: 12/12 passed
- baseline-red proof with unmodified `master`: 6 focused failures for first-live/all-dead/atomicity behavior
- Black, `py_compile`, and `git diff --check`: passed

## Independent agent review

A different agent re-read #865, expanded the tests to both ensemble types and second-key failures, audited all write/error/cleanup ordering, reran focused/legacy/baseline tests, and returned **REVIEW PASS** with no blocker. No merge was performed.