### PR TITLE
Harden EstimateBandwidth frequency bounds

### DIFF
--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -28,6 +28,14 @@ from mspasspy.util.decorators import mspass_func_wrapper
 # import matplotlib.pyplot as plt
 
 
+def _smooth_snr_curve(snrdata, npts):
+    """Return a truncated, renormalized moving average of an SNR curve."""
+    smoother = np.ones(npts)
+    smoothed_sum = np.convolve(snrdata, smoother, mode="same")
+    available_count = np.convolve(np.ones(len(snrdata)), smoother, mode="same")
+    return smoothed_sum / available_count
+
+
 def EstimateBandwidth(
     S,
     N,
@@ -56,7 +64,9 @@ def EstimateBandwidth(
     by the "f0" argument.  The basic idea is it hunts up and down the
     frequency axis until it detects the band edge.   The "band edge"
     detection is defined as the point where the signal-to-noise ratio
-    first falls below the value defined by the "snr_threshold" argument.
+    first falls below or equals the value defined by the "snr_threshold"
+    argument.  Samples are inside the passband only when their SNR is
+    strictly greater than the threshold.
     The algorithm has two variants of note:
 
     1.  If no point in the snr curve exceeds the valued defined by
@@ -78,7 +88,9 @@ def EstimateBandwidth(
     smoothing width be of the form k*tbp*df where tbp is the time
     bandwidth product, df is the Rayleigh bin size, and k is some
     small multipler (note multitaper spectra a inherently smoothed
-    by 2*tbp*df).
+    by 2*tbp*df).  At either end of the spectrum the moving average uses
+    only available frequency bins and renormalizes their weights; values
+    outside the measured spectrum are not treated as zeros or reflected.
 
     :param S: power spectrum computed from signal time window.
     :type S:  :py:class:`mspasspy.ccore.seismic.PowerSpectrum`
@@ -206,11 +218,10 @@ def EstimateBandwidth(
     snrdata = np.sqrt(snrdata)
     if df_smoother is not None:
         smoother_npts = min(len(snrdata), max(1, round(df_smoother / S.df())))
-        smoother = np.ones(smoother_npts) / smoother_npts
-        snrdata = np.convolve(snrdata, smoother, mode="same")
+        snrdata = _smooth_snr_curve(snrdata, smoother_npts)
     # test for no data exceeding tbhreshold - send null result if that is the case
     snrmax = np.max(snrdata)
-    if snrmax < snr_threshold:
+    if snrmax <= snr_threshold:
         result.high_edge_f = 0.0
         result.high_edge_snr = 0.0
         result.low_edge_f = 0.0
@@ -254,7 +265,7 @@ def EstimateBandwidth(
         # point above the threshold (there has to be one because of
         # test for max snrdata above)
         i = i0
-        while i >= 0 and snrdata[i] < snr_threshold:
+        while i >= 0 and snrdata[i] <= snr_threshold:
             i -= 1
         if i < 0:
             return result

--- a/python/mspasspy/algorithms/snr.py
+++ b/python/mspasspy/algorithms/snr.py
@@ -1,5 +1,5 @@
-import pickle
 import math
+import pickle
 from numbers import Real
 
 import numpy as np
@@ -137,22 +137,56 @@ def EstimateBandwidth(
             )
         )
         raise TypeError(message)
-    # set the ceiling on the high frequency band edge
-    # Default is 80% of Nyquist
-    if f_max:
-        if f_max > S.Nyquist():
-            # silently reset to Nyquist if f_max is illegal
-            high_f_ceiling = 0.8 * S.Nyquist()
-        high_f_ceiling = f_max
+    default_high_f_ceiling = 0.8 * S.Nyquist()
+    if f_max is None:
+        high_f_ceiling = default_high_f_ceiling
     else:
-        high_f_ceiling = 0.8 * S.Nyquist()
+        if (
+            isinstance(f_max, bool)
+            or not isinstance(f_max, Real)
+            or not math.isfinite(f_max)
+            or f_max <= 0.0
+        ):
+            raise ValueError("f_max must be a finite positive number")
+        high_f_ceiling = min(f_max, default_high_f_ceiling)
+    if (
+        isinstance(f0, bool)
+        or not isinstance(f0, Real)
+        or not math.isfinite(f0)
+        or f0 < 0.0
+        or f0 > high_f_ceiling
+    ):
+        raise ValueError("f0 must be finite and in the range [0, high_f_ceiling]")
+    if df_smoother is not None and (
+        isinstance(df_smoother, bool)
+        or not isinstance(df_smoother, Real)
+        or not math.isfinite(df_smoother)
+        or df_smoother <= 0.0
+    ):
+        raise ValueError("df_smoother must be a finite positive number")
+
+    result = BandwidthData()
+    if S.nf() == 0:
+        return result
+    result.f_range = S.frequency(S.nf() - 1) - S.frequency(0)
     # use the S grid to define the snr curve - note N grid can be different
     snrdata = np.zeros(S.nf())
+    noise_nfreq = N.nf()
+    if noise_nfreq > 0:
+        noise_first_frequency = N.frequency(0)
+        noise_terminal_frequency = N.frequency(noise_nfreq - 1)
     for i in range(S.nf()):
         f = S.frequency(i)
+        if (
+            noise_nfreq == 0
+            or f < noise_first_frequency
+            or f > noise_terminal_frequency
+        ):
+            snrdata[i] = 1.0
+            continue
         i_n = N.sample_number(f)
         # conditional needed in case S and N are computed with different sample intervals
-        if i_n < N.nf():
+        if 0 <= i_n < noise_nfreq:
             Nnow = N.spectrum[i_n]
             Snow = S.spectrum[i]
             if Snow <= 0.0:
@@ -170,14 +204,10 @@ def EstimateBandwidth(
             snrdata[i] = 1.0
     # S and N are power, convert to amplitude
     snrdata = np.sqrt(snrdata)
-    if df_smoother:
-        smoother_npts = round(df_smoother / S.df())
-        # silently do nothing if the smoother requested is smaller than df
-        if smoother_npts > 1:
-            smoother = np.ones(smoother_npts) / smoother_npts
-            np.convolve(snrdata, smoother, mode="valid")
-    result = BandwidthData()
-    result.f_range = S.frequency(S.nf() - 1) - S.frequency(0)
+    if df_smoother is not None:
+        smoother_npts = min(len(snrdata), max(1, round(df_smoother / S.df())))
+        smoother = np.ones(smoother_npts) / smoother_npts
+        snrdata = np.convolve(snrdata, smoother, mode="same")
     # test for no data exceeding tbhreshold - send null result if that is the case
     snrmax = np.max(snrdata)
     if snrmax < snr_threshold:
@@ -187,8 +217,24 @@ def EstimateBandwidth(
         result.low_edge_snr = 0.0
         return result
     # get index of search start
-    i0 = S.sample_number(f0)
-    i_max = S.sample_number(high_f_ceiling)
+    first_frequency = S.frequency(0)
+    terminal_frequency = S.frequency(len(snrdata) - 1)
+    if f0 <= first_frequency:
+        i0 = 0
+    elif f0 >= terminal_frequency:
+        i0 = len(snrdata) - 1
+    else:
+        i0 = S.sample_number(f0)
+    if high_f_ceiling >= terminal_frequency:
+        i_max = len(snrdata) - 1
+    elif high_f_ceiling <= first_frequency:
+        i_max = 0
+    else:
+        i_max = S.sample_number(high_f_ceiling)
+        i_max = min(max(i_max, 0), len(snrdata) - 1)
+        while i_max > 0 and S.frequency(i_max) > high_f_ceiling:
+            i_max -= 1
+    i0 = min(i0, i_max)
     # search upward in f
     i = i0
     while i < i_max:
@@ -208,10 +254,10 @@ def EstimateBandwidth(
         # point above the threshold (there has to be one because of
         # test for max snrdata above)
         i = i0
-        while (
-            snrdata[i] < snr_threshold and i >= 0
-        ):  # i>=0 test not essential but safer
+        while i >= 0 and snrdata[i] < snr_threshold:
             i -= 1
+        if i < 0:
+            return result
         result.high_edge_f = S.frequency(i)
         result.high_edge_snr = snrdata[i]
         i0 = i

--- a/python/tests/algorithms/test_estimate_bandwidth_contract.py
+++ b/python/tests/algorithms/test_estimate_bandwidth_contract.py
@@ -1,0 +1,227 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import mspasspy.algorithms.snr as snr_module
+import mspasspy.ccore.seismic as seismic_binding
+from mspasspy.ccore.seismic import DoubleVector, PowerSpectrum
+from mspasspy.ccore.utility import Metadata
+
+
+def _spectrum(values, df=1.0, dt=0.05):
+    return PowerSpectrum(
+        Metadata(),
+        DoubleVector(values),
+        df,
+        "test spectrum",
+        0.0,
+        dt,
+        20,
+    )
+
+
+def _signal_and_noise():
+    noise = _spectrum([1.0] * 11)
+    signal = _spectrum([0.25] + [4.0] * 8 + [0.25, 0.25])
+    return signal, noise
+
+
+def test_contract_suite_uses_worktree_module_and_real_binding():
+    expected_module = Path(__file__).resolve().parents[2] / "mspasspy/algorithms/snr.py"
+    assert Path(snr_module.__file__).resolve() == expected_module
+    assert Path(seismic_binding.__file__).suffix == ".so"
+
+
+@pytest.mark.parametrize(
+    "f_max,expected_high_edge",
+    [(4.0, 4.0), (4.6, 4.0), (8.0, 8.0), (20.0, 8.0), (None, 8.0)],
+)
+def test_fmax_is_bounded_by_eighty_percent_of_nyquist(f_max, expected_high_edge):
+    signal, noise = _signal_and_noise()
+
+    result = snr_module.EstimateBandwidth(
+        signal, noise, snr_threshold=1.5, f0=1.0, f_max=f_max
+    )
+
+    assert result.high_edge_f == expected_high_edge
+    assert result.f_range == 10.0
+
+
+@pytest.mark.parametrize(
+    "f_max", [0.0, -1.0, np.nan, np.inf, -np.inf, "8.0", True, np.bool_(True)]
+)
+def test_invalid_fmax_raises_value_error_before_spectrum_access(f_max):
+    signal, noise = _signal_and_noise()
+    signal.spectrum = DoubleVector()
+
+    with pytest.raises(ValueError, match="f_max must be a finite positive number"):
+        snr_module.EstimateBandwidth(signal, noise, f0=0.0, f_max=f_max)
+
+
+@pytest.mark.parametrize("f0", [0.0, 8.0])
+def test_f0_accepts_both_inclusive_frequency_bounds(f0):
+    signal, noise = _signal_and_noise()
+
+    result = snr_module.EstimateBandwidth(signal, noise, f0=f0)
+
+    assert result.f_range == 10.0
+
+
+def test_numpy_real_scalars_are_valid_numeric_arguments():
+    signal, noise = _signal_and_noise()
+
+    result = snr_module.EstimateBandwidth(
+        signal,
+        noise,
+        f0=np.int64(1),
+        f_max=np.float32(8.0),
+        df_smoother=np.float64(0.1),
+    )
+
+    assert result.high_edge_f == 8.0
+
+
+@pytest.mark.parametrize(
+    "f0",
+    [
+        -1.0,
+        np.nextafter(8.0, np.inf),
+        np.nan,
+        np.inf,
+        -np.inf,
+        "1.0",
+        True,
+        np.bool_(True),
+    ],
+)
+def test_invalid_f0_raises_value_error_instead_of_index_error(f0):
+    signal, noise = _signal_and_noise()
+    signal.spectrum = DoubleVector()
+
+    with pytest.raises(
+        ValueError, match=r"f0 must be finite and in the range \[0, high_f_ceiling\]"
+    ):
+        snr_module.EstimateBandwidth(signal, noise, f0=f0)
+
+
+@pytest.mark.parametrize("width,expected_nwin", [(0.1, 1), (3.0, 3), (100.0, 11)])
+def test_smoothing_replaces_snrdata_with_exact_same_mode_convolution(
+    monkeypatch, width, expected_nwin
+):
+    signal, noise = _signal_and_noise()
+    real_convolve = np.convolve
+    captured = {}
+
+    def capture_convolve(values, kernel, mode):
+        captured["values"] = np.array(values, copy=True)
+        captured["kernel"] = np.array(kernel, copy=True)
+        captured["mode"] = mode
+        captured["output"] = real_convolve(values, kernel, mode=mode)
+        return captured["output"]
+
+    monkeypatch.setattr(snr_module.np, "convolve", capture_convolve)
+
+    snr_module.EstimateBandwidth(signal, noise, f0=1.0, df_smoother=width)
+
+    expected_input = np.sqrt(np.asarray(signal.spectrum) / np.asarray(noise.spectrum))
+    expected_kernel = np.ones(expected_nwin) / expected_nwin
+    np.testing.assert_array_equal(captured["values"], expected_input)
+    np.testing.assert_array_equal(captured["kernel"], expected_kernel)
+    assert captured["mode"] == "same"
+    np.testing.assert_array_equal(
+        captured["output"],
+        real_convolve(expected_input, expected_kernel, mode="same"),
+    )
+
+
+def test_convolution_return_value_drives_the_bandwidth_result(monkeypatch):
+    signal, noise = _signal_and_noise()
+    calls = []
+
+    def replace_with_below_threshold(values, kernel, mode):
+        calls.append((np.array(values), np.array(kernel), mode))
+        return np.zeros_like(values)
+
+    monkeypatch.setattr(snr_module.np, "convolve", replace_with_below_threshold)
+
+    result = snr_module.EstimateBandwidth(signal, noise, f0=1.0, df_smoother=3.0)
+
+    assert len(calls) == 1
+    assert result.low_edge_f == 0.0
+    assert result.high_edge_f == 0.0
+    assert result.low_edge_snr == 0.0
+    assert result.high_edge_snr == 0.0
+    assert result.f_range == 10.0
+
+
+@pytest.mark.parametrize(
+    "width",
+    [0.0, -1.0, np.nan, np.inf, -np.inf, "1.0", True, np.bool_(True)],
+)
+def test_invalid_smoothing_width_raises_before_convolution(monkeypatch, width):
+    signal, noise = _signal_and_noise()
+    convolve = pytest.fail
+    monkeypatch.setattr(snr_module.np, "convolve", convolve)
+
+    with pytest.raises(
+        ValueError, match="df_smoother must be a finite positive number"
+    ):
+        snr_module.EstimateBandwidth(signal, noise, f0=1.0, df_smoother=width)
+
+
+def test_no_smoothed_value_at_threshold_returns_null_bandwidth():
+    signal = _spectrum([1.0] * 11)
+    noise = _spectrum([1.0] * 11)
+
+    result = snr_module.EstimateBandwidth(
+        signal,
+        noise,
+        snr_threshold=1.5,
+        f0=0.0,
+        df_smoother=100.0,
+    )
+
+    assert result.low_edge_f == 0.0
+    assert result.high_edge_f == 0.0
+    assert result.low_edge_snr == 0.0
+    assert result.high_edge_snr == 0.0
+    assert result.f_range == 10.0
+
+
+def test_value_equal_to_threshold_counts_as_reaching_it():
+    signal = _spectrum([1.0, 1.0, 2.25, 1.0, 1.0])
+    noise = _spectrum([1.0] * 5)
+
+    result = snr_module.EstimateBandwidth(signal, noise, snr_threshold=1.5, f0=2.0)
+
+    assert result.low_edge_f == 2.0
+    assert result.high_edge_f == 2.0
+    assert result.low_edge_snr == 1.5
+    assert result.high_edge_snr == 1.5
+    assert result.f_range == 4.0
+
+
+def test_searches_do_not_index_below_zero_or_past_a_truncated_spectrum():
+    noise = _spectrum([1.0] * 5)
+    signal = _spectrum([0.25, 4.0, 4.0, 4.0, 4.0])
+
+    below_start_result = snr_module.EstimateBandwidth(signal, noise, f0=0.0)
+    terminal_result = snr_module.EstimateBandwidth(signal, noise, f0=8.0)
+
+    assert below_start_result.low_edge_f == 0.0
+    assert below_start_result.high_edge_f == 0.0
+    assert terminal_result.high_edge_f == 4.0
+
+
+def test_truncated_noise_grid_is_checked_before_sample_number():
+    signal = _spectrum([4.0] * 5)
+    noise = _spectrum([1.0] * 2)
+
+    result = snr_module.EstimateBandwidth(signal, noise, f0=0.0)
+
+    assert result.low_edge_f == 0.0
+    assert result.low_edge_snr == 2.0
+    assert result.high_edge_f == 2.0
+    assert result.high_edge_snr == 1.0
+    assert result.f_range == 4.0

--- a/python/tests/algorithms/test_estimate_bandwidth_contract.py
+++ b/python/tests/algorithms/test_estimate_bandwidth_contract.py
@@ -128,33 +128,28 @@ def test_invalid_f0_raises_value_error_instead_of_index_error(f0):
         snr_module.EstimateBandwidth(signal, noise, f0=f0)
 
 
-@pytest.mark.parametrize("width,expected_nwin", [(0.1, 1), (3.0, 3), (100.0, 11)])
-def test_smoothing_replaces_snrdata_with_exact_same_mode_convolution(
-    monkeypatch, width, expected_nwin
-):
-    signal, noise = _signal_and_noise()
-    real_convolve = np.convolve
-    captured = {}
+@pytest.mark.parametrize("npts", [1, 3, 4, 11])
+def test_smoothing_uses_only_available_bins_and_renormalizes(npts):
+    values = np.arange(1.0, 12.0)
+    expected = []
+    left = npts // 2
+    right = (npts - 1) // 2
+    for i in range(len(values)):
+        expected.append(
+            np.mean(values[max(0, i - left) : min(len(values), i + right + 1)])
+        )
 
-    def capture_convolve(values, kernel, mode):
-        captured["values"] = np.array(values, copy=True)
-        captured["kernel"] = np.array(kernel, copy=True)
-        captured["mode"] = mode
-        captured["output"] = real_convolve(values, kernel, mode=mode)
-        return captured["output"]
+    actual = snr_module._smooth_snr_curve(values, npts)
 
-    monkeypatch.setattr(snr_module.np, "convolve", capture_convolve)
+    np.testing.assert_allclose(actual, expected)
 
-    snr_module.EstimateBandwidth(signal, noise, f0=1.0, df_smoother=width)
 
-    expected_input = np.sqrt(np.asarray(signal.spectrum) / np.asarray(noise.spectrum))
-    expected_kernel = np.ones(expected_nwin) / expected_nwin
-    np.testing.assert_array_equal(captured["values"], expected_input)
-    np.testing.assert_array_equal(captured["kernel"], expected_kernel)
-    assert captured["mode"] == "same"
-    np.testing.assert_array_equal(
-        captured["output"],
-        real_convolve(expected_input, expected_kernel, mode="same"),
+@pytest.mark.parametrize("npts", [1, 3, 4, 11])
+def test_smoothing_does_not_depress_a_constant_spectrum_at_edges(npts):
+    values = np.full(11, 2.75)
+
+    np.testing.assert_allclose(
+        snr_module._smooth_snr_curve(values, npts), values, rtol=0.0, atol=0.0
     )
 
 
@@ -162,11 +157,13 @@ def test_convolution_return_value_drives_the_bandwidth_result(monkeypatch):
     signal, noise = _signal_and_noise()
     calls = []
 
-    def replace_with_below_threshold(values, kernel, mode):
-        calls.append((np.array(values), np.array(kernel), mode))
+    def replace_with_below_threshold(values, npts):
+        calls.append((np.array(values), npts))
         return np.zeros_like(values)
 
-    monkeypatch.setattr(snr_module.np, "convolve", replace_with_below_threshold)
+    monkeypatch.setattr(
+        snr_module, "_smooth_snr_curve", replace_with_below_threshold
+    )
 
     result = snr_module.EstimateBandwidth(signal, noise, f0=1.0, df_smoother=3.0)
 
@@ -212,17 +209,29 @@ def test_no_smoothed_value_at_threshold_returns_null_bandwidth():
     assert result.f_range == 10.0
 
 
-def test_value_equal_to_threshold_counts_as_reaching_it():
+def test_value_equal_to_threshold_is_not_inside_the_passband():
     signal = _spectrum([1.0, 1.0, 2.25, 1.0, 1.0])
     noise = _spectrum([1.0] * 5)
 
     result = snr_module.EstimateBandwidth(signal, noise, snr_threshold=1.5, f0=2.0)
 
-    assert result.low_edge_f == 2.0
-    assert result.high_edge_f == 2.0
-    assert result.low_edge_snr == 1.5
-    assert result.high_edge_snr == 1.5
+    assert result.low_edge_f == 0.0
+    assert result.high_edge_f == 0.0
+    assert result.low_edge_snr == 0.0
+    assert result.high_edge_snr == 0.0
     assert result.f_range == 4.0
+
+
+def test_threshold_equality_marks_the_first_outside_band_edge():
+    signal = _spectrum([1.0, 4.0, 2.25, 1.0, 1.0])
+    noise = _spectrum([1.0] * 5)
+
+    result = snr_module.EstimateBandwidth(signal, noise, snr_threshold=1.5, f0=1.0)
+
+    assert result.low_edge_f == 0.0
+    assert result.low_edge_snr == 1.0
+    assert result.high_edge_f == 2.0
+    assert result.high_edge_snr == 1.5
 
 
 def test_searches_do_not_index_below_zero_or_past_a_truncated_spectrum():

--- a/python/tests/algorithms/test_estimate_bandwidth_contract.py
+++ b/python/tests/algorithms/test_estimate_bandwidth_contract.py
@@ -161,9 +161,7 @@ def test_convolution_return_value_drives_the_bandwidth_result(monkeypatch):
         calls.append((np.array(values), npts))
         return np.zeros_like(values)
 
-    monkeypatch.setattr(
-        snr_module, "_smooth_snr_curve", replace_with_below_threshold
-    )
+    monkeypatch.setattr(snr_module, "_smooth_snr_curve", replace_with_below_threshold)
 
     result = snr_module.EstimateBandwidth(signal, noise, f0=1.0, df_smoother=3.0)
 

--- a/python/tests/algorithms/test_estimate_bandwidth_contract.py
+++ b/python/tests/algorithms/test_estimate_bandwidth_contract.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+from importlib.metadata import distribution, version
 from pathlib import Path
 
 import numpy as np
@@ -27,9 +30,29 @@ def _signal_and_noise():
     return signal, noise
 
 
-def test_contract_suite_uses_worktree_module_and_real_binding():
-    expected_module = Path(__file__).resolve().parents[2] / "mspasspy/algorithms/snr.py"
-    assert Path(snr_module.__file__).resolve() == expected_module
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
+
+
+def test_contract_suite_uses_selected_build_and_real_binding():
+    _assert_module_from_selected_build(snr_module, "mspasspy/algorithms/snr.py")
     assert Path(seismic_binding.__file__).suffix == ".so"
 
 


### PR DESCRIPTION
Fixes #856.

## Maintainer-approved behavior

- Smooth the SNR curve with a centered moving average over the bins that actually exist at each edge; the shortened edge window is renormalized and no zero, reflection, or extrapolated bins are introduced.
- Define the passband by strict `SNR > threshold`; a bin equal to the threshold is outside the passband and is returned as the boundary bin.
- Validate frequency and smoother parameters before spectrum access, clamp the requested ceiling without rounding above it, and avoid out-of-range calls for empty or unequal-length spectra.

## Verification

- EstimateBandwidth contract suite: 47 passed
- Combined broadband/diagnostic/window/EstimateBandwidth contracts: 81 passed
- Existing non-database SNR numerical regressions: passed
- Black, Python 3.12/3.13 `py_compile`, and `git diff --check`: passed
- The tests include an independent manual truncated-window oracle, constant-spectrum edge preservation, exact-threshold cases, and bounded unequal-grid cases