### PR TITLE
Correct BasicGather resampling, intersection, and time conversion

### DIFF
--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -90,11 +90,28 @@ def regularize_ensemble(ens, regularizer=None):
     The purpose of this function is to set all member data to have the same start
     time.
     By default, the regularization is carried out by simply applying a time window
-    on each member.
+    on each live member.  The default window is the inclusive physical
+    intersection of the live member time ranges.  Consequently, an intersection
+    with equal start and end times contains one sample when all members share that
+    sample.  Dead members are not used to define the intersection and are returned
+    unchanged.
+
+    The windowed members must resolve to the same sampled time axis.  This is
+    checked after building all windowed copies and before replacing any ensemble
+    member, so a disjoint interval or incompatible sample grids leave the input
+    ensemble unchanged.  A user-supplied ``regularizer`` retains control of member
+    selection and replacement and is called with every member as in the original
+    API.
+
+    :param ens: input TimeSeriesEnsemble or SeismogramEnsemble.  The object is
+      modified in place and returned.
     :param regularizer: A function object defined by user that regularize all data
     members in the ensemble, it should take only one argument (a timeseries/seismogram)
     and return the regularized object.
     :type regularizer: Callable[[TimeSeries|Seismogram], TimeSeries|Seismogram]
+    :raises TypeError: if ``ens`` is not an MsPASS ensemble object.
+    :raises ValueError: when live members have no common physical sample or the
+      common window resolves to incompatible sample grids.
     """
     if not isOldEnsembleObject(ens):
         raise TypeError("Can't resample the object, not an old ensemble object")
@@ -104,12 +121,26 @@ def regularize_ensemble(ens, regularizer=None):
         for i in range(nmembers):
             ens.member[i] = regularizer(ens.member[i])
     else:
-        starttime = max(ens.member[i].t0 for i in range(nmembers))
-        endtime = min(ens.member[i].endtime() for i in range(nmembers))
-        if endtime <= starttime:
+        live_indexes = [i for i in range(nmembers) if ens.member[i].live]
+        if not live_indexes:
+            return ens
+        starttime = max(ens.member[i].t0 for i in live_indexes)
+        endtime = min(ens.member[i].endtime() for i in live_indexes)
+        if endtime < starttime:
             raise ValueError("ensemble members do not have a common time interval")
-        for i in range(nmembers):
-            ens.member[i] = WindowData(ens.member[i], starttime, endtime)
+        regularized_members = [
+            WindowData(ens.member[i], starttime, endtime) for i in live_indexes
+        ]
+        reference = regularized_members[0]
+        if any(
+            member.t0 != reference.t0
+            or member.dt != reference.dt
+            or member.npts != reference.npts
+            for member in regularized_members[1:]
+        ):
+            raise ValueError("ensemble members do not share a common sample grid")
+        for i, member in zip(live_indexes, regularized_members):
+            ens.member[i] = member
     return ens
 
 

--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -1,11 +1,7 @@
 from abc import ABC, abstractmethod
-<<<<<<< HEAD
 from copy import deepcopy
 import math
-=======
-import math
 from numbers import Real
->>>>>>> 89c398e9 (Fix Gather resampling and time conversion)
 
 import xarray as xr
 import dask.array as da
@@ -40,6 +36,27 @@ def _is_finite_number(value):
     return (
         isinstance(value, Real) and not isinstance(value, bool) and math.isfinite(value)
     )
+
+
+def _interpolate_to_grid(member, starttime, npts):
+    sample_interval = member.dt
+    source_times = member.t0 + np.arange(member.npts) * sample_interval
+    target_times = starttime + np.arange(npts) * sample_interval
+    if isinstance(member, TimeSeries):
+        values = np.interp(target_times, source_times, np.asarray(member.data))
+        result = TimeSeries(member)
+        result.set_npts(npts)
+        result.data = DoubleVector(values)
+    else:
+        source_data = np.asarray(member.data)
+        values = np.vstack(
+            [np.interp(target_times, source_times, row) for row in source_data]
+        )
+        result = Seismogram(member)
+        result.set_npts(npts)
+        result.data = dmatrix(values)
+    result.t0 = starttime
+    return result
 
 
 def isOldEnsembleObject(obj):
@@ -84,7 +101,7 @@ def resample_ensemble(ens, dt=None):
     return resample(ens, decimator, resampler)
 
 
-def regularize_ensemble(ens, regularizer=None):
+def regularize_ensemble(ens, regularizer=None, grid_alignment="snap"):
     """
     A helper function to regularize all the member data in an ensemble.
     The purpose of this function is to set all member data to have the same start
@@ -96,10 +113,14 @@ def regularize_ensemble(ens, regularizer=None):
     sample.  Dead members are not used to define the intersection and are returned
     unchanged.
 
-    The windowed members must resolve to the same sampled time axis.  This is
-    checked after building all windowed copies and before replacing any ensemble
+    The output members must resolve to the same sampled time axis.  This is
+    checked on copied members before replacing any ensemble
     member, so a disjoint interval or incompatible sample grids leave the input
-    ensemble unchanged.  A user-supplied ``regularizer`` retains control of member
+    ensemble unchanged.  By default, members with a common sample interval are
+    snapped to the first live member's nearest sample grid without changing sample
+    values.  Set ``grid_alignment="interpolate"`` to linearly interpolate those
+    members onto that grid instead.  Members with different sample intervals must
+    be resampled first.  A user-supplied ``regularizer`` retains control of member
     selection and replacement and is called with every member as in the original
     API.
 
@@ -109,9 +130,13 @@ def regularize_ensemble(ens, regularizer=None):
       members in the ensemble, it should take only one argument (a
       timeseries/seismogram) and return the regularized object.
     :type regularizer: Callable[[TimeSeries|Seismogram], TimeSeries|Seismogram]
+    :param grid_alignment: ``"snap"`` (default) preserves sample values and moves
+      each selected window to the common grid.  ``"interpolate"`` linearly
+      interpolates off-grid windows onto that grid.  Ignored when ``regularizer``
+      is supplied.
     :raises TypeError: if ``ens`` is not an MsPASS ensemble object.
     :raises ValueError: when live members have no common physical sample or the
-      common window resolves to incompatible sample grids.
+      common window has incompatible sample intervals.
     """
     if not isOldEnsembleObject(ens):
         raise TypeError("Can't resample the object, not an old ensemble object")
@@ -121,6 +146,8 @@ def regularize_ensemble(ens, regularizer=None):
         for i in range(nmembers):
             ens.member[i] = regularizer(ens.member[i])
     else:
+        if grid_alignment not in ("snap", "interpolate"):
+            raise ValueError('grid_alignment must be either "snap" or "interpolate"')
         live_indexes = [i for i in range(nmembers) if ens.member[i].live]
         if not live_indexes:
             return ens
@@ -128,17 +155,37 @@ def regularize_ensemble(ens, regularizer=None):
         endtime = min(ens.member[i].endtime() for i in live_indexes)
         if endtime < starttime:
             raise ValueError("ensemble members do not have a common time interval")
-        regularized_members = [
-            WindowData(ens.member[i], starttime, endtime) for i in live_indexes
-        ]
-        reference = regularized_members[0]
-        if any(
-            member.t0 != reference.t0
-            or member.dt != reference.dt
-            or member.npts != reference.npts
-            for member in regularized_members[1:]
-        ):
-            raise ValueError("ensemble members do not share a common sample grid")
+        reference = ens.member[live_indexes[0]]
+        if any(ens.member[i].dt != reference.dt for i in live_indexes[1:]):
+            raise ValueError("ensemble members do not share a common sample interval")
+
+        if grid_alignment == "interpolate":
+            start_coordinate = (starttime - reference.t0) / reference.dt
+            end_coordinate = (endtime - reference.t0) / reference.dt
+            sample_tolerance = 1.0e-6
+            start_index = math.ceil(start_coordinate - sample_tolerance)
+            end_index = math.floor(end_coordinate + sample_tolerance)
+            if end_index < start_index:
+                raise ValueError(
+                    "ensemble members do not share a common reference-grid sample"
+                )
+            target_start = reference.time(start_index)
+            target_npts = end_index - start_index + 1
+            regularized_members = [
+                _interpolate_to_grid(ens.member[i], target_start, target_npts)
+                for i in live_indexes
+            ]
+        else:
+            regularized_members = [
+                WindowData(ens.member[i], starttime, endtime) for i in live_indexes
+            ]
+            reference = regularized_members[0]
+            for member in regularized_members[1:]:
+                member.t0 = reference.t0
+                if member.npts != reference.npts:
+                    raise ValueError(
+                        "ensemble members could not be snapped to a common grid"
+                    )
         for i, member in zip(live_indexes, regularized_members):
             ens.member[i] = member
     return ens
@@ -894,24 +941,16 @@ class BasicGather(ABC):
             return self
 
         shift_key = "starttime_shift"
-        if shift_key not in self.ensemble_metadata:
+        if shift_key not in self._ensemble_metadata:
             raise ValueError("ensemble metadata does not define starttime_shift")
-        shift = self.ensemble_metadata[shift_key]
+        shift = self._ensemble_metadata[shift_key]
         if not _is_finite_number(shift):
             raise ValueError("starttime_shift must be a finite number")
 
-<<<<<<< HEAD
-        # TODO: do we need to check if the items are live or dead here?
-        self.member_metadata["starttime"].applymap(lambda x: (x + self.t0shift))
-
-        self.t0shift = 0
-        self._ensemble_metadata["is_utc"] = True
-=======
         self.member_metadata["starttime"] = self.member_metadata["starttime"] + shift
-        self.ensemble_metadata[shift_key] = 0.0
-        self.ensemble_metadata["is_utc"] = True
+        self._ensemble_metadata[shift_key] = 0.0
+        self._ensemble_metadata["is_utc"] = True
         return self
->>>>>>> 89c398e9 (Fix Gather resampling and time conversion)
 
     def ator(self, shift):
         """
@@ -923,8 +962,8 @@ class BasicGather(ABC):
             raise ValueError("shift must be a finite number")
 
         self.member_metadata["starttime"] = self.member_metadata["starttime"] - shift
-        self.ensemble_metadata["starttime_shift"] = shift
-        self.ensemble_metadata["is_utc"] = False
+        self._ensemble_metadata["starttime_shift"] = shift
+        self._ensemble_metadata["is_utc"] = False
         return self
 
     def shift(self, timeshift):
@@ -937,8 +976,8 @@ class BasicGather(ABC):
             raise ValueError("timeshift must be a finite number")
         shift_key = "starttime_shift"
         old_shift = (
-            self.ensemble_metadata[shift_key]
-            if shift_key in self.ensemble_metadata
+            self._ensemble_metadata[shift_key]
+            if shift_key in self._ensemble_metadata
             else 0.0
         )
         self.rtoa()

--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -1,6 +1,11 @@
 from abc import ABC, abstractmethod
+<<<<<<< HEAD
 from copy import deepcopy
 import math
+=======
+import math
+from numbers import Real
+>>>>>>> 89c398e9 (Fix Gather resampling and time conversion)
 
 import xarray as xr
 import dask.array as da
@@ -29,6 +34,12 @@ from mspasspy.ccore.utility import MsPASSError, ErrorSeverity, ErrorLogger
 
 from mspasspy.algorithms.window import WindowData
 from mspasspy.algorithms.resample import resample, ScipyDecimator, ScipyResampler
+
+
+def _is_finite_number(value):
+    return (
+        isinstance(value, Real) and not isinstance(value, bool) and math.isfinite(value)
+    )
 
 
 def isOldEnsembleObject(obj):
@@ -65,8 +76,11 @@ def resample_ensemble(ens, dt=None):
         raise TypeError("Can't resample the object, not an old ensemble object")
     if dt is None:
         dt = ens.member[0].dt
-    decimator = ScipyDecimator(dt)
-    resampler = ScipyResampler(dt)
+    if not _is_finite_number(dt) or dt <= 0.0:
+        raise ValueError("target dt must be a finite positive number")
+    sampling_rate = 1.0 / dt
+    decimator = ScipyDecimator(sampling_rate)
+    resampler = ScipyResampler(sampling_rate)
     return resample(ens, decimator, resampler)
 
 
@@ -90,8 +104,10 @@ def regularize_ensemble(ens, regularizer=None):
         for i in range(nmembers):
             ens.member[i] = regularizer(ens.member[i])
     else:
-        starttime = min([ens.member[i].t0 for i in range(nmembers)])
-        endtime = max([ens.member[i].endtime() for i in range(nmembers)])
+        starttime = max(ens.member[i].t0 for i in range(nmembers))
+        endtime = min(ens.member[i].endtime() for i in range(nmembers))
+        if endtime <= starttime:
+            raise ValueError("ensemble members do not have a common time interval")
         for i in range(nmembers):
             ens.member[i] = WindowData(ens.member[i], starttime, endtime)
     return ens
@@ -844,27 +860,41 @@ class BasicGather(ABC):
         Convert the relative time to absolute time
         """
         if not self.time_is_relative():
-            return
+            return self
 
-        if self.t0shift <= 100.0:
-            raise MsPASSError(
-                "time shift to return to UTC time is not defined", "Invalid"
-            )
+        shift_key = "starttime_shift"
+        if shift_key not in self.ensemble_metadata:
+            raise ValueError("ensemble metadata does not define starttime_shift")
+        shift = self.ensemble_metadata[shift_key]
+        if not _is_finite_number(shift):
+            raise ValueError("starttime_shift must be a finite number")
 
+<<<<<<< HEAD
         # TODO: do we need to check if the items are live or dead here?
         self.member_metadata["starttime"].applymap(lambda x: (x + self.t0shift))
 
         self.t0shift = 0
         self._ensemble_metadata["is_utc"] = True
+=======
+        self.member_metadata["starttime"] = self.member_metadata["starttime"] + shift
+        self.ensemble_metadata[shift_key] = 0.0
+        self.ensemble_metadata["is_utc"] = True
+        return self
+>>>>>>> 89c398e9 (Fix Gather resampling and time conversion)
 
     def ator(self, shift):
         """
         Convert the absolut time to relative time
         """
         if not self.time_is_UTC():
-            return
-        self.t0shift = shift
-        self.member_metadata["time"].applymap(lambda x: (x - self.t0shift))
+            return self
+        if not _is_finite_number(shift):
+            raise ValueError("shift must be a finite number")
+
+        self.member_metadata["starttime"] = self.member_metadata["starttime"] - shift
+        self.ensemble_metadata["starttime_shift"] = shift
+        self.ensemble_metadata["is_utc"] = False
+        return self
 
     def shift(self, timeshift):
         """
@@ -872,9 +902,16 @@ class BasicGather(ABC):
         :param timeshift: the shift time range
         :type timeshift: float
         """
-        old_t0shift = self.t0shift
+        if not _is_finite_number(timeshift):
+            raise ValueError("timeshift must be a finite number")
+        shift_key = "starttime_shift"
+        old_shift = (
+            self.ensemble_metadata[shift_key]
+            if shift_key in self.ensemble_metadata
+            else 0.0
+        )
         self.rtoa()
-        self.ator(old_t0shift + timeshift)
+        return self.ator(old_shift + timeshift)
 
     # The following methods in BasicTimeSeries are optional.  It isn't
     # clear to me if their use is required - at least initially.  With

--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -106,8 +106,8 @@ def regularize_ensemble(ens, regularizer=None):
     :param ens: input TimeSeriesEnsemble or SeismogramEnsemble.  The object is
       modified in place and returned.
     :param regularizer: A function object defined by user that regularize all data
-    members in the ensemble, it should take only one argument (a timeseries/seismogram)
-    and return the regularized object.
+      members in the ensemble, it should take only one argument (a
+      timeseries/seismogram) and return the regularized object.
     :type regularizer: Callable[[TimeSeries|Seismogram], TimeSeries|Seismogram]
     :raises TypeError: if ``ens`` is not an MsPASS ensemble object.
     :raises ValueError: when live members have no common physical sample or the

--- a/python/tests/seismic/test_gather_resample_time_contracts.py
+++ b/python/tests/seismic/test_gather_resample_time_contracts.py
@@ -5,7 +5,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
 from mspasspy.seismic.gather import (
     Gather,
     regularize_ensemble,
@@ -195,11 +200,99 @@ def test_regularize_ensemble_with_no_live_members_is_an_exact_noop():
     _assert_ensemble_matches_snapshot(ensemble, before)
 
 
-def test_regularize_ensemble_rejects_incompatible_sample_grids_atomically():
+def test_regularize_ensemble_snaps_off_grid_members_without_changing_samples():
+    ensemble = _ensemble([(0.0, 6, 1.0, 0.0), (0.25, 6, 1.0, 100.0)])
+    samples_before = [np.array(member.data, copy=True) for member in ensemble.member]
+
+    result = regularize_ensemble(ensemble)
+
+    assert result is ensemble
+    assert [(member.t0, member.endtime(), member.npts) for member in result.member] == [
+        (0.0, 5.0, 6),
+        (0.0, 5.0, 6),
+    ]
+    for member, expected in zip(result.member, samples_before):
+        np.testing.assert_array_equal(member.data, expected)
+
+
+def test_regularize_ensemble_interpolates_off_grid_members_when_requested():
+    ensemble = _ensemble([(0.0, 6, 1.0, 0.0), (0.25, 6, 1.0, 100.0)])
+
+    result = regularize_ensemble(ensemble, grid_alignment="interpolate")
+
+    assert [(member.t0, member.endtime(), member.npts) for member in result.member] == [
+        (1.0, 5.0, 5),
+        (1.0, 5.0, 5),
+    ]
+    np.testing.assert_allclose(result.member[0].data, [1.0, 2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_allclose(
+        result.member[1].data, [100.75, 101.75, 102.75, 103.75, 104.75]
+    )
+
+
+def test_interpolation_preserves_a_near_grid_boundary_sample():
+    ensemble = _ensemble([(0.0, 6, 0.1, 0.0), (0.30000000000000004, 3, 0.1, 100.0)])
+
+    result = regularize_ensemble(ensemble, grid_alignment="interpolate")
+
+    assert [member.npts for member in result.member] == [3, 3]
+    assert [member.t0 for member in result.member] == pytest.approx([0.3, 0.3])
+    np.testing.assert_allclose(result.member[0].data, [3.0, 4.0, 5.0])
+    np.testing.assert_allclose(result.member[1].data, [100.0, 101.0, 102.0])
+
+
+def test_regularize_ensemble_interpolates_three_component_members():
+    ensemble = SeismogramEnsemble()
+    for t0, offset in ((0.0, 0.0), (0.25, 100.0)):
+        member = Seismogram(6)
+        member.t0 = t0
+        member.dt = 1.0
+        member.set_live()
+        for component in range(3):
+            for sample in range(6):
+                member.data[component, sample] = offset + 10 * component + sample
+        ensemble.member.append(member)
+    ensemble.set_live()
+
+    result = regularize_ensemble(ensemble, grid_alignment="interpolate")
+
+    assert [(member.t0, member.endtime(), member.npts) for member in result.member] == [
+        (1.0, 5.0, 5),
+        (1.0, 5.0, 5),
+    ]
+    np.testing.assert_allclose(
+        result.member[0].data,
+        [
+            [1.0, 2.0, 3.0, 4.0, 5.0],
+            [11.0, 12.0, 13.0, 14.0, 15.0],
+            [21.0, 22.0, 23.0, 24.0, 25.0],
+        ],
+    )
+    np.testing.assert_allclose(
+        result.member[1].data,
+        [
+            [100.75, 101.75, 102.75, 103.75, 104.75],
+            [110.75, 111.75, 112.75, 113.75, 114.75],
+            [120.75, 121.75, 122.75, 123.75, 124.75],
+        ],
+    )
+
+
+def test_regularize_ensemble_rejects_invalid_alignment_mode_before_mutation():
     ensemble = _ensemble([(0.0, 6, 1.0, 0.0), (0.25, 6, 1.0, 100.0)])
     before = _ensemble_snapshot(ensemble)
 
-    with pytest.raises(ValueError, match="common sample grid"):
+    with pytest.raises(ValueError, match="grid_alignment"):
+        regularize_ensemble(ensemble, grid_alignment="invalid")
+
+    _assert_ensemble_matches_snapshot(ensemble, before)
+
+
+def test_regularize_ensemble_rejects_different_sample_intervals_atomically():
+    ensemble = _ensemble([(0.0, 6, 1.0, 0.0), (0.25, 12, 0.5, 100.0)])
+    before = _ensemble_snapshot(ensemble)
+
+    with pytest.raises(ValueError, match="common sample interval"):
         regularize_ensemble(ensemble)
 
     _assert_ensemble_matches_snapshot(ensemble, before)
@@ -248,7 +341,7 @@ def _gather(is_utc, starttime_shift=None):
 def _gather_snapshot(gather):
     return {
         "member_metadata": gather.member_metadata.copy(deep=True),
-        "ensemble_metadata": deepcopy(dict(gather.ensemble_metadata)),
+        "ensemble_metadata": deepcopy(dict(gather.ensemble_metadata())),
         "member_data": np.array(gather.member_data, copy=True),
         "fields": (
             gather.capacity,
@@ -280,7 +373,7 @@ def _assert_metadata_values_equal(actual, expected):
 def _assert_gather_matches_snapshot(gather, snapshot):
     pd.testing.assert_frame_equal(gather.member_metadata, snapshot["member_metadata"])
     _assert_metadata_values_equal(
-        dict(gather.ensemble_metadata), snapshot["ensemble_metadata"]
+        dict(gather.ensemble_metadata()), snapshot["ensemble_metadata"]
     )
     np.testing.assert_array_equal(gather.member_data, snapshot["member_data"])
     assert (
@@ -305,16 +398,16 @@ def test_ator_and_rtoa_are_exact_inverses_using_persisted_shift_metadata():
 
     assert gather.ator(2.5) is gather
     assert gather.member_metadata["starttime"].tolist() == [7.5, 17.5]
-    assert gather.ensemble_metadata["starttime_shift"] == 2.5
-    assert gather.ensemble_metadata["is_utc"] is False
+    assert gather.ensemble_metadata()["starttime_shift"] == 2.5
+    assert gather.ensemble_metadata()["is_utc"] is False
     assert "t0shift" not in vars(gather)
 
     assert gather.rtoa() is gather
     pd.testing.assert_series_equal(
         gather.member_metadata["starttime"], original_starttimes
     )
-    assert gather.ensemble_metadata["starttime_shift"] == 0.0
-    assert gather.ensemble_metadata["is_utc"] is True
+    assert gather.ensemble_metadata()["starttime_shift"] == 0.0
+    assert gather.ensemble_metadata()["is_utc"] is True
     assert "t0shift" not in vars(gather)
 
 
@@ -368,7 +461,7 @@ def test_rtoa_is_identity_on_already_utc_input_without_validating_stored_shift(
 ):
     gather = _gather(is_utc=True, starttime_shift=stored_shift)
     if stored_shift is None:
-        gather.ensemble_metadata.pop("starttime_shift", None)
+        gather.ensemble_metadata().pop("starttime_shift", None)
     before = _gather_snapshot(gather)
 
     assert gather.rtoa() is gather

--- a/python/tests/seismic/test_gather_resample_time_contracts.py
+++ b/python/tests/seismic/test_gather_resample_time_contracts.py
@@ -1,0 +1,318 @@
+from copy import deepcopy
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
+from mspasspy.seismic.gather import (
+    Gather,
+    regularize_ensemble,
+    resample_ensemble,
+)
+
+
+def _timeseries(t0, npts, dt, offset=0.0):
+    datum = TimeSeries(npts)
+    datum.t0 = t0
+    datum.dt = dt
+    datum["marker"] = offset
+    datum["sampling_rate"] = 1.0 / dt
+    datum.set_live()
+    for index in range(npts):
+        datum.data[index] = offset + index
+    return datum
+
+
+def _ensemble(specifications):
+    ensemble = TimeSeriesEnsemble()
+    ensemble["label"] = "original"
+    for specification in specifications:
+        ensemble.member.append(_timeseries(*specification))
+    ensemble.set_live()
+    return ensemble
+
+
+def _ensemble_snapshot(ensemble):
+    return {
+        "metadata": deepcopy(dict(ensemble)),
+        "live": ensemble.live,
+        "elog": [
+            (error.algorithm, error.message, error.badness)
+            for error in ensemble.elog.get_error_log()
+        ],
+        "members": [
+            {
+                "metadata": deepcopy(dict(member)),
+                "live": member.live,
+                "is_utc": member.time_is_UTC(),
+                "t0": member.t0,
+                "dt": member.dt,
+                "npts": member.npts,
+                "data": np.array(member.data, copy=True),
+                "elog": [
+                    (error.algorithm, error.message, error.badness)
+                    for error in member.elog.get_error_log()
+                ],
+                "history_stages": member.number_of_stages(),
+                "history_nodes": str(member.get_nodes()),
+            }
+            for member in ensemble.member
+        ],
+    }
+
+
+def _assert_ensemble_matches_snapshot(ensemble, snapshot):
+    assert dict(ensemble) == snapshot["metadata"]
+    assert ensemble.live == snapshot["live"]
+    assert [
+        (error.algorithm, error.message, error.badness)
+        for error in ensemble.elog.get_error_log()
+    ] == snapshot["elog"]
+    assert len(ensemble.member) == len(snapshot["members"])
+    for member, expected in zip(ensemble.member, snapshot["members"]):
+        assert dict(member) == expected["metadata"]
+        assert member.live == expected["live"]
+        assert member.time_is_UTC() == expected["is_utc"]
+        assert member.t0 == expected["t0"]
+        assert member.dt == expected["dt"]
+        assert member.npts == expected["npts"]
+        np.testing.assert_array_equal(member.data, expected["data"])
+        assert [
+            (error.algorithm, error.message, error.badness)
+            for error in member.elog.get_error_log()
+        ] == expected["elog"]
+        assert member.number_of_stages() == expected["history_stages"]
+        assert str(member.get_nodes()) == expected["history_nodes"]
+
+
+@pytest.mark.parametrize("target_dt", [None, 0.1])
+def test_resample_ensemble_uses_sample_interval_semantics(target_dt):
+    ensemble = _ensemble([(0.0, 200, 0.1, 1.0), (0.0, 100, 0.2, 2.0)])
+
+    result = resample_ensemble(ensemble, target_dt)
+
+    assert result is ensemble
+    for member in result.member:
+        assert member.live
+        assert member.dt == pytest.approx(0.1)
+        assert member.npts == 200
+        assert member["sampling_rate"] == pytest.approx(10.0)
+
+
+@pytest.mark.parametrize(
+    "target_dt", [0.0, -0.1, float("nan"), float("inf"), -float("inf"), "0.1", True]
+)
+def test_resample_ensemble_rejects_invalid_dt_before_mutation(target_dt):
+    ensemble = _ensemble([(0.0, 20, 0.1, 1.0), (0.0, 10, 0.2, 2.0)])
+    before = _ensemble_snapshot(ensemble)
+
+    with pytest.raises(ValueError, match="finite positive"):
+        resample_ensemble(ensemble, target_dt)
+
+    _assert_ensemble_matches_snapshot(ensemble, before)
+
+
+def test_regularize_ensemble_uses_the_inclusive_common_intersection():
+    ensemble = _ensemble([(0.0, 6, 1.0, 0.0), (2.0, 6, 1.0, 100.0)])
+
+    result = regularize_ensemble(ensemble)
+
+    assert result is ensemble
+    assert [(member.t0, member.endtime(), member.npts) for member in result.member] == [
+        (2.0, 5.0, 4),
+        (2.0, 5.0, 4),
+    ]
+    np.testing.assert_array_equal(result.member[0].data, [2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_array_equal(result.member[1].data, [100.0, 101.0, 102.0, 103.0])
+
+
+@pytest.mark.parametrize(
+    "specifications",
+    [
+        [(0.0, 3, 1.0, 0.0), (3.0, 3, 1.0, 100.0)],
+        [(0.0, 3, 1.0, 0.0), (2.0, 3, 1.0, 100.0)],
+    ],
+    ids=["disjoint", "touching"],
+)
+def test_regularize_ensemble_rejects_empty_intersection_before_mutation(
+    specifications,
+):
+    ensemble = _ensemble(specifications)
+    before = _ensemble_snapshot(ensemble)
+
+    with pytest.raises(ValueError, match="common time interval"):
+        regularize_ensemble(ensemble)
+
+    _assert_ensemble_matches_snapshot(ensemble, before)
+
+
+def test_custom_regularizer_retains_control_of_disjoint_members():
+    ensemble = _ensemble([(0.0, 3, 1.0, 0.0), (4.0, 3, 1.0, 100.0)])
+    members = list(ensemble.member)
+    calls = []
+
+    def regularizer(member):
+        calls.append(member)
+        return member
+
+    result = regularize_ensemble(ensemble, regularizer=regularizer)
+
+    assert result is ensemble
+    assert calls == members
+    assert list(result.member) == members
+
+
+def _gather(is_utc, starttime_shift=None):
+    metadata = {"is_utc": is_utc, "dt": 1.0, "label": "original"}
+    if starttime_shift is not None:
+        metadata["starttime_shift"] = starttime_shift
+    member_metadata = pd.DataFrame(
+        {
+            "delta": [1.0, 1.0],
+            "starttime": [10.0, 20.0],
+            "is_live": [True, True],
+            "marker": ["left", "right"],
+        }
+    )
+    return Gather(
+        capacity=2,
+        size=2,
+        npts=4,
+        num_components=1,
+        npartitions=1,
+        member_metadata=member_metadata,
+        ensemble_metadata=metadata,
+        array_type="numpy",
+    )
+
+
+def _gather_snapshot(gather):
+    return {
+        "member_metadata": gather.member_metadata.copy(deep=True),
+        "ensemble_metadata": deepcopy(dict(gather.ensemble_metadata)),
+        "member_data": np.array(gather.member_data, copy=True),
+        "fields": (
+            gather.capacity,
+            gather.size,
+            gather.npts,
+            gather.num_components,
+            gather.array_type,
+            gather.is_parallel,
+            gather.is_compact,
+            gather.npartitions,
+        ),
+        "elog": [
+            (error.algorithm, error.message, error.badness)
+            for error in gather.elog.get_error_log()
+        ],
+    }
+
+
+def _assert_metadata_values_equal(actual, expected):
+    assert actual.keys() == expected.keys()
+    for key, expected_value in expected.items():
+        actual_value = actual[key]
+        if isinstance(expected_value, float) and math.isnan(expected_value):
+            assert math.isnan(actual_value)
+        else:
+            assert actual_value == expected_value
+
+
+def _assert_gather_matches_snapshot(gather, snapshot):
+    pd.testing.assert_frame_equal(gather.member_metadata, snapshot["member_metadata"])
+    _assert_metadata_values_equal(
+        dict(gather.ensemble_metadata), snapshot["ensemble_metadata"]
+    )
+    np.testing.assert_array_equal(gather.member_data, snapshot["member_data"])
+    assert (
+        gather.capacity,
+        gather.size,
+        gather.npts,
+        gather.num_components,
+        gather.array_type,
+        gather.is_parallel,
+        gather.is_compact,
+        gather.npartitions,
+    ) == snapshot["fields"]
+    assert [
+        (error.algorithm, error.message, error.badness)
+        for error in gather.elog.get_error_log()
+    ] == snapshot["elog"]
+
+
+def test_ator_and_rtoa_are_exact_inverses_using_persisted_shift_metadata():
+    gather = _gather(is_utc=True)
+    original_starttimes = gather.member_metadata["starttime"].copy()
+
+    assert gather.ator(2.5) is gather
+    assert gather.member_metadata["starttime"].tolist() == [7.5, 17.5]
+    assert gather.ensemble_metadata["starttime_shift"] == 2.5
+    assert gather.ensemble_metadata["is_utc"] is False
+    assert "t0shift" not in vars(gather)
+
+    assert gather.rtoa() is gather
+    pd.testing.assert_series_equal(
+        gather.member_metadata["starttime"], original_starttimes
+    )
+    assert gather.ensemble_metadata["starttime_shift"] == 0.0
+    assert gather.ensemble_metadata["is_utc"] is True
+    assert "t0shift" not in vars(gather)
+
+
+@pytest.mark.parametrize(
+    "shift", [None, "2.5", float("nan"), float("inf"), -float("inf"), True]
+)
+def test_ator_rejects_invalid_shift_before_mutation(shift):
+    gather = _gather(is_utc=True)
+    before = _gather_snapshot(gather)
+
+    with pytest.raises(ValueError, match="finite number"):
+        gather.ator(shift)
+
+    _assert_gather_matches_snapshot(gather, before)
+
+
+def test_ator_is_identity_on_already_relative_input_without_validating_shift():
+    gather = _gather(is_utc=False, starttime_shift=4.0)
+    before = _gather_snapshot(gather)
+
+    assert gather.ator("not a number") is gather
+    _assert_gather_matches_snapshot(gather, before)
+
+
+def test_rtoa_rejects_missing_shift_before_mutation():
+    gather = _gather(is_utc=False)
+    before = _gather_snapshot(gather)
+
+    with pytest.raises(ValueError, match="does not define starttime_shift"):
+        gather.rtoa()
+
+    _assert_gather_matches_snapshot(gather, before)
+
+
+@pytest.mark.parametrize(
+    "shift", ["2.5", float("nan"), float("inf"), -float("inf"), True]
+)
+def test_rtoa_rejects_invalid_stored_shift_before_mutation(shift):
+    gather = _gather(is_utc=False, starttime_shift=shift)
+    before = _gather_snapshot(gather)
+
+    with pytest.raises(ValueError, match="finite number"):
+        gather.rtoa()
+
+    _assert_gather_matches_snapshot(gather, before)
+
+
+@pytest.mark.parametrize("stored_shift", [None, "invalid", float("nan")])
+def test_rtoa_is_identity_on_already_utc_input_without_validating_stored_shift(
+    stored_shift,
+):
+    gather = _gather(is_utc=True, starttime_shift=stored_shift)
+    if stored_shift is None:
+        gather.ensemble_metadata.pop("starttime_shift", None)
+    before = _gather_snapshot(gather)
+
+    assert gather.rtoa() is gather
+    _assert_gather_matches_snapshot(gather, before)

--- a/python/tests/seismic/test_gather_resample_time_contracts.py
+++ b/python/tests/seismic/test_gather_resample_time_contracts.py
@@ -128,21 +128,78 @@ def test_regularize_ensemble_uses_the_inclusive_common_intersection():
     np.testing.assert_array_equal(result.member[1].data, [100.0, 101.0, 102.0, 103.0])
 
 
-@pytest.mark.parametrize(
-    "specifications",
-    [
-        [(0.0, 3, 1.0, 0.0), (3.0, 3, 1.0, 100.0)],
-        [(0.0, 3, 1.0, 0.0), (2.0, 3, 1.0, 100.0)],
-    ],
-    ids=["disjoint", "touching"],
-)
-def test_regularize_ensemble_rejects_empty_intersection_before_mutation(
-    specifications,
-):
-    ensemble = _ensemble(specifications)
+def test_regularize_ensemble_rejects_disjoint_intersection_before_mutation():
+    ensemble = _ensemble([(0.0, 3, 1.0, 0.0), (3.0, 3, 1.0, 100.0)])
     before = _ensemble_snapshot(ensemble)
 
     with pytest.raises(ValueError, match="common time interval"):
+        regularize_ensemble(ensemble)
+
+    _assert_ensemble_matches_snapshot(ensemble, before)
+
+
+def test_regularize_ensemble_preserves_a_shared_endpoint_sample():
+    ensemble = _ensemble([(0.0, 3, 1.0, 0.0), (2.0, 3, 1.0, 100.0)])
+
+    result = regularize_ensemble(ensemble)
+
+    assert result is ensemble
+    assert [(member.t0, member.endtime(), member.npts) for member in result.member] == [
+        (2.0, 2.0, 1),
+        (2.0, 2.0, 1),
+    ]
+    np.testing.assert_array_equal(result.member[0].data, [2.0])
+    np.testing.assert_array_equal(result.member[1].data, [100.0])
+
+
+def test_regularize_ensemble_ignores_and_preserves_dead_member_spans():
+    ensemble = _ensemble(
+        [
+            (0.0, 6, 1.0, 0.0),
+            (2.0, 6, 1.0, 100.0),
+            (1000.0, 1, 10.0, 999.0),
+        ]
+    )
+    ensemble.member[2].kill()
+    dead_before = _ensemble_snapshot(ensemble)["members"][2]
+
+    result = regularize_ensemble(ensemble)
+
+    assert [
+        (member.t0, member.endtime(), member.npts) for member in result.member[:2]
+    ] == [
+        (2.0, 5.0, 4),
+        (2.0, 5.0, 4),
+    ]
+    dead = result.member[2]
+    assert dict(dead) == dead_before["metadata"]
+    assert dead.live == dead_before["live"]
+    assert dead.t0 == dead_before["t0"]
+    assert dead.dt == dead_before["dt"]
+    assert dead.npts == dead_before["npts"]
+    np.testing.assert_array_equal(dead.data, dead_before["data"])
+    assert [
+        (error.algorithm, error.message, error.badness)
+        for error in dead.elog.get_error_log()
+    ] == dead_before["elog"]
+
+
+def test_regularize_ensemble_with_no_live_members_is_an_exact_noop():
+    ensemble = _ensemble([(0.0, 3, 1.0, 0.0), (10.0, 2, 2.0, 100.0)])
+    for member in ensemble.member:
+        member.kill()
+    before = _ensemble_snapshot(ensemble)
+
+    assert regularize_ensemble(ensemble) is ensemble
+
+    _assert_ensemble_matches_snapshot(ensemble, before)
+
+
+def test_regularize_ensemble_rejects_incompatible_sample_grids_atomically():
+    ensemble = _ensemble([(0.0, 6, 1.0, 0.0), (0.25, 6, 1.0, 100.0)])
+    before = _ensemble_snapshot(ensemble)
+
+    with pytest.raises(ValueError, match="common sample grid"):
         regularize_ensemble(ensemble)
 
     _assert_ensemble_matches_snapshot(ensemble, before)


### PR DESCRIPTION
Fixes #875.

## Summary
- interpret target `dt` as a sample interval and pass `1.0 / dt` to resamplers
- regularize live members over their inclusive physical intersection and preserve dead members
- keep a shared endpoint as one real sample
- snap equal-rate off-grid windows to the first live member grid by default without changing sample values
- provide explicit linear interpolation on the reference grid with `grid_alignment="interpolate"`
- reject different sample intervals and invalid modes before replacing ensemble members
- persist relative/UTC shifts in `ensemble_metadata["starttime_shift"]`
- make `ator`, `rtoa`, and `shift` exact same-object operations compatible with #912 metadata APIs

## Verification
- integrated #912/#917 plus existing Gather tests: 88 passed
- scalar and three-component interpolation covered
- 1e-6-sample floating endpoint tolerance covered
- Black, `py_compile`, and `git diff --check` passed

## Review status
Ready to merge. The scientific/API decisions follow the maintainer-approved default snap and explicit interpolation policy.