### PR TITLE
Repair SpectrumDatabase CRUD and verification

### DIFF
--- a/python/mspasspy/db/spectrumdb.py
+++ b/python/mspasspy/db/spectrumdb.py
@@ -114,7 +114,7 @@ class BasicObjectDatabase(ABC):
         do_not_load_keyword = "DO_NOT_LOAD"
         self.name = name
         dbclient = DBClient()
-        self.db = dbclient.get_database(self.name)
+        self.db = dbclient.get_database(self.name, *args, **kwargs)
         self.type_list = type_list
         if isinstance(db_schema, DatabaseSchema):
             self.database_schema = db_schema
@@ -222,10 +222,15 @@ class SpectrumDatabase(BasicObjectDatabase):
         :type collection:  string
         """
         type_list = [PowerSpectrum]
-        BasicObjectDatabase.__init__(
-            name, type_list, db_schema="DO_NOT_LOAD", md_schema="DO_NOT_LOAD"
+        super().__init__(
+            name,
+            type_list,
+            *args,
+            db_schema="DO_NOT_LOAD",
+            md_schema="DO_NOT_LOAD",
+            **kwargs,
         )
-        self.collection = self[collection]
+        self.collection = self.db[collection]
 
     def save_data(self, datum, exclude=None, metadata2save=None, format="pickle"):
         """
@@ -247,37 +252,34 @@ class SpectrumDatabase(BasicObjectDatabase):
           pickles the input datum and saves the result with the key
           "serialized_data".
         """
+        if not self.data_valid(datum):
+            message = "SpectrumDatabase.save_data:  illegal data type for arg0. Found type={typ} - only support PowerSpectrum".format(
+                typ=type(datum)
+            )
+            raise MsPASSError(message, ErrorSeverity.Fatal)
+        if datum.dead():
+            return datum
         if format != "pickle":
             raise MsPASSError(
                 "SpectrumDatabase.save_data:  format can currently only be pickle",
                 ErrorSeverity.Fatal,
             )
-        if self.data_valid():
-            if datum.dead():
-                return datum
-            if metadata2save:
-                doc = dict()
-                for key in metadata2save:
-                    # if running this mode silently ignore any
-                    # metadata defined in the keep list but not defined
-                    # in the datum.   Questionable behavior
-                    if datum.is_defined(key):
-                        val = datum[key]
-                        doc[key] = val
-            else:
-                doc = dict(datum)
-                if exclude:
-                    for key in exclude:
-                        doc.pop(key)
-            doc["serialized_data"] = pickle.dumps(datum)
-            recid = self.collection.insert_one(doc).inserted_id
-            return recid
-
+        if metadata2save:
+            doc = dict()
+            for key in metadata2save:
+                # if running this mode silently ignore any
+                # metadata defined in the keep list but not defined
+                # in the datum.   Questionable behavior
+                if datum.is_defined(key):
+                    val = datum[key]
+                    doc[key] = val
         else:
-            message = "SpectrumDatabase.save_data:  illegal data type for arg0. Found type={typ} - only support PowerSpectrum".format(
-                typ=type(datum)
-            )
-            raise MsPASSError(message, ErrorSeverity.Fatal)
+            doc = dict(datum)
+            if exclude:
+                for key in exclude:
+                    doc.pop(key)
+        doc["serialized_data"] = pickle.dumps(datum)
+        return self.collection.insert_one(doc).inserted_id
 
     def read_data(
         self,
@@ -341,6 +343,14 @@ class SpectrumDatabase(BasicObjectDatabase):
             )
             raise MsPASSError(message, ErrorSeverity.Invalid)
 
+    def delete_data(self, id_or_doc):
+        """Delete one stored PowerSpectrum by ObjectId or document."""
+        if isinstance(id_or_doc, ObjectId):
+            oid = id_or_doc
+        else:
+            oid = id_or_doc["_id"]
+        self.collection.delete_one({"_id": oid})
+
     def verify(self, query=None, required=None):
         """
         Scans PowerSpectrum collection to verify the contents.  An optional
@@ -356,30 +366,20 @@ class SpectrumDatabase(BasicObjectDatabase):
         :param required:  optional list of keys every document scan is
           expected to contain.
 
-        :return:  tuple with two integers.  Component 0 will contain the
+        :return:  list with two integers.  Component 0 will contain the
           number of documents scanned and component 1 will contain the number
           the method considers valid.
         """
-        if query:
-            cursor = self.collection.find(query)
-        else:
-            cursor = self.collection.find[{}]
+        cursor = self.collection.find(query if query is not None else {})
         nprocessed = 0
         nvalid = 0
         testkey = "serialized_data"
         for doc in cursor:
-            if testkey in doc:
-                aok = True
-                if required:
-                    for k in required:
-                        if k not in doc:
-                            aok = False
-                            break
-
-            else:
-                aok = False
-        if aok:
-            nvalid += 1
-        nprocessed += 1
+            nprocessed += 1
+            aok = testkey in doc
+            if aok and required:
+                aok = all(k in doc for k in required)
+            if aok:
+                nvalid += 1
 
         return [nprocessed, nvalid]

--- a/python/mspasspy/db/spectrumdb.py
+++ b/python/mspasspy/db/spectrumdb.py
@@ -208,12 +208,9 @@ class SpectrumDatabase(BasicObjectDatabase):
         **kwargs,
     ):
         """
-        Constructor for this database handle.   Note because this class
-        inherits pymongo.database.Database.   You can pass arguments
-        to this constructor recognized by the base class constructor
-        for pymongo's handle like  "read_concern" or "write_concern" and
-        they will be passed to the pymongo constructor by the standard
-        python mechanism of *args and **kwargs.
+        Constructor for this database handle.  Additional positional and
+        keyword arguments are forwarded through :class:`BasicObjectDatabase`
+        when it creates the underlying database handle.
 
         :param name:  MongoDB database name to use.
         :type name:  string

--- a/python/tests/db/test_spectrumdb_contract.py
+++ b/python/tests/db/test_spectrumdb_contract.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+from importlib.metadata import distribution, version
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -94,11 +97,29 @@ def _live_spectrum():
     return spectrum
 
 
-def test_contract_suite_uses_worktree_module_and_real_binding():
-    expected_module = (
-        Path(__file__).resolve().parents[2] / "mspasspy" / "db" / "spectrumdb.py"
-    )
-    assert Path(spectrumdb_module.__file__).resolve() == expected_module
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
+
+
+def test_contract_suite_uses_selected_build_and_real_binding():
+    _assert_module_from_selected_build(spectrumdb_module, "mspasspy/db/spectrumdb.py")
     assert Path(seismic_binding.__file__).suffix == ".so"
 
 

--- a/python/tests/db/test_spectrumdb_contract.py
+++ b/python/tests/db/test_spectrumdb_contract.py
@@ -1,0 +1,236 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from bson import BSON, ObjectId
+from pymongo.results import DeleteResult, InsertOneResult
+
+import mspasspy.db.spectrumdb as spectrumdb_module
+import mspasspy.ccore.seismic as seismic_binding
+from mspasspy.ccore.seismic import DoubleVector, PowerSpectrum
+from mspasspy.ccore.utility import ErrorSeverity, Metadata, MsPASSError
+from mspasspy.db.spectrumdb import SpectrumDatabase
+
+
+class MemoryCollection:
+    """Small controllable collection implementing the CRUD calls under test."""
+
+    def __init__(self):
+        self.documents = []
+        self.insert_calls = 0
+
+    def insert_one(self, document):
+        self.insert_calls += 1
+        stored = dict(document)
+        stored.setdefault("_id", ObjectId())
+        self.documents.append(stored)
+        return InsertOneResult(stored["_id"], acknowledged=True)
+
+    def find_one(self, query):
+        return next(
+            (
+                dict(document)
+                for document in self.documents
+                if self._matches(document, query)
+            ),
+            None,
+        )
+
+    def find(self, query):
+        return [
+            dict(document)
+            for document in self.documents
+            if self._matches(document, query)
+        ]
+
+    def delete_one(self, query):
+        for index, document in enumerate(self.documents):
+            if self._matches(document, query):
+                del self.documents[index]
+                return DeleteResult({"n": 1, "ok": 1.0}, acknowledged=True)
+        return DeleteResult({"n": 0, "ok": 1.0}, acknowledged=True)
+
+    @staticmethod
+    def _matches(document, query):
+        return all(document.get(key) == value for key, value in query.items())
+
+
+class MemoryDatabase:
+    def __init__(self):
+        self.collections = {}
+
+    def __getitem__(self, name):
+        return self.collections.setdefault(name, MemoryCollection())
+
+
+def _build_database(monkeypatch, *args, **kwargs):
+    database = MemoryDatabase()
+    client = Mock()
+    client.get_database.return_value = database
+    monkeypatch.setattr(spectrumdb_module, "DBClient", Mock(return_value=client))
+    handle = SpectrumDatabase("spectra", *args, **kwargs)
+    return handle, client, database
+
+
+def _configured_handle():
+    handle = SpectrumDatabase.__new__(SpectrumDatabase)
+    handle.type_list = [PowerSpectrum]
+    handle.collection = MemoryCollection()
+    return handle
+
+
+def _live_spectrum():
+    spectrum = PowerSpectrum(
+        Metadata(),
+        DoubleVector([1.0, 4.0, 9.0]),
+        0.25,
+        "contract-test",
+        0.0,
+        1.0,
+        8,
+    )
+    spectrum["station"] = "AAA"
+    spectrum["quality"] = 7
+    return spectrum
+
+
+def test_contract_suite_uses_worktree_module_and_real_binding():
+    expected_module = (
+        Path(__file__).resolve().parents[2] / "mspasspy" / "db" / "spectrumdb.py"
+    )
+    assert Path(spectrumdb_module.__file__).resolve() == expected_module
+    assert Path(seismic_binding.__file__).suffix == ".so"
+
+
+def test_constructor_forwards_get_database_arguments_unchanged(monkeypatch):
+    sentinel_schema = object()
+    sentinel_codec = object()
+    sentinel_read_preference = object()
+    handle, client, database = _build_database(
+        monkeypatch,
+        sentinel_schema,
+        sentinel_codec,
+        read_preference=sentinel_read_preference,
+        collection="custom_spectra",
+    )
+
+    client.get_database.assert_called_once_with(
+        "spectra",
+        sentinel_schema,
+        sentinel_codec,
+        read_preference=sentinel_read_preference,
+    )
+    assert handle.collection is database["custom_spectra"]
+
+
+def test_live_save_read_and_delete_roundtrip(monkeypatch):
+    handle, _, _ = _build_database(monkeypatch)
+    original = _live_spectrum()
+
+    oid = handle.save_data(original)
+
+    assert isinstance(oid, ObjectId)
+    stored = handle.collection.find_one({"_id": oid})
+    assert stored["station"] == "AAA"
+    assert isinstance(stored["serialized_data"], bytes)
+    BSON.encode(stored)
+    restored = handle.read_data(oid)
+    assert isinstance(restored, PowerSpectrum)
+    assert restored.live()
+    assert dict(restored) == dict(original)
+    assert list(restored.spectrum) == pytest.approx([1.0, 4.0, 9.0])
+    assert restored.df() == pytest.approx(0.25)
+    assert restored.f0() == pytest.approx(0.0)
+    assert restored.dt() == pytest.approx(1.0)
+
+    handle.delete_data({"_id": oid})
+    assert handle.collection.find_one({"_id": oid}) is None
+    with pytest.raises(MsPASSError) as excinfo:
+        handle.read_data(oid)
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+
+
+def test_save_path_independently_validates_the_input_object():
+    handle = _configured_handle()
+    spectrum = _live_spectrum()
+
+    oid = handle.save_data(spectrum)
+
+    assert isinstance(oid, ObjectId)
+    assert handle.collection.insert_calls == 1
+
+
+def test_delete_path_independently_removes_the_selected_record():
+    handle = _configured_handle()
+    first = handle.collection.insert_one({"serialized_data": b"first"}).inserted_id
+    second = handle.collection.insert_one({"serialized_data": b"second"}).inserted_id
+
+    handle.delete_data(first)
+
+    assert handle.collection.find_one({"_id": first}) is None
+    assert handle.collection.find_one({"_id": second}) is not None
+
+
+def test_dead_save_returns_identity_and_performs_no_write(monkeypatch):
+    handle, _, _ = _build_database(monkeypatch)
+    dead = PowerSpectrum()
+    dead.kill()
+
+    result = handle.save_data(dead)
+
+    assert result is dead
+    assert handle.collection.insert_calls == 0
+    assert handle.collection.documents == []
+
+
+@pytest.mark.parametrize("value", (None, 1, "spectrum", {}, object()))
+def test_save_wrong_type_is_fatal(monkeypatch, value):
+    handle, _, _ = _build_database(monkeypatch)
+
+    with pytest.raises(MsPASSError) as excinfo:
+        handle.save_data(value)
+
+    assert excinfo.value.severity == ErrorSeverity.Fatal
+    assert handle.collection.insert_calls == 0
+
+
+def test_read_missing_is_invalid(monkeypatch):
+    handle, _, _ = _build_database(monkeypatch)
+
+    with pytest.raises(MsPASSError) as excinfo:
+        handle.read_data(ObjectId())
+
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+
+
+def test_verify_empty_all_valid_and_mixed(monkeypatch):
+    handle, _, _ = _build_database(monkeypatch)
+    assert handle.verify() == [0, 0]
+
+    first = handle.save_data(_live_spectrum())
+    second = handle.save_data(_live_spectrum())
+    assert handle.verify() == [2, 2]
+    assert handle.verify(required=["station", "quality"]) == [2, 2]
+
+    handle.collection.documents.append({"_id": ObjectId(), "station": "BAD"})
+    handle.collection.documents.append(
+        {"_id": ObjectId(), "serialized_data": b"not-used", "station": "PARTIAL"}
+    )
+    assert handle.verify() == [4, 3]
+    assert handle.verify(required=["station", "quality"]) == [4, 2]
+    assert handle.verify(query={"_id": first}) == [1, 1]
+    assert handle.verify(query={"_id": second}) == [1, 1]
+
+
+def test_verify_independently_counts_each_scanned_document():
+    handle = _configured_handle()
+    handle.collection.documents.extend(
+        [
+            {"serialized_data": b"first", "required": True},
+            {"serialized_data": b"second"},
+            {"required": True},
+        ]
+    )
+
+    assert handle.verify() == [3, 2]
+    assert handle.verify(required=["required"]) == [3, 1]


### PR DESCRIPTION
Closes #810.

## Summary
- forward `SpectrumDatabase` construction through `DBClient.get_database`
- restore live/dead/error contracts for save, read, and delete
- make collection verification return exact scanned and valid counts

## Tests
- added a 14-case contract suite covering constructor forwarding, CRUD, dead/wrong-type behavior, missing records, and empty/all-valid/mixed verification
- reviewer strengthened round-trip coverage with a non-empty real `PowerSpectrum`, its frequency grid, and BSON encoding
- focused contract plus PowerSpectrum pickle regression: 15 passed
- baseline contract run: 14 expected failures
- Black, Python 3.9/3.13 `py_compile`, and `git diff --check` passed

## Review
An independent agent reviewed the full diff and test oracles and reported zero remaining blockers. A local Mongo server was unavailable, so no server integration result is claimed; the constructor path and CRUD collection contract were exercised with controlled collections. This PR is ready for human review and is intentionally not merged.