### PR TITLE
Make scheduler transitions atomic

### DIFF
--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -3,7 +3,6 @@ import pymongo
 from urllib.parse import urlsplit
 
 from mspasspy.db.client import DBClient
-from mspasspy.util.db_utils import MongoDBWorker
 from mspasspy.db.database import Database
 from mspasspy.global_history.manager import GlobalHistoryManager
 
@@ -22,10 +21,16 @@ else:
 
 try:
     from dask.distributed import Client as DaskClient
+except ImportError as err:
+    DaskClient = None
+    MongoDBWorker = None
+    _mspasspy_has_dask_distributed = False
+    _mspasspy_dask_import_error = err
+else:
+    from mspasspy.util.db_utils import MongoDBWorker
 
     _mspasspy_has_dask_distributed = True
-except ImportError:
-    _mspasspy_has_dask_distributed = False
+    _mspasspy_dask_import_error = None
 
 from mspasspy.ccore.utility import MsPASSError
 
@@ -40,23 +45,64 @@ def _require_pyspark():
     raise MsPASSError(message + ".", "Fatal")
 
 
-def _address_has_port(address):
-    if "://" in address:
-        parsed_address = urlsplit(address)
-    else:
-        parsed_address = urlsplit("//" + address)
+def _require_dask():
+    if _mspasspy_has_dask_distributed:
+        return
+
+    message = "Dask scheduler was requested, but dask.distributed could not be imported"
+    if _mspasspy_dask_import_error is not None:
+        message += ": " + str(_mspasspy_dask_import_error)
+    raise MsPASSError(message + ".", "Fatal")
+
+
+def _build_scheduler_endpoint(
+    scheduler_address,
+    scheduler_port=None,
+    default_port=None,
+    default_scheme=None,
+):
+    endpoint = scheduler_address
+    if default_scheme == "spark" and (
+        endpoint == "local"
+        or (endpoint.startswith("local[") and endpoint.endswith("]"))
+    ):
+        return endpoint
+    if default_scheme and "://" not in endpoint:
+        endpoint = default_scheme + "://" + endpoint
+
+    parse_target = endpoint if "://" in endpoint else "//" + endpoint
+    parsed_address = urlsplit(parse_target)
     try:
-        return parsed_address.port is not None
-    except ValueError:
-        return False
+        embedded_port = parsed_address.port
+    except ValueError as err:
+        raise MsPASSError(
+            "Invalid scheduler address: " + scheduler_address,
+            "Fatal",
+        ) from err
+
+    if embedded_port is not None:
+        return endpoint
+
+    if scheduler_port is None or scheduler_port == "":
+        scheduler_port = default_port
+    if scheduler_port is None or scheduler_port == "":
+        return endpoint
+
+    parsed_address = parsed_address._replace(
+        netloc=parsed_address.netloc + ":" + str(scheduler_port)
+    )
+    endpoint = parsed_address.geturl()
+    if "://" not in scheduler_address:
+        endpoint = endpoint.removeprefix("//")
+    return endpoint
 
 
 def _build_dask_scheduler_address(scheduler_address, scheduler_port=None):
-    if _address_has_port(scheduler_address):
-        return scheduler_address
-    if scheduler_port is None or scheduler_port == "":
-        scheduler_port = "8786"
-    return scheduler_address + ":" + str(scheduler_port)
+    return _build_scheduler_endpoint(
+        scheduler_address,
+        scheduler_port=scheduler_port,
+        default_port="8786",
+    )
 
 
 class Client:
@@ -131,6 +177,7 @@ class Client:
                 "Fatal",
             )
         if dask_client is not None:
+            _require_dask()
             if scheduler == "none":
                 raise MsPASSError(
                     "dask_client cannot be used when scheduler is none.",
@@ -168,6 +215,10 @@ class Client:
             )
         ):
             _require_pyspark()
+        if not _mspasspy_has_dask_distributed and (
+            scheduler == "dask" or (scheduler is None and MSPASS_SCHEDULER == "dask")
+        ):
+            _require_dask()
 
         # create a database client
         # priority: parameter -> env -> default
@@ -245,81 +296,168 @@ class Client:
 
         # scheduler configuration
         if self._scheduler == "spark":
-            scheduler_host_has_port = False
             if scheduler_host:
-                self._spark_master_url = scheduler_host
-                # add spark:// prefix if not exist
-                if "spark://" not in scheduler_host:
-                    self._spark_master_url = "spark://" + self._spark_master_url
-                # check if spark host address contains port number already
-                if self._spark_master_url.count(":") == 2:
-                    scheduler_host_has_port = True
-
+                scheduler_address = scheduler_host
             elif MSPASS_SCHEDULER_ADDRESS:
-                self._spark_master_url = MSPASS_SCHEDULER_ADDRESS
-                # add spark:// prefix if not exist
-                if "spark://" not in MSPASS_SCHEDULER_ADDRESS:
-                    self._spark_master_url = "spark://" + self._spark_master_url
+                scheduler_address = MSPASS_SCHEDULER_ADDRESS
             else:
-                self._spark_master_url = "local"
+                scheduler_address = None
 
-            # add port number
-            # 1. not the default 'local'
-            # 2. scheduler_host and does not contain port number
-            # 3. SPARK_MASTER_PORT exists
-            if (
-                (scheduler_host or MSPASS_SCHEDULER_ADDRESS)
-                and not scheduler_host_has_port
-                and SPARK_MASTER_PORT
-            ):
-                self._spark_master_url += ":" + SPARK_MASTER_PORT
+            if scheduler_address is None:
+                spark_master_url = "local"
+            else:
+                spark_master_url = _build_scheduler_endpoint(
+                    scheduler_address,
+                    scheduler_port=SPARK_MASTER_PORT,
+                    default_scheme="spark",
+                )
 
             # sanity check
             try:
-                spark = (
-                    SparkSession.builder.appName("mspass")
-                    .master(self._spark_master_url)
-                    .getOrCreate()
-                )
-                self._spark_context = spark.sparkContext
+                spark_context = self._create_spark_context(spark_master_url)
             except Exception as err:
                 raise MsPASSError(
                     "Runntime error: cannot create a spark configuration with: "
-                    + self._spark_master_url,
+                    + spark_master_url,
                     "Fatal",
-                )
+                ) from err
+            self._commit_spark_scheduler(spark_context, spark_master_url)
 
         elif self._scheduler == "dask":
             # if no defind scheduler_host and no MSPASS_SCHEDULER_ADDRESS, use local cluster to create a client
             if dask_client is not None:
-                self._dask_client = dask_client
+                try:
+                    self._register_dask_plugin(dask_client)
+                except Exception as err:
+                    raise MsPASSError(
+                        "Runntime error: cannot configure the provided dask client",
+                        "Fatal",
+                    ) from err
+                self._commit_dask_scheduler(dask_client, None, owned=False)
             elif not scheduler_host and not MSPASS_SCHEDULER_ADDRESS:
-                self._dask_client = DaskClient()
+                try:
+                    new_dask_client = self._create_dask_client()
+                except Exception as err:
+                    raise MsPASSError(
+                        "Runntime error: cannot create a local dask client",
+                        "Fatal",
+                    ) from err
+                self._commit_dask_scheduler(new_dask_client, None, owned=True)
             else:
                 if scheduler_host:
                     scheduler_address = scheduler_host
                 else:
                     scheduler_address = MSPASS_SCHEDULER_ADDRESS
 
-                self._dask_client_address = _build_dask_scheduler_address(
+                dask_client_address = _build_dask_scheduler_address(
                     scheduler_address, DASK_SCHEDULER_PORT
                 )
                 # sanity check
                 try:
-                    self._dask_client = DaskClient(self._dask_client_address)
+                    new_dask_client = self._create_dask_client(dask_client_address)
                 except Exception as err:
                     raise MsPASSError(
                         "Runntime error: cannot create a dask client with: "
-                        + self._dask_client_address,
+                        + dask_client_address,
                         "Fatal",
-                    )
+                    ) from err
+                self._commit_dask_scheduler(
+                    new_dask_client, dask_client_address, owned=True
+                )
         elif not self._scheduler_disabled:
             print("There is no spark or dask installed, this client has no scheduler")
 
-        # Auto-register MongoDB worker plugin for dask to avoid DB serialization leaks
-        if self._scheduler == "dask":
-            mongo_plugin = MongoDBWorker(self, dbclient_key="dbclient")
-            self._dask_client.register_plugin(mongo_plugin, name="mongodb_worker")
+    def _register_dask_plugin(self, dask_client):
+        mongo_plugin = MongoDBWorker(self, dbclient_key="dbclient")
+        dask_client.register_plugin(mongo_plugin, name="mongodb_worker")
+
+    def _create_dask_client(self, scheduler_address=None):
+        _require_dask()
+        if scheduler_address is None:
+            dask_client = DaskClient()
+        else:
+            dask_client = DaskClient(scheduler_address)
+        try:
+            self._register_dask_plugin(dask_client)
+        except Exception:
+            dask_client.close()
+            raise
+        return dask_client
+
+    @staticmethod
+    def _create_spark_context(spark_master_url):
+        spark = (
+            SparkSession.builder.appName("mspass")
+            .master(spark_master_url)
+            .getOrCreate()
+        )
+        spark_context = spark.sparkContext
+        if spark_context.master != spark_master_url:
+            raise RuntimeError(
+                "SparkSession.getOrCreate() returned master "
+                + str(spark_context.master)
+                + " instead of "
+                + spark_master_url
+            )
+        return spark_context
+
+    def _commit_dask_scheduler(self, dask_client, scheduler_address, owned):
+        old_scheduler = getattr(self, "_scheduler", None)
+        old_dask_client = getattr(self, "_dask_client", None)
+        old_dask_owned = getattr(self, "_dask_client_owned", False)
+        old_spark_context = getattr(self, "_spark_context", None)
+        old_spark_owned = getattr(self, "_spark_context_owned", False)
+
+        self._scheduler = "dask"
+        self._scheduler_disabled = False
+        self._dask_client = dask_client
+        self._dask_client_address = scheduler_address
+        self._dask_client_owned = owned
+        for attribute in (
+            "_spark_context",
+            "_spark_master_url",
+            "_spark_context_owned",
+        ):
+            if hasattr(self, attribute):
+                delattr(self, attribute)
+
+        if old_scheduler == "dask" and old_dask_client is not None and old_dask_owned:
+            old_dask_client.close()
+        elif (
+            old_scheduler == "spark"
+            and old_spark_context is not None
+            and old_spark_owned
+        ):
+            old_spark_context.stop()
+
+    def _commit_spark_scheduler(self, spark_context, spark_master_url):
+        old_scheduler = getattr(self, "_scheduler", None)
+        old_dask_client = getattr(self, "_dask_client", None)
+        old_dask_owned = getattr(self, "_dask_client_owned", False)
+        old_spark_context = getattr(self, "_spark_context", None)
+        old_spark_owned = getattr(self, "_spark_context_owned", False)
+
+        self._scheduler = "spark"
+        self._scheduler_disabled = False
+        self._spark_context = spark_context
+        self._spark_master_url = spark_master_url
+        self._spark_context_owned = True
+        for attribute in (
+            "_dask_client",
+            "_dask_client_address",
+            "_dask_client_owned",
+        ):
+            if hasattr(self, attribute):
+                delattr(self, attribute)
+
+        if old_scheduler == "dask" and old_dask_client is not None and old_dask_owned:
+            old_dask_client.close()
+        elif (
+            old_scheduler == "spark"
+            and old_spark_context is not None
+            and old_spark_owned
+        ):
+            old_spark_context.stop()
 
     def get_database_client(self):
         """
@@ -448,93 +586,59 @@ class Client:
                 + " is found.",
                 "Fatal",
             )
-        if scheduler == "spark":
-            _require_pyspark()
-
-        prev_scheduler = self._scheduler
-        self._scheduler = scheduler
-        if scheduler == "spark":
-            scheduler_host_has_port = False
-
-            self._spark_master_url = scheduler_host
-            # add spark:// prefix if not exist
-            if "spark://" not in scheduler_host:
-                self._spark_master_url = "spark://" + self._spark_master_url
-            # check if spark host address contains port number already
-            if self._spark_master_url.count(":") == 2:
-                scheduler_host_has_port = True
-
-            # add port
-            if not scheduler_host_has_port and scheduler_port:
-                self._spark_master_url += ":" + scheduler_port
-
-            # sanity check
-            prev_spark_context = None
-            prev_spark_conf = None
-            if hasattr(self, "_spark_context"):
-                prev_spark_context = self._spark_context
-                prev_spark_conf = self._spark_context.getConf()
-            try:
-                if hasattr(self, "_spark_context") and isinstance(
-                    self._spark_context, SparkContext
-                ):
-                    # update the confinguration
-                    spark_conf = self._spark_context._conf.setMaster(
-                        self._spark_master_url
-                    )
-                else:
-                    spark_conf = (
-                        SparkConf()
-                        .setAppName("mspass")
-                        .setMaster(self._spark_master_url)
-                    )
-                # stop the previous spark context
-                # FIXME if the new context does not start, we shouldn't stop the previous here.
-                # if prev_spark_context:
-                #    prev_spark_context.stop()
-                # create a new spark context -> might cause error so that execute exception code
-                spark = SparkSession.builder.config(conf=spark_conf).getOrCreate()
-                self._spark_context = spark.sparkContext
-            except Exception as err:
-                # restore the spark context by the previous spark configuration
-                if prev_spark_conf:
-                    self._spark_context = SparkContext.getOrCreate(conf=prev_spark_conf)
-                # restore the scheduler type
-                if self._scheduler == "spark" and prev_scheduler == "dask":
-                    self._scheduler = prev_scheduler
-                raise MsPASSError(
-                    "Runntime error: cannot create a spark configuration with: "
-                    + self._spark_master_url,
-                    "Fatal",
-                )
-            # close previous dask client if success
-            if hasattr(self, "_dask_client"):
-                del self._dask_client
-
-        elif scheduler == "dask":
-            self._dask_client_address = _build_dask_scheduler_address(
-                scheduler_host, scheduler_port
+        if not type(scheduler_host) is str:
+            raise MsPASSError(
+                "scheduler_host should be a string but "
+                + str(type(scheduler_host))
+                + " is found.",
+                "Fatal",
             )
 
-            # sanity check
-            prev_dask_client = None
-            if hasattr(self, "_dask_client"):
-                prev_dask_client = self._dask_client
-            try:
-                # create a new dask client
-                self._dask_client = DaskClient(self._dask_client_address)
-            except Exception as err:
-                # restore the dask client if exists
-                if prev_dask_client:
-                    self._dask_client = prev_dask_client
-                # restore the scheduler type
-                if self._scheduler == "dask" and prev_scheduler == "spark":
-                    self._scheduler = prev_scheduler
+        if scheduler == "spark":
+            _require_pyspark()
+            spark_master_url = _build_scheduler_endpoint(
+                scheduler_host,
+                scheduler_port=scheduler_port,
+                default_scheme="spark",
+            )
+            if getattr(self, "_scheduler", None) == "spark":
+                active_master = getattr(self, "_spark_master_url", None)
+                if active_master is None:
+                    active_master = getattr(
+                        getattr(self, "_spark_context", None), "master", None
+                    )
+                if active_master == spark_master_url:
+                    return
                 raise MsPASSError(
-                    "Runntime error: cannot create a dask client with: "
-                    + self._dask_client_address,
+                    "Runntime error: cannot create a spark configuration with: "
+                    + spark_master_url
+                    + "; refusing to change active Spark master from "
+                    + str(active_master)
+                    + " because SparkSession.getOrCreate() cannot guarantee the switch.",
                     "Fatal",
                 )
-            # remove previous spark context if success setting new dask client
-            if hasattr(self, "_spark_context"):
-                del self._spark_context
+
+            try:
+                spark_context = self._create_spark_context(spark_master_url)
+            except Exception as err:
+                raise MsPASSError(
+                    "Runntime error: cannot create a spark configuration with: "
+                    + spark_master_url,
+                    "Fatal",
+                ) from err
+            self._commit_spark_scheduler(spark_context, spark_master_url)
+
+        else:
+            _require_dask()
+            dask_client_address = _build_dask_scheduler_address(
+                scheduler_host, scheduler_port
+            )
+            try:
+                dask_client = self._create_dask_client(dask_client_address)
+            except Exception as err:
+                raise MsPASSError(
+                    "Runntime error: cannot create a dask client with: "
+                    + dask_client_address,
+                    "Fatal",
+                ) from err
+            self._commit_dask_scheduler(dask_client, dask_client_address, owned=True)

--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -55,6 +55,12 @@ def _require_dask():
     raise MsPASSError(message + ".", "Fatal")
 
 
+def _is_local_spark_master(master):
+    return master == "local" or (
+        isinstance(master, str) and master.startswith("local[") and master.endswith("]")
+    )
+
+
 def _build_scheduler_endpoint(
     scheduler_address,
     scheduler_port=None,
@@ -62,10 +68,7 @@ def _build_scheduler_endpoint(
     default_scheme=None,
 ):
     endpoint = scheduler_address
-    if default_scheme == "spark" and (
-        endpoint == "local"
-        or (endpoint.startswith("local[") and endpoint.endswith("]"))
-    ):
+    if default_scheme == "spark" and _is_local_spark_master(endpoint):
         return endpoint
     if default_scheme and "://" not in endpoint:
         endpoint = default_scheme + "://" + endpoint
@@ -303,7 +306,8 @@ class Client:
             else:
                 scheduler_address = None
 
-            if scheduler_address is None:
+            implicit_local_scheduler = scheduler_address is None
+            if implicit_local_scheduler:
                 spark_master_url = "local"
             else:
                 spark_master_url = _build_scheduler_endpoint(
@@ -314,14 +318,21 @@ class Client:
 
             # sanity check
             try:
-                spark_context = self._create_spark_context(spark_master_url)
+                spark_context, spark_context_owned = self._create_spark_context(
+                    spark_master_url,
+                    allow_existing_local=implicit_local_scheduler,
+                )
             except Exception as err:
                 raise MsPASSError(
                     "Runntime error: cannot create a spark configuration with: "
                     + spark_master_url,
                     "Fatal",
                 ) from err
-            self._commit_spark_scheduler(spark_context, spark_master_url)
+            self._commit_spark_scheduler(
+                spark_context,
+                spark_context.master,
+                owned=spark_context_owned,
+            )
 
         elif self._scheduler == "dask":
             # if no defind scheduler_host and no MSPASS_SCHEDULER_ADDRESS, use local cluster to create a client
@@ -385,21 +396,30 @@ class Client:
         return dask_client
 
     @staticmethod
-    def _create_spark_context(spark_master_url):
+    def _create_spark_context(spark_master_url, allow_existing_local=False):
+        previous_context = getattr(SparkContext, "_active_spark_context", None)
         spark = (
             SparkSession.builder.appName("mspass")
             .master(spark_master_url)
             .getOrCreate()
         )
         spark_context = spark.sparkContext
-        if spark_context.master != spark_master_url:
+        reused_context = spark_context is previous_context
+        compatible_existing_local = (
+            allow_existing_local
+            and reused_context
+            and _is_local_spark_master(spark_context.master)
+        )
+        if spark_context.master != spark_master_url and not compatible_existing_local:
+            if not reused_context:
+                spark_context.stop()
             raise RuntimeError(
                 "SparkSession.getOrCreate() returned master "
                 + str(spark_context.master)
                 + " instead of "
                 + spark_master_url
             )
-        return spark_context
+        return spark_context, not reused_context
 
     def _commit_dask_scheduler(self, dask_client, scheduler_address, owned):
         old_scheduler = getattr(self, "_scheduler", None)
@@ -430,7 +450,7 @@ class Client:
         ):
             old_spark_context.stop()
 
-    def _commit_spark_scheduler(self, spark_context, spark_master_url):
+    def _commit_spark_scheduler(self, spark_context, spark_master_url, owned):
         old_scheduler = getattr(self, "_scheduler", None)
         old_dask_client = getattr(self, "_dask_client", None)
         old_dask_owned = getattr(self, "_dask_client_owned", False)
@@ -441,7 +461,7 @@ class Client:
         self._scheduler_disabled = False
         self._spark_context = spark_context
         self._spark_master_url = spark_master_url
-        self._spark_context_owned = True
+        self._spark_context_owned = owned
         for attribute in (
             "_dask_client",
             "_dask_client_address",
@@ -619,14 +639,20 @@ class Client:
                 )
 
             try:
-                spark_context = self._create_spark_context(spark_master_url)
+                spark_context, spark_context_owned = self._create_spark_context(
+                    spark_master_url
+                )
             except Exception as err:
                 raise MsPASSError(
                     "Runntime error: cannot create a spark configuration with: "
                     + spark_master_url,
                     "Fatal",
                 ) from err
-            self._commit_spark_scheduler(spark_context, spark_master_url)
+            self._commit_spark_scheduler(
+                spark_context,
+                spark_context.master,
+                owned=spark_context_owned,
+            )
 
         else:
             _require_dask()

--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -525,6 +525,42 @@ class Client:
             )
             return None
 
+    def close_scheduler(self):
+        """Detach the active scheduler and release it when owned by this client.
+
+        A local Dask client or Spark context created by this :class:`Client` is
+        closed or stopped exactly once.  A Dask client supplied by the caller
+        and a Spark context reused from the caller are detached but remain
+        running.  Repeated calls are no-ops.
+
+        Scheduler state is cleared before an owned resource is released.  If
+        ``close`` or ``stop`` raises, that exception is propagated and this
+        client remains detached from the scheduler.
+        """
+        scheduler = getattr(self, "_scheduler", None)
+        dask_client = getattr(self, "_dask_client", None)
+        dask_owned = getattr(self, "_dask_client_owned", False)
+        spark_context = getattr(self, "_spark_context", None)
+        spark_owned = getattr(self, "_spark_context_owned", False)
+
+        self._scheduler = None
+        self._scheduler_disabled = True
+        for attribute in (
+            "_dask_client",
+            "_dask_client_address",
+            "_dask_client_owned",
+            "_spark_context",
+            "_spark_master_url",
+            "_spark_context_owned",
+        ):
+            if hasattr(self, attribute):
+                delattr(self, attribute)
+
+        if scheduler == "dask" and dask_client is not None and dask_owned:
+            dask_client.close()
+        elif scheduler == "spark" and spark_context is not None and spark_owned:
+            spark_context.stop()
+
     def set_database_client(self, database_host, database_port=None):
         """
         Set a database client by database_host(and database_port)

--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -590,7 +590,25 @@ class Client:
 
     def set_scheduler(self, scheduler, scheduler_host, scheduler_port=None):
         """
-        Set a scheduler by scheduler type, scheduler_host(and scheduler_port)
+        Replace the scheduler used by this client.
+
+        The replacement scheduler is constructed and validated before any
+        scheduler state in this object is changed.  Consequently, a failure to
+        construct or validate the replacement leaves the current scheduler and
+        its ownership unchanged.  After a successful commit, a displaced Dask
+        client or Spark context is closed only when it was created by this
+        :class:`Client`; a Dask client supplied by the caller is never closed.
+
+        Cleanup of an owned, displaced scheduler happens after the replacement
+        is committed.  If its ``close`` or ``stop`` method raises, that exception
+        is propagated and the replacement remains the active scheduler.  This
+        distinction lets callers determine the active state with
+        :meth:`get_scheduler` without mistaking a cleanup failure for a failed
+        connection.
+
+        Requesting the currently active Spark master is an idempotent no-op.
+        Switching an active Spark context to another master is rejected because
+        ``SparkSession.getOrCreate`` cannot guarantee that transition.
 
         :param scheduler: the scheduler type, should be either dask or spark
         :type scheduler: :class:`str`
@@ -598,6 +616,13 @@ class Client:
         :type scheduler_host: :class:`str`
         :param scheduler_port: the port of scheduler
         :type scheduler_port: :class:`str`
+
+        :raises MsPASSError: if arguments are invalid, an optional scheduler
+            dependency is unavailable, the replacement cannot be constructed or
+            validated, or an active Spark master switch is requested.
+        :raises Exception: propagates an exception raised while closing or
+            stopping a displaced Client-owned scheduler after the replacement
+            has been committed.
         """
         if scheduler != "dask" and scheduler != "spark":
             raise MsPASSError(

--- a/python/tests/io/test_distributed.py
+++ b/python/tests/io/test_distributed.py
@@ -57,14 +57,16 @@ def dask_test_client():
         processes=False,
         n_workers=2,
         threads_per_worker=1,
-        dashboard_address=":0",
+        dashboard_address=None,
     )
     plugin = MongoDBWorker(
         _MongoPluginMsPASSClientStub(DBClient("mongodb://localhost:27017/"))
     )
     dask_client.register_plugin(plugin)
-    yield dask_client
-    dask_client.close()
+    try:
+        yield dask_client
+    finally:
+        dask_client.close()
 
 
 def _collect_parallel_data(container, scheduler, dask_client=None):

--- a/python/tests/test_client_scheduler_transitions.py
+++ b/python/tests/test_client_scheduler_transitions.py
@@ -1,0 +1,564 @@
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+import mspasspy.client as client_module
+import mspasspy.ccore.utility as utility_module
+from mspasspy.client import Client
+from mspasspy.ccore.utility import MsPASSError
+
+
+class FakeDaskClient:
+    instances = []
+    fail_construction = False
+    fail_registration = False
+
+    def __init__(self, address=None):
+        if self.fail_construction:
+            raise RuntimeError("dask construction failed")
+        self.address = address
+        self.close_calls = 0
+        self.register_calls = 0
+        self.on_close = None
+        type(self).instances.append(self)
+
+    def register_plugin(self, plugin, name=None):
+        self.register_calls += 1
+        if self.fail_registration:
+            raise RuntimeError("dask validation failed")
+
+    def close(self):
+        self.close_calls += 1
+        if self.on_close is not None:
+            self.on_close()
+
+
+class FakeSparkContext:
+    def __init__(self, master):
+        self.master = master
+        self.stop_calls = 0
+        self.on_stop = None
+
+    def stop(self):
+        self.stop_calls += 1
+        if self.on_stop is not None:
+            self.on_stop()
+
+
+class FakeSparkBuilder:
+    def __init__(self, returned_master=None, failure=None):
+        self.returned_master = returned_master
+        self.failure = failure
+        self.requested_master = None
+        self.get_or_create_calls = 0
+        self.context = None
+
+    def appName(self, name):
+        return self
+
+    def master(self, master):
+        self.requested_master = master
+        return self
+
+    def getOrCreate(self):
+        self.get_or_create_calls += 1
+        if self.failure is not None:
+            raise self.failure
+        master = self.returned_master or self.requested_master
+        self.context = FakeSparkContext(master)
+        return SimpleNamespace(sparkContext=self.context)
+
+
+@pytest.fixture
+def fake_schedulers(monkeypatch):
+    FakeDaskClient.instances = []
+    FakeDaskClient.fail_construction = False
+    FakeDaskClient.fail_registration = False
+    monkeypatch.setattr(client_module, "DaskClient", FakeDaskClient)
+    monkeypatch.setattr(client_module, "_mspasspy_has_dask_distributed", True)
+    monkeypatch.setattr(
+        client_module, "MongoDBWorker", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(client_module, "_mspasspy_has_pyspark", True)
+
+
+def _new_client_without_scheduler():
+    client = Client.__new__(Client)
+    client._scheduler = None
+    client._scheduler_disabled = True
+    return client
+
+
+def _new_dask_client_state(owned):
+    client = Client.__new__(Client)
+    old_dask = FakeDaskClient("tcp://old-dask:8786")
+    client._scheduler = "dask"
+    client._scheduler_disabled = False
+    client._dask_client = old_dask
+    client._dask_client_address = "tcp://old-dask:8786"
+    client._dask_client_owned = owned
+    return client, old_dask
+
+
+def _new_spark_client_state(owned=True):
+    client = Client.__new__(Client)
+    old_spark = FakeSparkContext("spark://old-spark:7077")
+    client._scheduler = "spark"
+    client._scheduler_disabled = False
+    client._spark_context = old_spark
+    client._spark_master_url = "spark://old-spark:7077"
+    client._spark_context_owned = owned
+    return client, old_spark
+
+
+def _patch_client_startup(monkeypatch):
+    monkeypatch.setenv("MSPASS_HOME", str(Path(__file__).resolve().parents[2]))
+    monkeypatch.setattr(client_module.DBClient, "server_info", lambda self: {})
+    monkeypatch.setattr(
+        client_module.GlobalHistoryManager,
+        "__init__",
+        lambda self, *args, **kwargs: None,
+    )
+
+
+@pytest.mark.parametrize(
+    "address,port,default_port,default_scheme,expected",
+    [
+        ("worker", None, "8786", None, "worker:8786"),
+        ("tcp://worker", None, "8786", None, "tcp://worker:8786"),
+        ("worker:9000", "9000", "8786", None, "worker:9000"),
+        ("worker:9000", "9999", "8786", None, "worker:9000"),
+        ("tcp://worker:9000", "9999", "8786", None, "tcp://worker:9000"),
+        ("[2001:db8::1]", None, "8786", None, "[2001:db8::1]:8786"),
+        ("[2001:db8::1]:9000", "9999", "8786", None, "[2001:db8::1]:9000"),
+        (
+            "tcp://[2001:db8::1]",
+            9000,
+            "8786",
+            None,
+            "tcp://[2001:db8::1]:9000",
+        ),
+        (
+            "tcp://[2001:db8::1]:9000",
+            "9999",
+            "8786",
+            None,
+            "tcp://[2001:db8::1]:9000",
+        ),
+        ("master", "7077", None, "spark", "spark://master:7077"),
+        (
+            "spark://[2001:db8::2]",
+            "7077",
+            None,
+            "spark",
+            "spark://[2001:db8::2]:7077",
+        ),
+        (
+            "spark://master:7077",
+            "9999",
+            None,
+            "spark",
+            "spark://master:7077",
+        ),
+        ("local", "9999", None, "spark", "local"),
+        ("local[*]", "9999", None, "spark", "local[*]"),
+    ],
+)
+def test_scheduler_endpoint_builder(
+    address, port, default_port, default_scheme, expected
+):
+    assert (
+        client_module._build_scheduler_endpoint(
+            address,
+            scheduler_port=port,
+            default_port=default_port,
+            default_scheme=default_scheme,
+        )
+        == expected
+    )
+
+
+def test_constructor_records_caller_and_client_dask_ownership(
+    monkeypatch, fake_schedulers
+):
+    _patch_client_startup(monkeypatch)
+    provided_dask = FakeDaskClient("caller-managed")
+
+    caller_owned_client = Client(scheduler="dask", dask_client=provided_dask)
+    client_owned_client = Client(
+        scheduler="dask",
+        scheduler_host="tcp://[2001:db8::4]:9000",
+    )
+
+    assert caller_owned_client._dask_client is provided_dask
+    assert caller_owned_client._dask_client_address is None
+    assert caller_owned_client._dask_client_owned is False
+    assert client_owned_client._dask_client.address == "tcp://[2001:db8::4]:9000"
+    assert client_owned_client._dask_client_address == "tcp://[2001:db8::4]:9000"
+    assert client_owned_client._dask_client_owned is True
+
+
+def test_constructor_records_active_spark_master(monkeypatch, fake_schedulers):
+    _patch_client_startup(monkeypatch)
+    monkeypatch.setenv("SPARK_MASTER_PORT", "9999")
+    builder = FakeSparkBuilder()
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+
+    client = Client(
+        scheduler="spark",
+        scheduler_host="spark://[2001:db8::5]:7077",
+    )
+
+    assert builder.requested_master == "spark://[2001:db8::5]:7077"
+    assert client._spark_master_url == "spark://[2001:db8::5]:7077"
+    assert client._spark_context is builder.context
+    assert client._spark_context_owned is True
+
+
+@pytest.mark.parametrize(
+    "scheduler,address,port,expected",
+    [
+        (
+            "dask",
+            "tcp://[2001:db8::6]:9000",
+            "9999",
+            "tcp://[2001:db8::6]:9000",
+        ),
+        (
+            "spark",
+            "spark://[2001:db8::7]:7077",
+            "9999",
+            "spark://[2001:db8::7]:7077",
+        ),
+    ],
+)
+def test_constructor_environment_endpoint_embedded_port_is_authoritative(
+    monkeypatch, fake_schedulers, scheduler, address, port, expected
+):
+    _patch_client_startup(monkeypatch)
+    monkeypatch.setenv("MSPASS_SCHEDULER", scheduler)
+    monkeypatch.setenv("MSPASS_SCHEDULER_ADDRESS", address)
+    if scheduler == "dask":
+        monkeypatch.setenv("DASK_SCHEDULER_PORT", port)
+    else:
+        monkeypatch.setenv("SPARK_MASTER_PORT", port)
+        builder = FakeSparkBuilder()
+        monkeypatch.setattr(
+            client_module, "SparkSession", SimpleNamespace(builder=builder)
+        )
+
+    client = Client()
+
+    if scheduler == "dask":
+        assert client._dask_client.address == expected
+        assert client._dask_client_address == expected
+    else:
+        assert builder.requested_master == expected
+        assert client._spark_master_url == expected
+
+
+@pytest.mark.parametrize(
+    "provided,expected_close_calls",
+    [(False, 1), (True, 0)],
+    ids=["client-owned", "caller-owned"],
+)
+def test_constructor_dask_validation_failure_respects_ownership(
+    monkeypatch, fake_schedulers, provided, expected_close_calls
+):
+    _patch_client_startup(monkeypatch)
+    dask_client = FakeDaskClient("provided") if provided else None
+    FakeDaskClient.fail_registration = True
+
+    with pytest.raises(MsPASSError, match="cannot (create|configure).+dask client"):
+        Client(scheduler="dask", dask_client=dask_client)
+
+    failed_client = dask_client or FakeDaskClient.instances[-1]
+    assert failed_client.register_calls == 1
+    assert failed_client.close_calls == expected_close_calls
+
+
+@pytest.mark.parametrize("old_owned,expected_close_calls", [(True, 1), (False, 0)])
+def test_dask_to_dask_commits_before_owned_cleanup(
+    monkeypatch, fake_schedulers, old_owned, expected_close_calls
+):
+    client, old_dask = _new_dask_client_state(old_owned)
+    state_seen_during_close = []
+    old_dask.on_close = lambda: state_seen_during_close.append(
+        (client._scheduler, client._dask_client)
+    )
+
+    client.set_scheduler("dask", "tcp://new-dask:9000", scheduler_port="9999")
+
+    new_dask = client._dask_client
+    assert new_dask is not old_dask
+    assert new_dask.address == "tcp://new-dask:9000"
+    assert new_dask.register_calls == 1
+    assert client._dask_client_address == "tcp://new-dask:9000"
+    assert client._dask_client_owned is True
+    assert old_dask.close_calls == expected_close_calls
+    if old_owned:
+        assert state_seen_during_close == [("dask", new_dask)]
+    else:
+        assert state_seen_during_close == []
+
+
+@pytest.mark.parametrize("old_owned,expected_close_calls", [(True, 1), (False, 0)])
+def test_dask_to_spark_commits_before_owned_cleanup(
+    monkeypatch, fake_schedulers, old_owned, expected_close_calls
+):
+    client, old_dask = _new_dask_client_state(old_owned)
+    builder = FakeSparkBuilder()
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+    state_seen_during_close = []
+    old_dask.on_close = lambda: state_seen_during_close.append(
+        (client._scheduler, client._spark_context)
+    )
+
+    client.set_scheduler("spark", "spark://new-spark:7077", scheduler_port="9999")
+
+    assert client._scheduler == "spark"
+    assert client._spark_context is builder.context
+    assert client._spark_master_url == "spark://new-spark:7077"
+    assert client._spark_context_owned is True
+    assert not hasattr(client, "_dask_client")
+    assert old_dask.close_calls == expected_close_calls
+    if old_owned:
+        assert state_seen_during_close == [("spark", builder.context)]
+    else:
+        assert state_seen_during_close == []
+
+
+@pytest.mark.parametrize("old_owned,expected_stop_calls", [(True, 1), (False, 0)])
+def test_spark_to_dask_commits_before_owned_cleanup(
+    fake_schedulers, old_owned, expected_stop_calls
+):
+    client, old_spark = _new_spark_client_state(old_owned)
+    state_seen_during_stop = []
+    old_spark.on_stop = lambda: state_seen_during_stop.append(
+        (client._scheduler, client._dask_client)
+    )
+
+    client.set_scheduler("dask", "[2001:db8::3]", scheduler_port=8787)
+
+    new_dask = client._dask_client
+    assert client._scheduler == "dask"
+    assert new_dask.address == "[2001:db8::3]:8787"
+    assert client._dask_client_address == "[2001:db8::3]:8787"
+    assert client._dask_client_owned is True
+    assert not hasattr(client, "_spark_context")
+    assert old_spark.stop_calls == expected_stop_calls
+    if old_owned:
+        assert state_seen_during_stop == [("dask", new_dask)]
+    else:
+        assert state_seen_during_stop == []
+
+
+def test_same_spark_master_is_no_op(monkeypatch, fake_schedulers):
+    client, old_spark = _new_spark_client_state()
+    builder = FakeSparkBuilder(failure=AssertionError("builder must not be called"))
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+    before = vars(client).copy()
+
+    result = client.set_scheduler(
+        "spark", "spark://old-spark:7077", scheduler_port="9999"
+    )
+
+    assert result is None
+    assert vars(client) == before
+    assert client._spark_context is old_spark
+    assert old_spark.stop_calls == 0
+    assert builder.get_or_create_calls == 0
+
+
+@pytest.mark.parametrize("master", ["local", "local[*]"])
+def test_same_local_spark_master_is_no_op(monkeypatch, fake_schedulers, master):
+    client, old_spark = _new_spark_client_state()
+    client._spark_master_url = master
+    old_spark.master = master
+    builder = FakeSparkBuilder(failure=AssertionError("builder must not be called"))
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+    before = vars(client).copy()
+
+    result = client.set_scheduler("spark", master, scheduler_port="9999")
+
+    assert result is None
+    assert vars(client) == before
+    assert client._spark_context is old_spark
+    assert old_spark.stop_calls == 0
+    assert builder.get_or_create_calls == 0
+
+
+def test_different_spark_master_is_rejected_atomically(monkeypatch, fake_schedulers):
+    client, old_spark = _new_spark_client_state()
+    builder = FakeSparkBuilder(failure=AssertionError("builder must not be called"))
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+    before = vars(client).copy()
+
+    with pytest.raises(MsPASSError, match="refusing to change active Spark master"):
+        client.set_scheduler("spark", "new-spark", scheduler_port="7077")
+
+    assert vars(client) == before
+    assert client._spark_context is old_spark
+    assert old_spark.stop_calls == 0
+    assert builder.get_or_create_calls == 0
+
+
+def test_none_to_dask_construction_failure_is_atomic(fake_schedulers):
+    client = _new_client_without_scheduler()
+    before = vars(client).copy()
+    FakeDaskClient.fail_construction = True
+
+    with pytest.raises(MsPASSError, match="cannot create a dask client"):
+        client.set_scheduler("dask", "new-dask", scheduler_port="8786")
+
+    assert vars(client) == before
+
+
+@pytest.mark.parametrize("old_owned", [True, False], ids=["owned", "caller-owned"])
+def test_dask_validation_failure_is_atomic_and_closes_only_new_client(
+    fake_schedulers, old_owned
+):
+    client, old_dask = _new_dask_client_state(owned=old_owned)
+    before = vars(client).copy()
+    FakeDaskClient.fail_registration = True
+
+    with pytest.raises(MsPASSError, match="cannot create a dask client"):
+        client.set_scheduler("dask", "new-dask", scheduler_port="8786")
+
+    new_dask = FakeDaskClient.instances[-1]
+    assert new_dask is not old_dask
+    assert new_dask.close_calls == 1
+    assert old_dask.close_calls == 0
+    assert vars(client) == before
+
+
+@pytest.mark.parametrize(
+    "old_owned,builder",
+    [
+        (
+            True,
+            FakeSparkBuilder(failure=RuntimeError("spark construction failed")),
+        ),
+        (
+            False,
+            FakeSparkBuilder(failure=RuntimeError("spark construction failed")),
+        ),
+        (True, FakeSparkBuilder(returned_master="spark://unexpected:7077")),
+        (False, FakeSparkBuilder(returned_master="spark://unexpected:7077")),
+    ],
+    ids=[
+        "owned-construction",
+        "caller-owned-construction",
+        "owned-master-validation",
+        "caller-owned-master-validation",
+    ],
+)
+def test_spark_construction_and_validation_failures_are_atomic(
+    monkeypatch, fake_schedulers, old_owned, builder
+):
+    client, old_dask = _new_dask_client_state(owned=old_owned)
+    before = vars(client).copy()
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+
+    with pytest.raises(MsPASSError, match="cannot create a spark configuration"):
+        client.set_scheduler("spark", "new-spark", scheduler_port="7077")
+
+    assert vars(client) == before
+    assert client._dask_client is old_dask
+    assert old_dask.close_calls == 0
+
+
+def test_spark_to_dask_construction_failure_is_atomic(fake_schedulers):
+    client, old_spark = _new_spark_client_state()
+    before = vars(client).copy()
+    FakeDaskClient.fail_construction = True
+
+    with pytest.raises(MsPASSError, match="cannot create a dask client"):
+        client.set_scheduler("dask", "new-dask", scheduler_port="8786")
+
+    assert vars(client) == before
+    assert client._spark_context is old_spark
+    assert old_spark.stop_calls == 0
+
+
+def test_missing_optional_dask_is_explicit_and_atomic(monkeypatch):
+    client, old_spark = _new_spark_client_state()
+    before = vars(client).copy()
+    monkeypatch.setattr(client_module, "DaskClient", None)
+    monkeypatch.setattr(client_module, "_mspasspy_has_dask_distributed", False)
+    monkeypatch.setattr(
+        client_module,
+        "_mspasspy_dask_import_error",
+        ImportError("dask is unavailable"),
+    )
+
+    with pytest.raises(MsPASSError, match="dask.distributed could not be imported"):
+        client.set_scheduler("dask", "new-dask", scheduler_port="8786")
+
+    assert vars(client) == before
+    assert client._spark_context is old_spark
+    assert old_spark.stop_calls == 0
+
+
+def test_client_import_and_request_with_missing_optional_dask(tmp_path):
+    dask_package = tmp_path / "dask"
+    dask_package.mkdir()
+    (dask_package / "__init__.py").write_text(
+        'raise ImportError("dask is unavailable")\n', encoding="utf-8"
+    )
+    env = os.environ.copy()
+    env["MSPASS_CLIENT_MODULE"] = str(Path(client_module.__file__).resolve())
+    runtime_python = Path(utility_module.__file__).resolve().parents[2]
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(tmp_path), str(runtime_python), env.get("PYTHONPATH", "")]
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import importlib.util
+import os
+import sys
+
+client_source = os.environ["MSPASS_CLIENT_MODULE"]
+spec = importlib.util.spec_from_file_location("mspasspy.client", client_source)
+client_module = importlib.util.module_from_spec(spec)
+sys.modules["mspasspy.client"] = client_module
+spec.loader.exec_module(client_module)
+
+from mspasspy.client import Client
+from mspasspy.ccore.utility import MsPASSError
+
+assert client_module.__file__ == client_source
+
+client = Client.__new__(Client)
+client._scheduler = None
+client._scheduler_disabled = True
+try:
+    client.set_scheduler("dask", "localhost")
+except MsPASSError as err:
+    assert "dask.distributed could not be imported" in str(err), str(err)
+else:
+    raise AssertionError("missing dask should raise MsPASSError")
+
+try:
+    Client(scheduler="dask")
+except MsPASSError as err:
+    assert "dask.distributed could not be imported" in str(err), str(err)
+else:
+    raise AssertionError("Client(scheduler='dask') should reject missing dask")
+""",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/python/tests/test_client_scheduler_transitions.py
+++ b/python/tests/test_client_scheduler_transitions.py
@@ -455,6 +455,62 @@ def test_spark_cleanup_failure_propagates_after_replacement_is_committed(
     assert old_spark.stop_calls == 1
 
 
+@pytest.mark.parametrize("scheduler", ["dask", "spark"])
+@pytest.mark.parametrize("owned", [True, False], ids=["owned", "caller-owned"])
+def test_close_scheduler_is_idempotent_and_respects_ownership(scheduler, owned):
+    if scheduler == "dask":
+        client, resource = _new_dask_client_state(owned)
+    else:
+        client, resource = _new_spark_client_state(owned)
+
+    assert client.close_scheduler() is None
+    assert client.get_scheduler() is None
+    assert client._scheduler is None
+    assert client._scheduler_disabled is True
+    assert not hasattr(client, "_dask_client")
+    assert not hasattr(client, "_spark_context")
+    call_count = resource.close_calls if scheduler == "dask" else resource.stop_calls
+    assert call_count == int(owned)
+
+    assert client.close_scheduler() is None
+    call_count = resource.close_calls if scheduler == "dask" else resource.stop_calls
+    assert call_count == int(owned)
+
+
+@pytest.mark.parametrize("scheduler", ["dask", "spark"])
+def test_close_scheduler_propagates_cleanup_failure_after_detaching(scheduler):
+    if scheduler == "dask":
+        client, resource = _new_dask_client_state(owned=True)
+        cleanup_error = RuntimeError("dask shutdown failed")
+
+        def fail_cleanup():
+            raise cleanup_error
+
+        resource.on_close = fail_cleanup
+    else:
+        client, resource = _new_spark_client_state(owned=True)
+        cleanup_error = RuntimeError("spark shutdown failed")
+
+        def fail_cleanup():
+            raise cleanup_error
+
+        resource.on_stop = fail_cleanup
+
+    with pytest.raises(RuntimeError) as caught:
+        client.close_scheduler()
+
+    assert caught.value is cleanup_error
+    assert client.get_scheduler() is None
+    assert client._scheduler is None
+    assert client._scheduler_disabled is True
+    assert not hasattr(client, "_dask_client")
+    assert not hasattr(client, "_spark_context")
+
+    assert client.close_scheduler() is None
+    call_count = resource.close_calls if scheduler == "dask" else resource.stop_calls
+    assert call_count == 1
+
+
 def test_same_spark_master_is_no_op(monkeypatch, fake_schedulers):
     client, old_spark = _new_spark_client_state()
     builder = FakeSparkBuilder(failure=AssertionError("builder must not be called"))

--- a/python/tests/test_client_scheduler_transitions.py
+++ b/python/tests/test_client_scheduler_transitions.py
@@ -409,6 +409,52 @@ def test_spark_to_dask_commits_before_owned_cleanup(
         assert state_seen_during_stop == []
 
 
+def test_dask_cleanup_failure_propagates_after_replacement_is_committed(
+    fake_schedulers,
+):
+    client, old_dask = _new_dask_client_state(owned=True)
+    cleanup_error = RuntimeError("old dask cleanup failed")
+
+    def fail_close():
+        raise cleanup_error
+
+    old_dask.on_close = fail_close
+
+    with pytest.raises(RuntimeError) as caught:
+        client.set_scheduler("dask", "tcp://new-dask:9000")
+
+    assert caught.value is cleanup_error
+    assert client._scheduler == "dask"
+    assert client._dask_client is not old_dask
+    assert client._dask_client.address == "tcp://new-dask:9000"
+    assert client._dask_client_address == "tcp://new-dask:9000"
+    assert client._dask_client_owned is True
+    assert old_dask.close_calls == 1
+
+
+def test_spark_cleanup_failure_propagates_after_replacement_is_committed(
+    fake_schedulers,
+):
+    client, old_spark = _new_spark_client_state(owned=True)
+    cleanup_error = RuntimeError("old spark cleanup failed")
+
+    def fail_stop():
+        raise cleanup_error
+
+    old_spark.on_stop = fail_stop
+
+    with pytest.raises(RuntimeError) as caught:
+        client.set_scheduler("dask", "tcp://new-dask:9000")
+
+    assert caught.value is cleanup_error
+    assert client._scheduler == "dask"
+    assert client._dask_client.address == "tcp://new-dask:9000"
+    assert client._dask_client_address == "tcp://new-dask:9000"
+    assert client._dask_client_owned is True
+    assert not hasattr(client, "_spark_context")
+    assert old_spark.stop_calls == 1
+
+
 def test_same_spark_master_is_no_op(monkeypatch, fake_schedulers):
     client, old_spark = _new_spark_client_state()
     builder = FakeSparkBuilder(failure=AssertionError("builder must not be called"))

--- a/python/tests/test_client_scheduler_transitions.py
+++ b/python/tests/test_client_scheduler_transitions.py
@@ -50,9 +50,10 @@ class FakeSparkContext:
 
 
 class FakeSparkBuilder:
-    def __init__(self, returned_master=None, failure=None):
+    def __init__(self, returned_master=None, failure=None, existing_context=None):
         self.returned_master = returned_master
         self.failure = failure
+        self.existing_context = existing_context
         self.requested_master = None
         self.get_or_create_calls = 0
         self.context = None
@@ -68,8 +69,11 @@ class FakeSparkBuilder:
         self.get_or_create_calls += 1
         if self.failure is not None:
             raise self.failure
-        master = self.returned_master or self.requested_master
-        self.context = FakeSparkContext(master)
+        if self.existing_context is not None:
+            self.context = self.existing_context
+        else:
+            master = self.returned_master or self.requested_master
+            self.context = FakeSparkContext(master)
         return SimpleNamespace(sparkContext=self.context)
 
 
@@ -84,6 +88,11 @@ def fake_schedulers(monkeypatch):
         client_module, "MongoDBWorker", lambda *args, **kwargs: object()
     )
     monkeypatch.setattr(client_module, "_mspasspy_has_pyspark", True)
+    monkeypatch.setattr(
+        client_module,
+        "SparkContext",
+        SimpleNamespace(_active_spark_context=None),
+    )
 
 
 def _new_client_without_scheduler():
@@ -217,6 +226,49 @@ def test_constructor_records_active_spark_master(monkeypatch, fake_schedulers):
     assert client._spark_master_url == "spark://[2001:db8::5]:7077"
     assert client._spark_context is builder.context
     assert client._spark_context_owned is True
+
+
+def test_constructor_reuses_existing_implicit_local_spark(monkeypatch, fake_schedulers):
+    _patch_client_startup(monkeypatch)
+    existing_context = FakeSparkContext("local[*]")
+    builder = FakeSparkBuilder(existing_context=existing_context)
+    client_module.SparkContext._active_spark_context = existing_context
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+
+    client = Client(scheduler="spark")
+
+    assert builder.requested_master == "local"
+    assert client._spark_context is existing_context
+    assert client._spark_master_url == "local[*]"
+    assert client._spark_context_owned is False
+
+
+def test_constructor_rejects_nonlocal_existing_context(monkeypatch, fake_schedulers):
+    _patch_client_startup(monkeypatch)
+    existing_context = FakeSparkContext("spark://existing:7077")
+    builder = FakeSparkBuilder(existing_context=existing_context)
+    client_module.SparkContext._active_spark_context = existing_context
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+
+    with pytest.raises(MsPASSError, match="cannot create a spark configuration"):
+        Client(scheduler="spark")
+
+    assert existing_context.stop_calls == 0
+
+
+def test_explicit_local_master_remains_strict_and_atomic(monkeypatch, fake_schedulers):
+    client, old_dask = _new_dask_client_state(owned=True)
+    builder = FakeSparkBuilder(returned_master="local[*]")
+    monkeypatch.setattr(client_module, "SparkSession", SimpleNamespace(builder=builder))
+    before = vars(client).copy()
+
+    with pytest.raises(MsPASSError, match="cannot create a spark configuration"):
+        client.set_scheduler("spark", "local")
+
+    assert vars(client) == before
+    assert client._dask_client is old_dask
+    assert old_dask.close_calls == 0
+    assert builder.context.stop_calls == 1
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_mspass_client_no_dask_spark.py
+++ b/python/tests/test_mspass_client_no_dask_spark.py
@@ -14,6 +14,9 @@ from mspasspy.db.client import DBClient
 import gridfs
 import numpy as np
 import obspy
+import os
+from pathlib import Path
+import subprocess
 import sys
 import re
 
@@ -34,10 +37,11 @@ with mock.patch.dict(
     sys.modules, {"pyspark": None, "dask.distributed": None, "dask": None}
 ):
     from mspasspy.client import Client
+    import mspasspy.client as client_module
 
     class TestMsPASSClient:
         def setup_class(self):
-            self.client = Client()
+            self.client = Client(scheduler="none")
 
         def test_init(self):
             with pytest.raises(
@@ -116,7 +120,7 @@ with mock.patch.dict(
 
             monkeypatch.setenv("MONGODB_PORT", "12345")
             monkeypatch.setenv("MSPASS_DB_ADDRESS", "168.0.0.1")
-            client = Client(database_host="localhost:27017")
+            client = Client(database_host="localhost:27017", scheduler="none")
             host, port = client._db_client.address
             assert host == "localhost"
             assert port == 27017
@@ -140,8 +144,42 @@ with mock.patch.dict(
             assert isinstance(manager, GlobalHistoryManager)
 
         def test_get_scheduler(self):
-            client = Client()
-            assert client.get_scheduler() == None
+            assert self.client.get_scheduler() is None
+            assert not hasattr(self.client, "_dask_client")
+            env = os.environ.copy()
+            env["MSPASS_CLIENT_MODULE"] = str(Path(client_module.__file__).resolve())
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    """
+import importlib.util
+import os
+import sys
+
+for name in ("pyspark", "dask", "dask.distributed"):
+    sys.modules[name] = None
+
+client_source = os.environ["MSPASS_CLIENT_MODULE"]
+spec = importlib.util.spec_from_file_location("mspasspy.client", client_source)
+client_module = importlib.util.module_from_spec(spec)
+sys.modules["mspasspy.client"] = client_module
+spec.loader.exec_module(client_module)
+assert client_module.__file__ == client_source
+
+client_module.DBClient.server_info = lambda self: {}
+client_module.GlobalHistoryManager.__init__ = lambda self, *args, **kwargs: None
+client = client_module.Client()
+assert client._scheduler is None
+assert client.get_scheduler() is None
+""",
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert result.returncode == 0, result.stderr
 
         def test_set_database_client(self, monkeypatch):
             self.client.set_database_client("localhost", database_port="27017")

--- a/python/tests/test_mspass_client_spark_dask.py
+++ b/python/tests/test_mspass_client_spark_dask.py
@@ -1,5 +1,6 @@
 import copy
 import os
+from unittest import mock
 
 import dask.bag as daskbag
 from pyspark import SparkConf, SparkContext
@@ -22,6 +23,7 @@ from datetime import datetime
 sys.path.append("python/tests")
 
 from mspasspy.util import logging_helper
+import mspasspy.client as client_module
 from mspasspy.client import Client
 from mspasspy.global_history.manager import GlobalHistoryManager
 from mspasspy.ccore.utility import MsPASSError
@@ -243,15 +245,20 @@ def test_dask_client_requires_distributed_client(monkeypatch):
 
 
 class TestMsPASSClient:
-    @staticmethod
-    def _close_dask_scheduler(client):
-        client.close_scheduler()
-
     def setup_class(self):
-        self.client = Client()
+        local_dask_client = DaskClient(
+            processes=False,
+            n_workers=2,
+            threads_per_worker=1,
+            dashboard_address=None,
+        )
+        with mock.patch.object(
+            client_module, "DaskClient", return_value=local_dask_client
+        ):
+            self.client = Client()
 
     def teardown_class(self):
-        self._close_dask_scheduler(self.client)
+        self.client.close_scheduler()
 
     def test_init(self):
         with pytest.raises(

--- a/python/tests/test_mspass_client_spark_dask.py
+++ b/python/tests/test_mspass_client_spark_dask.py
@@ -245,9 +245,7 @@ def test_dask_client_requires_distributed_client(monkeypatch):
 class TestMsPASSClient:
     @staticmethod
     def _close_dask_scheduler(client):
-        dask_client = getattr(client, "_dask_client", None)
-        if dask_client is not None:
-            dask_client.close()
+        client.close_scheduler()
 
     def setup_class(self):
         self.client = Client()
@@ -336,16 +334,13 @@ class TestMsPASSClient:
 
         monkeypatch.setenv("MONGODB_PORT", "12345")
         monkeypatch.setenv("MSPASS_DB_ADDRESS", "168.0.0.1")
-        self._close_dask_scheduler(self.client)
-        client = Client(database_host="localhost:27017")
+        client = Client(database_host="localhost:27017", scheduler="none")
         try:
             host, port = client._db_client.address
             assert host == "localhost"
             assert port == 27017
         finally:
-            self._close_dask_scheduler(client)
             monkeypatch.undo()
-            self.client = Client()
 
     def test_dask_scheduler(self, monkeypatch):
         monkeypatch.delenv("DASK_SCHEDULER_PORT", raising=False)
@@ -446,7 +441,10 @@ class TestMsPASSClient:
     def test_get_scheduler(self):
         assert isinstance(self.client.get_scheduler(), DaskClient)
         client = Client(scheduler="spark")
-        assert isinstance(client.get_scheduler(), SparkContext)
+        try:
+            assert isinstance(client.get_scheduler(), SparkContext)
+        finally:
+            client.close_scheduler()
 
     def test_set_database_client(self, monkeypatch):
         self.client.set_database_client("localhost", database_port="27017")
@@ -539,23 +537,26 @@ class TestMsPASSClient:
 
         # test set spark, previous is spark
         test_client_2 = Client(scheduler="spark")
-        monkeypatch.setattr(SparkSession, "builder", mock_excpt)
-        with pytest.raises(
-            MsPASSError,
-            match="Runntime error: cannot create a spark configuration with: spark://123.4.5.6:7077",
-        ):
-            test_client_2.set_scheduler("spark", "123.4.5.6", scheduler_port="7077")
-        monkeypatch.undo()
-        # restore back
-        assert test_client_2._scheduler == "spark"
+        try:
+            monkeypatch.setattr(SparkSession, "builder", mock_excpt)
+            with pytest.raises(
+                MsPASSError,
+                match="Runntime error: cannot create a spark configuration with: spark://123.4.5.6:7077",
+            ):
+                test_client_2.set_scheduler("spark", "123.4.5.6", scheduler_port="7077")
+            monkeypatch.undo()
+            # restore back
+            assert test_client_2._scheduler == "spark"
 
-        # test set dask, previous is spark
-        monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
-        with pytest.raises(
-            MsPASSError,
-            match="Runntime error: cannot create a dask client with: localhost:8786",
-        ):
-            test_client_2.set_scheduler("dask", "localhost", scheduler_port="8786")
-        monkeypatch.undo()
-        assert test_client_2._scheduler == "spark"
-        assert not hasattr(test_client_2, "_dask_client")
+            # test set dask, previous is spark
+            monkeypatch.setattr(DaskClient, "__init__", mock_excpt)
+            with pytest.raises(
+                MsPASSError,
+                match="Runntime error: cannot create a dask client with: localhost:8786",
+            ):
+                test_client_2.set_scheduler("dask", "localhost", scheduler_port="8786")
+            monkeypatch.undo()
+            assert test_client_2._scheduler == "spark"
+            assert not hasattr(test_client_2, "_dask_client")
+        finally:
+            test_client_2.close_scheduler()


### PR DESCRIPTION
## Summary
- normalize Dask and Spark endpoints with one URL-aware host/port/IPv6 builder
- build and validate replacements before committing scheduler state
- track Client-owned versus caller-owned scheduler resources
- keep the validated replacement active if cleanup of a displaced owned resource fails, while propagating the original cleanup exception
- add idempotent `close_scheduler()`: it detaches scheduler state, closes/stops Client-owned resources exactly once, and never shuts down caller-owned Dask/Spark resources
- preserve same-master Spark idempotence and reject unprovable active-master switches
- isolate test-owned local Dask clusters from the unused Bokeh dashboard so teardown does not leak into later tests

## Review decision
The maintainer confirmed the post-commit cleanup boundary and the explicit terminal scheduler shutdown API. No unresolved scheduler ownership or lifecycle decision remains.

## Verification
- focused scheduler and missing-optional-dependency contracts: 60 passed
- real Python 3.13 / Java 17 Dask-Spark client suite: 27 passed
- Dask distributed integration subset: 9 passed
- CI-order Dask distributed + client lifecycle regression: 36 passed
- integrated scheduler/database lifecycle suite: 134 passed
- GitHub Actions on `ff6d69b3`: CMake, Docker, Python 3.10/3.13, code-format, dependency alignment, and packaging all succeeded
- Black, Python 3.12/3.13 `py_compile`, and `git diff --check`: passed

Fixes #786