### PR TITLE
Bury each dead ensemble member exactly once

### DIFF
--- a/python/mspasspy/util/Undertaker.py
+++ b/python/mspasspy/util/Undertaker.py
@@ -235,7 +235,8 @@ class Undertaker:
 
         :param mummify_atomic_data:  When True (default) atomic data
           marked dead will be passed through self.mummify to reduce
-          memory use of the remains.   This parameter is ignored for ensembles.
+          memory use of the remains.  For ensembles this option is forwarded
+          when each dead member is buried.
         """
         # set as symbol to mesh with Database api.  It would make no sense
         # to ever set this False.  Done this way to make that clear
@@ -286,15 +287,20 @@ class Undertaker:
                 newens = SeismogramEnsemble(ensmd, nlive)
             else:
                 raise MsPASSError(
-                    "Undertaker.bury",
-                    "Coding error - newens constructor section has invalid type\nThat cannot happen unless the original code was incorrectly changed",
+                    "Undertaker.bury: Coding error - newens constructor section "
+                    "has invalid type\nThat cannot happen unless the original code "
+                    "was incorrectly changed",
                     ErrorSeverity.Invalid,
                 )
             for x in mspass_object.member:
                 if x.live:
                     newens.member.append(x)
                 else:
-                    self.bury(x, save_history=save_history, mummify_atomic_data=False)
+                    self.bury(
+                        x,
+                        save_history=save_history,
+                        mummify_atomic_data=mummify_atomic_data,
+                    )
             if nlive > 0:
                 newens.set_live()
             return newens
@@ -367,8 +373,9 @@ class Undertaker:
                 newens = SeismogramEnsemble(ensmd, nlive)
             else:
                 raise MsPASSError(
-                    "Undertaker.cremate:  ",
-                    "Coding error - newens constructor section has invalid type\nThat cannot happen unless the original code was incorrectly changed",
+                    "Undertaker.cremate: Coding error - newens constructor section "
+                    "has invalid type\nThat cannot happen unless the original code "
+                    "was incorrectly changed",
                     ErrorSeverity.Invalid,
                 )
             if mspass_object.live:
@@ -407,13 +414,11 @@ class Undertaker:
 
         :param d:  must be either a TimeSeriesEnsemble or SeismogramEnsemble of
            data to be processed.
-        :param bury:  if true the bury method will be called on the
-           ensemble of dead data before returning.   Note a limitation of
-           using this method is there is no way to save the optional
-           history data via this method.  If you need to save history
-           run this with bury=False and then run bury with save_history
-           true on the dead ensemble.   There is also no way to specify
-           an alternative to the default collection name of "cemetery"
+        :param bury:  if true the bury method will be called on each dead
+           member before returning.
+        :param save_history:  option forwarded to bury for every dead member.
+        :param mummify_atomic_data:  option forwarded to bury for every dead
+           member.
         :return: python list with two elements. 0 is ensemble with live data
            and 1 is ensemble with dead data.
         :rtype:  python list with two components
@@ -443,8 +448,9 @@ class Undertaker:
             bodies = SeismogramEnsemble(ensmd, ndead)
         else:
             raise MsPASSError(
-                "Undertaker.bring_out_your_dead",
-                "Coding error - newens constructor section has invalid type\nThat cannot happen unless the original code was incorrectly changed",
+                "Undertaker.bring_out_your_dead: Coding error - newens "
+                "constructor section has invalid type\nThat cannot happen unless "
+                "the original code was incorrectly changed",
                 ErrorSeverity.Invalid,
             )
         for x in d.member:
@@ -452,10 +458,12 @@ class Undertaker:
                 newens.member.append(x)
             else:
                 bodies.member.append(x)
-                # Note we don't support save_history through this
-                # mechanism.
                 if bury:
-                    self.bury(d)
+                    self.bury(
+                        x,
+                        save_history=save_history,
+                        mummify_atomic_data=mummify_atomic_data,
+                    )
         if len(newens.member) > 0:
             newens.set_live()
         return [newens, bodies]
@@ -613,7 +621,8 @@ class Undertaker:
                 message = "Warning:  dead datum has is_abortion attribute undefined - assumed False\n"
                 message += "MsPASS readers should always set this attribute"
                 err = MsPASSError(
-                    "Undertaker._is_abortion", message, ErrorSeverity.Complaint
+                    "Undertaker._is_abortion: " + message,
+                    ErrorSeverity.Complaint,
                 )
                 d.elog.log_error(err)
                 return False

--- a/python/tests/util/test_undertaker_burial_contract.py
+++ b/python/tests/util/test_undertaker_burial_contract.py
@@ -1,0 +1,205 @@
+import itertools
+
+import pytest
+
+from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
+from mspasspy.ccore.utility import ErrorSeverity
+from mspasspy.util.Undertaker import Undertaker
+
+
+class _FakeDatabase:
+    def __init__(self):
+        self.elog_calls = []
+        self.history_calls = []
+
+    def _save_elog(self, datum, collection, data_tag=None):
+        self.elog_calls.append(
+            (datum["member_id"], collection, data_tag, datum.elog.size())
+        )
+        return "cemetery-{}".format(len(self.elog_calls))
+
+    def _save_history(self, datum, alg_name):
+        self.history_calls.append((datum["member_id"], alg_name))
+
+
+class _SpyUndertaker(Undertaker):
+    def bury(self, mspass_object, save_history=False, mummify_atomic_data=True):
+        self.burial_calls.append((mspass_object, save_history, mummify_atomic_data))
+        return super().bury(
+            mspass_object,
+            save_history=save_history,
+            mummify_atomic_data=mummify_atomic_data,
+        )
+
+
+def _make_undertaker():
+    undertaker = _SpyUndertaker.__new__(_SpyUndertaker)
+    undertaker.db = _FakeDatabase()
+    undertaker.regular_data_collection = "cemetery"
+    undertaker.aborted_data_collection = "abortions"
+    undertaker.data_tag = "undertaker-contract"
+    undertaker.burial_calls = []
+    return undertaker
+
+
+_DEAD_INDEXES = {
+    0: (),
+    1: (1,),
+    2: (1, 3),
+    3: (0, 2, 4),
+}
+
+
+def _make_mixed_ensemble(dead_count):
+    dead_indexes = _DEAD_INDEXES[dead_count]
+    ensemble = TimeSeriesEnsemble()
+    ensemble["ensemble_marker"] = "preserve-me"
+    expected_samples = {}
+
+    for member_id in range(5):
+        datum = TimeSeries(3)
+        datum.dt = 0.1
+        datum.t0 = float(member_id)
+        datum["member_id"] = member_id
+        datum["is_abortion"] = False
+        datum["member_marker"] = "member-{}".format(member_id)
+        for sample_number in range(datum.npts):
+            datum.data[sample_number] = 10.0 * member_id + sample_number
+        datum.set_live()
+        expected_samples[member_id] = list(datum.data)
+        if member_id in dead_indexes:
+            datum.elog.log_error(
+                "test",
+                "dead member {}".format(member_id),
+                ErrorSeverity.Invalid,
+            )
+            datum.kill()
+        ensemble.member.append(datum)
+
+    ensemble.set_live()
+
+    live_ids = [i for i in range(5) if i not in dead_indexes]
+    return ensemble, live_ids, list(dead_indexes), expected_samples
+
+
+_OPTION_PAIRS = list(itertools.product((False, True), repeat=2))
+
+
+def _assert_burial_calls(
+    undertaker, dead_ids, save_history, mummify_atomic_data, ensemble_calls
+):
+    atomic_calls = [
+        call for call in undertaker.burial_calls if isinstance(call[0], TimeSeries)
+    ]
+    actual_ensemble_calls = [
+        call
+        for call in undertaker.burial_calls
+        if isinstance(call[0], TimeSeriesEnsemble)
+    ]
+
+    assert len(actual_ensemble_calls) == ensemble_calls
+    assert [call[1:] for call in actual_ensemble_calls] == [
+        (save_history, mummify_atomic_data)
+    ] * ensemble_calls
+    assert [call[0]["member_id"] for call in atomic_calls] == dead_ids
+    assert [call[1:] for call in atomic_calls] == [
+        (save_history, mummify_atomic_data)
+    ] * len(dead_ids)
+
+
+def _assert_database_writes(undertaker, dead_ids, save_history):
+    assert [call[0] for call in undertaker.db.elog_calls] == dead_ids
+    assert all(
+        call[1:] == ("cemetery", "undertaker-contract", 1)
+        for call in undertaker.db.elog_calls
+    )
+    expected_history_ids = dead_ids if save_history else []
+    assert [call[0] for call in undertaker.db.history_calls] == expected_history_ids
+    assert all(call[1] == "Undertaker.bury" for call in undertaker.db.history_calls)
+
+
+def _assert_live_members(ensemble, live_ids, expected_samples):
+    assert ensemble.live
+    assert ensemble["ensemble_marker"] == "preserve-me"
+    assert [member["member_id"] for member in ensemble.member] == live_ids
+    for member in ensemble.member:
+        member_id = member["member_id"]
+        assert member.live
+        assert member["member_marker"] == "member-{}".format(member_id)
+        assert list(member.data) == expected_samples[member_id]
+
+
+@pytest.mark.parametrize("dead_count", (0, 1, 2, 3))
+@pytest.mark.parametrize(("save_history", "mummify_atomic_data"), _OPTION_PAIRS)
+def test_bury_ensemble_calls_atomic_path_once_per_dead_member(
+    dead_count, save_history, mummify_atomic_data
+):
+    undertaker = _make_undertaker()
+    ensemble, live_ids, dead_ids, expected_samples = _make_mixed_ensemble(dead_count)
+
+    result = undertaker.bury(
+        ensemble,
+        save_history=save_history,
+        mummify_atomic_data=mummify_atomic_data,
+    )
+
+    _assert_burial_calls(
+        undertaker,
+        dead_ids,
+        save_history,
+        mummify_atomic_data,
+        ensemble_calls=1,
+    )
+    _assert_database_writes(undertaker, dead_ids, save_history)
+    _assert_live_members(result, live_ids, expected_samples)
+    for member in ensemble.member:
+        if member["member_id"] in dead_ids:
+            assert member.npts == (0 if mummify_atomic_data else 3)
+
+
+@pytest.mark.parametrize("dead_count", (0, 1, 2, 3))
+@pytest.mark.parametrize(("save_history", "mummify_atomic_data"), _OPTION_PAIRS)
+def test_bring_out_your_dead_calls_atomic_path_once_per_dead_member(
+    dead_count, save_history, mummify_atomic_data
+):
+    undertaker = _make_undertaker()
+    ensemble, live_ids, dead_ids, expected_samples = _make_mixed_ensemble(dead_count)
+
+    live_ensemble, bodies = undertaker.bring_out_your_dead(
+        ensemble,
+        bury=True,
+        save_history=save_history,
+        mummify_atomic_data=mummify_atomic_data,
+    )
+
+    _assert_burial_calls(
+        undertaker,
+        dead_ids,
+        save_history,
+        mummify_atomic_data,
+        ensemble_calls=0,
+    )
+    _assert_database_writes(undertaker, dead_ids, save_history)
+    _assert_live_members(live_ensemble, live_ids, expected_samples)
+    assert [member["member_id"] for member in bodies.member] == dead_ids
+    assert all(member.dead() for member in bodies.member)
+    for member in ensemble.member:
+        if member["member_id"] in dead_ids:
+            assert member.npts == (0 if mummify_atomic_data else 3)
+
+
+def test_is_abortion_logs_original_message_and_severity():
+    undertaker = _make_undertaker()
+    datum = TimeSeries(1)
+    datum.set_live()
+    datum.kill()
+    expected_message = (
+        "Undertaker._is_abortion: Warning:  dead datum has is_abortion attribute undefined - "
+        "assumed False\nMsPASS readers should always set this attribute"
+    )
+
+    assert undertaker._is_abortion(datum) is False
+    assert datum.elog.size() == 1
+    entry = datum.elog.get_error_log()[0]
+    assert entry.message == expected_message
+    assert entry.badness == ErrorSeverity.Complaint


### PR DESCRIPTION
Fixes #883.

## Summary
- route each dead ensemble member through the atomic burial path exactly once
- prevent whole-ensemble burial calls from occurring inside member loops
- forward `save_history` and `mummify_atomic_data` unchanged through both ensemble entry points
- normalize all Undertaker `MsPASSError` construction to the two-argument contract

## Verification
- Python 3.9 and 3.13 focused tests: 33 passed on each
- audited master baseline: 19 failures and 14 passes
- exact atomic/ensemble calls, four option pairs, cemetery/elog/history counts, and member ordering/state are asserted
- Black, both-version `py_compile`, and `git diff --check` passed
- independent agent review: PASS, zero blockers
- no local Mongo service was available; database calls are isolated with exact persistence-boundary counters and GitHub CI remains required

This PR is ready for human review. It must not be merged automatically.