### PR TITLE
Make graphics option state deterministic

### DIFF
--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -60,6 +60,16 @@ def _sample_coordinates(t0, dt, npts):
     return t0 + numpy.arange(npts, dtype=numpy.float64) * dt
 
 
+_VALID_PLOT_STYLES = ("wt", "wtva", "img", "wtvaimg")
+
+
+def _validate_plot_style(caller, style):
+    if not isinstance(style, str) or style not in _VALID_PLOT_STYLES:
+        accepted = ", ".join(_VALID_PLOT_STYLES)
+        raise TypeError(
+            f"{caller}: style {style!r} is invalid; expected one of {accepted}"
+        )
+
 def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False):
     """
     Plot a numpy 2D array (matrix) in a wiggle trace, variable area
@@ -577,6 +587,7 @@ class SectionPlotter:
             fill_color are ignored for this style so no exceptions should
             occur when the method is called with this value of newstyle.
         """
+        _validate_plot_style("SectionPlotter.change_style", newstyle)
         if newstyle == "wtva":
             if fill_color == None:
                 raise RuntimeError(
@@ -618,10 +629,6 @@ class SectionPlotter:
             self._color_map = None
             self._fill_color = None
             self._use_variable_area = False
-        else:
-            raise RuntimeError(
-                "SectionPlotter.change_style:  unknown style type=" + newstyle
-            )
 
     def plot(self, d):
         """
@@ -836,16 +843,10 @@ class SeismicPlotter(BasicSeismicPlotter):
         # Should be smaller than 1/screem horizontal pixel maximum size
         self._RANGE_RATIO_TEST = 0.0001
         self._default_single_ts_aspect = 0.25
-        if style in ["wt", "wtva", "img", "wtvaimg"]:
-            # use change_style to simply default style as this does more than
-            # just set a string name
-            self.change_style(style)
-        else:
-            message = "SeismicPlotter constuctor:  "
-            message += "Illegal valeu for style={}\n".format(style)
-            message + +"Must string froom this list of keywords:"
-            message += "wt, wtva, img, wtvaimg"
-            raise TypeError(message)
+        _validate_plot_style("SeismicPlotter constructor", style)
+        # use change_style to simply default style as this does more than
+        # just set a string name
+        self.change_style(style)
         # These are set whenever a plot is made.
         # None signals they aren't yet defined and need to be
         # initialized.
@@ -900,6 +901,7 @@ class SeismicPlotter(BasicSeismicPlotter):
             fill_color are ignored for this style so no exceptions should
             occur when the method is called with this value of newstyle.
         """
+        _validate_plot_style("SeismicPlotter.change_style", newstyle)
         if newstyle == "wtva":
             if fill_color == None:
                 raise RuntimeError(
@@ -933,10 +935,6 @@ class SeismicPlotter(BasicSeismicPlotter):
             self.style = "wt"
             self._color_map = None
             self._fill_color = None
-        else:
-            raise RuntimeError(
-                "SectionPlotter.change_style:  unknown style type=" + newstyle
-            )
         self.style = newstyle
 
     def plot(self, d):
@@ -1002,7 +1000,7 @@ class SeismicPlotter(BasicSeismicPlotter):
                 plt.title(self.title)
         elif isinstance(d, TimeSeries):
             _validate_plot_grid(d.npts, d.dt)
-            self.figre = self._wtva_TimeSeries(d, fill)
+            self.figure = self._wtva_TimeSeries(d, fill)
             if self.title != None:
                 plt.title(self.title)
         elif isinstance(d, Seismogram):
@@ -1216,6 +1214,9 @@ class SeismicPlotter(BasicSeismicPlotter):
             scale = numpy.abs([work.max(), work.min()]).max()
             vmin = -scale
             vmax = scale
+        else:
+            vmin = self._vmin
+            vmax = self._vmax
         # imshow handles topdown or updown order with this parameter
         if self._plot_topdown:
             origin_position = "upper"
@@ -1262,12 +1263,17 @@ class SeismicPlotter(BasicSeismicPlotter):
         extent = (d.t0, d.endtime(), -1.0, 1.0)
         for j in range(d.npts):
             work[0, j] = d.data[j]
-        if self._aspect == None:
+        if self._aspect is None:
             aspect = self._default_single_ts_aspect
+        else:
+            aspect = self._aspect
         if self._vmin is None and self._vmax is None:
             scale = numpy.abs([work.max(), work.min()]).max()
             vmin = -scale
             vmax = scale
+        else:
+            vmin = self._vmin
+            vmax = self._vmax
         plt.imshow(
             work,
             aspect=aspect,

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -63,12 +63,13 @@ def _sample_coordinates(t0, dt, npts):
 _VALID_PLOT_STYLES = ("wt", "wtva", "img", "wtvaimg")
 
 
-def _validate_plot_style(caller, style):
-    if not isinstance(style, str) or style not in _VALID_PLOT_STYLES:
-        accepted = ", ".join(_VALID_PLOT_STYLES)
-        raise TypeError(
-            f"{caller}: style {style!r} is invalid; expected one of {accepted}"
-        )
+def _validate_plot_style(caller, style, invalid_string_error=TypeError):
+    accepted = ", ".join(_VALID_PLOT_STYLES)
+    message = f"{caller}: style {style!r} is invalid; expected one of {accepted}"
+    if not isinstance(style, str):
+        raise TypeError(message)
+    if style not in _VALID_PLOT_STYLES:
+        raise invalid_string_error(message)
 
 def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False):
     """
@@ -586,8 +587,15 @@ class SectionPlotter:
             black line (that feature is currently frozen).   color_map and
             fill_color are ignored for this style so no exceptions should
             occur when the method is called with this value of newstyle.
+
+        A non-string value for ``newstyle`` raises ``TypeError``.  An unknown
+        string raises ``RuntimeError``, preserving the established
+        ``change_style`` error contract.  Both messages list the four valid
+        style names.
         """
-        _validate_plot_style("SectionPlotter.change_style", newstyle)
+        _validate_plot_style(
+            "SectionPlotter.change_style", newstyle, invalid_string_error=RuntimeError
+        )
         if newstyle == "wtva":
             if fill_color == None:
                 raise RuntimeError(
@@ -900,8 +908,15 @@ class SeismicPlotter(BasicSeismicPlotter):
             black line (that feature is currently frozen).   color_map and
             fill_color are ignored for this style so no exceptions should
             occur when the method is called with this value of newstyle.
+
+        A non-string value for ``newstyle`` raises ``TypeError``.  An unknown
+        string raises ``RuntimeError``, preserving the established
+        ``change_style`` error contract.  Both messages list the four valid
+        style names.
         """
-        _validate_plot_style("SeismicPlotter.change_style", newstyle)
+        _validate_plot_style(
+            "SeismicPlotter.change_style", newstyle, invalid_string_error=RuntimeError
+        )
         if newstyle == "wtva":
             if fill_color == None:
                 raise RuntimeError(

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -71,6 +71,7 @@ def _validate_plot_style(caller, style, invalid_string_error=TypeError):
     if style not in _VALID_PLOT_STYLES:
         raise invalid_string_error(message)
 
+
 def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False):
     """
     Plot a numpy 2D array (matrix) in a wiggle trace, variable area

--- a/python/tests/test_graphics_options_contract.py
+++ b/python/tests/test_graphics_options_contract.py
@@ -1,0 +1,129 @@
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+import mspasspy.graphics as graphics
+from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
+
+EXPECTED_STYLES = ("wt", "wtva", "img", "wtvaimg")
+INVALID_STYLES = (None, 1, ["wt"], np.array(["wt", "img"]), "unknown")
+INVALID_STYLE_IDS = ("none", "integer", "list", "ndarray", "unknown")
+
+
+def _timeseries():
+    datum = TimeSeries(2)
+    datum.t0 = 0.0
+    datum.dt = 1.0
+    datum.data[0] = 2.0
+    datum.data[1] = 4.0
+    datum.set_live()
+    return datum
+
+
+def test_valid_style_set_is_exact():
+    assert graphics._VALID_PLOT_STYLES == EXPECTED_STYLES
+
+
+def test_atomic_wt_stores_only_the_documented_figure_attribute(monkeypatch):
+    plotter = graphics.SeismicPlotter(style="wt")
+    datum = _timeseries()
+    expected = object()
+    render = Mock(return_value=expected)
+    monkeypatch.setattr(plotter, "_wtva_TimeSeries", render)
+
+    plotter.plot(datum)
+
+    assert plotter.figure is expected
+    assert plotter.get_plot_gcf() is expected
+    assert not hasattr(plotter, "figre")
+    render.assert_called_once_with(datum, False)
+
+
+@pytest.mark.parametrize("aspect", (None, 0.375), ids=("default", "custom"))
+@pytest.mark.parametrize(
+    "limits,expected_limits",
+    (
+        ((None, None), (-4.0, 4.0)),
+        ((-3.0, None), (-3.0, None)),
+        ((None, 5.0), (None, 5.0)),
+        ((-3.0, 5.0), (-3.0, 5.0)),
+    ),
+    ids=("automatic", "vmin-only", "vmax-only", "both"),
+)
+def test_atomic_image_options_are_defined_and_forwarded(
+    monkeypatch, aspect, limits, expected_limits
+):
+    plotter = graphics.SeismicPlotter(style="img")
+    plotter._aspect = aspect
+    plotter._vmin, plotter._vmax = limits
+    imshow = Mock()
+    figure = object()
+    monkeypatch.setattr(graphics.plt, "imshow", imshow)
+    monkeypatch.setattr(graphics.plt, "gcf", Mock(return_value=figure))
+
+    result = plotter._imageplot_TimeSeries(_timeseries())
+
+    assert result is figure
+    imshow.assert_called_once()
+    call = imshow.call_args
+    assert call.kwargs["aspect"] == (0.25 if aspect is None else aspect)
+    assert call.kwargs["vmin"] == expected_limits[0]
+    assert call.kwargs["vmax"] == expected_limits[1]
+    assert np.asarray(call.args[0]).shape == (1, 2)
+
+
+@pytest.mark.parametrize(
+    "limits,expected_limits",
+    (
+        ((None, None), (-4.0, 4.0)),
+        ((-3.0, None), (-3.0, None)),
+        ((None, 5.0), (None, 5.0)),
+        ((-3.0, 5.0), (-3.0, 5.0)),
+    ),
+    ids=("automatic", "vmin-only", "vmax-only", "both"),
+)
+def test_ensemble_color_limits_are_defined_and_forwarded(
+    monkeypatch, limits, expected_limits
+):
+    plotter = graphics.SeismicPlotter(style="img")
+    plotter._vmin, plotter._vmax = limits
+    imshow = Mock()
+    figure = object()
+    monkeypatch.setattr(graphics.plt, "imshow", imshow)
+    monkeypatch.setattr(graphics.plt, "gcf", Mock(return_value=figure))
+    ensemble = TimeSeriesEnsemble()
+    ensemble.member.append(_timeseries())
+
+    result = plotter._imageplot_TimeSeriesEnsemble(ensemble)
+
+    assert result is figure
+    imshow.assert_called_once()
+    call = imshow.call_args
+    assert call.kwargs["aspect"] == "auto"
+    assert call.kwargs["vmin"] == expected_limits[0]
+    assert call.kwargs["vmax"] == expected_limits[1]
+    assert np.asarray(call.args[0]).shape == (1, 2)
+
+
+@pytest.mark.parametrize("style", INVALID_STYLES, ids=INVALID_STYLE_IDS)
+def test_seismicplotter_constructor_rejects_every_invalid_style(style):
+    with pytest.raises(TypeError) as error:
+        graphics.SeismicPlotter(style=style)
+
+    for accepted in EXPECTED_STYLES:
+        assert accepted in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "plotter_type", (graphics.SectionPlotter, graphics.SeismicPlotter)
+)
+@pytest.mark.parametrize("style", INVALID_STYLES, ids=INVALID_STYLE_IDS)
+def test_change_style_rejects_every_invalid_style(plotter_type, style):
+    plotter = plotter_type()
+
+    with pytest.raises(TypeError) as error:
+        plotter.change_style(style)
+
+    for accepted in EXPECTED_STYLES:
+        assert accepted in str(error.value)

--- a/python/tests/test_graphics_options_contract.py
+++ b/python/tests/test_graphics_options_contract.py
@@ -7,8 +7,8 @@ import mspasspy.graphics as graphics
 from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
 
 EXPECTED_STYLES = ("wt", "wtva", "img", "wtvaimg")
-INVALID_STYLES = (None, 1, ["wt"], np.array(["wt", "img"]), "unknown")
-INVALID_STYLE_IDS = ("none", "integer", "list", "ndarray", "unknown")
+NON_STRING_STYLES = (None, 1, ["wt"], np.array(["wt", "img"]))
+NON_STRING_STYLE_IDS = ("none", "integer", "list", "ndarray")
 
 
 def _timeseries():
@@ -106,7 +106,9 @@ def test_ensemble_color_limits_are_defined_and_forwarded(
     assert np.asarray(call.args[0]).shape == (1, 2)
 
 
-@pytest.mark.parametrize("style", INVALID_STYLES, ids=INVALID_STYLE_IDS)
+@pytest.mark.parametrize(
+    "style", (*NON_STRING_STYLES, "unknown"), ids=(*NON_STRING_STYLE_IDS, "unknown")
+)
 def test_seismicplotter_constructor_rejects_every_invalid_style(style):
     with pytest.raises(TypeError) as error:
         graphics.SeismicPlotter(style=style)
@@ -118,12 +120,29 @@ def test_seismicplotter_constructor_rejects_every_invalid_style(style):
 @pytest.mark.parametrize(
     "plotter_type", (graphics.SectionPlotter, graphics.SeismicPlotter)
 )
-@pytest.mark.parametrize("style", INVALID_STYLES, ids=INVALID_STYLE_IDS)
-def test_change_style_rejects_every_invalid_style(plotter_type, style):
+@pytest.mark.parametrize("style", NON_STRING_STYLES, ids=NON_STRING_STYLE_IDS)
+def test_change_style_rejects_non_string_style(plotter_type, style):
     plotter = plotter_type()
+    original_style = plotter.style
 
     with pytest.raises(TypeError) as error:
         plotter.change_style(style)
 
     for accepted in EXPECTED_STYLES:
         assert accepted in str(error.value)
+    assert plotter.style == original_style
+
+
+@pytest.mark.parametrize(
+    "plotter_type", (graphics.SectionPlotter, graphics.SeismicPlotter)
+)
+def test_change_style_preserves_unknown_string_runtime_error(plotter_type):
+    plotter = plotter_type()
+    original_style = plotter.style
+
+    with pytest.raises(RuntimeError) as error:
+        plotter.change_style("unknown")
+
+    for accepted in EXPECTED_STYLES:
+        assert accepted in str(error.value)
+    assert plotter.style == original_style


### PR DESCRIPTION
## Summary

- store the atomic wiggle figure in the documented `figure` attribute
- define and forward default/custom aspect and all one-/two-sided color-limit combinations
- validate the exact style set without changing the established `change_style` exception boundary
- list every accepted style in invalid-style errors

## Validation

- integrated raw-grid, atomic SectionPlotter, option-state, and adjacent graphics tests: 96 passed

Closes #788
