### PR TITLE
Harden regularize_sampling grid validation

### DIFF
--- a/python/mspasspy/util/seismic.py
+++ b/python/mspasspy/util/seismic.py
@@ -7,6 +7,9 @@ from mspasspy.ccore.seismic import (
 from mspasspy.ccore.utility import Metadata, ErrorSeverity, MsPASSError
 from mspasspy.ccore.algorithms.basic import TimeWindow
 from bson import json_util
+import math
+import numbers
+
 import numpy as np
 import pandas as pd
 
@@ -109,7 +112,7 @@ def regularize_sampling(ensemble, dt_expected, Nsamp=10000, abort_on_error=False
     data created by some older digitizers that skewed the recorded sample interval to force
     time computed from N*dt to match time stamps on successive data packets.
     The formula used is the datum dt is declared constant if the difference from
-    the expected dt is less than or equal to dt_expected/2*(Nsamp-1).  That means
+    the expected dt is less than or equal to dt_expected/(2*(Nsamp-1)).  That means
     the computed endtime difference from that using dt_expected is less than
     or equal to dt/2.
 
@@ -149,28 +152,42 @@ def regularize_sampling(ensemble, dt_expected, Nsamp=10000, abort_on_error=False
 
     """
     alg = "regularize_sampling"
+    if isinstance(Nsamp, bool) or not isinstance(Nsamp, numbers.Integral) or Nsamp < 2:
+        raise ValueError("regularize_sampling: Nsamp must be an integer >= 2")
+    if (
+        isinstance(dt_expected, bool)
+        or not isinstance(dt_expected, numbers.Real)
+        or not math.isfinite(dt_expected)
+        or dt_expected <= 0.0
+    ):
+        raise ValueError(
+            "regularize_sampling: dt_expected must be a finite positive real number"
+        )
     if ensemble.dead():
         return ensemble
     # this formula will flag any ensemble member for which the sample
     # rate yields a computed end time that differs from the beam
     # by more than one half sample
     delta_dt_cutoff = dt_expected / (2.0 * (Nsamp - 1))
+    invalid_members = []
     for i in range(len(ensemble.member)):
         d = ensemble.member[i]
         if d.live:
-            if not np.isclose(dt_expected, d.dt):
-                if abs(dt_expected - d.dt) > delta_dt_cutoff:
-                    message = str()
-                    message = "Member {} of input ensemble has different sample rate={} than expected dt={}".format(
-                        i, d.dt, dt_expected
-                    )
-                    if abort_on_error:
-                        raise ValueError(message)
-                    else:
-                        ensemble.member[i].elog.log_error(
-                            alg, message, ErrorSeverity.Invalid
-                        )
-                        ensemble.member[i].kill()
+            invalid = (
+                not math.isfinite(d.dt)
+                or d.dt <= 0.0
+                or abs(dt_expected - d.dt) > delta_dt_cutoff
+            )
+            if invalid:
+                message = "Member {} of input ensemble has different sample rate={} than expected dt={}".format(
+                    i, d.dt, dt_expected
+                )
+                invalid_members.append((i, message))
+    if abort_on_error and invalid_members:
+        raise ValueError(invalid_members[0][1])
+    for i, message in invalid_members:
+        ensemble.member[i].elog.log_error(alg, message, ErrorSeverity.Invalid)
+        ensemble.member[i].kill()
     if not abort_on_error:
         nlive = number_live(ensemble)
         if nlive <= 0:
@@ -275,7 +292,7 @@ def sort_ensemble(ensemble, key, nullvalue=0.0, ascending=True, drop_dead=True):
     if not isinstance(ensemble, (TimeSeriesEnsemble, SeismogramEnsemble)):
         message = "arg0 must be a TimeSeriesEnsemble or SeismogramEnsemble object\n"
         message += "Actual type={}".format(type(ensemble))
-        raise MsPASSError(alg, message, ErrorSeverity.Fatal)
+        raise MsPASSError(alg + ": " + message, ErrorSeverity.Fatal)
     vallist = list()
     indexlist = list()
     for i in range(len(ensemble.member)):

--- a/python/tests/util/test_regularize_sampling_contracts.py
+++ b/python/tests/util/test_regularize_sampling_contracts.py
@@ -1,0 +1,227 @@
+import ast
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+from mspasspy.util.seismic import regularize_sampling, sort_ensemble
+
+
+def _ensemble(intervals, live=True):
+    ensemble = TimeSeriesEnsemble()
+    for index, interval in enumerate(intervals):
+        member = TimeSeries(3)
+        member.dt = interval
+        member["marker"] = index
+        member.set_live()
+        ensemble.member.append(member)
+    if live:
+        ensemble.set_live()
+    else:
+        ensemble.kill()
+    return ensemble
+
+
+def _snapshot(ensemble):
+    return (
+        ensemble.live,
+        ensemble.elog.size(),
+        tuple(
+            (
+                member.live,
+                member.dt,
+                dict(member),
+                member.elog.size(),
+                np.asarray(member.data).copy(),
+            )
+            for member in ensemble.member
+        ),
+    )
+
+
+@pytest.mark.parametrize("nsamp", [0, 1, 1.5, True, "2"])
+@pytest.mark.parametrize("abort", [False, True])
+def test_invalid_nsamp_is_rejected_before_scanning_or_mutation(nsamp, abort):
+    ensemble = _ensemble([0.1, math.nan])
+    before = _snapshot(ensemble)
+
+    with pytest.raises(ValueError, match="Nsamp must be an integer >= 2"):
+        regularize_sampling(ensemble, 0.1, Nsamp=nsamp, abort_on_error=abort)
+
+    _assert_snapshot_equal(_snapshot(ensemble), before)
+
+
+@pytest.mark.parametrize(
+    "expected", [0.0, -0.1, math.nan, math.inf, -math.inf, True, "0.1"]
+)
+@pytest.mark.parametrize("abort", [False, True])
+def test_invalid_expected_interval_is_rejected_before_scanning_or_mutation(
+    expected, abort
+):
+    ensemble = _ensemble([0.1, 0.2])
+    before = _snapshot(ensemble)
+
+    with pytest.raises(ValueError, match="finite positive real"):
+        regularize_sampling(ensemble, expected, Nsamp=2, abort_on_error=abort)
+
+    _assert_snapshot_equal(_snapshot(ensemble), before)
+
+
+def _assert_snapshot_equal(actual, expected):
+    assert actual[0:2] == expected[0:2]
+    assert len(actual[2]) == len(expected[2])
+    for actual_member, expected_member in zip(actual[2], expected[2]):
+        assert actual_member[0] == expected_member[0]
+        if math.isnan(expected_member[1]):
+            assert math.isnan(actual_member[1])
+        else:
+            assert actual_member[1] == expected_member[1]
+        assert actual_member[2].keys() == expected_member[2].keys()
+        for key, expected_value in expected_member[2].items():
+            actual_value = actual_member[2][key]
+            if isinstance(expected_value, float) and math.isnan(expected_value):
+                assert math.isnan(actual_value)
+            else:
+                assert actual_value == expected_value
+        assert actual_member[3] == expected_member[3]
+        assert np.array_equal(actual_member[4], expected_member[4])
+
+
+@pytest.mark.parametrize("abort", [False, True])
+def test_cutoff_is_inclusive_and_next_representable_value_is_invalid(abort):
+    expected = 0.125
+    nsamp = 2
+    cutoff = expected / (2 * (nsamp - 1))
+    at_cutoff = expected + cutoff
+    beyond = np.nextafter(at_cutoff, math.inf)
+    ensemble = _ensemble([at_cutoff, beyond])
+
+    if abort:
+        before = _snapshot(ensemble)
+        with pytest.raises(ValueError, match="Member 1"):
+            regularize_sampling(ensemble, expected, Nsamp=nsamp, abort_on_error=True)
+        _assert_snapshot_equal(_snapshot(ensemble), before)
+        return
+
+    result = regularize_sampling(ensemble, expected, Nsamp=nsamp, abort_on_error=False)
+
+    assert result is ensemble
+    assert result.member[0].live
+    assert result.member[0].elog.size() == 0
+    assert result.member[1].dead()
+    assert result.member[1].elog.size() == 1
+    assert result.member[1].elog.get_error_log()[0].badness == ErrorSeverity.Invalid
+
+
+@pytest.mark.parametrize("bad_interval", [0.0, -0.1, math.nan, math.inf, -math.inf])
+def test_invalid_member_intervals_are_atomic_or_killed_once(bad_interval):
+    abort_ensemble = _ensemble([0.1, bad_interval])
+    before = _snapshot(abort_ensemble)
+
+    with pytest.raises(ValueError, match="Member 1"):
+        regularize_sampling(abort_ensemble, 0.1, Nsamp=10, abort_on_error=True)
+
+    _assert_snapshot_equal(_snapshot(abort_ensemble), before)
+
+    nonabort_ensemble = _ensemble([0.1, bad_interval])
+    result = regularize_sampling(nonabort_ensemble, 0.1, Nsamp=10, abort_on_error=False)
+
+    assert result is nonabort_ensemble
+    assert [member.live for member in result.member] == [True, False]
+    assert [member.elog.size() for member in result.member] == [0, 1]
+    assert result.member[1].elog.get_error_log()[0].badness == ErrorSeverity.Invalid
+
+
+def test_nonabort_kills_each_invalid_live_member_once_and_preserves_others():
+    ensemble = _ensemble([0.2, 0.1, 0.3, 0.1])
+    ensemble.member[3].kill()
+    valid_before = (
+        ensemble.member[1].live,
+        ensemble.member[1].dt,
+        dict(ensemble.member[1]),
+        ensemble.member[1].elog.size(),
+        np.asarray(ensemble.member[1].data).copy(),
+    )
+    dead_before = (
+        ensemble.member[3].live,
+        ensemble.member[3].dt,
+        dict(ensemble.member[3]),
+        ensemble.member[3].elog.size(),
+        np.asarray(ensemble.member[3].data).copy(),
+    )
+
+    result = regularize_sampling(ensemble, 0.1, Nsamp=10, abort_on_error=False)
+
+    assert result is ensemble
+    assert result.live
+    assert [member.live for member in result.member] == [False, True, False, False]
+    assert [member.elog.size() for member in result.member] == [1, 0, 1, 0]
+    valid_after = (
+        result.member[1].live,
+        result.member[1].dt,
+        dict(result.member[1]),
+        result.member[1].elog.size(),
+        np.asarray(result.member[1].data).copy(),
+    )
+    dead_after = (
+        result.member[3].live,
+        result.member[3].dt,
+        dict(result.member[3]),
+        result.member[3].elog.size(),
+        np.asarray(result.member[3].data).copy(),
+    )
+    assert valid_after[0:4] == valid_before[0:4]
+    assert np.array_equal(valid_after[4], valid_before[4])
+    assert dead_after[0:4] == dead_before[0:4]
+    assert np.array_equal(dead_after[4], dead_before[4])
+
+
+def test_nonabort_kills_ensemble_and_logs_once_when_no_live_member_remains():
+    ensemble = _ensemble([0.2, math.inf])
+
+    result = regularize_sampling(ensemble, 0.1, Nsamp=10, abort_on_error=False)
+
+    assert result is ensemble
+    assert result.dead()
+    assert [member.elog.size() for member in result.member] == [1, 1]
+    assert result.elog.size() == 1
+    error = result.elog.get_error_log()[0]
+    assert error.badness == ErrorSeverity.Invalid
+    assert error.algorithm == "regularize_sampling"
+
+
+def test_dead_ensemble_is_returned_unchanged_after_validating_callers():
+    ensemble = _ensemble([math.nan], live=False)
+    before = _snapshot(ensemble)
+
+    result = regularize_sampling(ensemble, 0.1, Nsamp=2)
+
+    assert result is ensemble
+    _assert_snapshot_equal(_snapshot(ensemble), before)
+
+
+def test_sort_ensemble_type_error_contains_algorithm_type_and_severity():
+    with pytest.raises(MsPASSError) as captured:
+        sort_ensemble(TimeSeries(), "sta")
+
+    assert "sort_ensemble:" in captured.value.message
+    assert "TimeSeries" in captured.value.message
+    assert captured.value.severity == ErrorSeverity.Fatal
+
+
+def test_every_mspass_error_in_seismic_uses_two_arguments():
+    source_path = Path(__file__).resolve().parents[2] / "mspasspy/util/seismic.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "MsPASSError"
+    ]
+
+    assert calls
+    assert all(len(call.args) == 2 and not call.keywords for call in calls)

--- a/python/tests/util/test_seismic.py
+++ b/python/tests/util/test_seismic.py
@@ -8,7 +8,7 @@ from mspasspy.util.seismic import (
     sort_ensemble,
 )
 from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble, Seismogram
-from mspasspy.ccore.utility import MsPASSError
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
 import numpy as np
 
 
@@ -76,7 +76,9 @@ def test_has_live_data():
 def test_sort_ensemble_rejects_non_ensemble():
     with pytest.raises(MsPASSError) as err:
         sort_ensemble(TimeSeries(), "sta")
-    assert "arg0 must be a TimeSeriesEnsemble" in err.value.args[1]
+    assert "sort_ensemble: arg0 must be a TimeSeriesEnsemble" in err.value.message
+    assert "TimeSeries" in err.value.message
+    assert err.value.severity == ErrorSeverity.Fatal
 
 
 def test_sort_ensemble_returns_timeseries_ensemble():


### PR DESCRIPTION
Fixes #870.

## Summary
- validate `Nsamp` and the expected sample interval before scanning or mutating an ensemble
- use the documented half-sample cutoff and pre-scan every live member so abort mode is atomic
- in non-abort mode, kill and log each invalid member exactly once and mark an all-invalid ensemble dead
- normalize the adjacent `sort_ensemble` fatal exception contract

## Verification
- new and existing seismic utility tests: 43 passed
- exact baseline contract run: 26 failed, 10 passed
- independent agent review: PASS, zero blockers
- Black, `py_compile`, and `git diff --check`: passed

This PR is ready for human review. It must not be merged automatically.