### PR TITLE
Raise a complete fatal error for invalid datascope cross-references

### DIFF
--- a/python/mspasspy/preprocessing/css30/datascope.py
+++ b/python/mspasspy/preprocessing/css30/datascope.py
@@ -285,7 +285,7 @@ class DatascopeDatabase:
                 "AntelopeDatabase.join:  Illegal type="
                 + str(type(join_keys))
                 + " for join_key arg.\nMust be string, list, or dict",
-                "Fatal",
+                ErrorSeverity.Fatal,
             )
         # merge allows variations for left, right, inner, outter, and cross
         # for the how clause.  Default users the merge default of 'inner'
@@ -520,7 +520,7 @@ class DatascopeDatabase:
                 raise MsPASSError(
                     "parse_attribute_name_tbl:  unsupported data type file="
                     + typenamein,
-                    "Fatal",
+                    ErrorSeverity.Fatal,
                 )
             dtypes[name] = typ
             # this works becasue typ is now a python "type" class which
@@ -674,7 +674,6 @@ class DatascopeDatabase:
             do not define miniseed and (2) tuples failing the existence
             check (if enabled)
         """
-        alg = "DatascopeDatabase.wfdisc2doclist"
         if verbose:
             base_warning = "DatascopeDatabase.wfdisc2doclist (WARNING):  "
         if snetsta_xref is None:
@@ -686,13 +685,11 @@ class DatascopeDatabase:
                 nets[k] = snetsta_xref[k][0]
                 seedsta[k] = snetsta_xref[k][1]
         else:
-            message = "snetsta_xref parameter is invalid type={}\n".format(
-                type(snetsta_xref)
+            message = (
+                "DatascopeDatabase.wfdisc2doclist: snetsta_xref has invalid "
+                "type={}.  It must be a dict or None.".format(type(snetsta_xref))
             )
-            message += (
-                "Expected to be a python dictionary created by parse_snetsta method"
-            )
-            raise MsPASSError(alg, message, ErrorSeverity.Fatal)
+            raise MsPASSError(message, ErrorSeverity.Fatal)
         nets["default"] = default_net
 
         df = self.get_table("wfdisc")

--- a/python/tests/preprocessing/test_datascope_xref_contract.py
+++ b/python/tests/preprocessing/test_datascope_xref_contract.py
@@ -1,0 +1,78 @@
+import ast
+from pathlib import Path
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+from mspasspy.preprocessing.css30.datascope import DatascopeDatabase
+
+
+def _database(snetsta=None):
+    database = object.__new__(DatascopeDatabase)
+    database.parse_snetsta = Mock(return_value={} if snetsta is None else snetsta)
+    database.get_table = Mock(return_value=pd.DataFrame())
+    database.get_nulls = Mock(return_value={})
+    return database
+
+
+@pytest.mark.parametrize("xref", [{}, {"X_STA": ("X", "STA")}])
+def test_wfdisc2doclist_accepts_dict_without_row_processing(xref):
+    database = _database()
+
+    result = database.wfdisc2doclist(snetsta_xref=xref, verbose=False)
+
+    assert result == []
+    database.parse_snetsta.assert_not_called()
+    database.get_table.assert_called_once_with("wfdisc")
+
+
+def test_wfdisc2doclist_accepts_none_and_parses_xref_once():
+    database = _database({"X_STA": ("X", "STA")})
+
+    result = database.wfdisc2doclist(snetsta_xref=None, verbose=False)
+
+    assert result == []
+    database.parse_snetsta.assert_called_once_with()
+    database.get_table.assert_called_once_with("wfdisc")
+
+
+@pytest.mark.parametrize("xref", [[], (), "bad", 3])
+def test_wfdisc2doclist_rejects_invalid_xref_before_rows(xref):
+    database = _database()
+
+    with pytest.raises(MsPASSError) as captured:
+        database.wfdisc2doclist(snetsta_xref=xref, verbose=False)
+
+    error = captured.value
+    expected_message = (
+        "DatascopeDatabase.wfdisc2doclist: snetsta_xref has invalid "
+        f"type={type(xref)}.  It must be a dict or None."
+    )
+    assert error.severity == ErrorSeverity.Fatal
+    assert error.message == expected_message
+    database.parse_snetsta.assert_not_called()
+    database.get_table.assert_not_called()
+    database.get_nulls.assert_not_called()
+
+
+def test_datascope_mspass_errors_use_message_and_error_severity():
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "mspasspy/preprocessing/css30/datascope.py"
+    )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "MsPASSError"
+    ]
+
+    assert calls
+    for call in calls:
+        assert len(call.args) == 2
+        assert not call.keywords
+        assert ast.unparse(call.args[1]).startswith("ErrorSeverity.")


### PR DESCRIPTION
Fixes #879.

## Summary
- reject invalid `snetsta_xref` values before table access or row processing
- report one complete `MsPASSError` message with `ErrorSeverity.Fatal`
- normalize the remaining Datascope `MsPASSError` call sites to the two-argument contract
- preserve valid `None` and dictionary paths

## Verification
- Python 3.13 contract tests: 8 passed
- Python 3.9 contract and Datascope regressions: 10 passed
- baseline red: 4 failed, 4 passed
- Black, Python 3.9/3.13 `py_compile`, and `git diff --check` passed
- independent agent review: PASS with no blockers

This PR is ready for human review. Do not merge automatically.