### PR TITLE
Render ensemble members exactly once

### DIFF
--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -1401,8 +1401,10 @@ class LargeEnsemblePlotter(SeismicPlotter):
         :type ens:  Must be either a TimeSeriesEnsemble of SeismogramEnsemle
            or the method will throw a TypeError exception.
         :param skip_the_dead:  Boolean controllng how dead data are
-           handled.  Retained for call compatibility; dead members are always
-           excluded from frame membership.
+           handed.  When True (default) dead data will be silently skippped.
+           When False dead members retain an empty plot cell in their original
+           ensemble position.  Dead members are never used to select the time
+           span or sample interval.
 
         """
         alg = "LargeEnsemblePlotter.plot"
@@ -1422,6 +1424,7 @@ class LargeEnsemblePlotter(SeismicPlotter):
         if not live_members:
             print(alg + " ensemble has no live members - nothing to plot")
             return None
+        members_to_plot = live_members if skip_the_dead else ens.member
 
         ensemble_type = (
             TimeSeriesEnsemble
@@ -1430,7 +1433,7 @@ class LargeEnsemblePlotter(SeismicPlotter):
         )
         e2plot = ensemble_type()
         frame_number = 0
-        for member in live_members:
+        for member in members_to_plot:
             e2plot.member.append(member)
             if len(e2plot.member) == self.members_per_frame:
                 e2plot.set_live()

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -70,6 +70,7 @@ def _validate_plot_style(caller, style, invalid_string_error=TypeError):
     if style not in _VALID_PLOT_STYLES:
         raise invalid_string_error(message)
 
+
 def _validated_live_members(ensemble):
     """Return live members after validating their sample intervals."""
     live_members = [member for member in ensemble.member if member.live]

--- a/python/mspasspy/graphics.py
+++ b/python/mspasspy/graphics.py
@@ -9,7 +9,6 @@ from mspasspy.ccore.seismic import (
     TimeSeriesEnsemble,
     SeismogramEnsemble,
 )
-from mspasspy.util.seismic import number_live
 from mspasspy.algorithms.basic import ExtractComponent
 
 # set as this alias to avoid collision with internal scale
@@ -70,6 +69,16 @@ def _validate_plot_style(caller, style, invalid_string_error=TypeError):
         raise TypeError(message)
     if style not in _VALID_PLOT_STYLES:
         raise invalid_string_error(message)
+
+def _validated_live_members(ensemble):
+    """Return live members after validating their sample intervals."""
+    live_members = [member for member in ensemble.member if member.live]
+    for member in live_members:
+        if not numpy.isfinite(member.dt) or member.dt <= 0.0:
+            raise ValueError(
+                "Every live ensemble member must have a finite, positive dt"
+            )
+    return live_members
 
 
 def wtva_raw(section, t0, dt, ranges=None, scale=1.0, color="k", normalize=False):
@@ -960,6 +969,11 @@ class SeismicPlotter(BasicSeismicPlotter):
         :param d: data object or ensemble to plot.
         :return: ``None``; figures are created through matplotlib state.
         """
+        if isinstance(d, (TimeSeriesEnsemble, SeismogramEnsemble)):
+            if d.dead():
+                return None
+            if not _validated_live_members(d):
+                return None
         # make copy always to prevent unintentional scaling of input data
         if self.normalize:
             d2plot = self._deepcopy(d)
@@ -1091,6 +1105,7 @@ class SeismicPlotter(BasicSeismicPlotter):
         # the ratio of that time interval to data time interval span is too
         # small.
         moderror = "SeismicPlotter._get_ensemble_size (Error):  "
+        _validated_live_members(d)
         ndata = len(d.member)
         if ndata <= 0:
             raise RuntimeError("Trying to plot an empty ensemble")
@@ -1169,12 +1184,13 @@ class SeismicPlotter(BasicSeismicPlotter):
             # figure_title='Component %d' % k
             # plt.figure(figure_title)
             plt.figure(k)
-            handle = self._wtva(dcomp)
+            handle = self._wtva(dcomp, fill)
             figure_handles.append(handle)
         # plt.show()
         return figure_handles
 
     def _imageplot_TimeSeriesEnsemble(self, d):
+        live_members = _validated_live_members(d)
         ndata, tmin, tmax = self._get_ensemble_size(d)
         extent = (tmin, tmax, -0.5, float(ndata) - 0.5)
         # left off here - below is copy from SectionPlotter
@@ -1186,9 +1202,7 @@ class SeismicPlotter(BasicSeismicPlotter):
         # use a crude boxcar resampling for data with larger dt
         # Boxcar resampling is implict in use of time method which gets the
         # nearest sample
-        dt = 10000000.0
-        for i in range(ndata):
-            dt = min(dt, d.member[i].dt)
+        dt = min(member.dt for member in live_members)
         # compute the number of points for the time axis
         nt = int((tmax - tmin) / dt) + 1
         # Guard the full matrix byte size before requesting the allocation.
@@ -1214,7 +1228,7 @@ class SeismicPlotter(BasicSeismicPlotter):
             # tmax test shouldn't be necessary but small cost for safety
             while t <= endtime and t <= tmax:
                 k = d.member[i].sample_number(t)
-                if k > 0 and k < npts:
+                if k >= 0 and k < npts:
                     work[iwork, j] = d.member[i].data[k]
                 t += dt
                 j += 1
@@ -1241,7 +1255,7 @@ class SeismicPlotter(BasicSeismicPlotter):
             origin_position = "lower"
         plt.imshow(
             work,
-            aspect="auto",
+            aspect=aspect,
             cmap=self._color_map,
             origin=origin_position,
             extent=extent,
@@ -1387,9 +1401,8 @@ class LargeEnsemblePlotter(SeismicPlotter):
         :type ens:  Must be either a TimeSeriesEnsemble of SeismogramEnsemle
            or the method will throw a TypeError exception.
         :param skip_the_dead:  Boolean controllng how dead data are
-           handed.  When True (default) dead data will be silently skippped.
-           When False all dead data will create an empty plot cell in
-           the position of the body.
+           handled.  Retained for call compatibility; dead members are always
+           excluded from frame membership.
 
         """
         alg = "LargeEnsemblePlotter.plot"
@@ -1404,28 +1417,23 @@ class LargeEnsemblePlotter(SeismicPlotter):
                 alg
                 + "received ensemble marked dead - cannot  plot ensemble marked dead"
             )
-            return
-        N = len(ens.member)
-        Nlive = number_live(ens)
-        if Nlive <= 0:
+            return None
+        live_members = _validated_live_members(ens)
+        if not live_members:
             print(alg + " ensemble has no live members - nothing to plot")
-        if isinstance(ens, TimeSeriesEnsemble):
-            e2plot = TimeSeriesEnsemble()
-        else:
-            e2plot = SeismogramEnsemble()
-        count = 0
+            return None
+
+        ensemble_type = (
+            TimeSeriesEnsemble
+            if isinstance(ens, TimeSeriesEnsemble)
+            else SeismogramEnsemble
+        )
+        e2plot = ensemble_type()
         frame_number = 0
-        for i in range(len(ens.member)):
-            # shorthand
-            d = ens.member[i]
-            if skip_the_dead and d.dead():
-                # ddebug
-                print("skipping member ", i)
-                continue
-            if count < self.members_per_frame and i != (N - 1):
-                e2plot.member.append(d)
-                count += 1
-            else:
+        for member in live_members:
+            e2plot.member.append(member)
+            if len(e2plot.member) == self.members_per_frame:
+                e2plot.set_live()
                 if frame_number > 0:
                     self._clear_figure_canvases()
                 super().plot(e2plot)
@@ -1434,8 +1442,14 @@ class LargeEnsemblePlotter(SeismicPlotter):
                 # continue on producing multiple plot frames.
                 plt.show()
                 frame_number += 1
-                count = 0
-                e2plot.member.clear()
+                e2plot = ensemble_type()
+        if len(e2plot.member) > 0:
+            e2plot.set_live()
+            if frame_number > 0:
+                self._clear_figure_canvases()
+            super().plot(e2plot)
+            plt.show()
+        return None
 
     def _clear_figure_canvases(self):
         """

--- a/python/tests/test_graphics_ensemble_contract.py
+++ b/python/tests/test_graphics_ensemble_contract.py
@@ -53,6 +53,7 @@ def _ensemble(member_type, members, *, live=True):
 
 
 @pytest.mark.parametrize("member_type", (TimeSeries, Seismogram))
+@pytest.mark.parametrize("skip_the_dead", (True, False), ids=("skip", "keep-cells"))
 @pytest.mark.parametrize(
     "count,members_per_frame,expected_sizes",
     (
@@ -64,15 +65,20 @@ def _ensemble(member_type, members, *, live=True):
     ),
 )
 def test_large_ensemble_frames_every_live_member_once(
-    monkeypatch, member_type, count, members_per_frame, expected_sizes
+    monkeypatch,
+    member_type,
+    skip_the_dead,
+    count,
+    members_per_frame,
+    expected_sizes,
 ):
     members = []
-    expected_ids = []
+    live_ids = []
     for value in range(count):
         members.append(
             _timeseries(value) if member_type is TimeSeries else _seismogram(value)
         )
-        expected_ids.append(value)
+        live_ids.append(value)
         if value % 2 == 0:
             members.append(
                 _timeseries(100 + value, dt=np.nan, live=False)
@@ -95,8 +101,16 @@ def test_large_ensemble_frames_every_live_member_once(
     monkeypatch.setattr(graphics.plt, "show", show)
     monkeypatch.setattr(plotter, "_clear_figure_canvases", clear)
 
-    assert plotter.plot(ensemble, skip_the_dead=False) is None
+    assert plotter.plot(ensemble, skip_the_dead=skip_the_dead) is None
 
+    expected_ids = (
+        live_ids if skip_the_dead else [member["member_id"] for member in members]
+    )
+    if not skip_the_dead:
+        expected_sizes = tuple(
+            min(members_per_frame, len(expected_ids) - offset)
+            for offset in range(0, len(expected_ids), members_per_frame)
+        )
     assert tuple(map(len, plotted)) == expected_sizes
     assert [member_id for frame in plotted for member_id in frame] == expected_ids
     assert show.call_count == len(expected_sizes)

--- a/python/tests/test_graphics_ensemble_contract.py
+++ b/python/tests/test_graphics_ensemble_contract.py
@@ -1,0 +1,304 @@
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+import mspasspy.graphics as graphics
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+
+
+def _timeseries(value, *, dt=1.0, t0=0.0, live=True, npts=3):
+    datum = TimeSeries(npts)
+    datum.dt = dt
+    datum.t0 = t0
+    for sample in range(npts):
+        datum.data[sample] = value + sample
+    if live:
+        datum.set_live()
+    else:
+        datum.kill()
+    datum["member_id"] = value
+    return datum
+
+
+def _seismogram(value, *, dt=1.0, live=True):
+    datum = Seismogram(3)
+    datum.dt = dt
+    for component in range(3):
+        for sample in range(datum.npts):
+            datum.data[component, sample] = value + 10 * component + sample
+    if live:
+        datum.set_live()
+    else:
+        datum.kill()
+    datum["member_id"] = value
+    return datum
+
+
+def _ensemble(member_type, members, *, live=True):
+    ensemble_type = (
+        TimeSeriesEnsemble if member_type is TimeSeries else SeismogramEnsemble
+    )
+    ensemble = ensemble_type()
+    for member in members:
+        ensemble.member.append(member)
+    if live:
+        ensemble.set_live()
+    return ensemble
+
+
+@pytest.mark.parametrize("member_type", (TimeSeries, Seismogram))
+@pytest.mark.parametrize(
+    "count,members_per_frame,expected_sizes",
+    (
+        (1, 3, (1,)),
+        (2, 3, (2,)),
+        (3, 3, (3,)),
+        (4, 3, (3, 1)),
+        (8, 3, (3, 3, 2)),
+    ),
+)
+def test_large_ensemble_frames_every_live_member_once(
+    monkeypatch, member_type, count, members_per_frame, expected_sizes
+):
+    members = []
+    expected_ids = []
+    for value in range(count):
+        members.append(
+            _timeseries(value) if member_type is TimeSeries else _seismogram(value)
+        )
+        expected_ids.append(value)
+        if value % 2 == 0:
+            members.append(
+                _timeseries(100 + value, dt=np.nan, live=False)
+                if member_type is TimeSeries
+                else _seismogram(100 + value, dt=np.nan, live=False)
+            )
+    ensemble = _ensemble(member_type, members)
+    plotter = graphics.LargeEnsemblePlotter(
+        normalize=False, members_per_frame=members_per_frame
+    )
+    plotted = []
+    show = Mock()
+    clear = Mock()
+
+    def record_frame(self, frame):
+        assert frame.live
+        plotted.append([member["member_id"] for member in frame.member])
+
+    monkeypatch.setattr(graphics.SeismicPlotter, "plot", record_frame)
+    monkeypatch.setattr(graphics.plt, "show", show)
+    monkeypatch.setattr(plotter, "_clear_figure_canvases", clear)
+
+    assert plotter.plot(ensemble, skip_the_dead=False) is None
+
+    assert tuple(map(len, plotted)) == expected_sizes
+    assert [member_id for frame in plotted for member_id in frame] == expected_ids
+    assert show.call_count == len(expected_sizes)
+    assert clear.call_count == max(0, len(expected_sizes) - 1)
+
+
+@pytest.mark.parametrize("member_type", (TimeSeries, Seismogram))
+@pytest.mark.parametrize("mode", ("empty", "dead-ensemble", "all-dead"))
+def test_large_ensemble_without_live_members_never_plots(
+    monkeypatch, member_type, mode
+):
+    if mode == "empty":
+        ensemble = _ensemble(member_type, [], live=True)
+    elif mode == "dead-ensemble":
+        ensemble = _ensemble(
+            member_type,
+            [
+                (
+                    _timeseries(1, dt=np.nan)
+                    if member_type is TimeSeries
+                    else _seismogram(1, dt=np.nan)
+                )
+            ],
+            live=False,
+        )
+    else:
+        ensemble = _ensemble(
+            member_type,
+            [
+                (
+                    _timeseries(1, live=False)
+                    if member_type is TimeSeries
+                    else _seismogram(1, live=False)
+                )
+            ],
+            live=True,
+        )
+    plotter = graphics.LargeEnsemblePlotter(normalize=False)
+    render = Mock()
+    show = Mock()
+    figure = Mock()
+    monkeypatch.setattr(graphics.SeismicPlotter, "plot", render)
+    monkeypatch.setattr(graphics.plt, "show", show)
+    monkeypatch.setattr(graphics.plt, "figure", figure)
+
+    assert plotter.plot(ensemble) is None
+    render.assert_not_called()
+    show.assert_not_called()
+    figure.assert_not_called()
+
+
+@pytest.mark.parametrize("style", ("wt", "wtva", "img", "wtvaimg"))
+@pytest.mark.parametrize("member_type", (TimeSeries, Seismogram))
+@pytest.mark.parametrize("mode", ("empty", "dead-ensemble", "all-dead"))
+def test_seismic_plotter_without_live_members_never_creates_a_figure(
+    monkeypatch, style, member_type, mode
+):
+    members = []
+    ensemble_live = True
+    if mode == "dead-ensemble":
+        members = [
+            (
+                _timeseries(1, dt=np.nan)
+                if member_type is TimeSeries
+                else _seismogram(1, dt=np.nan)
+            )
+        ]
+        ensemble_live = False
+    elif mode == "all-dead":
+        members = [
+            (
+                _timeseries(1, live=False)
+                if member_type is TimeSeries
+                else _seismogram(1, live=False)
+            )
+        ]
+    ensemble = _ensemble(member_type, members, live=ensemble_live)
+    plotter = graphics.SeismicPlotter(style=style)
+    figure = Mock()
+    gcf = Mock()
+    draw_line = Mock()
+    imshow = Mock()
+    monkeypatch.setattr(graphics.plt, "figure", figure)
+    monkeypatch.setattr(graphics.plt, "gcf", gcf)
+    monkeypatch.setattr(graphics.plt, "plot", draw_line)
+    monkeypatch.setattr(graphics.plt, "imshow", imshow)
+
+    assert plotter.plot(ensemble) is None
+
+    figure.assert_not_called()
+    gcf.assert_not_called()
+    draw_line.assert_not_called()
+    imshow.assert_not_called()
+
+
+@pytest.mark.parametrize("member_type", (TimeSeries, Seismogram))
+@pytest.mark.parametrize("bad_dt", (0.0, -1.0, np.nan, np.inf, -np.inf))
+def test_invalid_live_dt_is_rejected_before_plotting(monkeypatch, member_type, bad_dt):
+    valid_members = (
+        [_timeseries(3), _timeseries(4)]
+        if member_type is TimeSeries
+        else [_seismogram(3), _seismogram(4)]
+    )
+    invalid = (
+        _timeseries(1, dt=bad_dt)
+        if member_type is TimeSeries
+        else _seismogram(1, dt=bad_dt)
+    )
+    dead = (
+        _timeseries(2, dt=np.nan, live=False)
+        if member_type is TimeSeries
+        else _seismogram(2, dt=np.nan, live=False)
+    )
+    ensemble = _ensemble(member_type, [*valid_members, dead, invalid])
+    plotter = graphics.LargeEnsemblePlotter(
+        normalize=False, members_per_frame=len(valid_members)
+    )
+    render = Mock()
+    show = Mock()
+    monkeypatch.setattr(graphics.SeismicPlotter, "plot", render)
+    monkeypatch.setattr(graphics.plt, "show", show)
+
+    with pytest.raises(ValueError, match="finite, positive dt"):
+        plotter.plot(ensemble)
+
+    render.assert_not_called()
+    show.assert_not_called()
+
+
+@pytest.mark.parametrize("style", ("wt", "wtva", "img", "wtvaimg"))
+@pytest.mark.parametrize("member_type", (TimeSeries, Seismogram))
+def test_seismic_plotter_rejects_invalid_live_dt_before_drawing(
+    monkeypatch, style, member_type
+):
+    invalid = (
+        _timeseries(1, dt=np.nan)
+        if member_type is TimeSeries
+        else _seismogram(1, dt=np.nan)
+    )
+    ensemble = _ensemble(member_type, [invalid])
+    plotter = graphics.SeismicPlotter(style=style)
+    figure = Mock()
+    draw_line = Mock()
+    imshow = Mock()
+    monkeypatch.setattr(graphics.plt, "figure", figure)
+    monkeypatch.setattr(graphics.plt, "plot", draw_line)
+    monkeypatch.setattr(graphics.plt, "imshow", imshow)
+
+    with pytest.raises(ValueError, match="finite, positive dt"):
+        plotter.plot(ensemble)
+
+    figure.assert_not_called()
+    draw_line.assert_not_called()
+    imshow.assert_not_called()
+
+
+def test_image_ensemble_uses_minimum_live_dt_and_copies_sample_zero(monkeypatch):
+    dead = _timeseries(100, dt=-1.0, live=False)
+    coarse = _timeseries(10, dt=1.0)
+    fine = _timeseries(20, dt=0.5)
+    ensemble = _ensemble(TimeSeries, [dead, coarse, fine])
+    plotter = graphics.SeismicPlotter(style="img")
+    imshow = Mock()
+    monkeypatch.setattr(graphics.plt, "imshow", imshow)
+    monkeypatch.setattr(graphics.plt, "gcf", Mock(return_value=object()))
+
+    plotter._imageplot_TimeSeriesEnsemble(ensemble)
+
+    matrix = np.asarray(imshow.call_args.args[0])
+    assert matrix.shape == (3, 5)
+    assert matrix[0].tolist() == [0.0] * 5
+    assert matrix[1, 0] == coarse.data[0]
+    assert matrix[2, 0] == fine.data[0]
+
+
+@pytest.mark.parametrize("aspect", (None, 0.375))
+def test_image_ensemble_forwards_calculated_or_custom_aspect(monkeypatch, aspect):
+    ensemble = _ensemble(TimeSeries, [_timeseries(1), _timeseries(2)])
+    plotter = graphics.SeismicPlotter(style="img")
+    plotter._aspect = aspect
+    imshow = Mock()
+    monkeypatch.setattr(graphics.plt, "imshow", imshow)
+    monkeypatch.setattr(graphics.plt, "gcf", Mock(return_value=object()))
+
+    plotter._imageplot_TimeSeriesEnsemble(ensemble)
+
+    assert imshow.call_args.kwargs["aspect"] == (1.0 if aspect is None else aspect)
+
+
+def test_three_component_wiggle_forwards_fill_to_every_component(monkeypatch):
+    ensemble = _ensemble(Seismogram, [_seismogram(1)])
+    plotter = graphics.SeismicPlotter(style="wtva")
+    fill_calls = []
+
+    def record(component_ensemble, fill=True):
+        fill_calls.append(fill)
+        return object()
+
+    monkeypatch.setattr(plotter, "_wtva", record)
+    monkeypatch.setattr(graphics.plt, "figure", Mock())
+
+    handles = plotter._wtva_SeismogramEnsemble(ensemble, False)
+
+    assert len(handles) == 3
+    assert fill_calls == [False, False, False]

--- a/python/tests/test_graphics_options_contract.py
+++ b/python/tests/test_graphics_options_contract.py
@@ -100,7 +100,7 @@ def test_ensemble_color_limits_are_defined_and_forwarded(
     assert result is figure
     imshow.assert_called_once()
     call = imshow.call_args
-    assert call.kwargs["aspect"] == "auto"
+    assert call.kwargs["aspect"] == 1.0
     assert call.kwargs["vmin"] == expected_limits[0]
     assert call.kwargs["vmax"] == expected_limits[1]
     assert np.asarray(call.args[0]).shape == (1, 2)

--- a/python/tests/test_graphics_raw_contract.py
+++ b/python/tests/test_graphics_raw_contract.py
@@ -234,7 +234,7 @@ def test_ensemble_image_rejects_platform_size_overflow_before_allocation(monkeyp
     zeros = Mock()
     monkeypatch.setattr(graphics.numpy, "zeros", zeros)
     columns = np.iinfo(np.intp).max // (2 * np.dtype(np.float64).itemsize) + 1
-    member = SimpleNamespace(dt=1.0 / (columns - 1))
+    member = SimpleNamespace(dt=1.0 / (columns - 1), live=True)
     ensemble = SimpleNamespace(member=[member, member])
     plotter = graphics.SeismicPlotter()
     monkeypatch.setattr(plotter, "_get_ensemble_size", lambda _: (2, 0.0, 1.0))


### PR DESCRIPTION
## Summary

- render every eligible ensemble member exactly once and flush the final partial frame
- return without creating a figure for empty, dead, or all-dead input
- validate live-member sample intervals and ignore dead-member intervals
- use the minimum live `dt`, copy sample zero, forward 3C fill, and preserve calculated/custom aspect
- retain the public `skip_the_dead=False` empty-cell behavior

## Validation

- complete integrated Group 10 graphics suite: 168 passed
- adjacent integration tests cover the live-member and calculated-aspect contracts

Closes #790
