### PR TITLE
Fix df2table empty-column and index-alignment edge cases

### DIFF
--- a/python/mspasspy/preprocessing/css30/datascope.py
+++ b/python/mspasspy/preprocessing/css30/datascope.py
@@ -310,11 +310,10 @@ class DatascopeDatabase:
         `df` to Datascope table inferred from the `table` argument.
         That is, the method attempts to write the contents of df to
         a file "db.table" with an optional diretory (dir argument).
-        It will immediately throw an exception if any of the df column
-        keys do not match an attribute name for the schema defined for
-        the specified table.  Missing keys will be written as the
-        null value defined for the schema using the pf file loaded
-        with the class constructor.
+        Input columns that are not defined by the target schema are dropped
+        after printing a warning.  Missing keys are written as the null value
+        defined for the schema using the pf file loaded with the class
+        constructor.
 
         Default behavior is to write to the Datascope handle defined as
         the "self" by the class constructor.   An alternative instance
@@ -324,8 +323,9 @@ class DatascopeDatabase:
         clear any previous content.
 
         :param df: pandas DataFrame containing data to be written.  Note the
-            column names must match css3.0 schema mames or an exception will
-            be thrown.
+            target-schema columns are written in schema order.  Extra columns
+            are dropped after printing a warning, and missing columns are
+            filled with the schema null value.
         :type df:  pandas DataFrame
         :param db:  output handle.   Default is None which is taken to mean
             use this instance.
@@ -399,6 +399,9 @@ class DatascopeDatabase:
             need_to_rearrange = True
 
         if need_to_rearrange:
+            # Initialize the copy before the loop so a DataFrame with no
+            # columns still has a valid output object.
+            dfout = pd.DataFrame(df)
             # note we can use the keys list as is for input to dataframe's
             # reindex method.  However, to do that we have to add nulls
             # for any dfkeys that don't have values for an attribute defines
@@ -438,8 +441,12 @@ class DatascopeDatabase:
                 for k in null_columns:
                     nullvalue = nulls[k]
                     # a bit obscure python syntax to full array with null values and
-                    # insert in one line
-                    dfout[k] = pd.Series([nullvalue for x in range(len(dfout.index))])
+                    # insert in one line.  Use the DataFrame index to avoid
+                    # pandas aligning a default RangeIndex to unrelated labels.
+                    dfout[k] = pd.Series(
+                        [nullvalue for x in range(len(dfout.index))],
+                        index=dfout.index,
+                    )
 
             # Now we rearrange - simple with reindex method of pandas
             dfout = dfout.reindex(columns=keys)

--- a/python/tests/preprocessing/test_datascope_df2table_contract.py
+++ b/python/tests/preprocessing/test_datascope_df2table_contract.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from mspasspy.preprocessing.css30.datascope import DatascopeDatabase
+
+KEYS = ["ival", "fval", "sval"]
+NULLS = {"ival": -1, "fval": -99.0, "sval": "-"}
+FORMATS = [["ival", "%d"], ["fval", "%.1f"], ["sval", "%s"]]
+
+
+def _database():
+    database = object.__new__(DatascopeDatabase)
+    database.dbname = "output"
+    database._get_line_format_pf = lambda table: FORMATS
+    database._parse_attribute_name_tbl = lambda table: ({}, {}, NULLS, {})
+    return database
+
+
+def _target(tmp_path):
+    return Path(tmp_path) / "output.test"
+
+
+@pytest.mark.parametrize("row_count", [0, 1, 3])
+def test_zero_column_dataframe_uses_schema_nulls(tmp_path, row_count):
+    database = _database()
+    frame = pd.DataFrame(index=[11, 17, 23][:row_count])
+    original = frame.copy(deep=True)
+
+    result = database.df2table(frame, table="test", dir=str(tmp_path), append=False)
+
+    assert list(result.columns) == KEYS
+    assert list(result.index) == list(frame.index)
+    assert result["ival"].tolist() == [-1] * row_count
+    assert result["fval"].tolist() == [-99.0] * row_count
+    assert result["sval"].tolist() == ["-"] * row_count
+    pd.testing.assert_frame_equal(frame, original)
+    expected = "" if row_count == 0 else "-1 -99.0 -\n" * row_count
+    assert _target(tmp_path).read_text(encoding="utf-8") == expected
+
+
+def test_missing_columns_align_to_the_caller_index(tmp_path):
+    database = _database()
+    frame = pd.DataFrame(
+        {"fval": [1.5, 2.5], "sval": ["a", "b"]},
+        index=[4, 7],
+    )
+    original = frame.copy(deep=True)
+
+    result = database.df2table(frame, table="test", dir=str(tmp_path), append=False)
+
+    assert list(result.columns) == KEYS
+    assert list(result.index) == [4, 7]
+    assert result["ival"].tolist() == [-1, -1]
+    assert result["fval"].tolist() == [1.5, 2.5]
+    assert result["sval"].tolist() == ["a", "b"]
+    pd.testing.assert_frame_equal(frame, original)
+    assert _target(tmp_path).read_text(encoding="utf-8") == "-1 1.5 a\n-1 2.5 b\n"
+
+
+def test_zero_rows_preserve_append_and_overwrite_behavior(tmp_path):
+    database = _database()
+    target = _target(tmp_path)
+    target.write_bytes(b"existing\n")
+    empty = pd.DataFrame(columns=["sval", "ival"])
+
+    appended = database.df2table(empty, table="test", dir=str(tmp_path), append=True)
+
+    assert list(appended.columns) == KEYS
+    assert appended.empty
+    assert target.read_bytes() == b"existing\n"
+
+    overwritten = database.df2table(
+        empty, table="test", dir=str(tmp_path), append=False
+    )
+
+    assert list(overwritten.columns) == KEYS
+    assert overwritten.empty
+    assert target.read_bytes() == b""
+
+
+def test_matching_schema_preserves_the_existing_fast_path(tmp_path):
+    database = _database()
+    frame = pd.DataFrame({"ival": [1], "fval": [2.5], "sval": ["a"]})
+    original_dtypes = frame.dtypes.copy()
+
+    result = database.df2table(frame, table="test", dir=str(tmp_path), append=False)
+
+    assert result is frame
+    pd.testing.assert_series_equal(result.dtypes, original_dtypes)
+    assert _target(tmp_path).read_text(encoding="utf-8") == "1 2.5 a\n"
+
+
+def test_extra_columns_keep_the_existing_print_and_drop_behavior(tmp_path, capsys):
+    database = _database()
+    frame = pd.DataFrame({"ival": [1], "fval": [2.5], "sval": ["a"], "extra": [9]})
+
+    result = database.df2table(frame, table="test", dir=str(tmp_path), append=False)
+
+    output = capsys.readouterr().out
+    assert "extra" in output
+    assert list(result.columns) == KEYS
+    assert _target(tmp_path).read_text(encoding="utf-8") == "1 2.5 a\n"


### PR DESCRIPTION
Fixes #881.

## Summary
- initialize the existing rearrangement branch before its column loop so zero-column DataFrames are valid
- align newly added schema-null columns to the caller's existing DataFrame index
- preserve the exact-schema fast path, return identity, dtype inference, printed extra-column warning, append/overwrite behavior, and existing file formatting
- correct the detailed docstring to describe the behavior the method already implements

## Scope correction
The previous version replaced the established control flow, always copied/reindexed the DataFrame, forced missing columns to `dtype=object`, and changed printed diagnostics to `UserWarning`.  Those unrelated behavior changes have been removed.

## Verification
- focused compatibility regressions: 7 passed
- existing Datascope tests: 2 passed
- baseline proof: the four zero-column/index-alignment regressions fail on the pre-fix implementation
- Black, `py_compile`, and `git diff --check` passed

This PR remains draft while refreshed GitHub checks run.
