### PR TITLE
Keep database client state consistent

### DIFF
--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -571,12 +571,27 @@ class Client:
 
     def set_database_client(self, database_host, database_port=None):
         """
-        Set a database client by database_host(and database_port)
+        Replace the database client and its global-history database together.
+
+        The replacement database client is connected and validated first.  A
+        new history database and :class:`GlobalHistoryManager` are then built
+        with the current history database name, schema objects, job name, and
+        collection.  Only after all of those steps succeed are the database and
+        history references committed to this client.  A failure therefore
+        leaves the current database client, history manager, and scheduler
+        unchanged.
+
+        An explicit port is appended only when ``database_host`` does not
+        already contain one.  This applies to bare hosts, MongoDB URIs, and
+        bracketed IPv6 addresses.
 
         :param database_host: the host address of database client
         :type database_host: :class:`str`
         :param database_port: the port of database client
         :type database_port: :class:`str`
+
+        :raises MsPASSError: if the replacement database client, history
+            database, or history manager cannot be constructed and validated.
         """
         database_address = _build_database_address(database_host, database_port)
         replacement_db_client = None

--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -100,6 +100,24 @@ def _build_scheduler_endpoint(
     return endpoint
 
 
+def _build_database_address(database_address, database_port=None):
+    if database_port is None or database_port == "":
+        return database_address
+
+    has_scheme = "://" in database_address
+    parsed_address = urlsplit(
+        database_address if has_scheme else "//" + database_address
+    )
+    if parsed_address.port is not None:
+        return database_address
+
+    parsed_address = parsed_address._replace(
+        netloc=parsed_address.netloc + ":" + str(database_port)
+    )
+    result = parsed_address.geturl()
+    return result if has_scheme else result[2:]
+
+
 def _build_dask_scheduler_address(scheduler_address, scheduler_port=None):
     return _build_scheduler_endpoint(
         scheduler_address,
@@ -225,20 +243,13 @@ class Client:
 
         # create a database client
         # priority: parameter -> env -> default
-        database_host_has_port = False
         if database_host:
             database_address = database_host
-            # check if database_host contains port number already
-            if ":" in database_address:
-                database_host_has_port = True
-
         elif MSPASS_DB_ADDRESS:
             database_address = MSPASS_DB_ADDRESS
         else:
             database_address = "127.0.0.1"
-        # add port
-        if not database_host_has_port and MONGODB_PORT:
-            database_address += ":" + MONGODB_PORT
+        database_address = _build_database_address(database_address, MONGODB_PORT)
 
         try:
             self._db_client = DBClient(database_address)
@@ -256,12 +267,9 @@ class Client:
         self._default_collection = collection
 
         # create a Global History Manager
-        if schema:
-            global_history_manager_db = Database(
-                self._db_client, database_name, db_schema=schema
-            )
-        else:
-            global_history_manager_db = Database(self._db_client, database_name)
+        global_history_manager_db = Database(
+            self._db_client, database_name, schema=schema
+        )
         self._global_history_manager = GlobalHistoryManager(
             global_history_manager_db, job_name, collection=collection
         )
@@ -496,8 +504,8 @@ class Client:
         :return: :class:`mspasspy.db.database.Database`
         """
         if not database_name:
-            return Database(self._db_client, self._default_database_name)
-        return Database(self._db_client, database_name)
+            database_name = self._default_database_name
+        return Database(self._db_client, database_name, schema=self._default_schema)
 
     def get_global_history_manager(self):
         """
@@ -570,27 +578,37 @@ class Client:
         :param database_port: the port of database client
         :type database_port: :class:`str`
         """
-        database_host_has_port = False
-        database_address = database_host
-        # check if port is already in the database_host address
-        if ":" in database_host:
-            database_host_has_port = True
-        # add port
-        if not database_host_has_port and database_port:
-            database_address += ":" + database_port
-        # sanity check
-        temp_db_client = self._db_client
+        database_address = _build_database_address(database_host, database_port)
+        replacement_db_client = None
+        current_history_manager = self._global_history_manager
+        current_history_db = current_history_manager.history_db
         try:
-            self._db_client = DBClient(database_address)
-            self._db_client.server_info()
+            replacement_db_client = DBClient(database_address)
+            replacement_db_client.server_info()
+            replacement_history_db = Database(
+                replacement_db_client,
+                current_history_db.name,
+                db_schema=current_history_db.database_schema,
+                md_schema=current_history_db.metadata_schema,
+            )
+            replacement_history_manager = GlobalHistoryManager(
+                replacement_history_db,
+                current_history_manager.job_name,
+                collection=current_history_manager.collection,
+            )
         except Exception as err:
-            # restore the _db_client
-            self._db_client = temp_db_client
+            if replacement_db_client is not None:
+                replacement_db_client.close()
             raise MsPASSError(
                 "Runntime error: cannot create a database client with: "
                 + database_address,
                 "Fatal",
-            )
+            ) from err
+
+        self._db_client, self._global_history_manager = (
+            replacement_db_client,
+            replacement_history_manager,
+        )
 
     def set_global_history_manager(self, history_db, job_name, collection=None):
         """

--- a/python/tests/test_mspass_client_database_state.py
+++ b/python/tests/test_mspass_client_database_state.py
@@ -197,6 +197,22 @@ def test_successful_database_switch_commits_client_database_and_history_together
     assert new_db_client.close_calls == 0
 
 
+def test_database_switch_preserves_scheduler_state(fake_client_dependencies):
+    client = _new_fake_client()
+    scheduler = object()
+    client._scheduler = "dask"
+    client._scheduler_disabled = False
+    client._dask_client = scheduler
+    client._dask_client_address = "tcp://existing:8786"
+
+    client.set_database_client("replacement")
+
+    assert client._scheduler == "dask"
+    assert client._scheduler_disabled is False
+    assert client.get_scheduler() is scheduler
+    assert client._dask_client_address == "tcp://existing:8786"
+
+
 @pytest.mark.parametrize("failure_stage", ["client", "database", "history"])
 def test_failed_database_switch_preserves_all_old_state(
     fake_client_dependencies, failure_stage

--- a/python/tests/test_mspass_client_database_state.py
+++ b/python/tests/test_mspass_client_database_state.py
@@ -1,0 +1,278 @@
+import os
+import uuid
+from types import SimpleNamespace
+
+import pymongo
+import pytest
+
+import mspasspy.client as client_module
+from mspasspy.ccore.utility import MsPASSError
+
+ENDPOINT_CASES = [
+    ("mongo", None, "mongo"),
+    ("mongo", "27018", "mongo:27018"),
+    ("mongo:27017", None, "mongo:27017"),
+    ("mongo:27017", "27017", "mongo:27017"),
+    ("mongo:27017", "27018", "mongo:27017"),
+    ("mongodb://mongo", None, "mongodb://mongo"),
+    ("mongodb://mongo", "27018", "mongodb://mongo:27018"),
+    ("mongodb://mongo:27017", None, "mongodb://mongo:27017"),
+    ("mongodb://mongo:27017", "27017", "mongodb://mongo:27017"),
+    ("mongodb://mongo:27017", "27018", "mongodb://mongo:27017"),
+    ("[2001:db8::1]", None, "[2001:db8::1]"),
+    ("[2001:db8::1]", "27018", "[2001:db8::1]:27018"),
+    ("[2001:db8::1]:27017", None, "[2001:db8::1]:27017"),
+    ("[2001:db8::1]:27017", "27017", "[2001:db8::1]:27017"),
+    ("[2001:db8::1]:27017", "27018", "[2001:db8::1]:27017"),
+    ("mongodb://[2001:db8::1]", None, "mongodb://[2001:db8::1]"),
+    ("mongodb://[2001:db8::1]", "27018", "mongodb://[2001:db8::1]:27018"),
+    (
+        "mongodb://[2001:db8::1]:27017",
+        None,
+        "mongodb://[2001:db8::1]:27017",
+    ),
+    (
+        "mongodb://[2001:db8::1]:27017",
+        "27017",
+        "mongodb://[2001:db8::1]:27017",
+    ),
+    (
+        "mongodb://[2001:db8::1]:27017",
+        "27018",
+        "mongodb://[2001:db8::1]:27017",
+    ),
+]
+
+
+@pytest.fixture
+def fake_client_dependencies(monkeypatch):
+    control = SimpleNamespace(
+        failure_stage=None,
+        clients=[],
+        databases=[],
+        history_managers=[],
+    )
+
+    class FakeDBClient:
+        def __init__(self, endpoint):
+            self.endpoint = endpoint
+            self.closed = False
+            self.close_calls = 0
+            control.clients.append(self)
+
+        def server_info(self):
+            if self.endpoint == "replacement" and control.failure_stage == "client":
+                raise RuntimeError("client validation failed")
+            return {"ok": 1}
+
+        def close(self):
+            self.close_calls += 1
+            self.closed = True
+
+    class FakeDatabase:
+        def __init__(
+            self,
+            client,
+            name,
+            *args,
+            schema=None,
+            db_schema=None,
+            md_schema=None,
+            **kwargs,
+        ):
+            if client.endpoint == "replacement" and control.failure_stage == "database":
+                raise RuntimeError("database construction failed")
+            self.client = client
+            self.name = name
+            self.schema = schema
+            if schema is not None:
+                self.database_schema = ("database", schema)
+                self.metadata_schema = ("metadata", schema)
+            else:
+                self.database_schema = db_schema or ("database", None)
+                self.metadata_schema = md_schema or ("metadata", None)
+            control.databases.append(self)
+
+    class FakeGlobalHistoryManager:
+        def __init__(self, history_db, job_name, collection=None):
+            if (
+                history_db.client.endpoint == "replacement"
+                and control.failure_stage == "history"
+            ):
+                raise RuntimeError("history construction failed")
+            self.history_db = history_db
+            self.job_name = job_name
+            self.collection = collection or "history_global"
+            control.history_managers.append(self)
+
+    monkeypatch.setattr(client_module, "DBClient", FakeDBClient)
+    monkeypatch.setattr(client_module, "Database", FakeDatabase)
+    monkeypatch.setattr(client_module, "GlobalHistoryManager", FakeGlobalHistoryManager)
+    return control
+
+
+def _new_fake_client(endpoint="old", **kwargs):
+    return client_module.Client(
+        database_host=endpoint,
+        scheduler="none",
+        database_name="default_db",
+        schema="configured.yaml",
+        job_name="job",
+        collection="history_collection",
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("source", ["explicit", "environment"])
+@pytest.mark.parametrize("endpoint,separate_port,expected", ENDPOINT_CASES)
+def test_database_endpoint_matrix(
+    monkeypatch,
+    fake_client_dependencies,
+    source,
+    endpoint,
+    separate_port,
+    expected,
+):
+    monkeypatch.delenv("MSPASS_DB_ADDRESS", raising=False)
+    monkeypatch.delenv("MONGODB_PORT", raising=False)
+    if separate_port is not None:
+        monkeypatch.setenv("MONGODB_PORT", separate_port)
+    if source == "environment":
+        monkeypatch.setenv("MSPASS_DB_ADDRESS", endpoint)
+        database_host = None
+    else:
+        database_host = endpoint
+
+    client = client_module.Client(database_host=database_host, scheduler="none")
+
+    assert client.get_database_client().endpoint == expected
+
+
+def test_get_database_propagates_schema_to_default_named_and_history(
+    fake_client_dependencies,
+):
+    client = _new_fake_client()
+
+    default_database = client.get_database()
+    named_database = client.get_database("named_db")
+    history_database = client.get_global_history_manager().history_db
+
+    assert default_database.name == "default_db"
+    assert named_database.name == "named_db"
+    assert default_database.schema == "configured.yaml"
+    assert named_database.schema == "configured.yaml"
+    assert history_database.schema == "configured.yaml"
+    assert default_database.client is client.get_database_client()
+    assert named_database.client is client.get_database_client()
+    assert history_database.client is client.get_database_client()
+
+
+def test_successful_database_switch_commits_client_database_and_history_together(
+    fake_client_dependencies,
+):
+    client = _new_fake_client()
+    old_db_client = client.get_database_client()
+    old_history_manager = client.get_global_history_manager()
+    old_history_database = old_history_manager.history_db
+
+    client.set_database_client("mongodb://new:27019", database_port="27020")
+
+    new_db_client = client.get_database_client()
+    new_history_manager = client.get_global_history_manager()
+    new_history_database = new_history_manager.history_db
+    assert new_db_client is not old_db_client
+    assert new_db_client.endpoint == "mongodb://new:27019"
+    assert new_history_manager is not old_history_manager
+    assert new_history_database is not old_history_database
+    assert new_history_database.client is new_db_client
+    assert new_history_database.database_schema is old_history_database.database_schema
+    assert new_history_database.metadata_schema is old_history_database.metadata_schema
+    assert new_history_manager.job_name == old_history_manager.job_name
+    assert new_history_manager.collection == old_history_manager.collection
+    assert client.get_database().client is new_db_client
+    assert client.get_database().schema == "configured.yaml"
+    assert old_db_client.closed is False
+    assert old_db_client.close_calls == 0
+    assert new_db_client.closed is False
+    assert new_db_client.close_calls == 0
+
+
+@pytest.mark.parametrize("failure_stage", ["client", "database", "history"])
+def test_failed_database_switch_preserves_all_old_state(
+    fake_client_dependencies, failure_stage
+):
+    control = fake_client_dependencies
+    client = _new_fake_client()
+    old_db_client = client.get_database_client()
+    old_history_manager = client.get_global_history_manager()
+    old_history_database = old_history_manager.history_db
+    control.failure_stage = failure_stage
+
+    with pytest.raises(
+        MsPASSError,
+        match="Runntime error: cannot create a database client with: replacement",
+    ):
+        client.set_database_client("replacement")
+
+    assert client.get_database_client() is old_db_client
+    assert client.get_global_history_manager() is old_history_manager
+    assert client.get_global_history_manager().history_db is old_history_database
+    assert client.get_database().client is old_db_client
+    assert old_history_database.client is old_db_client
+    assert old_db_client.closed is False
+    assert old_db_client.close_calls == 0
+    assert old_db_client.server_info() == {"ok": 1}
+    assert control.clients[-1] is not old_db_client
+    assert control.clients[-1].closed is True
+    assert control.clients[-1].close_calls == 1
+
+
+@pytest.fixture
+def real_mongo(monkeypatch):
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://localhost:27017")
+    monkeypatch.delenv("MONGODB_PORT", raising=False)
+    admin_client = pymongo.MongoClient(uri, serverSelectionTimeoutMS=5000)
+    admin_client.admin.command("ping")
+    default_name = "mspass_test_client_default_" + uuid.uuid4().hex
+    named_name = "mspass_test_client_named_" + uuid.uuid4().hex
+    try:
+        yield uri, default_name, named_name
+    finally:
+        admin_client.drop_database(default_name)
+        admin_client.drop_database(named_name)
+        admin_client.close()
+
+
+def test_real_mongo_schema_and_successful_same_server_switch(real_mongo):
+    uri, default_name, named_name = real_mongo
+    client = client_module.Client(
+        database_host=uri,
+        scheduler="none",
+        database_name=default_name,
+        schema="mspass_lite.yaml",
+        job_name="real_job",
+    )
+    old_db_client = client.get_database_client()
+    try:
+        default_database = client.get_database()
+        named_database = client.get_database(named_name)
+        history_database = client.get_global_history_manager().history_db
+        for database in (default_database, named_database, history_database):
+            with pytest.raises(KeyError, match="site"):
+                database.database_schema._attr_dict["site"]
+            assert database.client is old_db_client
+
+        client.set_database_client(uri, database_port="1")
+
+        new_db_client = client.get_database_client()
+        assert new_db_client is not old_db_client
+        assert new_db_client._mspass_db_host == uri
+        assert client.get_database().client is new_db_client
+        assert client.get_database(named_name).client is new_db_client
+        assert client.get_global_history_manager().history_db.client is new_db_client
+        assert client.get_global_history_manager().job_name == "real_job"
+        with pytest.raises(KeyError, match="site"):
+            client.get_database().database_schema._attr_dict["site"]
+    finally:
+        old_db_client.close()
+        client.get_database_client().close()

--- a/python/tests/test_mspass_client_no_dask_spark.py
+++ b/python/tests/test_mspass_client_no_dask_spark.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import mspasspy
 from mspasspy.ccore.seismic import (
     Seismogram,
     TimeSeries,
@@ -9,6 +10,7 @@ from mspasspy.ccore.seismic import (
 from mspasspy.ccore.utility import MsPASSError
 from mspasspy.global_history.manager import GlobalHistoryManager
 from mspasspy.util import logging_helper
+import mspasspy.util.db_utils as _db_utils  # preload before masking optional Dask
 from mspasspy.db.client import DBClient
 
 import gridfs
@@ -33,9 +35,13 @@ def mock_excpt(*args, **kwargs):
     raise Exception("mocked exception")
 
 
+_client_attribute_was_present = hasattr(mspasspy, "client")
+_original_client_attribute = getattr(mspasspy, "client", None)
 with mock.patch.dict(
     sys.modules, {"pyspark": None, "dask.distributed": None, "dask": None}
 ):
+    # Re-evaluate optional scheduler availability inside the isolated module map.
+    sys.modules.pop("mspasspy.client", None)
     from mspasspy.client import Client
     import mspasspy.client as client_module
 
@@ -227,3 +233,9 @@ assert client.get_scheduler() is None
             assert self.client._global_history_manager.job_name == "test_job"
             assert self.client._global_history_manager.collection == "test_history"
             assert self.client._global_history_manager.history_db.name == "test"
+
+
+if _client_attribute_was_present:
+    mspasspy.client = _original_client_attribute
+else:
+    delattr(mspasspy, "client")

--- a/python/tests/test_mspass_client_no_dask_spark.py
+++ b/python/tests/test_mspass_client_no_dask_spark.py
@@ -1,5 +1,4 @@
 from unittest import mock
-import mspasspy
 from mspasspy.ccore.seismic import (
     Seismogram,
     TimeSeries,
@@ -10,7 +9,6 @@ from mspasspy.ccore.seismic import (
 from mspasspy.ccore.utility import MsPASSError
 from mspasspy.global_history.manager import GlobalHistoryManager
 from mspasspy.util import logging_helper
-import mspasspy.util.db_utils as _db_utils  # preload before masking optional Dask
 from mspasspy.db.client import DBClient
 
 import gridfs
@@ -35,13 +33,9 @@ def mock_excpt(*args, **kwargs):
     raise Exception("mocked exception")
 
 
-_client_attribute_was_present = hasattr(mspasspy, "client")
-_original_client_attribute = getattr(mspasspy, "client", None)
 with mock.patch.dict(
     sys.modules, {"pyspark": None, "dask.distributed": None, "dask": None}
 ):
-    # Re-evaluate optional scheduler availability inside the isolated module map.
-    sys.modules.pop("mspasspy.client", None)
     from mspasspy.client import Client
     import mspasspy.client as client_module
 
@@ -233,9 +227,3 @@ assert client.get_scheduler() is None
             assert self.client._global_history_manager.job_name == "test_job"
             assert self.client._global_history_manager.collection == "test_history"
             assert self.client._global_history_manager.history_db.name == "test"
-
-
-if _client_attribute_was_present:
-    mspasspy.client = _original_client_attribute
-else:
-    delattr(mspasspy, "client")


### PR DESCRIPTION
## Summary
- normalize explicit and environment Mongo endpoints with one URL-aware builder
- preserve an endpoint-embedded port for bare hosts, MongoDB URIs, and bracketed IPv6 addresses
- propagate the configured schema through default, named, and global-history database handles
- construct and validate the replacement DB client, history database, and history manager before one state commit
- close a failed replacement while leaving the old database/history and scheduler state unchanged

## Review decision
No unresolved API or lifecycle decision remains. This PR is limited to the Mongo endpoint/database/history state defined by Issue #785 and is rebased onto the merged scheduler lifecycle fix from #936.

## Verification
- endpoint/schema/database-state contract suite and scheduler integration: 134 passed on Python 3.13 with MongoDB 8.0.29 and Java 17 Dask/Spark
- successful switch preserves exact schema objects and keeps application/history handles on the same new client
- failed client, database, or history construction leaves every old object active and unchanged
- final diff relative to master contains only `python/mspasspy/client.py` and `python/tests/test_mspass_client_database_state.py`
- Black, Python 3.12/3.13 `py_compile`, and `git diff --check`: passed

Fixes #785