### PR TITLE
Correct graphics coordinates and allocation guards

### DIFF
--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -16,6 +16,42 @@ from mspasspy.algorithms.basic import ExtractComponent
 # not sure that is necessary but this makes context clearer
 from mspasspy.algorithms.window import scale as mspass_scale_function
 
+_MAX_PLOT_ARRAY_BYTES = 536870912
+
+
+def _validate_plot_grid(npts, dt):
+    if npts <= 0:
+        raise ValueError("plot input is empty")
+    if not numpy.isfinite(dt) or dt <= 0.0:
+        raise ValueError("plot sample interval must be finite and positive")
+
+
+def _checked_plot_allocation(rows, columns, itemsize):
+    max_index = numpy.iinfo(numpy.intp).max
+    if rows < 0 or columns < 0 or itemsize <= 0:
+        raise ValueError("plot array dimensions and item size must be positive")
+    if rows and columns > max_index // rows:
+        raise MemoryError("plot array dimensions overflow the platform index size")
+    elements = rows * columns
+    if elements and itemsize > max_index // elements:
+        raise MemoryError("plot array byte size overflows the platform index size")
+    byte_count = elements * itemsize
+    if byte_count > _MAX_PLOT_ARRAY_BYTES:
+        raise MemoryError("plot array exceeds the 512 MiB allocation limit")
+    return byte_count
+
+
+def _allocate_plot_matrix(rows, columns, dtype=numpy.float64):
+    dtype = numpy.dtype(dtype)
+    _checked_plot_allocation(rows, columns, dtype.itemsize)
+    return numpy.zeros(shape=(rows, columns), dtype=dtype)
+
+
+def _sample_coordinates(t0, dt, npts):
+    _validate_plot_grid(npts, dt)
+    _checked_plot_allocation(1, npts, numpy.dtype(numpy.float64).itemsize)
+    return t0 + numpy.arange(npts, dtype=numpy.float64) * dt
+
 
 def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False):
     """
@@ -68,10 +104,8 @@ def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False
     """
     npts, ntraces = section.shape  # time/traces
     if ntraces < 1:
-        raise IndexError("Nothing to plot")
-    if npts < 1:
-        raise IndexError("Nothing to plot")
-    t = numpy.linspace(t0, t0 + dt * npts, npts)
+        raise ValueError("plot input is empty")
+    t = _sample_coordinates(t0, dt, npts)
     amp = 1.0  # normalization factor
     gmin = 0.0  # global minimum
     toffset = 0.0  # offset in time to make 0 centered
@@ -79,8 +113,9 @@ def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False
         gmax = section.max()
         gmin = section.min()
         amp = gmax - gmin
-        toffset = 0.5
-    plt.ylim(max(t), 0)
+        if amp != 0.0:
+            toffset = 0.5
+    plt.ylim(t[-1], t[0])
     if ranges is None:
         ranges = (0, ntraces)
     x0, x1 = ranges
@@ -88,7 +123,10 @@ def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False
     dx = (x1 - x0) / ntraces
     plt.xlim(x0 - dx / 2.0, x1 + dx / 2.0)
     for i, trace in enumerate(section.transpose()):
-        tr = (((trace - gmin) / amp) - toffset) * scale * dx
+        if normalize and amp == 0.0:
+            tr = numpy.zeros_like(trace, dtype=numpy.float64)
+        else:
+            tr = (((trace - gmin) / amp) - toffset) * scale * dx
         x = x0 + i * dx  # x position for this trace
         plt.plot(x + tr, t, "k")
         if color != None:
@@ -140,15 +178,13 @@ def image_raw(
     """
     npts, maxtraces = section.shape  # time/traces
     if maxtraces < 1:
-        raise IndexError("Nothing to plot")
-    if npts < 1:
-        raise IndexError("Nothing to plot")
-    t = numpy.linspace(t0, t0 + dt * npts, npts)
+        raise ValueError("plot input is empty")
+    t = _sample_coordinates(t0, dt, npts)
     data = section
     if ranges is None:
         ranges = (0, maxtraces - 1)
     x0, x1 = ranges
-    extent = (x0 - 0.5, x1 + 0.5, t[npts - 1], t[0])
+    extent = (x0 - 0.5, x1 + 0.5, t[-1], t[0])
     if aspect is None:  # guarantee a rectangular picture
         aspect = numpy.round((x1 - x0) / numpy.max(t))
         if aspect <= 0.0:
@@ -182,14 +218,18 @@ def tse2nparray(ens):
     :return: three-element list ``[t0, dt, data]`` containing the earliest
         start time, sample interval, and 2-D NumPy array.
     :rtype: list
-    :raises RuntimeError: if ensemble members have inconsistent sample rates
-        or imply an unreasonably large time span.
+    :raises ValueError: if the ensemble is empty or a sample grid is invalid.
+    :raises RuntimeError: if ensemble members have inconsistent sample rates.
+    :raises MemoryError: if the output matrix exceeds the allocation limit.
     """
     nseis = len(ens.member)
+    if nseis == 0:
+        raise ValueError("cannot convert an empty ensemble")
     tmax = 0.0
     tmin = 0.0
     dt = 0.0
     for i in range(nseis):
+        _validate_plot_grid(ens.member[i].npts, ens.member[i].dt)
         if i == 0:
             tmin = ens.member[i].t0
             tmax = ens.member[i].endtime()
@@ -208,13 +248,11 @@ def tse2nparray(ens):
     # spanning years.  The calculation here uses a threshold on size
     # as a sanity check to avoid absurd malloc requests
     n = nseis
-    m = int((tmax - tmin) / dt + 1)
-    Mmax = 10000000  # size limit hard wired
-    if m > Mmax:
-        raise RuntimeError(
-            "tse2dmatix:  irrational computed time range - you are probably incorrectly using data with large range of absolute times"
-        )
-    work = numpy.zeros(shape=[m, n])
+    sample_span = (tmax - tmin) / dt
+    if not numpy.isfinite(sample_span):
+        raise MemoryError("ensemble time span overflows the plot sample grid")
+    m = int(sample_span + 1)
+    work = _allocate_plot_matrix(m, n)
     # The algorithm used here is horribly inefficient if there are large
     # differences in start and end times but this approach is safer
     for j in range(n):
@@ -240,6 +278,8 @@ def seis2nparray(d):
     """
     tmin = d.t0
     dt = d.dt
+    _validate_plot_grid(d.npts, dt)
+    _checked_plot_allocation(3, d.npts, numpy.dtype(numpy.float64).itemsize)
     work = numpy.array(d.data)
     return [tmin, dt, work]
 
@@ -256,6 +296,8 @@ def ts2nparray(d):
     """
     tmin = d.t0
     dt = d.dt
+    _validate_plot_grid(d.npts, dt)
+    _checked_plot_allocation(1, d.npts, numpy.dtype(numpy.float64).itemsize)
     work = numpy.array(d.data)
     return [tmin, dt, work]
 
@@ -940,14 +982,12 @@ class SeismicPlotter(BasicSeismicPlotter):
             if self.title != None:
                 plt.title(self.title)
         elif isinstance(d, TimeSeries):
-            if d.npts <= 0:
-                raise IndexError(base_error + "data vector is empty.  Nothing to plot")
+            _validate_plot_grid(d.npts, d.dt)
             self.figre = self._wtva_TimeSeries(d, fill)
             if self.title != None:
                 plt.title(self.title)
         elif isinstance(d, Seismogram):
-            if d.npts <= 0:
-                raise IndexError(base_error + "data vector is empty.  Nothing to plot")
+            _validate_plot_grid(d.npts, d.dt)
             self.figure = self._wtva_Seismogram(d, fill)
             if self.title != None:
                 plt.title(self.title)
@@ -971,14 +1011,12 @@ class SeismicPlotter(BasicSeismicPlotter):
             if self.title != None:
                 plt.title(self.title)
         elif isinstance(d, TimeSeries):
-            if d.npts <= 0:
-                raise IndexError(base_error + "data vector is empty.  Nothing to plot")
+            _validate_plot_grid(d.npts, d.dt)
             self.figure = self._imageplot_TimeSeries(d)
             if self.title != None:
                 plt.title(self.title)
         elif isinstance(d, Seismogram):
-            if d.npts <= 0:
-                raise IndexError(base_error + "data vector is empty.  Nothing to plot")
+            _validate_plot_grid(d.npts, d.dt)
             self.figure = self._imageplot_Seismogram(d)
             if self.title != None:
                 plt.title(self.title)
@@ -990,7 +1028,8 @@ class SeismicPlotter(BasicSeismicPlotter):
         # a single trace - pretty much like the obspy plot but with optional
         # shading.  It assumes d is a TimeSeries.
 
-        t = numpy.linspace(d.t0, d.t0 + d.dt * d.npts, d.npts)
+        t = _sample_coordinates(d.t0, d.dt, d.npts)
+        plt.xlim(t[0], t[-1])
         # We don't need a gain factor here - will be needed for an image overlay through
         plt.plot(t, d.data, "k")
         if fill:
@@ -1119,10 +1158,8 @@ class SeismicPlotter(BasicSeismicPlotter):
             dt = min(dt, d.member[i].dt)
         # compute the number of points for the time axis
         nt = int((tmax - tmin) / dt) + 1
-        # WARNING - this assumes size of nt is limited by error checking
-        # in get_ensemble_size called above.  Prone to malloc error if nt
-        # is huge - easy to do with absolute time data segments
-        work = numpy.zeros(shape=[ndata, nt])
+        # Guard the full matrix byte size before requesting the allocation.
+        work = _allocate_plot_matrix(ndata, nt)
         for i in range(ndata):
             # skip data marked dead
             if d.member[i].dead():
@@ -1201,7 +1238,8 @@ class SeismicPlotter(BasicSeismicPlotter):
     def _imageplot_TimeSeries(self, d):
         # somewhat inefficient, but TimeSeries size in this context
         # would always be small enough to be irrelevant
-        work = numpy.zeros(shape=[1, d.npts])
+        _validate_plot_grid(d.npts, d.dt)
+        work = _allocate_plot_matrix(1, d.npts)
         extent = (d.t0, d.endtime(), -1.0, 1.0)
         for j in range(d.npts):
             work[0, j] = d.data[j]

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -16,12 +16,12 @@ from mspasspy.algorithms.basic import ExtractComponent
 # not sure that is necessary but this makes context clearer
 from mspasspy.algorithms.window import scale as mspass_scale_function
 
-_MAX_PLOT_ARRAY_BYTES = 536870912
+_MAX_ENSEMBLE_MATRIX_ROWS = 10000000
 
 
 def _validate_plot_grid(npts, dt):
     if npts <= 0:
-        raise ValueError("plot input is empty")
+        raise IndexError("plot input is empty")
     if not numpy.isfinite(dt) or dt <= 0.0:
         raise ValueError("plot sample interval must be finite and positive")
 
@@ -36,9 +36,16 @@ def _checked_plot_allocation(rows, columns, itemsize):
     if elements and itemsize > max_index // elements:
         raise MemoryError("plot array byte size overflows the platform index size")
     byte_count = elements * itemsize
-    if byte_count > _MAX_PLOT_ARRAY_BYTES:
-        raise MemoryError("plot array exceeds the 512 MiB allocation limit")
     return byte_count
+
+
+def _validate_ensemble_matrix_rows(rows):
+    """Preserve the established absolute-time-span sanity limit."""
+    if rows > _MAX_ENSEMBLE_MATRIX_ROWS:
+        raise RuntimeError(
+            "tse2dmatix:  irrational computed time range - you are probably "
+            "incorrectly using data with large range of absolute times"
+        )
 
 
 def _allocate_plot_matrix(rows, columns, dtype=numpy.float64):
@@ -104,7 +111,7 @@ def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False
     """
     npts, ntraces = section.shape  # time/traces
     if ntraces < 1:
-        raise ValueError("plot input is empty")
+        raise IndexError("Nothing to plot")
     t = _sample_coordinates(t0, dt, npts)
     amp = 1.0  # normalization factor
     gmin = 0.0  # global minimum
@@ -178,7 +185,7 @@ def image_raw(
     """
     npts, maxtraces = section.shape  # time/traces
     if maxtraces < 1:
-        raise ValueError("plot input is empty")
+        raise IndexError("Nothing to plot")
     t = _sample_coordinates(t0, dt, npts)
     data = section
     if ranges is None:
@@ -218,13 +225,17 @@ def tse2nparray(ens):
     :return: three-element list ``[t0, dt, data]`` containing the earliest
         start time, sample interval, and 2-D NumPy array.
     :rtype: list
-    :raises ValueError: if the ensemble is empty or a sample grid is invalid.
+    :raises IndexError: if the ensemble or one of its members is empty.
+    :raises ValueError: if a sample interval is invalid.
     :raises RuntimeError: if ensemble members have inconsistent sample rates.
-    :raises MemoryError: if the output matrix exceeds the allocation limit.
+        A ``RuntimeError`` is also raised when the sampled time span would
+        exceed the established ten-million-row sanity limit, which normally
+        indicates that unrelated absolute-time segments were mixed.
+    :raises MemoryError: if matrix dimensions overflow the platform index size.
     """
     nseis = len(ens.member)
     if nseis == 0:
-        raise ValueError("cannot convert an empty ensemble")
+        raise IndexError("cannot convert an empty ensemble")
     tmax = 0.0
     tmin = 0.0
     dt = 0.0
@@ -250,8 +261,9 @@ def tse2nparray(ens):
     n = nseis
     sample_span = (tmax - tmin) / dt
     if not numpy.isfinite(sample_span):
-        raise MemoryError("ensemble time span overflows the plot sample grid")
+        raise RuntimeError("ensemble time span is not finite")
     m = int(sample_span + 1)
+    _validate_ensemble_matrix_rows(m)
     work = _allocate_plot_matrix(m, n)
     # The algorithm used here is horribly inefficient if there are large
     # differences in start and end times but this approach is safer
@@ -278,8 +290,8 @@ def seis2nparray(d):
     """
     tmin = d.t0
     dt = d.dt
-    _validate_plot_grid(d.npts, dt)
-    _checked_plot_allocation(3, d.npts, numpy.dtype(numpy.float64).itemsize)
+    if d.npts > 0:
+        _validate_plot_grid(d.npts, dt)
     work = numpy.array(d.data)
     return [tmin, dt, work]
 
@@ -296,8 +308,8 @@ def ts2nparray(d):
     """
     tmin = d.t0
     dt = d.dt
-    _validate_plot_grid(d.npts, dt)
-    _checked_plot_allocation(1, d.npts, numpy.dtype(numpy.float64).itemsize)
+    if d.npts > 0:
+        _validate_plot_grid(d.npts, dt)
     work = numpy.array(d.data)
     return [tmin, dt, work]
 

--- a/python/tests/test_graphics_raw_contract.py
+++ b/python/tests/test_graphics_raw_contract.py
@@ -86,7 +86,7 @@ def test_constant_normalization_produces_only_finite_zero_offsets():
 @pytest.mark.parametrize("function", (graphics.wtva_raw, graphics.image_raw))
 @pytest.mark.parametrize("shape", ((0, 2), (2, 0)))
 def test_raw_plotters_reject_empty_input(function, shape):
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(IndexError, match="Nothing to plot|empty"):
         function(np.empty(shape), 1.0, 0.5)
 
 
@@ -101,9 +101,12 @@ def test_raw_plotters_reject_invalid_sample_intervals(function, dt):
     "converter,datum_type",
     ((graphics.ts2nparray, TimeSeries), (graphics.seis2nparray, Seismogram)),
 )
-def test_atomic_converters_reject_empty_input(converter, datum_type):
-    with pytest.raises(ValueError, match="empty"):
-        converter(datum_type())
+def test_atomic_converters_preserve_empty_array_result(converter, datum_type):
+    t0, dt, data = converter(datum_type())
+
+    assert np.asarray(data).size == 0
+    assert isinstance(t0, float)
+    assert isinstance(dt, float)
 
 
 @pytest.mark.parametrize(
@@ -120,7 +123,7 @@ def test_atomic_converters_reject_invalid_sample_intervals(converter, datum_type
 
 
 def test_ensemble_converter_rejects_empty_input():
-    with pytest.raises(ValueError, match="empty ensemble"):
+    with pytest.raises(IndexError, match="empty ensemble"):
         graphics.tse2nparray(TimeSeriesEnsemble())
 
 
@@ -138,7 +141,7 @@ def test_ensemble_converter_rejects_invalid_sample_intervals(dt):
 def test_plotter_atomic_paths_reject_empty_and_invalid_grids():
     plotter = graphics.SeismicPlotter()
 
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(IndexError, match="empty"):
         plotter._wtva(TimeSeries(), False)
     invalid = TimeSeries(2)
     invalid.dt = 0.0
@@ -146,21 +149,19 @@ def test_plotter_atomic_paths_reject_empty_and_invalid_grids():
         plotter._imageplot(invalid)
 
 
-def test_checked_allocation_allows_exact_limit_and_rejects_one_byte_more(
-    monkeypatch,
-):
+def test_checked_allocation_does_not_invent_a_512_mib_policy_limit(monkeypatch):
     zeros = Mock(return_value=object())
     monkeypatch.setattr(graphics.numpy, "zeros", zeros)
-    limit = graphics._MAX_PLOT_ARRAY_BYTES
+    one_byte_over_old_issue_limit = 536870913
 
-    result = graphics._allocate_plot_matrix(limit, 1, dtype=np.uint8)
+    result = graphics._allocate_plot_matrix(
+        one_byte_over_old_issue_limit, 1, dtype=np.uint8
+    )
 
     assert result is zeros.return_value
-    zeros.assert_called_once_with(shape=(limit, 1), dtype=np.dtype(np.uint8))
-    zeros.reset_mock()
-    with pytest.raises(MemoryError, match="512 MiB"):
-        graphics._allocate_plot_matrix(limit + 1, 1, dtype=np.uint8)
-    zeros.assert_not_called()
+    zeros.assert_called_once_with(
+        shape=(one_byte_over_old_issue_limit, 1), dtype=np.dtype(np.uint8)
+    )
 
 
 @pytest.mark.parametrize(
@@ -182,12 +183,14 @@ def test_checked_allocation_rejects_integer_multiplication_overflow(
     zeros.assert_not_called()
 
 
-def test_ensemble_conversion_rejects_oversized_matrix_before_allocation(
-    monkeypatch,
-):
+def test_ensemble_conversion_preserves_ten_million_row_sanity_limit(monkeypatch):
+    assert (
+        graphics._validate_ensemble_matrix_rows(graphics._MAX_ENSEMBLE_MATRIX_ROWS)
+        is None
+    )
     zeros = Mock()
     monkeypatch.setattr(graphics.numpy, "zeros", zeros)
-    rows = graphics._MAX_PLOT_ARRAY_BYTES // np.dtype(np.float64).itemsize + 1
+    rows = graphics._MAX_ENSEMBLE_MATRIX_ROWS + 1
     member = SimpleNamespace(
         npts=2,
         dt=1.0,
@@ -196,58 +199,47 @@ def test_ensemble_conversion_rejects_oversized_matrix_before_allocation(
     )
     ensemble = SimpleNamespace(member=[member])
 
-    with pytest.raises(MemoryError, match="512 MiB"):
+    with pytest.raises(RuntimeError, match="irrational computed time range"):
         graphics.tse2nparray(ensemble)
 
     zeros.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "converter,item_count",
-    (
-        (graphics.ts2nparray, 1),
-        (graphics.seis2nparray, 3),
-    ),
-)
-def test_atomic_conversion_rejects_oversized_array_before_allocation(
-    monkeypatch, converter, item_count
-):
-    array = Mock()
+@pytest.mark.parametrize("converter", (graphics.ts2nparray, graphics.seis2nparray))
+def test_atomic_conversion_has_no_new_policy_size_limit(monkeypatch, converter):
+    array = Mock(return_value=object())
     monkeypatch.setattr(graphics.numpy, "array", array)
-    npts = (
-        graphics._MAX_PLOT_ARRAY_BYTES // (item_count * np.dtype(np.float64).itemsize)
-        + 1
-    )
+    npts = 536870913
     datum = SimpleNamespace(t0=0.0, dt=1.0, npts=npts, data=object())
 
-    with pytest.raises(MemoryError, match="512 MiB"):
-        converter(datum)
+    _, _, result = converter(datum)
 
-    array.assert_not_called()
+    assert result is array.return_value
+    array.assert_called_once_with(datum.data)
 
 
-def test_atomic_image_rejects_oversized_matrix_before_allocation(monkeypatch):
+def test_atomic_image_rejects_platform_size_overflow_before_allocation(monkeypatch):
     zeros = Mock()
     monkeypatch.setattr(graphics.numpy, "zeros", zeros)
-    npts = graphics._MAX_PLOT_ARRAY_BYTES // np.dtype(np.float64).itemsize + 1
+    npts = np.iinfo(np.intp).max // np.dtype(np.float64).itemsize + 1
     datum = SimpleNamespace(t0=0.0, dt=1.0, npts=npts, data=object())
 
-    with pytest.raises(MemoryError, match="512 MiB"):
+    with pytest.raises(MemoryError, match="overflow"):
         graphics.SeismicPlotter()._imageplot_TimeSeries(datum)
 
     zeros.assert_not_called()
 
 
-def test_ensemble_image_rejects_oversized_matrix_before_allocation(monkeypatch):
+def test_ensemble_image_rejects_platform_size_overflow_before_allocation(monkeypatch):
     zeros = Mock()
     monkeypatch.setattr(graphics.numpy, "zeros", zeros)
-    columns = graphics._MAX_PLOT_ARRAY_BYTES // (2 * np.dtype(np.float64).itemsize) + 1
+    columns = np.iinfo(np.intp).max // (2 * np.dtype(np.float64).itemsize) + 1
     member = SimpleNamespace(dt=1.0 / (columns - 1))
     ensemble = SimpleNamespace(member=[member, member])
     plotter = graphics.SeismicPlotter()
     monkeypatch.setattr(plotter, "_get_ensemble_size", lambda _: (2, 0.0, 1.0))
 
-    with pytest.raises(MemoryError, match="512 MiB"):
+    with pytest.raises(MemoryError, match="overflow"):
         plotter._imageplot_TimeSeriesEnsemble(ensemble)
 
     zeros.assert_not_called()

--- a/python/tests/test_graphics_raw_contract.py
+++ b/python/tests/test_graphics_raw_contract.py
@@ -1,0 +1,253 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import mspasspy.graphics as graphics
+from mspasspy.ccore.seismic import Seismogram, TimeSeries, TimeSeriesEnsemble
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+@pytest.mark.parametrize("t0", (3.5, -4.5))
+def test_wtva_raw_uses_exact_sample_coordinates_and_bounds(t0):
+    section = np.array([[1.0, -1.0], [2.0, -2.0], [3.0, -3.0]])
+
+    graphics.wtva_raw(section, t0, 0.25, color=None)
+
+    expected = t0 + np.arange(3) * 0.25
+    axes = plt.gca()
+    assert len(axes.lines) == 2
+    for line in axes.lines:
+        np.testing.assert_array_equal(line.get_ydata(), expected)
+    assert axes.get_ylim() == pytest.approx((expected[-1], expected[0]))
+
+
+@pytest.mark.parametrize("t0", (3.5, -4.5))
+def test_image_raw_uses_exact_first_and_last_sample_bounds(t0):
+    section = np.arange(6.0).reshape(3, 2)
+
+    graphics.image_raw(section, t0, 0.25, ranges=(10.0, 20.0), aspect=1.0)
+
+    assert plt.gca().images[0].get_extent() == pytest.approx((9.5, 20.5, t0 + 0.5, t0))
+
+
+@pytest.mark.parametrize("t0", (3.5, -4.5))
+def test_atomic_wiggle_uses_exact_sample_coordinates_and_bounds(t0):
+    datum = TimeSeries(4)
+    datum.t0 = t0
+    datum.dt = 0.25
+    for index, value in enumerate((1.0, 2.0, 3.0, 4.0)):
+        datum.data[index] = value
+    plotter = graphics.SeismicPlotter()
+
+    plotter._wtva_TimeSeries(datum, False)
+
+    expected = t0 + np.arange(4) * 0.25
+    axes = plt.gca()
+    np.testing.assert_array_equal(axes.lines[0].get_xdata(), expected)
+    assert axes.get_xlim() == pytest.approx((expected[0], expected[-1]))
+
+
+@pytest.mark.parametrize("t0", (3.5, -4.5))
+def test_atomic_image_uses_exact_first_and_last_sample_bounds(t0):
+    datum = TimeSeries(4)
+    datum.t0 = t0
+    datum.dt = 0.25
+    for index, value in enumerate((1.0, 2.0, 3.0, 4.0)):
+        datum.data[index] = value
+    plotter = graphics.SeismicPlotter()
+
+    plotter._imageplot_TimeSeries(datum)
+
+    assert plt.gca().images[0].get_extent() == pytest.approx(
+        (t0, t0 + 3 * 0.25, -1.0, 1.0)
+    )
+
+
+def test_constant_normalization_produces_only_finite_zero_offsets():
+    section = np.full((4, 2), 7.0)
+
+    graphics.wtva_raw(section, -2.0, 0.5, ranges=(0.0, 2.0), color=None, normalize=True)
+
+    for trace_number, line in enumerate(plt.gca().lines):
+        offsets = np.asarray(line.get_xdata()) - trace_number
+        assert np.isfinite(offsets).all()
+        np.testing.assert_array_equal(offsets, np.zeros(4))
+
+
+@pytest.mark.parametrize("function", (graphics.wtva_raw, graphics.image_raw))
+@pytest.mark.parametrize("shape", ((0, 2), (2, 0)))
+def test_raw_plotters_reject_empty_input(function, shape):
+    with pytest.raises(ValueError, match="empty"):
+        function(np.empty(shape), 1.0, 0.5)
+
+
+@pytest.mark.parametrize("function", (graphics.wtva_raw, graphics.image_raw))
+@pytest.mark.parametrize("dt", (0.0, -1.0, np.nan, np.inf, -np.inf))
+def test_raw_plotters_reject_invalid_sample_intervals(function, dt):
+    with pytest.raises(ValueError, match="finite and positive"):
+        function(np.ones((2, 1)), 1.0, dt)
+
+
+@pytest.mark.parametrize(
+    "converter,datum_type",
+    ((graphics.ts2nparray, TimeSeries), (graphics.seis2nparray, Seismogram)),
+)
+def test_atomic_converters_reject_empty_input(converter, datum_type):
+    with pytest.raises(ValueError, match="empty"):
+        converter(datum_type())
+
+
+@pytest.mark.parametrize(
+    "converter,datum_type",
+    ((graphics.ts2nparray, TimeSeries), (graphics.seis2nparray, Seismogram)),
+)
+@pytest.mark.parametrize("dt", (0.0, -1.0, np.nan, np.inf, -np.inf))
+def test_atomic_converters_reject_invalid_sample_intervals(converter, datum_type, dt):
+    datum = datum_type(2)
+    datum.dt = dt
+
+    with pytest.raises(ValueError, match="finite and positive"):
+        converter(datum)
+
+
+def test_ensemble_converter_rejects_empty_input():
+    with pytest.raises(ValueError, match="empty ensemble"):
+        graphics.tse2nparray(TimeSeriesEnsemble())
+
+
+@pytest.mark.parametrize("dt", (0.0, -1.0, np.nan, np.inf, -np.inf))
+def test_ensemble_converter_rejects_invalid_sample_intervals(dt):
+    ensemble = TimeSeriesEnsemble()
+    member = TimeSeries(2)
+    member.dt = dt
+    ensemble.member.append(member)
+
+    with pytest.raises(ValueError, match="finite and positive"):
+        graphics.tse2nparray(ensemble)
+
+
+def test_plotter_atomic_paths_reject_empty_and_invalid_grids():
+    plotter = graphics.SeismicPlotter()
+
+    with pytest.raises(ValueError, match="empty"):
+        plotter._wtva(TimeSeries(), False)
+    invalid = TimeSeries(2)
+    invalid.dt = 0.0
+    with pytest.raises(ValueError, match="finite and positive"):
+        plotter._imageplot(invalid)
+
+
+def test_checked_allocation_allows_exact_limit_and_rejects_one_byte_more(
+    monkeypatch,
+):
+    zeros = Mock(return_value=object())
+    monkeypatch.setattr(graphics.numpy, "zeros", zeros)
+    limit = graphics._MAX_PLOT_ARRAY_BYTES
+
+    result = graphics._allocate_plot_matrix(limit, 1, dtype=np.uint8)
+
+    assert result is zeros.return_value
+    zeros.assert_called_once_with(shape=(limit, 1), dtype=np.dtype(np.uint8))
+    zeros.reset_mock()
+    with pytest.raises(MemoryError, match="512 MiB"):
+        graphics._allocate_plot_matrix(limit + 1, 1, dtype=np.uint8)
+    zeros.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "rows,columns,dtype",
+    (
+        (np.iinfo(np.intp).max, 2, np.uint8),
+        (np.iinfo(np.intp).max // np.dtype(np.float64).itemsize + 1, 1, np.float64),
+    ),
+)
+def test_checked_allocation_rejects_integer_multiplication_overflow(
+    monkeypatch, rows, columns, dtype
+):
+    zeros = Mock()
+    monkeypatch.setattr(graphics.numpy, "zeros", zeros)
+
+    with pytest.raises(MemoryError, match="overflow"):
+        graphics._allocate_plot_matrix(rows, columns, dtype=dtype)
+
+    zeros.assert_not_called()
+
+
+def test_ensemble_conversion_rejects_oversized_matrix_before_allocation(
+    monkeypatch,
+):
+    zeros = Mock()
+    monkeypatch.setattr(graphics.numpy, "zeros", zeros)
+    rows = graphics._MAX_PLOT_ARRAY_BYTES // np.dtype(np.float64).itemsize + 1
+    member = SimpleNamespace(
+        npts=2,
+        dt=1.0,
+        t0=0.0,
+        endtime=lambda: float(rows - 1),
+    )
+    ensemble = SimpleNamespace(member=[member])
+
+    with pytest.raises(MemoryError, match="512 MiB"):
+        graphics.tse2nparray(ensemble)
+
+    zeros.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "converter,item_count",
+    (
+        (graphics.ts2nparray, 1),
+        (graphics.seis2nparray, 3),
+    ),
+)
+def test_atomic_conversion_rejects_oversized_array_before_allocation(
+    monkeypatch, converter, item_count
+):
+    array = Mock()
+    monkeypatch.setattr(graphics.numpy, "array", array)
+    npts = (
+        graphics._MAX_PLOT_ARRAY_BYTES // (item_count * np.dtype(np.float64).itemsize)
+        + 1
+    )
+    datum = SimpleNamespace(t0=0.0, dt=1.0, npts=npts, data=object())
+
+    with pytest.raises(MemoryError, match="512 MiB"):
+        converter(datum)
+
+    array.assert_not_called()
+
+
+def test_atomic_image_rejects_oversized_matrix_before_allocation(monkeypatch):
+    zeros = Mock()
+    monkeypatch.setattr(graphics.numpy, "zeros", zeros)
+    npts = graphics._MAX_PLOT_ARRAY_BYTES // np.dtype(np.float64).itemsize + 1
+    datum = SimpleNamespace(t0=0.0, dt=1.0, npts=npts, data=object())
+
+    with pytest.raises(MemoryError, match="512 MiB"):
+        graphics.SeismicPlotter()._imageplot_TimeSeries(datum)
+
+    zeros.assert_not_called()
+
+
+def test_ensemble_image_rejects_oversized_matrix_before_allocation(monkeypatch):
+    zeros = Mock()
+    monkeypatch.setattr(graphics.numpy, "zeros", zeros)
+    columns = graphics._MAX_PLOT_ARRAY_BYTES // (2 * np.dtype(np.float64).itemsize) + 1
+    member = SimpleNamespace(dt=1.0 / (columns - 1))
+    ensemble = SimpleNamespace(member=[member, member])
+    plotter = graphics.SeismicPlotter()
+    monkeypatch.setattr(plotter, "_get_ensemble_size", lambda _: (2, 0.0, 1.0))
+
+    with pytest.raises(MemoryError, match="512 MiB"):
+        plotter._imageplot_TimeSeriesEnsemble(ensemble)
+
+    zeros.assert_not_called()


### PR DESCRIPTION
## Summary

- coordinate raw and atomic plots on the exact `t0 + i*dt` sample grid
- use the true first and final sample for line and image bounds
- normalize constant sections to finite zero offsets
- reject non-finite/non-positive sample intervals before plotting or allocation
- check matrix dimension multiplication against the platform index size before allocation
- preserve the established ten-million-row absolute-time-span sanity policy

## Approved API policy

This PR does not add the fixed 512 MiB limit proposed in the original Issue. It preserves existing public empty-input behavior and the existing 10,000,000-row ensemble time-span guard, while adding platform integer-overflow checks before allocation. Ordinary resource exhaustion remains NumPy/the host's responsibility.

## Validation

- raw, atomic, allocation, and adjacent graphics tests: 51 passed
- `git diff --check`: passed
- Black reports the changed files unchanged

Closes #787
