### PR TITLE
Correct MCXcor physical-overlap calculations

### DIFF
--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -1700,8 +1700,18 @@ _SAMPLE_GRID_TOLERANCE = 1.0e-6
 
 def _validate_sample_grid_compatibility(d, beam):
     dt_scale = max(abs(d.dt), abs(beam.dt))
-    if dt_scale == 0.0 or abs(d.dt - beam.dt) > _SAMPLE_GRID_TOLERANCE * dt_scale:
-        raise ValueError("d and beam sample intervals are incompatible")
+    if d.dt <= 0.0 or beam.dt <= 0.0:
+        raise ValueError(
+            "d and beam sample intervals are incompatible across their sample "
+            "span; resample before comparison"
+        )
+    paired_intervals = max(0, min(d.npts, beam.npts) - 1)
+    accumulated_drift = abs(d.dt - beam.dt) * paired_intervals / dt_scale
+    if accumulated_drift > _SAMPLE_GRID_TOLERANCE:
+        raise ValueError(
+            "d and beam sample intervals are incompatible across their sample "
+            "span; resample before comparison"
+        )
     offset_in_samples = (d.t0 - beam.t0) / dt_scale
     if abs(offset_in_samples - round(offset_in_samples)) > _SAMPLE_GRID_TOLERANCE:
         raise ValueError("d and beam start times are on incompatible sample grids")
@@ -1763,15 +1773,8 @@ def beam_correlation(d, beam, window=None, aligned=True) -> float:
         raise TypeError(message)
     if d.dead() or beam.dead():
         return 0.0
-    vectors = _overlap_vectors(d, beam, window)
-    if vectors is None:
-        return 0.0
-    d_vector, beam_vector = vectors
-    nrm1 = np.linalg.norm(d_vector)
-    nrm2 = np.linalg.norm(beam_vector)
-    if nrm1 <= 0.0 or nrm2 <= 0.0:
-        return 0.0
     if not aligned:
+        _validate_sample_grid_compatibility(d, beam)
         d_for_shift = TimeSeries(d)
         beam_for_shift = TimeSeries(beam)
         if window:
@@ -1785,13 +1788,15 @@ def beam_correlation(d, beam, window=None, aligned=True) -> float:
         timelag = _xcor_shift(d_for_shift, beam_for_shift)
         shifted_d.set_t0(shifted_d.t0 - timelag)
         vectors = _overlap_vectors(shifted_d, beam, window)
-        if vectors is None:
-            return 0.0
-        d_vector, beam_vector = vectors
-        nrm1 = np.linalg.norm(d_vector)
-        nrm2 = np.linalg.norm(beam_vector)
-        if nrm1 <= 0.0 or nrm2 <= 0.0:
-            return 0.0
+    else:
+        vectors = _overlap_vectors(d, beam, window)
+    if vectors is None:
+        return 0.0
+    d_vector, beam_vector = vectors
+    nrm1 = np.linalg.norm(d_vector)
+    nrm2 = np.linalg.norm(beam_vector)
+    if nrm1 <= 0.0 or nrm2 <= 0.0:
+        return 0.0
     return abs(np.dot(d_vector, beam_vector) / (nrm1 * nrm2))
 
 

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -8,6 +8,8 @@ Created on Tue Jul  9 05:37:40 2024
 @author: pavlis
 """
 
+from functools import wraps
+
 import numpy as np
 from scipy import signal
 from mspasspy.util.decorators import mspass_func_wrapper
@@ -1693,6 +1695,52 @@ def align_and_stack(
 
 
 # these are intended to use only on the output from align_and stack
+_SAMPLE_GRID_TOLERANCE = 1.0e-6
+
+
+def _validate_sample_grid_compatibility(d, beam):
+    dt_scale = max(abs(d.dt), abs(beam.dt))
+    if dt_scale == 0.0 or abs(d.dt - beam.dt) > _SAMPLE_GRID_TOLERANCE * dt_scale:
+        raise ValueError("d and beam sample intervals are incompatible")
+    offset_in_samples = (d.t0 - beam.t0) / dt_scale
+    if abs(offset_in_samples - round(offset_in_samples)) > _SAMPLE_GRID_TOLERANCE:
+        raise ValueError("d and beam start times are on incompatible sample grids")
+
+
+def _inclusive_sample_bounds(d, start, end):
+    first = int(np.ceil((start - d.t0) / d.dt - _SAMPLE_GRID_TOLERANCE))
+    last = int(np.floor((end - d.t0) / d.dt + _SAMPLE_GRID_TOLERANCE))
+    return max(0, first), min(d.npts - 1, last)
+
+
+def _common_sample_interval(d, beam, window=None):
+    _validate_sample_grid_compatibility(d, beam)
+    overlap_start = max(d.t0, beam.t0)
+    overlap_end = min(d.endtime(), beam.endtime())
+    if window:
+        overlap_start = max(overlap_start, window.start)
+        overlap_end = min(overlap_end, window.end)
+    if overlap_start > overlap_end:
+        return None
+
+    d_start, d_end = _inclusive_sample_bounds(d, overlap_start, overlap_end)
+    beam_start, beam_end = _inclusive_sample_bounds(beam, overlap_start, overlap_end)
+    sample_count = min(d_end - d_start + 1, beam_end - beam_start + 1)
+    if sample_count <= 0:
+        return None
+    return d_start, beam_start, sample_count
+
+
+def _overlap_vectors(d, beam, window=None):
+    indices = _common_sample_interval(d, beam, window)
+    if indices is None:
+        return None
+    d_start, beam_start, sample_count = indices
+    d_vector = np.asarray(d.data[d_start : d_start + sample_count])
+    beam_vector = np.asarray(beam.data[beam_start : beam_start + sample_count])
+    return d_vector, beam_vector
+
+
 def beam_correlation(d, beam, window=None, aligned=True) -> float:
     """
     Computes normalized peak cross-correlation value a datum with an array stack.
@@ -1713,32 +1761,38 @@ def beam_correlation(d, beam, window=None, aligned=True) -> float:
         message = alg
         message += ":  arg0 must be a TimeSeries. Actual type={}".format(type(beam))
         raise TypeError(message)
-    # assume beam is live but don't assume d is
-    if d.dead():
+    if d.dead() or beam.dead():
         return 0.0
-    if window:
-        d1 = WindowData(d, window.start, window.end, short_segment_handling="pad")
-        d2 = WindowData(beam, window.start, window.end, short_segment_handling="pad")
-    else:
-        d1 = TimeSeries(d)
-        d2 = TimeSeries(beam)
-    nrm1 = np.linalg.norm(d1.data)
-    d1.data /= nrm1
-    nrm2 = np.linalg.norm(d2.data)
-    d2.data /= nrm2
+    vectors = _overlap_vectors(d, beam, window)
+    if vectors is None:
+        return 0.0
+    d_vector, beam_vector = vectors
+    nrm1 = np.linalg.norm(d_vector)
+    nrm2 = np.linalg.norm(beam_vector)
+    if nrm1 <= 0.0 or nrm2 <= 0.0:
+        return 0.0
     if not aligned:
-        timelag = _xcor_shift(d1, d2)
-        d1.shift(timelag)
-    t0max = max(d1.t0, d2.t0)
-    etmin = min(d1.endtime(), d2.endtime())
-    d1s = d1.sample_number(t0max)
-    d2s = d2.sample_number(t0max)
-    d1e = d1.sample_number(etmin)
-    d2e = d2.sample_number(etmin)
-    # this may not be necessary but with rounding errors it could be needed
-    N = min(d1e - d1s, d2e - d2s)
-    xcor_0 = np.dot(d1.data[0:N], d2.data[0:N])
-    return abs(xcor_0)
+        d_for_shift = TimeSeries(d)
+        beam_for_shift = TimeSeries(beam)
+        if window:
+            d_for_shift = WindowData(
+                d, window.start, window.end, short_segment_handling="pad"
+            )
+            beam_for_shift = WindowData(
+                beam, window.start, window.end, short_segment_handling="pad"
+            )
+        shifted_d = TimeSeries(d)
+        timelag = _xcor_shift(d_for_shift, beam_for_shift)
+        shifted_d.set_t0(shifted_d.t0 - timelag)
+        vectors = _overlap_vectors(shifted_d, beam, window)
+        if vectors is None:
+            return 0.0
+        d_vector, beam_vector = vectors
+        nrm1 = np.linalg.norm(d_vector)
+        nrm2 = np.linalg.norm(beam_vector)
+        if nrm1 <= 0.0 or nrm2 <= 0.0:
+            return 0.0
+    return abs(np.dot(d_vector, beam_vector) / (nrm1 * nrm2))
 
 
 def beam_coherence(d, beam, window=None) -> float:
@@ -1766,30 +1820,20 @@ def beam_coherence(d, beam, window=None) -> float:
     # assume beam is live but don't assume d is
     if d.dead() or beam.dead():
         return 0.0
-    if window is None:
-        st = min(d.t0, beam.t0)
-        et = max(d.endtime(), beam.endtime())
-        window = TimeWindow(st, et)
-    # Making a blatant assumption d and beam are on the same time base here
-    d1 = WindowData(d, window.start, window.end, short_segment_handling="pad")
-    d2 = WindowData(beam, window.start, window.end, short_segment_handling="pad")
-    # return 0 immediately if the data vector is all zeros
-    nrmd1 = np.linalg.norm(d1.data)
+    vectors = _overlap_vectors(d, beam, window)
+    if vectors is None:
+        return 0.0
+    d_vector, beam_vector = vectors
+    nrmd1 = np.linalg.norm(d_vector)
     if nrmd1 <= 0.0:
         return 0.0
-    # make d2 a unit vector
-    nrmd2 = np.linalg.norm(d2.data)
+    nrmd2 = np.linalg.norm(beam_vector)
     if nrmd2 <= 0.0:
         return 0.0
-    else:
-        d2 *= 1.0 / nrmd2
-    # this may not be necessary but more robust - assumes window can
-    # return inconsistent lengths due to subsample rounding issue
-    N = min(d1.npts, d2.npts)
-    amp = np.dot(d1.data[0:N], d2.data[0:N])
-    d2 *= amp
-    r = d1 - d2
-    coh = 1.0 - np.linalg.norm(r.data) / nrmd1
+    normalized_beam = beam_vector / nrmd2
+    amp = np.dot(d_vector, normalized_beam)
+    residual = d_vector - amp * normalized_beam
+    coh = 1.0 - np.linalg.norm(residual) / nrmd1
     if coh < 0.0:
         coh = 0.0
     return coh
@@ -1823,22 +1867,17 @@ def amplitude_relative_to_beam(d, beam, normalize_beam=True, window=None):
     """
     if d.dead() or beam.dead():
         return -1.0
-    if window is None:
-        st = min(d.t0, beam.t0)
-        et = max(d.endtime(), beam.endtime())
-        window = TimeWindow(st, et)
-    # Making a blatant assumption d and beam are on the same time base here
-    d1 = WindowData(d, window.start, window.end, short_segment_handling="pad")
-    d2 = WindowData(beam, window.start, window.end, short_segment_handling="pad")
+    vectors = _overlap_vectors(d, beam, window)
+    if vectors is None:
+        return -1.0
+    d_vector, beam_vector = vectors
+    nrm_d = np.linalg.norm(d_vector)
+    nrm_beam = np.linalg.norm(beam_vector)
+    if nrm_d <= 0.0 or nrm_beam <= 0.0:
+        return -1.0
     if normalize_beam:
-        nrm_beam = np.linalg.norm(d2.data)
-        if nrm_beam <= 0.0:
-            return -1.0
-        d2 *= 1.0 / nrm_beam
-
-    # careful of subsample t0 value causing an off by one roundoff problem
-    N = min(d1.npts, d2.npts)
-    return np.dot(d1.data[0:N], d2.data[0:N]) / float(N)
+        beam_vector = beam_vector / nrm_beam
+    return np.dot(d_vector, beam_vector) / float(len(d_vector))
 
 
 def phase_time(
@@ -2112,6 +2151,22 @@ def demean_residuals(
     return ensemble
 
 
+def _require_incident_grid_compatibility(func):
+    @wraps(func)
+    def checked(d, beam, *args, **kwargs):
+        if (
+            isinstance(d, TimeSeries)
+            and isinstance(beam, TimeSeries)
+            and d.live
+            and beam.live
+        ):
+            _validate_sample_grid_compatibility(d, beam)
+        return func(d, beam, *args, **kwargs)
+
+    return checked
+
+
+@_require_incident_grid_compatibility
 @mspass_func_wrapper
 def remove_incident_wavefield(d, beam, *args, handles_ensembles=True, **kwargs):
     """
@@ -2157,24 +2212,18 @@ def remove_incident_wavefield(d, beam, *args, handles_ensembles=True, **kwargs):
     """
     if beam.dead() or d.dead():
         return d
-    st = max(d.t0, beam.t0)
-    et = min(d.endtime(), beam.endtime())
-    isd = d.sample_number(st)
-    isb = beam.sample_number(st)
-    ied = d.sample_number(et)
-    ieb = beam.sample_number(et)
-    # necessary to use : notation to prevent subsample t0 value rounding
-    # from causing an indexing error
-    Nd = ied - isd + 1
-    Nb = ieb - isb + 1
-    if Nd < Nb:
-        ieb = Nd + isb - 1
-    elif Nd > Nb:
-        ied = Nb + isd - 1
-    amp = np.dot(d.data[ied:ieb], beam.data[ieb:ied])
-    x = DoubleVector(beam.data[ieb:ied])
+    indices = _common_sample_interval(d, beam)
+    if indices is None:
+        return d
+    d_start, beam_start, sample_count = indices
+    d_vector = np.asarray(d.data[d_start : d_start + sample_count])
+    beam_vector = np.asarray(beam.data[beam_start : beam_start + sample_count])
+    if np.linalg.norm(d_vector) <= 0.0 or np.linalg.norm(beam_vector) <= 0.0:
+        return d
+    amp = np.dot(d_vector, beam_vector)
+    x = DoubleVector(beam.data[beam_start : beam_start + sample_count])
     x *= amp
-    d.data[ied:ieb] -= x
+    d.data[d_start : d_start + sample_count] -= x
     return d
 
 

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -1800,8 +1800,12 @@ def beam_coherence(d, beam, window=None) -> float:
     Compute time-domain coherence of a datum relative to the stack.
 
     Time domain coherence is a measure of misfit between a signal and a
-    a reference signal (normally a stack).   The formula is
-    1.0 - norm(residual)/norm(beam) where residual=d-beam.
+    reference signal (normally a stack).  On the physical overlap, let
+    ``bhat = beam / norm(beam)``, ``a = d dot bhat``, and
+    ``residual = d - a*bhat``.  This implementation returns
+    ``max(0, 1 - norm(residual)/norm(d))``.  Thus the measure compares the
+    residual after the best scalar projection on the beam with the energy in
+    the datum; it is not the unscaled ``d - beam`` residual.
 
     This function has an optional window parameter that computes the
     coherence with a specified time window.  By default the entire
@@ -1844,12 +1848,12 @@ def amplitude_relative_to_beam(d, beam, normalize_beam=True, window=None):
     Compute and return amplitude relative to the stack (beam).
 
     dbxcor computed a useful metric of amplitude relative to the beam
-    (stack) as `(d dot beam)/N` where "dot" means vector dot product with
-    between the sample vectbeam_coherence(d,beam,window=None,filter=True)ors of b and beam and N is vector size.   The formula
-    requires the beam to be normalized so its L2 norm is 1.  By default it assumes
-    that but that can be overriden with the normalize_beam argument.
-    Default assumes d and beam cover the same time span.  If they aren't
-    the minimum overlap of the two signals is used.
+    (stack) as ``(d dot beam)/N``, where ``dot`` is the vector dot product
+    over the physical sample overlap and ``N`` is the number of samples in
+    that overlap.  Relative-amplitude use normally requires a unit-L2 beam,
+    so by default this function normalizes the overlapping beam vector first.
+    That normalization can be disabled with ``normalize_beam=False`` when the
+    caller has already prepared the desired beam scaling.
 
     :param d:  datum for which the relative amplitude is to be computed.
     :type d:  `TimeSeries` assumed - will throw an exception if it isn't
@@ -1863,7 +1867,11 @@ def amplitude_relative_to_beam(d, beam, normalize_beam=True, window=None):
        if beam is already normalized.
     :type normalize_beam:  boolean
 
-    :return:  float value of amplitude.  A negative number indicates an error.
+    :return: float amplitude.  ``-1.0`` indicates dead input, no physical
+      overlap, or a zero-norm beam when normalization was requested.  A
+      zero-norm datum has the valid dot-product amplitude ``0.0``.  With
+      ``normalize_beam=False``, a zero-norm beam also yields ``0.0`` because
+      no division by its norm is required.
     """
     if d.dead() or beam.dead():
         return -1.0
@@ -1871,11 +1879,10 @@ def amplitude_relative_to_beam(d, beam, normalize_beam=True, window=None):
     if vectors is None:
         return -1.0
     d_vector, beam_vector = vectors
-    nrm_d = np.linalg.norm(d_vector)
-    nrm_beam = np.linalg.norm(beam_vector)
-    if nrm_d <= 0.0 or nrm_beam <= 0.0:
-        return -1.0
     if normalize_beam:
+        nrm_beam = np.linalg.norm(beam_vector)
+        if nrm_beam <= 0.0:
+            return -1.0
         beam_vector = beam_vector / nrm_beam
     return np.dot(d_vector, beam_vector) / float(len(d_vector))
 

--- a/python/tests/algorithms/test_mcxcor_overlap_contract.py
+++ b/python/tests/algorithms/test_mcxcor_overlap_contract.py
@@ -1,0 +1,292 @@
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import mspasspy.algorithms.MCXcorStacking as mcxcor_module
+import mspasspy.ccore.seismic as seismic_binding
+from mspasspy.algorithms.MCXcorStacking import (
+    amplitude_relative_to_beam,
+    beam_coherence,
+    beam_correlation,
+    remove_incident_wavefield,
+)
+from mspasspy.ccore.algorithms.basic import TimeWindow
+from mspasspy.ccore.seismic import DoubleVector, TimeReferenceType, TimeSeries
+
+GRID_TOLERANCE = 1.0e-6
+
+
+def _timeseries(values, t0=0.0, dt=1.0):
+    result = TimeSeries(len(values))
+    result.t0 = t0
+    result.dt = dt
+    result.tref = TimeReferenceType.Relative
+    result.data[:] = DoubleVector(values)
+    result.set_live()
+    result["contract_marker"] = f"{t0}:{dt}:{len(values)}"
+    return result
+
+
+def _snapshot(datum):
+    logs = [
+        (entry.algorithm, entry.message, entry.badness)
+        for entry in datum.elog.get_error_log()
+    ]
+    return (
+        datum.t0,
+        datum.dt,
+        datum.npts,
+        datum.tref,
+        dict(datum),
+        logs,
+        np.asarray(datum.data).copy(),
+        datum.live,
+    )
+
+
+def _assert_unchanged(datum, snapshot):
+    t0, dt, npts, tref, metadata, logs, data, live = snapshot
+    assert datum.t0 == t0
+    assert datum.dt == dt
+    assert datum.npts == npts
+    assert datum.tref == tref
+    assert dict(datum) == metadata
+    assert [
+        (entry.algorithm, entry.message, entry.badness)
+        for entry in datum.elog.get_error_log()
+    ] == logs
+    np.testing.assert_array_equal(datum.data, data)
+    assert datum.live is live
+
+
+def test_contract_suite_uses_worktree_module_and_real_binding():
+    expected_module = (
+        Path(__file__).resolve().parents[2]
+        / "mspasspy"
+        / "algorithms"
+        / "MCXcorStacking.py"
+    )
+    assert Path(mcxcor_module.__file__).resolve() == expected_module
+    assert Path(seismic_binding.__file__).suffix == ".so"
+    assert str(inspect.signature(remove_incident_wavefield)) == (
+        "(d, beam, *args, handles_ensembles=True, **kwargs)"
+    )
+
+
+def test_aligned_metrics_use_the_full_inclusive_interval_without_mutation():
+    datum = _timeseries([1.0, 2.0, 3.0])
+    beam = _timeseries([1.0, 2.0, 3.0])
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert beam_correlation(datum, beam) == pytest.approx(1.0)
+    assert beam_coherence(datum, beam) == pytest.approx(1.0)
+    assert amplitude_relative_to_beam(datum, beam) == pytest.approx(np.sqrt(14.0) / 3.0)
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
+def test_integer_shifted_partial_overlap_uses_independent_indices_and_endpoints():
+    datum = _timeseries([100.0, 1.0, 2.0, 3.0], t0=0.0)
+    beam = _timeseries([1.0, 2.0, 3.0, 100.0], t0=1.0)
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert beam_correlation(datum, beam) == pytest.approx(1.0)
+    assert beam_coherence(datum, beam) == pytest.approx(1.0)
+    assert amplitude_relative_to_beam(datum, beam) == pytest.approx(np.sqrt(14.0) / 3.0)
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+    normalized_beam = _timeseries(
+        [1.0 / np.sqrt(14.0), 2.0 / np.sqrt(14.0), 3.0 / np.sqrt(14.0), 100.0],
+        t0=1.0,
+    )
+    beam_before = _snapshot(normalized_beam)
+    output = remove_incident_wavefield(datum, normalized_beam)
+
+    assert output is datum
+    np.testing.assert_allclose(datum.data, [100.0, 0.0, 0.0, 0.0], atol=1.0e-14)
+    _assert_unchanged(normalized_beam, beam_before)
+
+
+def test_unaligned_correlation_shifts_only_a_copy():
+    datum = _timeseries([0.0, 1.0, 2.0, 0.0])
+    beam = _timeseries([1.0, 2.0, 0.0, 0.0])
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert beam_correlation(datum, beam, aligned=False) == pytest.approx(1.0)
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
+def test_incident_removal_outer_guard_preserves_dryrun_api_and_inputs():
+    datum = _timeseries([1.0, 2.0, 3.0])
+    beam = _timeseries([1.0, 2.0, 3.0])
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert remove_incident_wavefield(datum, beam, dryrun=True) == "OK"
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
+def test_explicit_window_is_inclusive_and_does_not_add_padded_samples():
+    datum = _timeseries([100.0, 1.0, 2.0, 100.0])
+    beam = _timeseries([200.0, 1.0, 2.0, 200.0])
+    window = TimeWindow(1.0, 2.0)
+
+    assert beam_correlation(datum, beam, window=window) == pytest.approx(1.0)
+    assert beam_coherence(datum, beam, window=window) == pytest.approx(1.0)
+    assert amplitude_relative_to_beam(datum, beam, window=window) == pytest.approx(
+        np.sqrt(5.0) / 2.0
+    )
+
+
+@pytest.mark.parametrize(
+    "metric,sentinel",
+    [
+        pytest.param(beam_correlation, 0.0, id="correlation"),
+        pytest.param(beam_coherence, 0.0, id="coherence"),
+        pytest.param(amplitude_relative_to_beam, -1.0, id="amplitude"),
+    ],
+)
+def test_window_with_no_physical_sample_returns_sentinel(metric, sentinel):
+    datum = _timeseries([1.0, 2.0], t0=0.0, dt=1.0)
+    beam = _timeseries([1.0, 2.0], t0=0.0, dt=1.0)
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert metric(datum, beam, window=TimeWindow(0.1, 0.4)) == sentinel
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
+def test_one_sample_overlap_includes_the_shared_endpoint():
+    datum = _timeseries([5.0], t0=2.0)
+    beam = _timeseries([9.0, 8.0, 1.0], t0=0.0)
+
+    assert beam_correlation(datum, beam) == pytest.approx(1.0)
+    assert beam_coherence(datum, beam) == pytest.approx(1.0)
+    assert amplitude_relative_to_beam(datum, beam) == pytest.approx(5.0)
+
+    output = remove_incident_wavefield(datum, beam)
+    assert output is datum
+    np.testing.assert_allclose(datum.data, [0.0])
+
+
+def test_no_overlap_returns_sentinels_and_incident_removal_identity():
+    datum = _timeseries([1.0, 2.0], t0=0.0)
+    beam = _timeseries([1.0, 2.0], t0=2.0)
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert beam_correlation(datum, beam) == 0.0
+    assert beam_coherence(datum, beam) == 0.0
+    assert amplitude_relative_to_beam(datum, beam) == -1.0
+    assert remove_incident_wavefield(datum, beam) is datum
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
+@pytest.mark.parametrize(
+    "datum_values,beam_values",
+    [([0.0, 0.0, 0.0], [1.0, 2.0, 3.0]), ([1.0, 2.0, 3.0], [0.0, 0.0, 0.0])],
+)
+def test_zero_norm_overlap_returns_sentinels_and_does_not_mutate(
+    datum_values, beam_values
+):
+    datum = _timeseries(datum_values)
+    beam = _timeseries(beam_values)
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert beam_correlation(datum, beam) == 0.0
+    assert beam_coherence(datum, beam) == 0.0
+    assert amplitude_relative_to_beam(datum, beam) == -1.0
+    assert remove_incident_wavefield(datum, beam) is datum
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
+METRIC_CALLS = [
+    pytest.param(beam_correlation, id="correlation"),
+    pytest.param(beam_coherence, id="coherence"),
+    pytest.param(amplitude_relative_to_beam, id="amplitude"),
+    pytest.param(remove_incident_wavefield, id="incident-removal"),
+]
+
+
+@pytest.mark.parametrize("metric", METRIC_CALLS)
+def test_dt_at_relative_tolerance_is_accepted(metric):
+    dt_at_tolerance = np.nextafter(1.0 / (1.0 - GRID_TOLERANCE), 1.0)
+    datum = _timeseries([1.0, 2.0, 3.0], dt=1.0)
+    beam = _timeseries([1.0, 2.0, 3.0], dt=dt_at_tolerance)
+
+    metric(datum, beam)
+
+
+@pytest.mark.parametrize("metric", METRIC_CALLS)
+def test_dt_beyond_relative_tolerance_raises_before_mutation(metric):
+    dt_beyond_tolerance = np.nextafter(1.0 / (1.0 - GRID_TOLERANCE), np.inf)
+    datum = _timeseries([1.0, 2.0, 3.0], dt=1.0)
+    beam = _timeseries([1.0, 2.0, 3.0], dt=dt_beyond_tolerance)
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    with pytest.raises(ValueError, match="sample intervals are incompatible"):
+        metric(datum, beam)
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
+@pytest.mark.parametrize("metric", METRIC_CALLS)
+def test_start_grid_tolerance_is_symmetric_for_compatible_dt(metric):
+    larger_dt = 1.0 + GRID_TOLERANCE / 2.0
+    offset = np.nextafter(GRID_TOLERANCE * larger_dt, 0.0)
+    first = _timeseries([0.0, 0.0], t0=offset, dt=1.0)
+    second = _timeseries([0.0, 0.0], t0=0.0, dt=larger_dt)
+    first_before = _snapshot(first)
+    second_before = _snapshot(second)
+
+    metric(first, second)
+    metric(second, first)
+
+    _assert_unchanged(first, first_before)
+    _assert_unchanged(second, second_before)
+
+
+@pytest.mark.parametrize("metric", METRIC_CALLS)
+def test_start_grid_offset_at_tolerance_is_accepted(metric):
+    datum = _timeseries([1.0, 2.0, 3.0], t0=GRID_TOLERANCE)
+    beam = _timeseries([1.0, 2.0, 3.0], t0=0.0)
+
+    metric(datum, beam)
+
+
+@pytest.mark.parametrize("metric", METRIC_CALLS)
+def test_start_grid_offset_beyond_tolerance_raises_before_mutation(metric):
+    invalid_offset = np.nextafter(GRID_TOLERANCE, np.inf)
+    datum = _timeseries([1.0, 2.0, 3.0], t0=invalid_offset)
+    beam = _timeseries([1.0, 2.0, 3.0], t0=0.0)
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    with pytest.raises(
+        ValueError, match="start times are on incompatible sample grids"
+    ):
+        metric(datum, beam)
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)

--- a/python/tests/algorithms/test_mcxcor_overlap_contract.py
+++ b/python/tests/algorithms/test_mcxcor_overlap_contract.py
@@ -162,6 +162,18 @@ def test_unaligned_correlation_shifts_only_a_copy():
     _assert_unchanged(beam, beam_before)
 
 
+def test_unaligned_correlation_aligns_initially_disjoint_time_ranges():
+    datum = _timeseries([0.0, 1.0, 2.0, 0.0], t0=10.0)
+    beam = _timeseries([1.0, 2.0, 0.0, 0.0], t0=0.0)
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert beam_correlation(datum, beam, aligned=False) == pytest.approx(1.0)
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
 def test_incident_removal_outer_guard_preserves_dryrun_api_and_inputs():
     datum = _timeseries([1.0, 2.0, 3.0])
     beam = _timeseries([1.0, 2.0, 3.0])
@@ -288,19 +300,19 @@ METRIC_CALLS = [
 
 
 @pytest.mark.parametrize("metric", METRIC_CALLS)
-def test_dt_at_relative_tolerance_is_accepted(metric):
-    dt_at_tolerance = np.nextafter(1.0 / (1.0 - GRID_TOLERANCE), 1.0)
+def test_accumulated_dt_drift_within_grid_tolerance_is_accepted(metric):
+    compatible_dt = 1.0 + 0.4 * GRID_TOLERANCE
     datum = _timeseries([1.0, 2.0, 3.0], dt=1.0)
-    beam = _timeseries([1.0, 2.0, 3.0], dt=dt_at_tolerance)
+    beam = _timeseries([1.0, 2.0, 3.0], dt=compatible_dt)
 
     metric(datum, beam)
 
 
 @pytest.mark.parametrize("metric", METRIC_CALLS)
-def test_dt_beyond_relative_tolerance_raises_before_mutation(metric):
-    dt_beyond_tolerance = np.nextafter(1.0 / (1.0 - GRID_TOLERANCE), np.inf)
+def test_accumulated_dt_drift_beyond_tolerance_raises_before_mutation(metric):
+    incompatible_dt = 1.0 + 0.6 * GRID_TOLERANCE
     datum = _timeseries([1.0, 2.0, 3.0], dt=1.0)
-    beam = _timeseries([1.0, 2.0, 3.0], dt=dt_beyond_tolerance)
+    beam = _timeseries([1.0, 2.0, 3.0], dt=incompatible_dt)
     datum_before = _snapshot(datum)
     beam_before = _snapshot(beam)
 

--- a/python/tests/algorithms/test_mcxcor_overlap_contract.py
+++ b/python/tests/algorithms/test_mcxcor_overlap_contract.py
@@ -1,4 +1,7 @@
 import inspect
+import os
+import subprocess
+from importlib.metadata import distribution, version
 from pathlib import Path
 
 import numpy as np
@@ -61,14 +64,31 @@ def _assert_unchanged(datum, snapshot):
     assert datum.live is live
 
 
-def test_contract_suite_uses_worktree_module_and_real_binding():
-    expected_module = (
-        Path(__file__).resolve().parents[2]
-        / "mspasspy"
-        / "algorithms"
-        / "MCXcorStacking.py"
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
+
+
+def test_contract_suite_uses_selected_build_and_real_binding():
+    _assert_module_from_selected_build(
+        mcxcor_module, "mspasspy/algorithms/MCXcorStacking.py"
     )
-    assert Path(mcxcor_module.__file__).resolve() == expected_module
     assert Path(seismic_binding.__file__).suffix == ".so"
     assert str(inspect.signature(remove_incident_wavefield)) == (
         "(d, beam, *args, handles_ensembles=True, **kwargs)"

--- a/python/tests/algorithms/test_mcxcor_overlap_contract.py
+++ b/python/tests/algorithms/test_mcxcor_overlap_contract.py
@@ -109,6 +109,22 @@ def test_aligned_metrics_use_the_full_inclusive_interval_without_mutation():
     _assert_unchanged(beam, beam_before)
 
 
+def test_coherence_uses_projected_residual_relative_to_datum_norm():
+    datum = _timeseries([1.0, 1.0])
+    beam = _timeseries([1.0, 0.0])
+
+    assert beam_coherence(datum, beam) == pytest.approx(1.0 - 1.0 / np.sqrt(2.0))
+
+
+def test_unnormalized_relative_amplitude_is_the_documented_dot_product():
+    datum = _timeseries([1.0, 2.0])
+    beam = _timeseries([3.0, 4.0])
+
+    assert amplitude_relative_to_beam(
+        datum, beam, normalize_beam=False
+    ) == pytest.approx(11.0 / 2.0)
+
+
 def test_integer_shifted_partial_overlap_uses_independent_indices_and_endpoints():
     datum = _timeseries([100.0, 1.0, 2.0, 3.0], t0=0.0)
     beam = _timeseries([1.0, 2.0, 3.0, 100.0], t0=1.0)
@@ -219,11 +235,14 @@ def test_no_overlap_returns_sentinels_and_incident_removal_identity():
 
 
 @pytest.mark.parametrize(
-    "datum_values,beam_values",
-    [([0.0, 0.0, 0.0], [1.0, 2.0, 3.0]), ([1.0, 2.0, 3.0], [0.0, 0.0, 0.0])],
+    "datum_values,beam_values,expected_amplitude",
+    [
+        ([0.0, 0.0, 0.0], [1.0, 2.0, 3.0], 0.0),
+        ([1.0, 2.0, 3.0], [0.0, 0.0, 0.0], -1.0),
+    ],
 )
-def test_zero_norm_overlap_returns_sentinels_and_does_not_mutate(
-    datum_values, beam_values
+def test_zero_norm_overlap_preserves_metric_semantics_and_does_not_mutate(
+    datum_values, beam_values, expected_amplitude
 ):
     datum = _timeseries(datum_values)
     beam = _timeseries(beam_values)
@@ -232,8 +251,29 @@ def test_zero_norm_overlap_returns_sentinels_and_does_not_mutate(
 
     assert beam_correlation(datum, beam) == 0.0
     assert beam_coherence(datum, beam) == 0.0
-    assert amplitude_relative_to_beam(datum, beam) == -1.0
+    assert amplitude_relative_to_beam(datum, beam) == expected_amplitude
     assert remove_incident_wavefield(datum, beam) is datum
+
+    _assert_unchanged(datum, datum_before)
+    _assert_unchanged(beam, beam_before)
+
+
+@pytest.mark.parametrize(
+    "datum_values,beam_values",
+    [
+        ([0.0, 0.0, 0.0], [1.0, 2.0, 3.0]),
+        ([1.0, 2.0, 3.0], [0.0, 0.0, 0.0]),
+    ],
+)
+def test_unnormalized_relative_amplitude_does_not_require_nonzero_norm(
+    datum_values, beam_values
+):
+    datum = _timeseries(datum_values)
+    beam = _timeseries(beam_values)
+    datum_before = _snapshot(datum)
+    beam_before = _snapshot(beam)
+
+    assert amplitude_relative_to_beam(datum, beam, normalize_beam=False) == 0.0
 
     _assert_unchanged(datum, datum_before)
     _assert_unchanged(beam, beam_before)


### PR DESCRIPTION
Closes #851

## Summary
- Validate compatible sample grids before MCXcor overlap operations.
- Compute inclusive physical intersections with independent indices for datum and beam.
- Apply correlation, coherence, relative amplitude, and incident-wavefield removal only to real overlap samples.
- Preserve established metric meanings, zero-value behavior, and sentinels without mutating inputs.
- Preserve the whole-trace nearest-grid alignment policy merged in #899.

## Maintainer decisions
Coherence retains the implementation used since the function was introduced: best scalar projection onto a unit beam, with residual normalized by the datum norm. Unnormalized relative amplitude remains the documented dot product divided by sample count. A zero datum, and a zero beam when normalization is disabled, produce the valid result 0; -1 is reserved for dead input, no physical overlap, or a zero beam when normalization was requested. Grid offsets accumulate from the actual shifted trace and overlap is computed only after any requested alignment shift.

## Validation
- Combined waveform arithmetic and complete MCXcor regressions after rebasing onto #899: 59 passed
- Black, Python byte compilation, and git diff --check: passed