### PR TITLE
Repair SNR diagnostic exceptions and taper-count boundary text

### DIFF
--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -638,7 +638,7 @@ def FD_snr_estimator(
                 ntapers=ntapers, tbp=tbp
             )
         )
-        message += "ntapers must be >= round(2*tbp)"
+        message += "ntapers must be <= round(2*tbp)={}".format(round(2 * tbp))
         raise MsPASSError(message, ErrorSeverity.Fatal)
     if data_object.dead():
         my_logger.log_error(
@@ -1630,7 +1630,6 @@ def visualize_qcdata(
     :type qc_subdoc_key:  string or None.  Default "Parrival"
        is default of `broadband_arrival_QC`.
     """
-    import matplotlib.pyplot as plt
 
     def pts2box(xmin, xmax, ymin, ymax) -> tuple:
         """
@@ -1647,14 +1646,17 @@ def visualize_qcdata(
     if isinstance(d, Seismogram):
         d = _ExtractComponent(d, component)
     if not isinstance(d, TimeSeries):
-        message = "arg0 value must be a TimeSeries object\n"
-        message += "Actual type={}".str(type(d))
-        raise ValueError(message)
+        raise TypeError(
+            "visualize_qcdata: arg0 must be a TimeSeries or Seismogram; "
+            "actual type={}".format(type(d))
+        )
     if qc_subdoc_key:
-        doc = d[qc_subdoc_key]
+        doc = d[qc_subdoc_key] if d.is_defined(qc_subdoc_key) else {}
     else:
         doc = dict(d)
     if "signal_spectrum" in doc and "noise_spectrum" in doc:
+        import matplotlib.pyplot as plt
+
         pdata = doc["signal_spectrum"]
         S = pickle.loads(pdata)
         pdata = doc["noise_spectrum"]
@@ -1699,8 +1701,11 @@ def visualize_qcdata(
             )
             print("Cannot make the time series data showing oiginal and filtered data")
     else:
-        message = (
-            "Missing required metadata with keys signal_spectrum and noise_spectrum\n"
+        missing = [
+            key for key in ("signal_spectrum", "noise_spectrum") if key not in doc
+        ]
+        message = "visualize_qcdata: missing required spectrum metadata: {}\n".format(
+            ", ".join(missing)
         )
         message += "You probably need to run the data through broadband_snr_QC with save_spectra set True"
-        raise MsPASSError("visuallize_qcdata", message, ErrorSeverity.Invalid)
+        raise MsPASSError(message, ErrorSeverity.Invalid)

--- a/python/tests/algorithms/test_snr_diagnostic_contract.py
+++ b/python/tests/algorithms/test_snr_diagnostic_contract.py
@@ -1,0 +1,80 @@
+import pytest
+
+from mspasspy.algorithms.snr import FD_snr_estimator, visualize_qcdata
+from mspasspy.ccore.seismic import TimeSeries
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+
+
+def _assert_no_output(capsys):
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize("bad", [object(), [], "timeseries"])
+def test_visualize_wrong_type_reports_actual_type_without_output(bad, capsys):
+    with pytest.raises(TypeError) as captured:
+        visualize_qcdata(bad)
+
+    message = str(captured.value)
+    assert "visualize_qcdata" in message
+    assert "TimeSeries or Seismogram" in message
+    assert str(type(bad)) in message
+    _assert_no_output(capsys)
+
+
+@pytest.mark.parametrize(
+    "subdocument,missing",
+    [
+        (None, ("signal_spectrum", "noise_spectrum")),
+        ({}, ("signal_spectrum", "noise_spectrum")),
+        ({"signal_spectrum": b"unused"}, ("noise_spectrum",)),
+        ({"noise_spectrum": b"unused"}, ("signal_spectrum",)),
+    ],
+)
+def test_visualize_missing_spectrum_raises_complete_invalid_error(
+    subdocument, missing, capsys
+):
+    datum = TimeSeries(4)
+    datum.set_live()
+    if subdocument is not None:
+        datum["Parrival"] = subdocument
+
+    with pytest.raises(MsPASSError) as captured:
+        visualize_qcdata(datum)
+
+    error = captured.value
+    assert error.severity == ErrorSeverity.Invalid
+    assert "visualize_qcdata" in error.message
+    assert "missing required spectrum metadata" in error.message
+    for key in missing:
+        assert key in error.message
+    for key in {"signal_spectrum", "noise_spectrum"} - set(missing):
+        assert key not in error.message.splitlines()[0]
+    _assert_no_output(capsys)
+
+
+def test_taper_count_equal_to_boundary_is_accepted_without_output(capsys):
+    datum = TimeSeries(4)
+    datum.kill()
+
+    result, elog = FD_snr_estimator(datum, tbp=4.0, ntapers=8)
+
+    assert result == {}
+    assert elog.size() == 1
+    _assert_no_output(capsys)
+
+
+def test_taper_count_above_boundary_reports_values_and_inequality(capsys):
+    datum = TimeSeries(4)
+    datum.kill()
+
+    with pytest.raises(MsPASSError) as captured:
+        FD_snr_estimator(datum, tbp=4.0, ntapers=9)
+
+    error = captured.value
+    assert error.severity == ErrorSeverity.Fatal
+    assert "ntapers=9" in error.message
+    assert "tbp=4.0" in error.message
+    assert "ntapers must be <= round(2*tbp)=8" in error.message
+    _assert_no_output(capsys)


### PR DESCRIPTION
Fixes #858.

## Summary
- report invalid visualization types with `TypeError` and the actual Python type
- raise two-argument `MsPASSError` diagnostics that identify every missing spectrum
- handle a missing `Parrival` subdocument through the same deterministic diagnostic
- correct the taper-count boundary text and include the computed limit
- defer pyplot import so diagnostic paths remain silent

## Verification
- contract plus adjacent FD-SNR regressions: 11 passed
- baseline red proof: 8 failed, 1 passed
- Python 3.9/3.13 `py_compile`, Black, and `git diff --check` passed
- independent agent review: PASS; reviewer fixed the missing-subdocument path and re-ran all checks

Ready for human review. Do not merge automatically.