### PR TITLE
Allocate history job IDs atomically

### DIFF
--- a/python/mspasspy/history.py
+++ b/python/mspasspy/history.py
@@ -34,6 +34,42 @@ def get_jobid(db):
     return counter["value"]
 
 
+def bootstrap_history_jobid_counter(db):
+    """Raise the job-id counter to the largest legacy history job id.
+
+    This is an explicit, idempotent deployment step for databases created
+    before job ids were allocated from ``history_counters``.  Runtime job-id
+    allocation does not call this function or scan the history collection.
+
+    :param db: database handle
+    :type db: top level database handle returned by a call to
+      MongoClient.database
+    :return: the resulting counter high-water mark
+    """
+    legacy_max_document = db.history.find_one(
+        {"jobid": {"$type": ["int", "long"]}},
+        projection={"_id": False, "jobid": True},
+        sort=[("jobid", pymongo.DESCENDING)],
+    )
+    legacy_max = legacy_max_document["jobid"] if legacy_max_document else 0
+    counters = _jobid_counter(db)
+    current_value = {"$ifNull": ["$value", 0]}
+    counter = counters.find_one_and_update(
+        {"counter_name": _JOB_ID_COUNTER_NAME},
+        [
+            {
+                "$set": {
+                    "counter_name": _JOB_ID_COUNTER_NAME,
+                    "value": {"$max": [current_value, legacy_max]},
+                }
+            }
+        ],
+        upsert=True,
+        return_document=pymongo.ReturnDocument.AFTER,
+    )
+    return counter["value"]
+
+
 def _reserve_requested_jobid(db, requested_jobid):
     """Atomically reserve an explicit job id or the next available value."""
     counters = _jobid_counter(db)
@@ -203,7 +239,10 @@ class HistoryLogger:
            (default is 0 which automatically allocates from the counter)
            Users can get the actual value set from the jobid variable after
            successful creation of this object.
+        :raises TypeError: if job is not a non-boolean integer.
         """
+        if isinstance(job, bool) or not isinstance(job, int):
+            raise TypeError("HistoryLogger job must be a non-boolean integer")
         self.history_collection = db.history
         # Check the input job id for validity and use get_jobid if needed
         if job == 0:

--- a/python/mspasspy/history.py
+++ b/python/mspasspy/history.py
@@ -2,29 +2,66 @@ from collections import OrderedDict
 
 import pymongo
 
+_HISTORY_COUNTER_COLLECTION = "history_counters"
+_JOB_ID_COUNTER_NAME = "jobid"
+
+
+def _jobid_counter(db):
+    counters = db[_HISTORY_COUNTER_COLLECTION]
+    counters.create_index([("counter_name", pymongo.ASCENDING)], unique=True)
+    return counters
+
 
 def get_jobid(db):
     """
-    Ask MongoDB for the a valid jobid.
+    Ask MongoDB for a valid jobid.
 
     All processing jobs should have a call to this function at the beginning
-    of the job script.  It simply queries MongoDB for the largest current
-    value of the key "jobid" in the history collection.   If the history
-    collection is empty it returns 1 under a bias that a jobid of 0 is
-    illogical.
+    of the job script.  Job ids are allocated by atomically incrementing a
+    named counter in the ``history_counters`` collection.  The first id
+    allocated for a new database is 1.
 
     :param db: database handle
     :type db:  top level database handle returned by a call to MongoClient.database
     """
-    hiscol = db.history
-    hist_size = hiscol.count_documents({})
-    if hist_size <= 0:
-        return 1
-    else:
-        maxcur = hiscol.find().sort([("jobid", pymongo.DESCENDING)]).limit(1)
-        maxcur.rewind()  # may not be necessary but near zero cost
-        maxdoc = maxcur[0]
-        return maxdoc["jobid"] + 1
+    counters = _jobid_counter(db)
+    counter = counters.find_one_and_update(
+        {"counter_name": _JOB_ID_COUNTER_NAME},
+        {"$inc": {"value": 1}},
+        upsert=True,
+        return_document=pymongo.ReturnDocument.AFTER,
+    )
+    return counter["value"]
+
+
+def _reserve_requested_jobid(db, requested_jobid):
+    """Atomically reserve an explicit job id or the next available value."""
+    counters = _jobid_counter(db)
+    next_jobid = {"$add": [{"$ifNull": ["$value", 0]}, 1]}
+    previous = counters.find_one_and_update(
+        {"counter_name": _JOB_ID_COUNTER_NAME},
+        [
+            {
+                "$set": {
+                    "counter_name": _JOB_ID_COUNTER_NAME,
+                    "value": {
+                        "$cond": [
+                            {"$gt": [requested_jobid, next_jobid]},
+                            requested_jobid,
+                            next_jobid,
+                        ]
+                    },
+                }
+            }
+        ],
+        upsert=True,
+        return_document=pymongo.ReturnDocument.BEFORE,
+    )
+    previous_value = previous["value"] if previous is not None else 0
+    allocated_jobid = previous_value + 1
+    if requested_jobid > allocated_jobid:
+        return requested_jobid, True
+    return allocated_jobid, False
 
 
 def _antelope_pf_to_dict(pf):
@@ -159,12 +196,11 @@ class HistoryLogger:
         :param db:   is a top level handle to a MongoDB server created by
            calling the database method of a MongoClient instance.
         :param job: job can be used to manually set the jobid.  We use
-           a simple high water mark comparable to lastid in the
-           Antelope/Datascope database where the next valid id is lastid+1.
-           Hence if the input value of job is less than the current high
-           water mark in the history collection for jobid, the jobid is
-           silently set to the +1 of the largest jobid found in history.
-           (default is 0 which automatically uses the high water mark method)
+           an atomic counter comparable to lastid in the Antelope/Datascope
+           database.  Hence if the input value of job is less than the next
+           value allocated by the counter, the jobid is silently set to that
+           allocated value.
+           (default is 0 which automatically allocates from the counter)
            Users can get the actual value set from the jobid variable after
            successful creation of this object.
         """
@@ -173,16 +209,13 @@ class HistoryLogger:
         if job == 0:
             self.jobid = get_jobid(db)
         else:
-            jobtmp = get_jobid(db)
-            if job > jobtmp:
-                self.jobid = job
-            else:
-                self.jobid = jobtmp
+            self.jobid, requested_jobid_was_used = _reserve_requested_jobid(db, job)
+            if not requested_jobid_was_used:
                 print(
                     "HistoryLogger(Warning):  input jobid=",
                     job,
                     " was invalid.  Set jobid=",
-                    jobtmp,
+                    self.jobid,
                 )
         self.history_chain = []  # create empty container for history record
 

--- a/python/tests/test_history_jobid.py
+++ b/python/tests/test_history_jobid.py
@@ -1,7 +1,9 @@
 import os
+import subprocess
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from importlib.metadata import distribution, version
 from pathlib import Path
 
 import pymongo
@@ -15,9 +17,29 @@ COUNTER_COLLECTION = "history_counters"
 COUNTER_NAME = "jobid"
 
 
-def test_history_module_is_loaded_from_this_worktree():
-    expected = Path(__file__).resolve().parents[1] / "mspasspy" / "history.py"
-    assert Path(history_module.__file__).resolve() == expected
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
+
+
+def test_history_module_is_loaded_from_selected_build():
+    _assert_module_from_selected_build(history_module, "mspasspy/history.py")
 
 
 class AtomicCounterCollection:

--- a/python/tests/test_history_jobid.py
+++ b/python/tests/test_history_jobid.py
@@ -1,0 +1,301 @@
+import os
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pymongo
+import pytest
+from pymongo.errors import DuplicateKeyError, OperationFailure
+
+import mspasspy.history as history_module
+from mspasspy.history import HistoryLogger, get_jobid
+
+COUNTER_COLLECTION = "history_counters"
+COUNTER_NAME = "jobid"
+
+
+def test_history_module_is_loaded_from_this_worktree():
+    expected = Path(__file__).resolve().parents[1] / "mspasspy" / "history.py"
+    assert Path(history_module.__file__).resolve() == expected
+
+
+class AtomicCounterCollection:
+    """Small controllable Mongo collection double for the allocation contract."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.value = 0
+        self.exists = False
+        self.index_calls = []
+        self.update_calls = []
+
+    def create_index(self, keys, **kwargs):
+        self.index_calls.append((keys, kwargs))
+        return "counter_name_1"
+
+    def find_one_and_update(self, query, update, **kwargs):
+        self.update_calls.append((query, update, kwargs))
+        with self._lock:
+            if isinstance(update, list):
+                previous = (
+                    {"counter_name": query["counter_name"], "value": self.value}
+                    if self.exists
+                    else None
+                )
+                condition = update[0]["$set"]["value"]["$cond"][0]
+                requested_jobid = condition["$gt"][0]
+                self.value = max(requested_jobid, self.value + 1)
+                self.exists = True
+                return previous
+            self.value += update["$inc"]["value"]
+            self.exists = True
+            return {"counter_name": query["counter_name"], "value": self.value}
+
+
+class CounterDatabase:
+    def __init__(self, counters=None):
+        self.counters = counters or AtomicCounterCollection()
+
+    def __getitem__(self, collection):
+        assert collection == COUNTER_COLLECTION
+        return self.counters
+
+    @property
+    def history(self):
+        raise AssertionError("job-id allocation must not scan history")
+
+
+class UnscannableHistoryCollection:
+    def count_documents(self, *args, **kwargs):
+        raise AssertionError("job-id allocation must not count history documents")
+
+    def find(self, *args, **kwargs):
+        raise AssertionError("job-id allocation must not find history documents")
+
+
+class HistoryLoggerDatabase(CounterDatabase):
+    def __init__(self):
+        super().__init__()
+        self.legacy_history = UnscannableHistoryCollection()
+
+    @property
+    def history(self):
+        return self.legacy_history
+
+
+def _assert_counter_operation(call):
+    query, update, kwargs = call
+    assert query == {"counter_name": COUNTER_NAME}
+    assert update == {"$inc": {"value": 1}}
+    assert kwargs == {
+        "upsert": True,
+        "return_document": pymongo.ReturnDocument.AFTER,
+    }
+
+
+def _assert_requested_counter_operation(call, requested_jobid):
+    query, update, kwargs = call
+    next_jobid = {"$add": [{"$ifNull": ["$value", 0]}, 1]}
+    assert query == {"counter_name": COUNTER_NAME}
+    assert update == [
+        {
+            "$set": {
+                "counter_name": COUNTER_NAME,
+                "value": {
+                    "$cond": [
+                        {"$gt": [requested_jobid, next_jobid]},
+                        requested_jobid,
+                        next_jobid,
+                    ]
+                },
+            }
+        }
+    ]
+    assert kwargs == {
+        "upsert": True,
+        "return_document": pymongo.ReturnDocument.BEFORE,
+    }
+
+
+def _allocate_concurrently(database, worker_count=16, allocations_per_worker=8):
+    start = threading.Barrier(worker_count)
+
+    def allocate_batch():
+        start.wait()
+        return [get_jobid(database) for _ in range(allocations_per_worker)]
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        batches = [executor.submit(allocate_batch) for _ in range(worker_count)]
+        return [jobid for batch in batches for jobid in batch.result()]
+
+
+def test_get_jobid_uses_one_atomic_counter_operation():
+    database = CounterDatabase()
+
+    assert get_jobid(database) == 1
+    assert database.counters.index_calls == [
+        ([("counter_name", pymongo.ASCENDING)], {"unique": True})
+    ]
+    assert len(database.counters.update_calls) == 1
+    _assert_counter_operation(database.counters.update_calls[0])
+
+
+def test_history_logger_automatic_jobid_uses_counter_without_scanning_history():
+    database = HistoryLoggerDatabase()
+
+    logger = HistoryLogger(database)
+
+    assert logger.jobid == 1
+    assert logger.history_collection is database.legacy_history
+    assert len(database.counters.update_calls) == 1
+    _assert_counter_operation(database.counters.update_calls[0])
+
+
+def test_history_logger_explicit_jobid_advances_the_counter(capsys):
+    database = HistoryLoggerDatabase()
+
+    requested = HistoryLogger(database, job=10)
+    automatic = HistoryLogger(database)
+    replaced = HistoryLogger(database, job=5)
+
+    assert requested.jobid == 10
+    assert automatic.jobid == 11
+    assert replaced.jobid == 12
+    _assert_requested_counter_operation(database.counters.update_calls[0], 10)
+    _assert_counter_operation(database.counters.update_calls[1])
+    _assert_requested_counter_operation(database.counters.update_calls[2], 5)
+    assert capsys.readouterr().out == (
+        "HistoryLogger(Warning):  input jobid= 5  was invalid.  Set jobid= 12\n"
+    )
+
+
+def test_get_jobid_controlled_concurrency_is_unique_and_contiguous():
+    database = CounterDatabase()
+    allocation_count = 128
+
+    jobids = _allocate_concurrently(database)
+
+    assert (
+        database.counters.index_calls
+        == [([("counter_name", pymongo.ASCENDING)], {"unique": True})]
+        * allocation_count
+    )
+    assert len(database.counters.update_calls) == allocation_count
+    assert all(
+        call == database.counters.update_calls[0]
+        for call in database.counters.update_calls
+    )
+    _assert_counter_operation(database.counters.update_calls[0])
+    assert len(set(jobids)) == allocation_count
+    assert sorted(jobids) == list(range(1, allocation_count + 1))
+
+
+class FailingCounterCollection(AtomicCounterCollection):
+    def __init__(self, error):
+        super().__init__()
+        self.error = error
+
+    def find_one_and_update(self, query, update, **kwargs):
+        raise self.error
+
+
+class FailingIndexCollection(AtomicCounterCollection):
+    def __init__(self, error):
+        super().__init__()
+        self.error = error
+
+    def create_index(self, keys, **kwargs):
+        raise self.error
+
+
+@pytest.mark.parametrize("failure_stage", ("index", "counter"))
+def test_get_jobid_propagates_mongo_errors_without_history_fallback(failure_stage):
+    error = OperationFailure(f"{failure_stage} unavailable", code=91)
+    counters = (
+        FailingIndexCollection(error)
+        if failure_stage == "index"
+        else FailingCounterCollection(error)
+    )
+    database = CounterDatabase(counters)
+
+    with pytest.raises(OperationFailure, match=failure_stage) as caught:
+        get_jobid(database)
+    assert caught.value is error
+
+
+def test_explicit_jobid_propagates_counter_errors_without_history_fallback():
+    database = HistoryLoggerDatabase()
+    error = OperationFailure("counter unavailable", code=91)
+    database.counters = FailingCounterCollection(error)
+
+    with pytest.raises(OperationFailure, match="counter unavailable") as caught:
+        HistoryLogger(database, job=10)
+    assert caught.value is error
+
+
+@pytest.fixture
+def mongo_database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://localhost:27017")
+    client = pymongo.MongoClient(uri, serverSelectionTimeoutMS=5000)
+    database_name = None
+    try:
+        client.admin.command("ping")
+        database_name = "mspass_test_history_jobid_" + uuid.uuid4().hex
+        database = client[database_name]
+        yield database
+    finally:
+        if database_name is not None:
+            client.drop_database(database_name)
+        client.close()
+
+
+def test_get_jobid_real_mongo_initializes_counter_and_unique_index(mongo_database):
+    assert get_jobid(mongo_database) == 1
+
+    counters = mongo_database[COUNTER_COLLECTION]
+    assert counters.find_one({"counter_name": COUNTER_NAME})["value"] == 1
+    counter_index = next(
+        info
+        for info in counters.index_information().values()
+        if info["key"] == [("counter_name", pymongo.ASCENDING)]
+    )
+    assert counter_index["unique"] is True
+    with pytest.raises(DuplicateKeyError):
+        counters.insert_one({"counter_name": COUNTER_NAME, "value": 999})
+
+
+def test_get_jobid_real_mongo_concurrent_allocations(mongo_database):
+    allocation_count = 128
+
+    jobids = _allocate_concurrently(mongo_database)
+
+    assert len(set(jobids)) == allocation_count
+    assert sorted(jobids) == list(range(1, allocation_count + 1))
+    assert (
+        mongo_database[COUNTER_COLLECTION].find_one({"counter_name": COUNTER_NAME})[
+            "value"
+        ]
+        == allocation_count
+    )
+
+
+def test_history_logger_real_mongo_explicit_jobid_reserves_high_water_mark(
+    mongo_database, capsys
+):
+    requested = HistoryLogger(mongo_database, job=10)
+    automatic = HistoryLogger(mongo_database)
+    replaced = HistoryLogger(mongo_database, job=5)
+
+    assert requested.jobid == 10
+    assert automatic.jobid == 11
+    assert replaced.jobid == 12
+    assert (
+        mongo_database[COUNTER_COLLECTION].find_one({"counter_name": COUNTER_NAME})[
+            "value"
+        ]
+        == 12
+    )
+    assert capsys.readouterr().out == (
+        "HistoryLogger(Warning):  input jobid= 5  was invalid.  Set jobid= 12\n"
+    )

--- a/python/tests/test_history_jobid.py
+++ b/python/tests/test_history_jobid.py
@@ -11,7 +11,11 @@ import pytest
 from pymongo.errors import DuplicateKeyError, OperationFailure
 
 import mspasspy.history as history_module
-from mspasspy.history import HistoryLogger, get_jobid
+from mspasspy.history import (
+    HistoryLogger,
+    bootstrap_history_jobid_counter,
+    get_jobid,
+)
 
 COUNTER_COLLECTION = "history_counters"
 COUNTER_NAME = "jobid"
@@ -65,10 +69,17 @@ class AtomicCounterCollection:
                     if self.exists
                     else None
                 )
-                condition = update[0]["$set"]["value"]["$cond"][0]
-                requested_jobid = condition["$gt"][0]
-                self.value = max(requested_jobid, self.value + 1)
+                value_expression = update[0]["$set"]["value"]
+                if "$max" in value_expression:
+                    legacy_max = value_expression["$max"][1]
+                    self.value = max(legacy_max, self.value)
+                else:
+                    condition = value_expression["$cond"][0]
+                    requested_jobid = condition["$gt"][0]
+                    self.value = max(requested_jobid, self.value + 1)
                 self.exists = True
+                if kwargs["return_document"] == pymongo.ReturnDocument.AFTER:
+                    return {"counter_name": query["counter_name"], "value": self.value}
                 return previous
             self.value += update["$inc"]["value"]
             self.exists = True
@@ -106,6 +117,51 @@ class HistoryLoggerDatabase(CounterDatabase):
         return self.legacy_history
 
 
+class LegacyHistoryCollection:
+    def __init__(self, jobids):
+        self.jobids = list(jobids)
+        self.find_calls = []
+
+    def find_one(self, query, **kwargs):
+        self.find_calls.append((query, kwargs))
+        integer_jobids = [
+            jobid
+            for jobid in self.jobids
+            if isinstance(jobid, int) and not isinstance(jobid, bool)
+        ]
+        if not integer_jobids:
+            return None
+        return {"jobid": max(integer_jobids)}
+
+
+class BootstrapDatabase(CounterDatabase):
+    def __init__(self, jobids, counters=None):
+        super().__init__(counters)
+        self.legacy_history = LegacyHistoryCollection(jobids)
+
+    @property
+    def history(self):
+        return self.legacy_history
+
+
+class NoMongoOperationsDatabase:
+    def __init__(self):
+        self.counters = AtomicCounterCollection()
+        self.counters.value = 17
+        self.counters.exists = True
+        self.operations = []
+        self.legacy_history = object()
+
+    @property
+    def history(self):
+        self.operations.append("history")
+        return self.legacy_history
+
+    def __getitem__(self, collection):
+        self.operations.append(("counter", collection))
+        return self.counters
+
+
 def _assert_counter_operation(call):
     query, update, kwargs = call
     assert query == {"counter_name": COUNTER_NAME}
@@ -137,6 +193,25 @@ def _assert_requested_counter_operation(call, requested_jobid):
     assert kwargs == {
         "upsert": True,
         "return_document": pymongo.ReturnDocument.BEFORE,
+    }
+
+
+def _assert_bootstrap_counter_operation(call, legacy_max):
+    query, update, kwargs = call
+    assert query == {"counter_name": COUNTER_NAME}
+    assert update == [
+        {
+            "$set": {
+                "counter_name": COUNTER_NAME,
+                "value": {
+                    "$max": [{"$ifNull": ["$value", 0]}, legacy_max],
+                },
+            }
+        }
+    ]
+    assert kwargs == {
+        "upsert": True,
+        "return_document": pymongo.ReturnDocument.AFTER,
     }
 
 
@@ -190,6 +265,49 @@ def test_history_logger_explicit_jobid_advances_the_counter(capsys):
     assert capsys.readouterr().out == (
         "HistoryLogger(Warning):  input jobid= 5  was invalid.  Set jobid= 12\n"
     )
+
+
+@pytest.mark.parametrize("invalid_jobid", [True, False, None, 1.0, "1"])
+def test_history_logger_rejects_invalid_jobid_before_mongo_access(invalid_jobid):
+    database = NoMongoOperationsDatabase()
+
+    with pytest.raises(TypeError, match="non-boolean integer"):
+        HistoryLogger(database, job=invalid_jobid)
+
+    assert database.operations == []
+    assert database.counters.value == 17
+    assert database.counters.index_calls == []
+    assert database.counters.update_calls == []
+
+
+def test_bootstrap_uses_legacy_high_water_mark_once_and_is_idempotent():
+    database = BootstrapDatabase([3, True, 41, 7, 1.5])
+
+    assert bootstrap_history_jobid_counter(database) == 41
+    assert bootstrap_history_jobid_counter(database) == 41
+    assert get_jobid(database) == 42
+
+    expected_history_call = (
+        {"jobid": {"$type": ["int", "long"]}},
+        {
+            "projection": {"_id": False, "jobid": True},
+            "sort": [("jobid", pymongo.DESCENDING)],
+        },
+    )
+    assert database.legacy_history.find_calls == [expected_history_call] * 2
+    _assert_bootstrap_counter_operation(database.counters.update_calls[0], 41)
+    _assert_bootstrap_counter_operation(database.counters.update_calls[1], 41)
+    _assert_counter_operation(database.counters.update_calls[2])
+
+
+def test_bootstrap_never_lowers_an_existing_counter():
+    counters = AtomicCounterCollection()
+    counters.value = 73
+    counters.exists = True
+    database = BootstrapDatabase([41], counters)
+
+    assert bootstrap_history_jobid_counter(database) == 73
+    assert get_jobid(database) == 74
 
 
 def test_get_jobid_controlled_concurrency_is_unique_and_contiguous():
@@ -321,3 +439,13 @@ def test_history_logger_real_mongo_explicit_jobid_reserves_high_water_mark(
     assert capsys.readouterr().out == (
         "HistoryLogger(Warning):  input jobid= 5  was invalid.  Set jobid= 12\n"
     )
+
+
+def test_bootstrap_real_mongo_preserves_legacy_high_water_mark(mongo_database):
+    mongo_database.history.insert_many(
+        [{"jobid": 7}, {"jobid": True}, {"jobid": 41}, {"jobid": 1.5}]
+    )
+
+    assert bootstrap_history_jobid_counter(mongo_database) == 41
+    assert bootstrap_history_jobid_counter(mongo_database) == 41
+    assert get_jobid(mongo_database) == 42


### PR DESCRIPTION
## Summary

- Allocate history job IDs from one atomic MongoDB counter.
- Keep legacy scanning out of normal allocation; provide an explicit, idempotent bootstrap for the historical high-water mark.
- Reserve explicit IDs and reject booleans/non-integers before database access.
- Add contract, concurrency, and real-Mongo coverage.

Closes #782
