### PR TITLE
Support atomic SectionPlotter inputs with correct orientation

### DIFF
--- a/docs/source/user_manual/graphics.rst
+++ b/docs/source/user_manual/graphics.rst
@@ -215,23 +215,20 @@ types differs in a few important ways:
 2.  A :py:class:`Seismogram <mspasspy.ccore.seismic.Seismogram>` is displayed
     by ``SeismicPlotter`` in one figure, with components 0, 1, and 2 at equal
     vertical intervals from bottom to top.
-3.  :py:class:`TimeSeriesEnsemble <mspasspy.ccore.seismic.TimeSeriesEnsemble>`
+3.  :py:class:`SectionPlotter <mspasspy.graphics.SectionPlotter>` uses a
+    downward-running vertical time axis.  It displays an atomic ``TimeSeries``
+    as one trace and an atomic ``Seismogram`` as three traces, with components
+    0, 1, and 2 ordered from left to right.
+4.  :py:class:`TimeSeriesEnsemble <mspasspy.ccore.seismic.TimeSeriesEnsemble>`
     members are equally spaced.  ``SeismicPlotter`` defaults to member 0 at
     the bottom and can reverse the order with its ``topdown`` method.
     :py:class:`SectionPlotter <mspasspy.graphics.SectionPlotter>` places the
     members from left to right and currently has no public order-reversal or
     variable-spacing option.  Use a custom Matplotlib plot when physical
     offsets rather than equal trace spacing are required.
-4.  :py:class:`SeismogramEnsemble <mspasspy.ccore.seismic.SeismogramEnsemble>`
+5.  :py:class:`SeismogramEnsemble <mspasspy.ccore.seismic.SeismogramEnsemble>`
     data are displayed as three figures, one per component.  Each component
     figure is produced using the corresponding ``TimeSeriesEnsemble`` path.
-
-.. warning::
-
-   Atomic ``TimeSeries`` and ``Seismogram`` inputs to ``SectionPlotter`` are
-   deprecated and unsupported.  ``SectionPlotter.plot`` raises ``TypeError``
-   for both types and directs callers to ``SeismicPlotter``.  The ensemble
-   paths continue to support all four plot styles described above.
 
 A final point is that plotting earthquake data nearly always requires some
 form of scaling to prevent strong signals from clipping while weaker but valid

--- a/docs/source/user_manual/graphics.rst
+++ b/docs/source/user_manual/graphics.rst
@@ -228,11 +228,10 @@ types differs in a few important ways:
 
 .. warning::
 
-   Use ``SeismicPlotter`` for atomic ``TimeSeries`` and ``Seismogram`` data.
-   The current ``SectionPlotter`` atomic ``TimeSeries`` path raises an error,
-   and its atomic ``Seismogram`` conversion does not orient the sample matrix
-   as three traces.  Its ensemble paths support all four plot styles described
-   above.
+   Atomic ``TimeSeries`` and ``Seismogram`` inputs to ``SectionPlotter`` are
+   deprecated and unsupported.  ``SectionPlotter.plot`` raises ``TypeError``
+   for both types and directs callers to ``SeismicPlotter``.  The ensemble
+   paths continue to support all four plot styles described above.
 
 A final point is that plotting earthquake data nearly always requires some
 form of scaling to prevent strong signals from clipping while weaker but valid

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -314,6 +314,15 @@ def ts2nparray(d):
     return [tmin, dt, work]
 
 
+def _orient_section_data(d, data):
+    """Return atomic data with samples on rows and traces on columns."""
+    if isinstance(d, TimeSeries):
+        return data.reshape((-1, 1))
+    if isinstance(d, Seismogram):
+        return data.transpose()
+    return data
+
+
 def wtvaplot(
     d, ranges=None, scale=1.0, fill_color="k", normalize=False, cmap=None, title=None
 ):
@@ -378,7 +387,7 @@ def wtvaplot(
                 )
             t0 = plotdata[0]
             dt = plotdata[1]
-            section = plotdata[2]
+            section = _orient_section_data(d, plotdata[2])
             wtva_raw(section, t0, dt, ranges, scale, fill_color, normalize)
             if cmap != None:
                 image_raw(section, t0, dt, ranges, cmap)
@@ -451,7 +460,7 @@ def imageplot(
                 )
             t0 = plotdata[0]
             dt = plotdata[1]
-            section = plotdata[2]
+            section = _orient_section_data(d, plotdata[2])
             image_raw(section, t0, dt, ranges, cmap, aspect, vmin, vmax)
             if title != None:
                 plt.title(title)
@@ -471,11 +480,12 @@ class SectionPlotter:
     and a wiggletrace variable area plot overlaying an image plot.
 
     The object itself only defines the style of plot to be produced along
-    with other assorted plot parameters.  Atomic ``TimeSeries`` and
-    ``Seismogram`` inputs are deprecated and unsupported; use
-    :class:`SeismicPlotter` for those types.  ``TimeSeriesEnsemble`` inputs
-    produce conventional reflection style sections with the data displayed
-    from left to right in whatever order the ensemble is sorted to.
+    with other assorted plot parameters.  An atomic ``TimeSeries`` is drawn
+    as one vertical trace.  An atomic ``Seismogram`` is drawn as three
+    vertical traces, with components ordered from left to right.
+    ``TimeSeriesEnsemble`` inputs produce conventional reflection style
+    sections with the data displayed from left to right in whatever order
+    the ensemble is sorted to.
     SeismogramEnsembles are the only type that create multiple windows.
     That is, each component is displayed in a different window.   The
     display can be understood as a conversion of a SeismogramEnsemble to
@@ -615,11 +625,11 @@ class SectionPlotter:
 
     def plot(self, d):
         """
-        Plot an ensemble using the current style and public attributes.
+        Plot atomic or ensemble data using the current style and public
+        attributes.
 
-        :param d: a ``TimeSeriesEnsemble`` or ``SeismogramEnsemble``.  Atomic
-            ``TimeSeries`` and ``Seismogram`` inputs are unsupported and raise
-            ``TypeError``; use :class:`SeismicPlotter` for those types.
+        :param d: a ``TimeSeries``, ``Seismogram``, ``TimeSeriesEnsemble``, or
+            ``SeismogramEnsemble``.
 
         :Returns: an array of one or 3 (only for SeismogramEnsemble dat)
           matplotlib.pylot.gcf() plot handle(s).
@@ -627,11 +637,6 @@ class SectionPlotter:
           is the return of plt.gcf() and can be used to alter some properties
           of the figure.  See matplotlib documentation.
         """
-        if isinstance(d, (TimeSeries, Seismogram)):
-            raise TypeError(
-                "SectionPlotter.plot does not support atomic TimeSeries or "
-                "Seismogram inputs; use SeismicPlotter instead"
-            )
         # these are all handled by the same function with argument combinations defined by
         # change_style determining the behavior.
         if self.style == "wtva" or self.style == "wtvaimg" or self.style == "wt":

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -471,13 +471,11 @@ class SectionPlotter:
     and a wiggletrace variable area plot overlaying an image plot.
 
     The object itself only defines the style of plot to be produced along
-    with other assorted plot parameters.   The plot method can be called on
-    any mspass data object to produce a graphic display.   TimeSeries
-    data produce a frame with one seismogram plotted.  Seismogram data
-    will produce a one frame display with the 3 components arranged in
-    component order from left to right.  TimeSeriesEnsembles produce
-    conventional reflection style sections with the data displayed from
-    left to right in whatever order the ensemble is sorted to.
+    with other assorted plot parameters.  Atomic ``TimeSeries`` and
+    ``Seismogram`` inputs are deprecated and unsupported; use
+    :class:`SeismicPlotter` for those types.  ``TimeSeriesEnsemble`` inputs
+    produce conventional reflection style sections with the data displayed
+    from left to right in whatever order the ensemble is sorted to.
     SeismogramEnsembles are the only type that create multiple windows.
     That is, each component is displayed in a different window.   The
     display can be understood as a conversion of a SeismogramEnsemble to
@@ -617,12 +615,11 @@ class SectionPlotter:
 
     def plot(self, d):
         """
-        Call this method to plot any data using the current style setup and any
-        details defined by public attributes.
+        Plot an ensemble using the current style and public attributes.
 
-        :param d:  is the data to be plotted.   It can be any of the following:
-            TimeSeries, Seismogram, TimeSeriesEnsemble, or SeismogramEnsemble.
-            If d is any other type the method will throw a RuntimeError exception.
+        :param d: a ``TimeSeriesEnsemble`` or ``SeismogramEnsemble``.  Atomic
+            ``TimeSeries`` and ``Seismogram`` inputs are unsupported and raise
+            ``TypeError``; use :class:`SeismicPlotter` for those types.
 
         :Returns: an array of one or 3 (only for SeismogramEnsemble dat)
           matplotlib.pylot.gcf() plot handle(s).
@@ -630,6 +627,11 @@ class SectionPlotter:
           is the return of plt.gcf() and can be used to alter some properties
           of the figure.  See matplotlib documentation.
         """
+        if isinstance(d, (TimeSeries, Seismogram)):
+            raise TypeError(
+                "SectionPlotter.plot does not support atomic TimeSeries or "
+                "Seismogram inputs; use SeismicPlotter instead"
+            )
         # these are all handled by the same function with argument combinations defined by
         # change_style determining the behavior.
         if self.style == "wtva" or self.style == "wtvaimg" or self.style == "wt":

--- a/python/tests/test_sectionplotter_contract.py
+++ b/python/tests/test_sectionplotter_contract.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
 import mspasspy.graphics as graphics
@@ -11,23 +13,46 @@ from mspasspy.ccore.seismic import (
 )
 
 
-@pytest.mark.parametrize("datum_type", (TimeSeries, Seismogram))
+@pytest.fixture(autouse=True)
+def close_figures():
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+def make_atomic(datum_type):
+    datum = datum_type(4)
+    datum.t0 = 1.0
+    datum.dt = 0.25
+    if isinstance(datum, TimeSeries):
+        for index, value in enumerate((1.0, 2.0, 3.0, 4.0)):
+            datum.data[index] = value
+    else:
+        datum.data[:, :] = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0], [3.0, 4.0, 5.0, 6.0]]
+        )
+    return datum
+
+
+@pytest.mark.parametrize("datum_type,trace_count", ((TimeSeries, 1), (Seismogram, 3)))
 @pytest.mark.parametrize("style", ("wt", "wtva", "img", "wtvaimg"))
-def test_sectionplotter_rejects_atomic_inputs_before_plotting(
-    monkeypatch, datum_type, style
-):
+def test_sectionplotter_supports_atomic_inputs(datum_type, trace_count, style):
     plotter = graphics.SectionPlotter()
     plotter.change_style(style)
-    wtva = Mock()
-    image = Mock()
-    monkeypatch.setattr(graphics, "wtvaplot", wtva)
-    monkeypatch.setattr(graphics, "imageplot", image)
+    datum = make_atomic(datum_type)
 
-    with pytest.raises(TypeError, match="use SeismicPlotter"):
-        plotter.plot(datum_type())
+    handles = plotter.plot(datum)
 
-    wtva.assert_not_called()
-    image.assert_not_called()
+    assert len(handles) == 1
+    axes = handles[0].axes[0]
+    expected_times = datum.t0 + np.arange(datum.npts) * datum.dt
+    if style != "img":
+        assert len(axes.lines) == trace_count
+        for line in axes.lines:
+            np.testing.assert_array_equal(line.get_ydata(), expected_times)
+    if "img" in style:
+        assert len(axes.images) == 1
+        assert axes.images[0].get_array().shape == (datum.npts, trace_count)
 
 
 @pytest.mark.parametrize("ensemble_type", (TimeSeriesEnsemble, SeismogramEnsemble))

--- a/python/tests/test_sectionplotter_contract.py
+++ b/python/tests/test_sectionplotter_contract.py
@@ -1,0 +1,56 @@
+from unittest.mock import Mock
+
+import pytest
+
+import mspasspy.graphics as graphics
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+
+
+@pytest.mark.parametrize("datum_type", (TimeSeries, Seismogram))
+@pytest.mark.parametrize("style", ("wt", "wtva", "img", "wtvaimg"))
+def test_sectionplotter_rejects_atomic_inputs_before_plotting(
+    monkeypatch, datum_type, style
+):
+    plotter = graphics.SectionPlotter()
+    plotter.change_style(style)
+    wtva = Mock()
+    image = Mock()
+    monkeypatch.setattr(graphics, "wtvaplot", wtva)
+    monkeypatch.setattr(graphics, "imageplot", image)
+
+    with pytest.raises(TypeError, match="use SeismicPlotter"):
+        plotter.plot(datum_type())
+
+    wtva.assert_not_called()
+    image.assert_not_called()
+
+
+@pytest.mark.parametrize("ensemble_type", (TimeSeriesEnsemble, SeismogramEnsemble))
+@pytest.mark.parametrize("style", ("wt", "wtva", "img", "wtvaimg"))
+def test_sectionplotter_preserves_ensemble_style_dispatch(
+    monkeypatch, ensemble_type, style
+):
+    plotter = graphics.SectionPlotter()
+    plotter.change_style(style)
+    ensemble = ensemble_type()
+    expected = [object()]
+    wtva = Mock(return_value=expected)
+    image = Mock(return_value=expected)
+    monkeypatch.setattr(graphics, "wtvaplot", wtva)
+    monkeypatch.setattr(graphics, "imageplot", image)
+
+    assert plotter.plot(ensemble) is expected
+
+    if style == "img":
+        image.assert_called_once()
+        assert image.call_args.args[0] is ensemble
+        wtva.assert_not_called()
+    else:
+        wtva.assert_called_once()
+        assert wtva.call_args.args[0] is ensemble
+        image.assert_not_called()


### PR DESCRIPTION
## Summary

- support atomic `TimeSeries` as one vertical SectionPlotter trace
- orient atomic `Seismogram` data as `npts x 3`, with components 0, 1, and 2 from left to right
- preserve the downward-running time axis and all four existing styles
- keep ensemble dispatch unchanged
- document the atomic SectionPlotter behavior

## Validation

- raw-grid, atomic SectionPlotter, and adjacent graphics tests: 67 passed
- both atomic types exercised through `wt`, `wtva`, `img`, and `wtvaimg`
- `git diff --check` and Python compilation: passed
- Black reports the changed Python files unchanged

Closes #789
