### PR TITLE
Preserve callable and iterable semantics in metadata edit chains

### DIFF
--- a/docs/source/user_manual/data_editing.rst
+++ b/docs/source/user_manual/data_editing.rst
@@ -310,12 +310,11 @@ the constructor is different and has this signature:
 
 where ``executioner_list`` is expected to be any iterable container made up
 only of Python objects that are instances of Executioner subclasses. (All the
-classes covered in this document are subclasses of Executioner.)  Use a
-reusable iterable such as a list or tuple rather than a one-shot generator,
-because the constructor iterates over it once for validation and again to
-copy it.  ``FiringSquad`` itself has no verbose constructor option.  Any
-testers needing verbose output must have that option enabled during their
-construction.
+classes covered in this document are subclasses of Executioner.)  The input is
+materialized once, so reusable containers and one-shot generators preserve the
+same execution order.  ``FiringSquad`` itself has no verbose constructor
+option.  Any testers needing verbose output must have that option enabled
+during their construction.
 
 When the ``kill_if_true`` method is called for this class the list of
 executioners are called in order defined by the list.  The victim cannot

--- a/python/mspasspy/algorithms/edit.py
+++ b/python/mspasspy/algorithms/edit.py
@@ -56,7 +56,7 @@ class Executioner(ABC):
     class as it has no functionality by itself.
     """
 
-    def __call__(self, d):
+    def __call__(self, d, *args, **kwargs):
         """
         This method can make the object callable and easier to use.
         After an instance is iniated, instead of explicitly calling
@@ -66,7 +66,7 @@ class Executioner(ABC):
         We can just call this:
         int_tester(enscpy, apply_to_members=True)
         """
-        self.kill_if_true(d)
+        return self.kill_if_true(d, *args, **kwargs)
 
     @abstractmethod
     def kill_if_true(self, d):
@@ -829,23 +829,19 @@ class FiringSquad(Executioner):
         are copied to a python list container so this the contents of
         executioner_list are treated as immutable.
 
-        The constructor will throw a MsPASSError exception if any of the
-        contents of executioner_list is not a child of the
-        Executioner class.
+        The constructor will throw a TypeError exception if executioner_list
+        is not iterable or if any of its contents is not an Executioner with
+        a callable kill_if_true method.
         """
-        for ex in executioner_list:
-            if not isinstance(ex, Executioner):
-                raise MsPASSError(
-                    "FiringSquad constructor:  invalid input.  Expected array of Executioners",
-                    ErrorSeverity.Fatal,
-                )
-
-        # to allow flexibility of the structure used for input we should
-        # copy the executioner_list.  Further, this assure the
-        # result will iterate correctly and allow for append
-        self.executioners = list()
-        for ex in executioner_list:
-            self.executioners.append(ex)
+        executioners = list(executioner_list)
+        if any(
+            not isinstance(ex, Executioner) or not callable(ex.kill_if_true)
+            for ex in executioners
+        ):
+            raise TypeError(
+                "FiringSquad constructor: expected an iterable of Executioners"
+            )
+        self.executioners = executioners
 
     @mspass_method_wrapper
     def kill_if_true(
@@ -2579,23 +2575,19 @@ class MetadataOperatorChain(MetadataOperator):
         operator_list sent to the constructor are treated not unintentionally
         modified.
 
-        The constructor will throw a MsPASSError exception if any of the
-        contents of operator_list is not a child of the
-        MetadataOperator base class.
+        The constructor will throw a TypeError exception if operator_list is
+        not iterable or if any of its contents is not a MetadataOperator with
+        a callable apply method.
         """
-        for ex in operator_list:
-            if not isinstance(ex, MetadataOperator):
-                raise MsPASSError(
-                    "MetadataOperatorChain constructor:  invalid input.  Expected iterable container of MetadataOperator objects",
-                    ErrorSeverity.Fatal,
-                )
-
-        # to allow flexibility of the structure used for input we should
-        # copy the operator_list.  Further, this assure the
-        # result will iterate correctly and allow for append
-        self.oplist = list()
-        for ex in operator_list:
-            self.oplist.append(ex)
+        operators = list(operator_list)
+        if any(
+            not isinstance(op, MetadataOperator) or not callable(op.apply)
+            for op in operators
+        ):
+            raise TypeError(
+                "MetadataOperatorChain constructor: expected an iterable of MetadataOperators"
+            )
+        self.oplist = operators
 
     @mspass_method_wrapper
     def apply(

--- a/python/tests/algorithms/test_edit_chain_contracts.py
+++ b/python/tests/algorithms/test_edit_chain_contracts.py
@@ -1,0 +1,308 @@
+import pytest
+
+from mspasspy.algorithms.edit import (
+    Executioner,
+    FiringSquad,
+    MetadataOperator,
+    MetadataOperatorChain,
+)
+from mspasspy.ccore.seismic import TimeSeries
+
+
+class RecordingExecutioner(Executioner):
+    def __init__(self, label, calls, result=None, arguments=None):
+        self.label = label
+        self.calls = calls
+        self.result = result
+        self.arguments = arguments
+
+    def kill_if_true(self, datum, *args, **kwargs):
+        self.calls.append(self.label)
+        if self.arguments is not None:
+            self.arguments.append((args, kwargs))
+        if self.result is not None:
+            return self.result
+        return datum
+
+
+class RecordingMetadataOperator(MetadataOperator):
+    def __init__(self, label, calls):
+        self.label = label
+        self.calls = calls
+
+    def apply(self, datum, *args, **kwargs):
+        self.calls.append(self.label)
+        return datum
+
+    def check_keys(self, datum):
+        return True
+
+    def check_operation(self, datum):
+        return True
+
+
+def live_timeseries():
+    datum = TimeSeries(1)
+    datum.set_live()
+    return datum
+
+
+def test_executioner_callable_returns_the_named_operation_result():
+    calls = []
+    result = object()
+    executioner = RecordingExecutioner("return", calls, result=result)
+    datum = live_timeseries()
+
+    assert executioner.kill_if_true(datum) is result
+    assert executioner(datum) is result
+    assert calls == ["return", "return"]
+
+
+def test_executioner_callable_forwards_arguments():
+    calls = []
+    arguments = []
+    result = object()
+    executioner = RecordingExecutioner("forward", calls, result, arguments)
+    datum = live_timeseries()
+
+    assert executioner(datum, "extra", apply_to_members=True) is result
+    assert calls == ["forward"]
+    assert arguments == [(("extra",), {"apply_to_members": True})]
+
+
+@pytest.mark.parametrize("container_type", [list, tuple])
+def test_firing_squad_list_and_tuple_execute_once_in_order(container_type):
+    calls = []
+    executioners = [
+        RecordingExecutioner("first", calls),
+        RecordingExecutioner("second", calls),
+    ]
+    squad = FiringSquad(container_type(executioners))
+    datum = live_timeseries()
+
+    assert squad.kill_if_true(datum) is datum
+    assert calls == ["first", "second"]
+
+
+def test_firing_squad_materializes_a_one_shot_generator_once():
+    calls = []
+    yielded = []
+    executioners = [
+        RecordingExecutioner("first", calls),
+        RecordingExecutioner("second", calls),
+    ]
+
+    def one_shot_generator():
+        for executioner in executioners:
+            yielded.append(executioner.label)
+            yield executioner
+
+    squad = FiringSquad(one_shot_generator())
+    datum = live_timeseries()
+
+    assert yielded == ["first", "second"]
+    assert squad.kill_if_true(datum) is datum
+    assert calls == ["first", "second"]
+
+
+def test_firing_squad_empty_iterable_is_identity():
+    squad = FiringSquad(iter(()))
+    datum = live_timeseries()
+
+    assert squad.kill_if_true(datum) is datum
+
+
+@pytest.mark.parametrize("container_type", [list, tuple])
+def test_metadata_operator_chain_list_and_tuple_execute_once_in_order(
+    container_type,
+):
+    calls = []
+    operators = [
+        RecordingMetadataOperator("first", calls),
+        RecordingMetadataOperator("second", calls),
+    ]
+    chain = MetadataOperatorChain(container_type(operators))
+    datum = live_timeseries()
+
+    assert chain.apply(datum) is datum
+    assert calls == ["first", "second"]
+
+
+def test_metadata_operator_chain_materializes_a_one_shot_generator_once():
+    calls = []
+    yielded = []
+    operators = [
+        RecordingMetadataOperator("first", calls),
+        RecordingMetadataOperator("second", calls),
+    ]
+
+    def one_shot_generator():
+        for operator in operators:
+            yielded.append(operator.label)
+            yield operator
+
+    chain = MetadataOperatorChain(one_shot_generator())
+    datum = live_timeseries()
+
+    assert yielded == ["first", "second"]
+    assert chain.apply(datum) is datum
+    assert calls == ["first", "second"]
+
+
+def test_metadata_operator_chain_empty_iterable_is_identity():
+    chain = MetadataOperatorChain(iter(()))
+    datum = live_timeseries()
+
+    assert chain.apply(datum) is datum
+
+
+@pytest.mark.parametrize(
+    "chain_class,method_name,items",
+    [
+        (
+            FiringSquad,
+            "kill_if_true",
+            lambda calls: [
+                RecordingExecutioner("first", calls),
+                RecordingExecutioner("second", calls),
+            ],
+        ),
+        (
+            MetadataOperatorChain,
+            "apply",
+            lambda calls: [
+                RecordingMetadataOperator("first", calls),
+                RecordingMetadataOperator("second", calls),
+            ],
+        ),
+    ],
+)
+def test_nonempty_chain_returns_dead_input_without_running_items(
+    chain_class, method_name, items
+):
+    calls = []
+    chain = chain_class(items(calls))
+    datum = live_timeseries()
+    datum.kill()
+
+    result = getattr(chain, method_name)(datum)
+
+    assert result is datum
+    assert datum.dead()
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "chain_class, attribute_name",
+    [
+        (FiringSquad, "executioners"),
+        (MetadataOperatorChain, "oplist"),
+    ],
+)
+def test_chain_constructor_rejects_noniterable_without_partial_state(
+    chain_class, attribute_name
+):
+    candidate = chain_class.__new__(chain_class)
+
+    with pytest.raises(TypeError):
+        chain_class.__init__(candidate, 42)
+
+    assert not hasattr(candidate, attribute_name)
+
+
+@pytest.mark.parametrize(
+    "chain_class, attribute_name, valid_item",
+    [
+        (
+            FiringSquad,
+            "executioners",
+            lambda calls: RecordingExecutioner("valid", calls),
+        ),
+        (
+            MetadataOperatorChain,
+            "oplist",
+            lambda calls: RecordingMetadataOperator("valid", calls),
+        ),
+    ],
+)
+def test_chain_constructor_rejects_invalid_second_item_before_storing_or_running(
+    chain_class, attribute_name, valid_item
+):
+    calls = []
+    candidate = chain_class.__new__(chain_class)
+
+    with pytest.raises(TypeError):
+        chain_class.__init__(candidate, [valid_item(calls), object()])
+
+    assert not hasattr(candidate, attribute_name)
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "chain_class,attribute_name,valid_item",
+    [
+        (
+            FiringSquad,
+            "executioners",
+            lambda label, calls: RecordingExecutioner(label, calls),
+        ),
+        (
+            MetadataOperatorChain,
+            "oplist",
+            lambda label, calls: RecordingMetadataOperator(label, calls),
+        ),
+    ],
+)
+def test_invalid_second_item_is_rejected_after_materializing_entire_generator(
+    chain_class, attribute_name, valid_item
+):
+    calls = []
+    yielded = []
+
+    def input_items():
+        yielded.append("first")
+        yield valid_item("first", calls)
+        yielded.append("invalid")
+        yield object()
+        yielded.append("tail")
+        yield valid_item("tail", calls)
+
+    candidate = chain_class.__new__(chain_class)
+    with pytest.raises(TypeError):
+        chain_class.__init__(candidate, input_items())
+
+    assert yielded == ["first", "invalid", "tail"]
+    assert not hasattr(candidate, attribute_name)
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "chain_class, attribute_name, method_name, valid_item",
+    [
+        (
+            FiringSquad,
+            "executioners",
+            "kill_if_true",
+            lambda calls: RecordingExecutioner("valid", calls),
+        ),
+        (
+            MetadataOperatorChain,
+            "oplist",
+            "apply",
+            lambda calls: RecordingMetadataOperator("valid", calls),
+        ),
+    ],
+)
+def test_chain_constructor_rejects_noncallable_operation_without_partial_state(
+    chain_class, attribute_name, method_name, valid_item
+):
+    calls = []
+    invalid_item = valid_item(calls)
+    setattr(invalid_item, method_name, None)
+    candidate = chain_class.__new__(chain_class)
+
+    with pytest.raises(TypeError):
+        chain_class.__init__(candidate, [invalid_item])
+
+    assert not hasattr(candidate, attribute_name)
+    assert calls == []


### PR DESCRIPTION
Fixes #873.

## Summary
- return the wrapped execution result from `Executioner.__call__`
- materialize edit-chain iterables exactly once before validating them
- reject invalid/non-callable chain members atomically with `TypeError`
- preserve empty-chain identity and operation ordering

## Verification
- focused and existing related tests: 20 passed
- baseline red: 9 failed, 10 passed
- Black, `py_compile`, and `git diff --check` passed
- independent agent review: PASS with no blockers

This PR is ready for human review. Do not merge automatically.