### PR TITLE
Move Anaconda credentials out of conda image builds

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -27,15 +27,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
           
-      - name: Build and publish conda package arm64
+      - name: Build and export conda package arm64
         uses: docker/build-push-action@v7
         with:
           context: .
           file: scripts/Dockerfile_conda_build
           platforms: linux/arm64
+          target: package
+          outputs: type=local,dest=${{ runner.temp }}/conda-package
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
-            ANACONDA_API_TOKEN=${{ secrets.CONDA_TOKEN }}
+
+      - name: Install Anaconda upload client
+        shell: bash
+        run: |
+          python3 -m venv "${RUNNER_TEMP}/anaconda-client"
+          "${RUNNER_TEMP}/anaconda-client/bin/pip" install anaconda-client
+
+      - name: Upload conda package arm64
+        shell: bash
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.CONDA_TOKEN }}
+        run: |
+          scripts/upload_conda_package.sh \
+            "${RUNNER_TEMP}/conda-package" \
+            "${{ matrix.python-version }}" \
+            "${RUNNER_TEMP}/anaconda-client/bin/anaconda"
 
   conda-build-amd64:
     runs-on: ubuntu-latest
@@ -51,15 +68,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
           
-      - name: Build and publish conda package amd64
+      - name: Build and export conda package amd64
         uses: docker/build-push-action@v7
         with:
           context: .
           file: scripts/Dockerfile_conda_build
           platforms: linux/amd64
+          target: package
+          outputs: type=local,dest=${{ runner.temp }}/conda-package
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
-            ANACONDA_API_TOKEN=${{ secrets.CONDA_TOKEN }}
+
+      - name: Install Anaconda upload client
+        shell: bash
+        run: |
+          python3 -m venv "${RUNNER_TEMP}/anaconda-client"
+          "${RUNNER_TEMP}/anaconda-client/bin/pip" install anaconda-client
+
+      - name: Upload conda package amd64
+        shell: bash
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.CONDA_TOKEN }}
+        run: |
+          scripts/upload_conda_package.sh \
+            "${RUNNER_TEMP}/conda-package" \
+            "${{ matrix.python-version }}" \
+            "${RUNNER_TEMP}/anaconda-client/bin/anaconda"
 
   conda-build-osx:
       runs-on: ${{ matrix.os }}
@@ -90,18 +124,26 @@ jobs:
             activate-environment: ""
             auto-activate: true
 
-        - name: Build and Upload
+        - name: Install conda build and upload clients
+          shell: bash -el {0}
+          run: conda install -n base -y conda-build anaconda-client
+
+        - name: Build conda package
+          id: build_package
+          shell: bash -el {0}
+          run: |
+            export PYTHON_VERSION=${{ matrix.python-version }}
+            conda config --set anaconda_upload no
+            PACKAGE_PATH=$(conda build . --python ${{ matrix.python-version }} --output)
+            conda build . --python ${{ matrix.python-version }}
+            printf 'package_path=%s\n' "$PACKAGE_PATH" >> "$GITHUB_OUTPUT"
+
+        - name: Upload conda package osx
           shell: bash -el {0}
           env:
             ANACONDA_API_TOKEN: ${{ secrets.CONDA_TOKEN }}
           run: |
-            export PYTHON_VERSION=${{ matrix.python-version }}
-            conda install -n base -y conda-build anaconda-client
-            conda config --set anaconda_upload no
-            PACKAGE_PATH=$(conda build . --python ${{ matrix.python-version }} --output)
-            conda build . --python ${{ matrix.python-version }}
-            if [ "${{ matrix.python-version }}" == "3.13" ]; then
-              anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label main --label py${{ matrix.python-version }} --force
-            else
-              anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label py${{ matrix.python-version }} --force
-            fi
+            scripts/upload_conda_package.sh \
+              "${{ steps.build_package.outputs.package_path }}" \
+              "${{ matrix.python-version }}" \
+              "$(command -v anaconda)"

--- a/python/tests/test_conda_secret_boundary.py
+++ b/python/tests/test_conda_secret_boundary.py
@@ -1,0 +1,257 @@
+import os
+from pathlib import Path
+import re
+import subprocess
+from uuid import uuid4
+
+import pytest
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "conda-build.yml"
+DOCKERFILE_PATH = REPOSITORY_ROOT / "scripts" / "Dockerfile_conda_build"
+UPLOAD_SCRIPT = REPOSITORY_ROOT / "scripts" / "upload_conda_package.sh"
+
+
+def _secret_paths(value, path=()):
+    paths = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            paths.extend(_secret_paths(child, path + (str(key),)))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            paths.extend(_secret_paths(child, path + (str(index),)))
+    elif isinstance(value, str) and "secrets.CONDA_TOKEN" in value:
+        paths.append(path)
+    return paths
+
+
+def test_docker_build_and_export_have_no_credential_input():
+    dockerfile = DOCKERFILE_PATH.read_text()
+    assert "ANACONDA_API_TOKEN" not in dockerfile
+    assert "CONDA_TOKEN" not in dockerfile
+    assert not re.search(r"\banaconda\b.*\bupload\b", dockerfile)
+    assert not re.search(r"^ARG\s+\S*TOKEN", dockerfile, flags=re.MULTILINE)
+    assert dockerfile.rstrip().endswith(
+        "FROM scratch AS package\nCOPY --from=build /conda-package/ /"
+    )
+
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
+    for job_name in ("conda-build-arm64", "conda-build-amd64"):
+        steps = workflow["jobs"][job_name]["steps"]
+        build_step = next(
+            step for step in steps if step.get("uses") == "docker/build-push-action@v7"
+        )
+        serialized_build = yaml.safe_dump(build_step)
+        assert "CONDA_TOKEN" not in serialized_build
+        assert "ANACONDA_API_TOKEN" not in serialized_build
+        assert build_step["with"]["target"] == "package"
+        assert build_step["with"]["outputs"].startswith("type=local,dest=")
+        assert build_step["with"]["build-args"].strip().startswith("PYTHON_VERSION=")
+
+
+def test_conda_secret_is_scoped_only_to_host_upload_steps():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
+    secret_paths = _secret_paths(workflow)
+    assert len(secret_paths) == 3
+
+    for job_name, job in workflow["jobs"].items():
+        assert "env" not in job
+        upload_steps = [
+            step for step in job["steps"] if step.get("name", "").startswith("Upload ")
+        ]
+        assert len(upload_steps) == 1, job_name
+        upload_step = upload_steps[0]
+        assert upload_step["env"] == {
+            "ANACONDA_API_TOKEN": "${{ secrets.CONDA_TOKEN }}"
+        }
+        assert "upload_conda_package.sh" in upload_step["run"]
+
+        for step in job["steps"]:
+            if step is upload_step:
+                continue
+            assert "secrets.CONDA_TOKEN" not in yaml.safe_dump(step)
+            assert "ANACONDA_API_TOKEN" not in yaml.safe_dump(step)
+
+
+def test_each_package_is_built_before_its_upload_step():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
+    for job_name, job in workflow["jobs"].items():
+        steps = job["steps"]
+        upload_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name", "").startswith("Upload ")
+        )
+        if job_name == "conda-build-osx":
+            build_index = next(
+                index
+                for index, step in enumerate(steps)
+                if step.get("name") == "Build conda package"
+            )
+            assert "conda build" in steps[build_index]["run"]
+            assert "export PYTHON_VERSION=" in steps[build_index]["run"]
+            assert (
+                '"${{ steps.build_package.outputs.package_path }}"'
+                in steps[upload_index]["run"]
+            )
+        else:
+            build_index = next(
+                index
+                for index, step in enumerate(steps)
+                if step.get("uses") == "docker/build-push-action@v7"
+            )
+            assert steps[build_index]["with"]["outputs"] == (
+                "type=local,dest=${{ runner.temp }}/conda-package"
+            )
+            assert '"${RUNNER_TEMP}/conda-package"' in steps[upload_index]["run"]
+        assert build_index < upload_index
+        assert "conda build" not in steps[upload_index]["run"]
+
+
+def _fake_anaconda(tmp_path):
+    executable = tmp_path / "anaconda"
+    executable.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        '[[ "$ANACONDA_API_TOKEN" == "$EXPECTED_TOKEN" ]]\n'
+        'printf \'%s\\n\' "$@" > "$CAPTURE_FILE"\n'
+    )
+    executable.chmod(0o755)
+    return executable
+
+
+@pytest.mark.parametrize(
+    "python_version,expected_labels,use_directory",
+    (
+        ("3.12", ["--label", "py3.12"], False),
+        ("3.13", ["--label", "main", "--label", "py3.13"], True),
+    ),
+)
+def test_upload_script_calls_a_mock_client_without_logging_the_token(
+    tmp_path, python_version, expected_labels, use_directory
+):
+    sentinel = "mspass-conda-secret-" + uuid4().hex
+    package_dir = tmp_path / "artifact"
+    package_dir.mkdir()
+    package = package_dir / "mspass-package.conda"
+    package.write_bytes(b"credential-free package")
+    (package_dir / "build-metadata.txt").write_text("credential-free metadata")
+    assert sentinel.encode() not in package.read_bytes()
+    source = package_dir if use_directory else package
+    capture = tmp_path / "client-arguments"
+    environment = os.environ.copy()
+    environment.update(
+        ANACONDA_API_TOKEN=sentinel,
+        EXPECTED_TOKEN=sentinel,
+        CAPTURE_FILE=str(capture),
+    )
+
+    result = subprocess.run(
+        [
+            str(UPLOAD_SCRIPT),
+            str(source),
+            python_version,
+            str(_fake_anaconda(tmp_path)),
+        ],
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert sentinel not in result.stdout
+    assert sentinel not in result.stderr
+    assert capture.read_text().splitlines() == [
+        "upload",
+        str(package),
+        *expected_labels,
+        "--force",
+    ]
+    assert sentinel not in capture.read_text()
+
+
+@pytest.mark.parametrize("package_count", (0, 2))
+def test_upload_script_rejects_an_ambiguous_artifact_before_client_call(
+    tmp_path, package_count
+):
+    package_dir = tmp_path / "artifact"
+    package_dir.mkdir()
+    for index in range(package_count):
+        (package_dir / f"package-{index}.conda").write_bytes(b"package")
+    capture = tmp_path / "client-arguments"
+    environment = os.environ.copy()
+    environment.update(
+        ANACONDA_API_TOKEN="test-token",
+        EXPECTED_TOKEN="test-token",
+        CAPTURE_FILE=str(capture),
+    )
+
+    result = subprocess.run(
+        [
+            str(UPLOAD_SCRIPT),
+            str(package_dir),
+            "3.13",
+            str(_fake_anaconda(tmp_path)),
+        ],
+        env=environment,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert f"expected exactly one conda package, found {package_count}" in result.stderr
+    assert not capture.exists()
+
+
+def test_upload_script_rejects_a_non_package_file_before_client_call(tmp_path):
+    wrong_artifact = tmp_path / "not-a-package.txt"
+    wrong_artifact.write_bytes(b"not a conda package")
+    capture = tmp_path / "client-arguments"
+    environment = os.environ.copy()
+    environment.update(
+        ANACONDA_API_TOKEN="test-token",
+        EXPECTED_TOKEN="test-token",
+        CAPTURE_FILE=str(capture),
+    )
+
+    result = subprocess.run(
+        [
+            str(UPLOAD_SCRIPT),
+            str(wrong_artifact),
+            "3.13",
+            str(_fake_anaconda(tmp_path)),
+        ],
+        env=environment,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert "package source is not a conda package" in result.stderr
+    assert not capture.exists()
+
+
+def test_upload_script_requires_the_token_before_client_call(tmp_path):
+    package = tmp_path / "package.conda"
+    package.write_bytes(b"package")
+    capture = tmp_path / "client-arguments"
+    environment = os.environ.copy()
+    environment.pop("ANACONDA_API_TOKEN", None)
+    environment["CAPTURE_FILE"] = str(capture)
+
+    result = subprocess.run(
+        [
+            str(UPLOAD_SCRIPT),
+            str(package),
+            "3.13",
+            str(_fake_anaconda(tmp_path)),
+        ],
+        env=environment,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode != 0
+    assert "ANACONDA_API_TOKEN is required" in result.stderr
+    assert not capture.exists()

--- a/scripts/Dockerfile_conda_build
+++ b/scripts/Dockerfile_conda_build
@@ -1,6 +1,6 @@
-FROM continuumio/miniconda3:latest
+FROM continuumio/miniconda3:latest AS build
 
-RUN conda install -n base -y conda-build anaconda-client && \
+RUN conda install -n base -y conda-build && \
     conda config --add channels conda-forge && \
     conda config --set anaconda_upload no && \
     conda clean -afy
@@ -11,7 +11,6 @@ RUN mv /mspass /mspasspy_build && cd /mspasspy_build && git status
 
 ARG PYTHON_VERSION
 ARG TARGETARCH
-ARG ANACONDA_API_TOKEN
 
 ENV PATH /opt/conda/bin:$PATH
 ENV MSPASS_BOOST_ROOT=/tmp/mspass-boost-1.86.0
@@ -25,6 +24,8 @@ RUN cd /mspasspy_build \
     && export CONDA_BUILD_DEBUG=1 \
     && PACKAGE_PATH=$(conda build . --python ${PYTHON_VERSION} --output) \
     && conda build . --python ${PYTHON_VERSION} --debug \
-    && if [ "$PYTHON_VERSION" = "3.13" ]; then \
-       anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label main --label py${PYTHON_VERSION} --force ; \
-       else anaconda -t $ANACONDA_API_TOKEN upload $PACKAGE_PATH --label py${PYTHON_VERSION} --force ; fi
+    && mkdir -p /conda-package \
+    && cp "$PACKAGE_PATH" /conda-package/
+
+FROM scratch AS package
+COPY --from=build /conda-package/ /

--- a/scripts/upload_conda_package.sh
+++ b/scripts/upload_conda_package.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 PACKAGE_OR_DIRECTORY PYTHON_VERSION ANACONDA_COMMAND" >&2
+  exit 2
+fi
+
+package_source=$1
+python_version=$2
+anaconda_command=$3
+: "${ANACONDA_API_TOKEN:?ANACONDA_API_TOKEN is required}"
+
+packages=()
+if [[ -f "$package_source" ]]; then
+  if [[ "$package_source" == *.conda || "$package_source" == *.tar.bz2 ]]; then
+    packages=("$package_source")
+  else
+    echo "package source is not a conda package: $package_source" >&2
+    exit 1
+  fi
+elif [[ -d "$package_source" ]]; then
+  while IFS= read -r -d '' package; do
+    packages+=("$package")
+  done < <(
+    find "$package_source" -type f \
+      \( -name '*.conda' -o -name '*.tar.bz2' \) -print0
+  )
+else
+  echo "package source does not exist: $package_source" >&2
+  exit 1
+fi
+
+if [[ ${#packages[@]} -ne 1 ]]; then
+  echo "expected exactly one conda package, found ${#packages[@]}" >&2
+  exit 1
+fi
+
+labels=(--label "py${python_version}")
+if [[ "$python_version" == "3.13" ]]; then
+  labels=(--label main "${labels[@]}")
+fi
+
+"$anaconda_command" upload "${packages[0]}" \
+  "${labels[@]}" --force


### PR DESCRIPTION
Closes #792.

Moves conda package upload to credential-scoped host workflow steps. Docker builds now export one credential-free package artifact, while a shared helper validates the artifact and lets `anaconda-client` read `ANACONDA_API_TOKEN` only from the upload-step environment. The macOS build preserves the selected Python version and passes its exact package path through `GITHUB_OUTPUT`.

Validation:
- contract tests: 9 passed; exact master baseline: 9 failed
- workflow YAML and all shell run blocks: `bash -n` passed
- helper `bash -n`, Black, `py_compile`, and `git diff --check`: passed
- conda render preserved Python 3.13 host/run dependencies

Independent agent review: PASS after fixing non-package-file validation and the macOS Python-version regression.

Docker daemon access is unavailable in the review environment, so no local Buildx/history claim is made; CI is expected to exercise the real builds.