### PR TITLE
Record cumulative calibration state and forward ensemble options

### DIFF
--- a/python/mspasspy/algorithms/calib.py
+++ b/python/mspasspy/algorithms/calib.py
@@ -1,4 +1,6 @@
 import pickle
+import math
+import numbers
 import numpy as np
 from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
 from mspasspy.ccore.utility import MsPASSError, ErrorSeverity
@@ -186,9 +188,10 @@ class ApplyCalibEngine:
         loaded in the cache by the constructor.   By default the key
         used is "channel_id".  That can be changed with the "id_key"
         argument.  If a match is found all
-        the sample valued are multiplied by calib AND the calib attribute is
-        set.   Note a complaint will be issued if calib was found to already
-        be defined in  AND is not 1.0 (a default sometimes appropriate)
+        the sample values are multiplied by calib AND the calib attribute is
+        set to the cumulative conversion factor applied to the samples.  Note
+        a complaint will be issued if calib was found to already be defined
+        AND is not 1.0 (a default sometimes appropriate).
 
         This method can easily become a mass murderer.   By default any
         datum with an undefined calib value in the cache of this object will
@@ -214,11 +217,23 @@ class ApplyCalibEngine:
                     if idstr in self.calib:
                         this_calib = self.calib[idstr]
                         if "calib" in d:
-                            if not np.isclose(d["calib"], 1.0):
-                                old_calib = d["calib"]
-                                new_metadata_calib = old_calib * this_calib
+                            old_calib = d["calib"]
+                            if (
+                                isinstance(old_calib, bool)
+                                or not isinstance(old_calib, numbers.Real)
+                                or not math.isfinite(old_calib)
+                            ):
+                                message = (
+                                    "Existing calib metadata must be a finite numeric value; "
+                                    + "received {}".format(repr(old_calib))
+                                )
+                                d.elog.log_error(alg, message, ErrorSeverity.Invalid)
+                                d.kill()
+                                return d
+                            new_metadata_calib = old_calib * this_calib
+                            if not np.isclose(old_calib, 1.0):
                                 message = "calib was already defined in this datum as {}\n".format(
-                                    d["calib"]
+                                    old_calib
                                 )
                                 message += "Data will be multiplied by calib defined in this object={}\n".format(
                                     this_calib
@@ -228,10 +243,10 @@ class ApplyCalibEngine:
                                 )
                                 message += "Amplitudes may be wrong with this datum"
                                 d.elog.log_error(alg, message, ErrorSeverity.Complaint)
-                                d["calib"] = new_metadata_calib
-                            else:
-                                d["calib"] = this_calib
+                        else:
+                            new_metadata_calib = this_calib
                         d.data *= this_calib
+                        d["calib"] = new_metadata_calib
                     else:
                         message = "calib factor could not be determined\n"
                         message += "Response data missing or flawed"
@@ -241,7 +256,9 @@ class ApplyCalibEngine:
                         else:
                             d.elog.log_error(alg, message, ErrorSeverity.Complaint)
                 else:
-                    message = "Missing required channel_id need to get calib factor"
+                    message = "Missing required {} needed to get calib factor".format(
+                        id_key
+                    )
                     if kill_if_undefined:
                         d.elog.log_error(alg, message, ErrorSeverity.Invalid)
                         d.kill()
@@ -249,7 +266,9 @@ class ApplyCalibEngine:
                         d.elog.log_error(alg, message, ErrorSeverity.Complaint)
         elif isinstance(d, TimeSeriesEnsemble):
             for i in range(len(d.member)):
-                d.member[i] = self.apply_calib(d.member[i])
+                d.member[i] = self.apply_calib(
+                    d.member[i], id_key=id_key, kill_if_undefined=kill_if_undefined
+                )
         else:
             message = "Illegal input data type={}".format(str(type(d)))
             raise ValueError(message)

--- a/python/tests/algorithms/test_calib_contracts.py
+++ b/python/tests/algorithms/test_calib_contracts.py
@@ -1,0 +1,131 @@
+import math
+
+import numpy as np
+import pytest
+
+from mspasspy.algorithms.calib import ApplyCalibEngine
+from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
+from mspasspy.ccore.utility import ErrorSeverity
+
+
+def _engine():
+    result = object.__new__(ApplyCalibEngine)
+    result.calib = {"matched": 3.0}
+    return result
+
+
+def _datum(old_calib=None, include_calib=True, id_value="matched"):
+    result = TimeSeries(4)
+    result.set_live()
+    result["custom_id"] = id_value
+    for sample in range(result.npts):
+        result.data[sample] = sample + 1.0
+    if include_calib:
+        result["calib"] = old_calib
+    return result
+
+
+@pytest.mark.parametrize(
+    "old_calib,include_calib,expected_calib",
+    [
+        (None, False, 3.0),
+        (1.0, True, 3.0),
+        (2.5, True, 7.5),
+    ],
+)
+def test_apply_calib_records_the_cumulative_applied_factor(
+    old_calib, include_calib, expected_calib
+):
+    datum = _datum(old_calib, include_calib)
+    original_samples = np.array(datum.data, copy=True)
+
+    result = _engine().apply_calib(datum, id_key="custom_id")
+
+    assert result is datum
+    assert np.array_equal(np.asarray(datum.data), original_samples * 3.0)
+    assert datum["calib"] == expected_calib
+    assert datum.live
+
+
+@pytest.mark.parametrize("old_calib", ["bad", math.nan, math.inf, -math.inf])
+def test_apply_calib_rejects_invalid_existing_calibration_without_mutation(old_calib):
+    datum = _datum(old_calib)
+    original_samples = np.array(datum.data, copy=True)
+    original_calib = datum["calib"]
+    original_elog_size = datum.elog.size()
+
+    result = _engine().apply_calib(datum, id_key="custom_id")
+
+    assert result is datum
+    assert datum.dead()
+    assert np.array_equal(np.asarray(datum.data), original_samples)
+    if isinstance(original_calib, float) and math.isnan(original_calib):
+        assert math.isnan(datum["calib"])
+    else:
+        assert datum["calib"] == original_calib
+    assert datum.elog.size() == original_elog_size + 1
+    error = datum.elog.get_error_log()[-1]
+    assert error.algorithm == "ApplyCalibEngine.apply_calib"
+    assert error.badness == ErrorSeverity.Invalid
+    assert "Existing calib metadata must be a finite numeric value" in error.message
+    assert repr(old_calib) in error.message
+
+
+@pytest.mark.parametrize("kill_if_undefined", [False, True])
+@pytest.mark.parametrize("failure", ["missing_id", "cache_miss"])
+def test_ensemble_forwards_matching_and_error_options(kill_if_undefined, failure):
+    if failure == "missing_id":
+        atomic = _datum(1.0)
+        atomic.erase("custom_id")
+    else:
+        atomic = _datum(1.0, id_value="not-cached")
+    matched = _datum(1.0)
+    ensemble = TimeSeriesEnsemble()
+    ensemble.member.append(TimeSeries(atomic))
+    ensemble.member.append(TimeSeries(matched))
+
+    engine = _engine()
+    direct = [
+        engine.apply_calib(
+            datum, id_key="custom_id", kill_if_undefined=kill_if_undefined
+        )
+        for datum in (atomic, matched)
+    ]
+    result = engine.apply_calib(
+        ensemble, id_key="custom_id", kill_if_undefined=kill_if_undefined
+    )
+
+    for member, expected in zip(result.member, direct):
+        assert member.live == expected.live
+        assert np.array_equal(np.asarray(member.data), np.asarray(expected.data))
+        assert dict(member) == dict(expected)
+        assert member.elog.size() == expected.elog.size()
+        if member.elog.size():
+            member_error = member.elog.get_error_log()[-1]
+            expected_error = expected.elog.get_error_log()[-1]
+            assert member_error.algorithm == expected_error.algorithm
+            assert member_error.message == expected_error.message
+            assert member_error.badness == expected_error.badness
+
+
+def test_ensemble_custom_id_success_matches_direct_atomic_call():
+    atomic = _datum(2.0)
+    ensemble = TimeSeriesEnsemble()
+    ensemble.member.append(TimeSeries(atomic))
+
+    engine = _engine()
+    direct = engine.apply_calib(atomic, id_key="custom_id", kill_if_undefined=False)
+    result = engine.apply_calib(ensemble, id_key="custom_id", kill_if_undefined=False)
+
+    assert result is ensemble
+    member = result.member[0]
+    assert member.live == direct.live
+    assert np.array_equal(np.asarray(member.data), np.asarray(direct.data))
+    assert dict(member) == dict(direct)
+    assert member["calib"] == direct["calib"] == 6.0
+    assert member.elog.size() == direct.elog.size() == 1
+    member_error = member.elog.get_error_log()[-1]
+    direct_error = direct.elog.get_error_log()[-1]
+    assert member_error.algorithm == direct_error.algorithm
+    assert member_error.message == direct_error.message
+    assert member_error.badness == direct_error.badness


### PR DESCRIPTION
Fixes #869.

## Summary
- record successful calibration as the cumulative conversion factor already applied to the samples
- reject nonnumeric or nonfinite existing calibration metadata atomically with one Invalid elog entry
- forward custom identifier and undefined-calibration policy through ensemble recursion
- add direct atomic/ensemble parity regression coverage

## Verification
- focused public-path calibration tests: 12 passed
- master-baseline proof: 10 failures and 2 passes
- Black, `py_compile`, and `git diff --check` passed
- independent agent review: PASS, zero blockers
- local Mongo-backed legacy test was not claimed because no Mongo listener was available; GitHub CI remains required

This PR is ready for human review. It must not be merged automatically.