### PR TITLE
Restore BasicGather construction and metadata invariants

### DIFF
--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -1,4 +1,7 @@
 from abc import ABC, abstractmethod
+from copy import deepcopy
+import math
+
 import xarray as xr
 import dask.array as da
 import dask
@@ -207,14 +210,14 @@ class BasicGather(ABC):
             self.npts,
             self.array_type,
             self.num_components,
-            self.ensemble_metadata,
+            self._ensemble_metadata,
             self.member_metadata,
             self.is_parallel,
             self.is_compact,
             self.npartitions,
             self.elog,
             self.member_data,
-            self.column_values,
+            self._column_values,
         )
 
     def __default_constructor__(
@@ -274,13 +277,13 @@ class BasicGather(ABC):
         self.size = 0
         self.array_type = array_type
         self.num_components = num_components
-        self.ensemble_metadata = None
+        self._ensemble_metadata = None
         self.member_metadata = None
         self.member_data = None
         self.is_compact = is_compact
         self.npartitions = npartitions
         self.elog = ErrorLogger()
-        self.column_values = None
+        self._column_values = None
 
         supported_array_types = [
             "numpy",
@@ -355,12 +358,13 @@ class BasicGather(ABC):
         self.size = 0
         self.array_type = array_type
         self.num_components = 0
-        self.ensemble_metadata = None
+        self._ensemble_metadata = None
         self.member_metadata = None
         self.member_data = None
         self.is_compact = is_compact
         self.npartitions = npartitions
         self.elog = ErrorLogger()
+        self._column_values = None
 
         supported_types = (da.Array, np.ndarray)
         if not isinstance(input_data, supported_types):
@@ -505,7 +509,7 @@ class BasicGather(ABC):
             )
 
         # Add the ensemble's metadata
-        self.ensemble_metadata = dict(input_obj)
+        self._ensemble_metadata = deepcopy(dict(input_obj))
 
         # Extract Member Metadata from old ensemble
         # Add the members' metadata
@@ -584,6 +588,45 @@ class BasicGather(ABC):
 
         """
 
+        derived_dimensions = None
+        if input_obj is not None and len(input_obj.member) > 0:
+            derived_size = len(input_obj.member)
+            derived_dimensions = {
+                "capacity": derived_size,
+                "size": derived_size,
+                "npts": input_obj.member[0].npts,
+                "num_components": (
+                    1 if isinstance(input_obj, TimeSeriesEnsemble) else 3
+                ),
+            }
+        elif input_data is not None:
+            derived_dimensions = {
+                "capacity": input_data.shape[0],
+                "size": input_data.shape[0],
+                "npts": input_data.shape[2],
+                "num_components": input_data.shape[1],
+            }
+
+        if derived_dimensions is not None:
+            supplied_dimensions = {
+                "capacity": capacity,
+                "size": size,
+                "npts": npts,
+                "num_components": num_components,
+            }
+            for name, derived_value in derived_dimensions.items():
+                supplied_value = supplied_dimensions[name]
+                if supplied_value not in (None, 0) and supplied_value != derived_value:
+                    raise ValueError(
+                        "{}={} conflicts with the value {} derived from input data".format(
+                            name, supplied_value, derived_value
+                        )
+                    )
+            capacity = derived_dimensions["capacity"]
+            size = derived_dimensions["size"]
+            npts = derived_dimensions["npts"]
+            num_components = derived_dimensions["num_components"]
+
         self.capacity = capacity
         self.size = size
 
@@ -622,7 +665,10 @@ class BasicGather(ABC):
         self.npts = npts
         self.array_type = array_type
         self.num_components = num_components
-        self.ensemble_metadata = ensemble_metadata
+        if ensemble_metadata is not None:
+            if not isinstance(ensemble_metadata, (dict, Metadata)):
+                raise TypeError("ensemble metadata should be a dict-like object")
+            self._ensemble_metadata = deepcopy(dict(ensemble_metadata))
         if self.member_metadata is None:
             self.member_metadata = member_metadata
         self.is_parallel = is_parallel
@@ -632,12 +678,11 @@ class BasicGather(ABC):
 
         if dt is None:
             dt = self.member_metadata["delta"][0]
-        if self.ensemble_metadata is None:  # default setting for the metadata
-            self.ensemble_metadata = {
-                "is_live": False,
-                "is_utc": False,
-                "dt": dt,
-            }
+        if self._ensemble_metadata is None:
+            self._ensemble_metadata = {}
+        self._ensemble_metadata.setdefault("is_live", False)
+        self._ensemble_metadata.setdefault("is_utc", False)
+        self._ensemble_metadata.setdefault("dt", dt)
 
     def append(self, mspass_object):
         """
@@ -690,10 +735,10 @@ class BasicGather(ABC):
         should be allowed to be anything, however, to handle things
         like variable offset record sections.
         """
-        if self.column_values is None:
+        if self._column_values is None:
             return list(range(self.size))
         else:
-            return self.column_values
+            return self._column_values
 
     def set_column_values(self, x):
         """
@@ -703,13 +748,13 @@ class BasicGather(ABC):
         # Sanity check: the input be a list
         if type(x) != list:
             raise TypeError("The column values should be a list")
-        self.column_values = x
+        self._column_values = deepcopy(x)
 
     def dt(self):
         """
         Return the sample rate of the ensemble
         """
-        return self.ensemble_metadata["dt"]
+        return self._ensemble_metadata["dt"]
 
     # The following names match BasicTimeSeries because the match in
     # concept.  starttime above doesn't really because in a single object
@@ -736,15 +781,19 @@ class BasicGather(ABC):
         :param x: a list of column names
         :param time: the time (row) value
         """
-        indexes = [self.column_values.index(i) for i in x]
-        ans = [(time - self.starttime()[ind]) / self.dt() for ind in indexes]
-        return np.asarray(ans)
+        column_values = self.column_values()
+        indexes = [column_values.index(i) for i in x]
+        sample_numbers = []
+        for index in indexes:
+            q = (time - self.starttime()[index]) / self.dt()
+            sample_numbers.append(math.floor(q + 0.5) if q >= 0 else math.ceil(q - 0.5))
+        return np.asarray(sample_numbers, dtype=int)
 
     def time_is_UTC(self):
         """
         Returns True if the time standard for the data is set as UTC
         """
-        return self.ensemble_metadata["is_utc"]
+        return self._ensemble_metadata["is_utc"]
 
     def time_is_relative(self):
         """
@@ -791,7 +840,7 @@ class BasicGather(ABC):
         self.member_metadata["starttime"].applymap(lambda x: (x + self.t0shift))
 
         self.t0shift = 0
-        self.ensemble_metadata["is_utc"] = True
+        self._ensemble_metadata["is_utc"] = True
 
     def ator(self, shift):
         """
@@ -855,10 +904,10 @@ class BasicGather(ABC):
         """
         if not isinstance(md, (dict, Metadata)):
             raise TypeError("The metadata should be a dict-like object")
-        if isinstance(md, Metadata):
-            md = md.to_dict()
-        md_df = pd.DataFrame.from_dict(md)
-        self.member_metadata.loc[j] = md_df
+        for key, val in dict(md).items():
+            if key not in self.member_metadata.columns:
+                self.member_metadata[key] = None
+            self.member_metadata.at[j, key] = deepcopy(val)
 
     def edit_metadata(self, j, md):
         """
@@ -872,15 +921,13 @@ class BasicGather(ABC):
         """
         if not isinstance(md, (dict, Metadata)):
             raise TypeError("The metadata should be a dict-like object")
-        if isinstance(md, Metadata):
-            md = md.to_dict()
-        for key, val in md:
+        for key, val in dict(md).items():
             # We assume that user shouldn't add new metadata
             if key not in self.member_metadata.columns:
                 raise TypeError(
                     "key {} is not presented in the member metadata".format(key)
                 )
-            self.member_metadata[key][j] = val
+            self.member_metadata.at[j, key] = deepcopy(val)
 
     @abstractmethod
     def member(self, j):
@@ -915,9 +962,9 @@ class BasicGather(ABC):
                 )
             )
         if return_type == "dict":
-            return self.ensemble_metadata
+            return self._ensemble_metadata
         elif return_type == "metadata":
-            return Metadata(self.ensemble_metadata)
+            return Metadata(self._ensemble_metadata)
 
     def sync_metadata(self):
         """
@@ -925,8 +972,10 @@ class BasicGather(ABC):
         ensemble key-value pairs to the members.  It is debatable that
         this would be needed but would be trivial to implement.
         """
-        for key, val in self.ensemble_metadata:
-            self.member_metadata = self.member_metadata.assign(key=val)
+        for key, val in self._ensemble_metadata.items():
+            self.member_metadata[key] = [
+                deepcopy(val) for _ in range(len(self.member_metadata))
+            ]
 
     # not sure if we can make this member abstract.  It needs to
     # be in this design to allow different signatures for scalar and 3c data

--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -594,6 +594,8 @@ class BasicGather(ABC):
         # Apply those transformations before deriving or validating dimensions so
         # ``npts`` always describes the array that will actually be stored.
         if input_obj is not None:
+            if resample or regularize:
+                input_obj = deepcopy(input_obj)
             if resample:
                 input_obj = resample_ensemble(input_obj, dt)
             if regularize:

--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -557,7 +557,9 @@ class BasicGather(ABC):
 
         :param npts:  length in samples of all members.  This parameter
           is required and there is no default due to the expected use only
-          by subclasses
+          by subclasses.  When ``input_obj`` is supplied, the value is derived
+          after any requested resampling or regularization.  A supplied
+          nonzero value must match that post-transformation length.
         :type npts:  integer
 
         :param dt:  sample interval of all data in ensemble.  Default is
@@ -587,6 +589,17 @@ class BasicGather(ABC):
         :type regularizer: Callable[[TimeSeries|Seismogram], TimeSeries|Seismogram]
 
         """
+
+        # Resampling and regularization can change the number of samples.
+        # Apply those transformations before deriving or validating dimensions so
+        # ``npts`` always describes the array that will actually be stored.
+        if input_obj is not None:
+            if resample:
+                input_obj = resample_ensemble(input_obj, dt)
+            if regularize:
+                input_obj = regularize_ensemble(input_obj, regularizer)
+            resample = False
+            regularize = False
 
         derived_dimensions = None
         if input_obj is not None and len(input_obj.member) > 0:
@@ -895,8 +908,15 @@ class BasicGather(ABC):
 
     def set_metadata(self, j, md):
         """
-        Setter for metadata of member j.   md is the new continer that would
-        replace current conent.  Most useful for constructors.
+        Replace the metadata of member ``j`` with the content of ``md``.
+
+        Member metadata are stored in a rectangular DataFrame.  Consequently,
+        columns used by other members remain in the table, but keys omitted
+        from ``md`` become missing values in row ``j``.  Values are copied so
+        later edits to mutable objects held by the caller do not alter the
+        gather.  This full-row replacement is most useful for constructors;
+        use :meth:`edit_metadata` for a partial update.
+
         :param j: index of member
         :type j: int
         :param md: the metadata to set, dict or metadata
@@ -904,16 +924,28 @@ class BasicGather(ABC):
         """
         if not isinstance(md, (dict, Metadata)):
             raise TypeError("The metadata should be a dict-like object")
-        for key, val in dict(md).items():
+        replacement = deepcopy(dict(md))
+        for key in replacement:
             if key not in self.member_metadata.columns:
                 self.member_metadata[key] = None
-            self.member_metadata.at[j, key] = deepcopy(val)
+        missing_keys = [
+            key for key in self.member_metadata.columns if key not in replacement
+        ]
+        if missing_keys:
+            self.member_metadata[missing_keys] = self.member_metadata[
+                missing_keys
+            ].astype(object)
+        self.member_metadata.loc[j] = pd.Series(replacement, dtype=object)
 
     def edit_metadata(self, j, md):
         """
-        Differs from set_metadata in that the contents of md are added to
-        the current and do not fully repalce them.   Needed for updating
-        metadata after costruction
+        Add the contents of ``md`` to the current metadata for member ``j``.
+
+        Unlike :meth:`set_metadata`, this method leaves every omitted key
+        unchanged.  It only accepts keys already represented by the member
+        metadata table and copies mutable values from the caller.  This is
+        intended for updating metadata after construction.
+
         :param j: index of member
         :type j: int
         :param md: the metadata to edit, dict or metadata

--- a/python/tests/seismic/test_gather_construction_metadata_contracts.py
+++ b/python/tests/seismic/test_gather_construction_metadata_contracts.py
@@ -184,6 +184,8 @@ def test_ensemble_dimensions_are_derived_after_resampling(
     assert result.npts == 50
     assert result.member_data.shape == (2, component_count, 50)
     assert result.member_metadata["npts"].tolist() == [50, 50]
+    assert [datum.npts for datum in source.member] == [100, 100]
+    assert [datum.dt for datum in source.member] == [0.25, 0.25]
 
     conflicting = _ensemble(gather_class, size=2, npts=100)
     uninitialized = gather_class.__new__(gather_class)
@@ -199,7 +201,11 @@ def test_ensemble_dimensions_are_derived_after_resampling(
         )
 
     assert vars(uninitialized) == {}
-    assert calls == [(id(source), 0.5), (id(conflicting), 0.5)]
+    assert [datum.npts for datum in conflicting.member] == [100, 100]
+    assert [datum.dt for datum in conflicting.member] == [0.25, 0.25]
+    assert [requested_dt for _, requested_dt in calls] == [0.5, 0.5]
+    assert calls[0][0] != id(source)
+    assert calls[1][0] != id(conflicting)
 
 
 def _scalar_gather(ensemble_metadata=None, starttimes=None):

--- a/python/tests/seismic/test_gather_construction_metadata_contracts.py
+++ b/python/tests/seismic/test_gather_construction_metadata_contracts.py
@@ -1,0 +1,259 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+from mspasspy.ccore.utility import Metadata
+from mspasspy.seismic.gather import Gather, SeismogramGather
+
+
+def _member_metadata(size, npts, dt=0.25, starttimes=None):
+    if starttimes is None:
+        starttimes = [float(index) for index in range(size)]
+    return pd.DataFrame(
+        {
+            "delta": [dt] * size,
+            "starttime": starttimes,
+            "npts": [npts] * size,
+            "is_live": [True] * size,
+            "x": list(range(size)),
+            "station_code": [f"S{index}" for index in range(size)],
+            "payload": [None] * size,
+        }
+    )
+
+
+def _array_constructor(gather_class, component_count, dimensions):
+    size, npts = 2, 4
+    values = {
+        "capacity": size,
+        "size": size,
+        "npts": npts,
+        "num_components": component_count,
+    }
+    explicit = {key: dimensions(value) for key, value in values.items()}
+    return gather_class(
+        input_data=np.arange(size * component_count * npts, dtype=float).reshape(
+            size, component_count, npts
+        ),
+        member_metadata=_member_metadata(size, npts),
+        ensemble_metadata={"source": "array"},
+        array_type="numpy",
+        npartitions=1,
+        **explicit,
+    )
+
+
+def _ensemble(gather_class, size=2, npts=4):
+    if gather_class is Gather:
+        ensemble = TimeSeriesEnsemble()
+        datum_class = TimeSeries
+    else:
+        ensemble = SeismogramEnsemble()
+        datum_class = Seismogram
+    ensemble["source"] = "ensemble"
+    ensemble["payload"] = {"tags": ["original"]}
+    for index in range(size):
+        datum = datum_class(npts)
+        datum.dt = 0.25
+        datum.t0 = float(index)
+        datum["marker"] = index
+        datum.set_live()
+        ensemble.member.append(datum)
+    ensemble.set_live()
+    return ensemble
+
+
+def _ensemble_constructor(gather_class, component_count, dimensions):
+    size, npts = 2, 4
+    values = {
+        "capacity": size,
+        "size": size,
+        "npts": npts,
+        "num_components": component_count,
+    }
+    explicit = {key: dimensions(value) for key, value in values.items()}
+    source = _ensemble(gather_class, size=size, npts=npts)
+    result = gather_class(
+        input_obj=source,
+        resample=False,
+        array_type="numpy",
+        npartitions=1,
+        **explicit,
+    )
+    source["source"] = "mutated after construction"
+    source["payload"]["tags"].append("caller mutation")
+    return result
+
+
+@pytest.mark.parametrize(
+    "gather_class,component_count",
+    [(Gather, 1), (SeismogramGather, 3)],
+)
+@pytest.mark.parametrize(
+    "dimensions", [lambda _: 0, lambda _: None, lambda value: value]
+)
+@pytest.mark.parametrize("constructor", [_array_constructor, _ensemble_constructor])
+def test_input_construction_derives_or_accepts_matching_dimensions(
+    gather_class, component_count, dimensions, constructor
+):
+    result = constructor(gather_class, component_count, dimensions)
+
+    assert result.capacity == 2
+    assert result.size == 2
+    assert result.npts == 4
+    assert result.num_components == component_count
+    assert result.member_data.shape == (2, component_count, 4)
+    assert result.ensemble_metadata()["source"] in {"array", "ensemble"}
+    if constructor is _ensemble_constructor:
+        assert result.ensemble_metadata()["payload"] == {"tags": ["original"]}
+
+
+@pytest.mark.parametrize(
+    "gather_class,component_count",
+    [(Gather, 1), (SeismogramGather, 3)],
+)
+@pytest.mark.parametrize("input_kind", ["array", "ensemble"])
+@pytest.mark.parametrize(
+    "field,conflict",
+    [
+        ("capacity", 3),
+        ("size", 3),
+        ("npts", 5),
+        ("num_components", 2),
+    ],
+)
+def test_input_dimension_conflicts_raise_before_assigning_fields(
+    gather_class, component_count, input_kind, field, conflict
+):
+    if field == "num_components" and component_count == 3:
+        conflict = 4
+    kwargs = {
+        "array_type": "numpy",
+        "npartitions": 1,
+        field: conflict,
+    }
+    if input_kind == "array":
+        kwargs.update(
+            input_data=np.zeros((2, component_count, 4)),
+            member_metadata=_member_metadata(2, 4),
+        )
+    else:
+        kwargs.update(input_obj=_ensemble(gather_class), resample=False)
+
+    uninitialized = gather_class.__new__(gather_class)
+    with pytest.raises(ValueError, match=f"{field}=.*conflicts"):
+        gather_class.__init__(uninitialized, **kwargs)
+
+    assert vars(uninitialized) == {}
+
+
+def _scalar_gather(ensemble_metadata=None, starttimes=None):
+    return Gather(
+        input_data=np.zeros((2, 1, 4)),
+        member_metadata=_member_metadata(
+            2, 4, dt=2.0, starttimes=starttimes or [0.0, 2.0]
+        ),
+        ensemble_metadata=ensemble_metadata,
+        array_type="numpy",
+        npartitions=1,
+    )
+
+
+@pytest.mark.parametrize("metadata_class", [dict, Metadata])
+def test_ensemble_metadata_method_and_sync_broadcast_copied_values(metadata_class):
+    source = metadata_class(
+        {
+            "x": 11,
+            "station_code": "SYNC",
+            "payload": {"tags": ["original"]},
+        }
+    )
+    gather = _scalar_gather(source)
+
+    assert callable(gather.ensemble_metadata)
+    assert gather.ensemble_metadata()["x"] == 11
+    assert isinstance(gather.ensemble_metadata("metadata"), Metadata)
+
+    source["x"] = 99
+    source["station_code"] = "MUTATED"
+    source["payload"]["tags"].append("caller mutation")
+    gather.sync_metadata()
+
+    assert gather.member_metadata["x"].tolist() == [11, 11]
+    assert gather.member_metadata["station_code"].tolist() == ["SYNC", "SYNC"]
+    payloads = gather.member_metadata["payload"].tolist()
+    assert payloads == [{"tags": ["original"]}, {"tags": ["original"]}]
+    assert payloads[0] is not payloads[1]
+    assert payloads[0]["tags"] is not payloads[1]["tags"]
+
+
+def test_member_metadata_dict_and_metadata_edits_are_row_local_and_copied():
+    gather = _scalar_gather()
+    row_zero_before = gather.get_metadata(0)
+
+    replacement = {
+        "x": 21,
+        "station_code": "DICT",
+        "payload": {"tags": ["dict"]},
+    }
+    gather.set_metadata(1, replacement)
+    replacement["x"] = 999
+    replacement["station_code"] = "MUTATED"
+    replacement["payload"]["tags"].append("caller mutation")
+
+    assert gather.get_metadata(0) == row_zero_before
+    assert gather.get_metadata(1)["x"] == 21
+    assert gather.get_metadata(1)["station_code"] == "DICT"
+    assert gather.get_metadata(1)["payload"] == {"tags": ["dict"]}
+
+    edit = Metadata(
+        {
+            "x": 31,
+            "station_code": "METADATA",
+            "payload": {"tags": ["metadata"]},
+        }
+    )
+    row_one_before = gather.get_metadata(1)
+    gather.edit_metadata(0, edit)
+    edit["x"] = 888
+    edit["station_code"] = "MUTATED"
+    edit["payload"]["tags"].append("caller mutation")
+
+    assert gather.get_metadata(1) == row_one_before
+    assert gather.get_metadata(0)["x"] == 31
+    assert gather.get_metadata(0)["station_code"] == "METADATA"
+    assert gather.get_metadata(0)["payload"] == {"tags": ["metadata"]}
+
+
+def test_column_values_method_is_callable_and_copies_input():
+    gather = _scalar_gather()
+
+    assert callable(gather.column_values)
+    assert gather.column_values() == [0, 1]
+
+    labels = [["left"], ["right"]]
+    gather.set_column_values(labels)
+    labels[0].append("caller mutation")
+
+    assert gather.column_values() == [["left"], ["right"]]
+
+
+def test_sample_number_uses_half_away_from_zero_integer_rounding():
+    gather = _scalar_gather(starttimes=[0.0, 2.0])
+
+    default_columns = gather.sample_number(1.0, [0, 1])
+    assert np.issubdtype(default_columns.dtype, np.integer)
+    assert np.array_equal(default_columns, [1, -1])
+
+    gather = _scalar_gather(starttimes=[-2.0, 4.0])
+    gather.set_column_values(["positive", "negative"])
+    named_columns = gather.sample_number(1.0, ["positive", "negative"])
+
+    assert np.issubdtype(named_columns.dtype, np.integer)
+    assert np.array_equal(named_columns, [2, -2])

--- a/python/tests/seismic/test_gather_construction_metadata_contracts.py
+++ b/python/tests/seismic/test_gather_construction_metadata_contracts.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import mspasspy.seismic.gather as gather_module
 from mspasspy.ccore.seismic import (
     Seismogram,
     SeismogramEnsemble,
@@ -153,6 +154,54 @@ def test_input_dimension_conflicts_raise_before_assigning_fields(
     assert vars(uninitialized) == {}
 
 
+@pytest.mark.parametrize(
+    "gather_class,component_count",
+    [(Gather, 1), (SeismogramGather, 3)],
+)
+def test_ensemble_dimensions_are_derived_after_resampling(
+    gather_class, component_count, monkeypatch
+):
+    calls = []
+
+    def resample_to_fifty_samples(ensemble, requested_dt):
+        calls.append((id(ensemble), requested_dt))
+        for datum in ensemble.member:
+            datum.set_npts(50)
+            datum.dt = requested_dt
+        return ensemble
+
+    monkeypatch.setattr(gather_module, "resample_ensemble", resample_to_fifty_samples)
+    source = _ensemble(gather_class, size=2, npts=100)
+
+    result = gather_class(
+        input_obj=source,
+        dt=0.5,
+        resample=True,
+        array_type="numpy",
+        npartitions=1,
+    )
+
+    assert result.npts == 50
+    assert result.member_data.shape == (2, component_count, 50)
+    assert result.member_metadata["npts"].tolist() == [50, 50]
+
+    conflicting = _ensemble(gather_class, size=2, npts=100)
+    uninitialized = gather_class.__new__(gather_class)
+    with pytest.raises(ValueError, match="npts=100 conflicts with the value 50"):
+        gather_class.__init__(
+            uninitialized,
+            input_obj=conflicting,
+            npts=100,
+            dt=0.5,
+            resample=True,
+            array_type="numpy",
+            npartitions=1,
+        )
+
+    assert vars(uninitialized) == {}
+    assert calls == [(id(source), 0.5), (id(conflicting), 0.5)]
+
+
 def _scalar_gather(ensemble_metadata=None, starttimes=None):
     return Gather(
         input_data=np.zeros((2, 1, 4)),
@@ -211,6 +260,10 @@ def test_member_metadata_dict_and_metadata_edits_are_row_local_and_copied():
     assert gather.get_metadata(1)["x"] == 21
     assert gather.get_metadata(1)["station_code"] == "DICT"
     assert gather.get_metadata(1)["payload"] == {"tags": ["dict"]}
+    assert pd.isna(gather.get_metadata(1)["delta"])
+    assert pd.isna(gather.get_metadata(1)["starttime"])
+    assert pd.isna(gather.get_metadata(1)["npts"])
+    assert pd.isna(gather.get_metadata(1)["is_live"])
 
     edit = Metadata(
         {
@@ -219,16 +272,20 @@ def test_member_metadata_dict_and_metadata_edits_are_row_local_and_copied():
             "payload": {"tags": ["metadata"]},
         }
     )
-    row_one_before = gather.get_metadata(1)
+    row_one_before = gather.member_metadata.loc[1].copy(deep=True)
     gather.edit_metadata(0, edit)
     edit["x"] = 888
     edit["station_code"] = "MUTATED"
     edit["payload"]["tags"].append("caller mutation")
 
-    assert gather.get_metadata(1) == row_one_before
+    pd.testing.assert_series_equal(gather.member_metadata.loc[1], row_one_before)
     assert gather.get_metadata(0)["x"] == 31
     assert gather.get_metadata(0)["station_code"] == "METADATA"
     assert gather.get_metadata(0)["payload"] == {"tags": ["metadata"]}
+    assert gather.get_metadata(0)["delta"] == row_zero_before["delta"]
+    assert gather.get_metadata(0)["starttime"] == row_zero_before["starttime"]
+    assert gather.get_metadata(0)["npts"] == row_zero_before["npts"]
+    assert gather.get_metadata(0)["is_live"] == row_zero_before["is_live"]
 
 
 def test_column_values_method_is_callable_and_copies_input():


### PR DESCRIPTION
Fixes #874.

## Summary
- derive and validate Gather dimensions before assigning object state
- isolate resampling and regularization from the caller-owned input ensemble
- preserve copied ensemble metadata and restore callable metadata/column APIs
- keep row replacement, partial edits, and broadcast metadata behavior distinct
- return integer sample numbers with half-away-from-zero rounding
- derive `npts` from the post-transformation data actually stored

## Verification
- Gather construction and existing Gather tests: 50 passed
- Black check passed for both changed files
- `git diff --check` passed

## Review status
Ready to merge. No unresolved scientific or API decision remains in this PR.