### PR TITLE
Reject incomplete ObsPy stream component groups

### DIFF
--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -818,8 +818,12 @@ def Stream2SeismogramEnsemble(stream):
     :return: converted seismogram ensemble
     """
     size = len(stream)
+    if size % 3 != 0:
+        raise ValueError(
+            "Stream2SeismogramEnsemble: stream length must be divisible by 3"
+        )
     res = SeismogramEnsemble()
-    for i in range(int(size / 3)):
+    for i in range(size // 3):
         res.member.append(Stream2Seismogram(stream[i * 3 : i * 3 + 3], cardinal=True))
         # fixme cardinal
     # Handle the ensemble metadata.   The little helper we call here

--- a/python/tests/util/test_stream2seismogram_ensemble.py
+++ b/python/tests/util/test_stream2seismogram_ensemble.py
@@ -1,0 +1,67 @@
+import numpy as np
+import obspy
+import pytest
+
+from mspasspy.ccore.seismic import SeismogramEnsemble
+from mspasspy.util import converter
+
+
+def _stream(group_count):
+    result = obspy.Stream()
+    channels = ("E", "N", "Z")
+    for group in range(group_count):
+        for component, channel in enumerate(channels):
+            trace = obspy.Trace(
+                data=np.full(4, group * 10 + component + 1, dtype=np.float64)
+            )
+            trace.stats.station = f"STA{group}"
+            trace.stats.channel = channel
+            trace.stats.delta = 0.1
+            result.append(trace)
+    return result
+
+
+@pytest.mark.parametrize("group_count", [0, 1, 2])
+def test_stream2seismogramensemble_converts_complete_groups_in_order(group_count):
+    result = converter.Stream2SeismogramEnsemble(_stream(group_count))
+
+    assert isinstance(result, SeismogramEnsemble)
+    assert len(result.member) == group_count
+    assert result.live is (group_count > 0)
+    assert [member["sta"] for member in result.member] == [
+        f"STA{group}" for group in range(group_count)
+    ]
+    assert all(member.live for member in result.member)
+    for group, member in enumerate(result.member):
+        expected = np.array(
+            [
+                [group * 10 + 1] * 4,
+                [group * 10 + 2] * 4,
+                [group * 10 + 3] * 4,
+            ]
+        )
+        assert np.array_equal(np.asarray(member.data), expected)
+
+
+def test_stream2seismogramensemble_rejects_incomplete_group_before_side_effects(
+    monkeypatch,
+):
+    stream = _stream(1)
+    stream.append(obspy.Trace(data=np.arange(4, dtype=np.float64)))
+    calls = {"constructor": 0, "metadata": 0}
+
+    def unexpected_constructor(*args, **kwargs):
+        calls["constructor"] += 1
+        raise AssertionError("conversion must not start")
+
+    def unexpected_metadata(*args, **kwargs):
+        calls["metadata"] += 1
+        raise AssertionError("metadata posting must not start")
+
+    monkeypatch.setattr(converter, "Stream2Seismogram", unexpected_constructor)
+    monkeypatch.setattr(converter, "post_ensemble_metadata", unexpected_metadata)
+
+    with pytest.raises(ValueError, match="divisible by 3"):
+        converter.Stream2SeismogramEnsemble(stream)
+
+    assert calls == {"constructor": 0, "metadata": 0}


### PR DESCRIPTION
Fixes #866.

## Summary
- reject streams whose trace count is not divisible by three before constructing an ensemble or converting members
- preserve contiguous three-trace grouping and ordering for valid 0/3/6-trace inputs
- add focused regression coverage for valid groups and pre-mutation failure

## Verification
- focused and existing converter tests: 16 passed
- master-baseline proof: the new incomplete-stream test fails on the audited baseline
- Black, `py_compile`, and diff/whitespace checks passed
- independent agent review: PASS, zero blockers

This PR is ready for human review. It must not be merged automatically.