### PR TITLE
Harden Compose authentication and credentials

### DIFF
--- a/data/yaml/compose.yaml
+++ b/data/yaml/compose.yaml
@@ -5,12 +5,15 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 27017:27017
+      - "127.0.0.1:27017:27017"
     environment:
       MSPASS_ROLE: db
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MONGODB_PORT: 27017
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet 
+      test: ["CMD-SHELL", "mongosh --host 127.0.0.1 --port 27017 admin --quiet --eval 'const enabled = [\"true\", \"1\", \"yes\"].includes((process.env.MSPASS_MONGO_AUTH || \"\").toLowerCase()); if (enabled && !db.auth(process.env.MONGO_INITDB_ROOT_USERNAME, process.env.MONGO_INITDB_ROOT_PASSWORD)) { quit(1); } if (!db.runCommand({ping: 1}).ok) { quit(1); }'"]
       interval: 10s
       timeout: 60s
       retries: 5
@@ -21,8 +24,8 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 8786:8786
-      - 8787:8787
+      - "127.0.0.1:8786:8786"
+      - "127.0.0.1:8787:8787"
     environment:
       MSPASS_ROLE: scheduler
       MSPASS_SCHEDULER: dask
@@ -56,7 +59,7 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 8888:8888
+      - "127.0.0.1:8888:8888"
     depends_on:
       mspass-db:
         condition: service_started
@@ -67,5 +70,8 @@ services:
       MSPASS_SCHEDULER: dask
       MSPASS_SCHEDULER_ADDRESS: mspass-scheduler
       MSPASS_DB_ADDRESS: mspass-db
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MSPASS_JUPYTER_PWD: mspass
       JUPYTER_PORT: 8888

--- a/data/yaml/docker-compose_sharding.yaml
+++ b/data/yaml/docker-compose_sharding.yaml
@@ -7,16 +7,19 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 27017:27017
+      - "127.0.0.1:27017:27017"
     depends_on:
       - mspass-shard-0
       - mspass-shard-1
     environment:
       MSPASS_ROLE: dbmanager
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MSPASS_SHARD_LIST: rs0/mspass-shard-0:27017 rs1/mspass-shard-1:27017
       MONGODB_PORT: 27017
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet 
+      test: ["CMD-SHELL", "mongosh --host 127.0.0.1 --port 27017 admin --quiet --eval 'const enabled = [\"true\", \"1\", \"yes\"].includes((process.env.MSPASS_MONGO_AUTH || \"\").toLowerCase()); if (enabled && !db.auth(process.env.MONGO_INITDB_ROOT_USERNAME, process.env.MONGO_INITDB_ROOT_PASSWORD)) { quit(1); } if (!db.runCommand({ping: 1}).ok) { quit(1); }'"]
       interval: 10s
       timeout: 60s
       retries: 5
@@ -29,11 +32,14 @@ services:
       - "${PWD}/:/home"
     environment:
       MSPASS_ROLE: shard
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MSPASS_SHARD_ID: 0
       MONGODB_PORT: 27017
       SHARD_DB_PATH: scratch
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet 
+      test: ["CMD-SHELL", "mongosh --host 127.0.0.1 --port 27017 admin --quiet --eval 'const enabled = [\"true\", \"1\", \"yes\"].includes((process.env.MSPASS_MONGO_AUTH || \"\").toLowerCase()); if (enabled && !db.auth(process.env.MONGO_INITDB_ROOT_USERNAME, process.env.MONGO_INITDB_ROOT_PASSWORD)) { quit(1); } if (!db.runCommand({ping: 1}).ok) { quit(1); }'"]
       interval: 10s
       timeout: 60s
       retries: 5
@@ -46,11 +52,14 @@ services:
       - "${PWD}/:/home"
     environment:
       MSPASS_ROLE: shard
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MSPASS_SHARD_ID: 1
       MONGODB_PORT: 27017
       SHARD_DB_PATH: scratch
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      test: ["CMD-SHELL", "mongosh --host 127.0.0.1 --port 27017 admin --quiet --eval 'const enabled = [\"true\", \"1\", \"yes\"].includes((process.env.MSPASS_MONGO_AUTH || \"\").toLowerCase()); if (enabled && !db.auth(process.env.MONGO_INITDB_ROOT_USERNAME, process.env.MONGO_INITDB_ROOT_PASSWORD)) { quit(1); } if (!db.runCommand({ping: 1}).ok) { quit(1); }'"]
       interval: 10s
       timeout: 60s
       retries: 5
@@ -61,7 +70,7 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 8786:8786
+      - "127.0.0.1:8786:8786"
     environment:
       MSPASS_ROLE: scheduler
       MSPASS_SCHEDULER: dask
@@ -94,7 +103,7 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 8888:8888
+      - "127.0.0.1:8888:8888"
     depends_on:
       mspass-dbmanager:
         condition: service_started
@@ -105,5 +114,8 @@ services:
       MSPASS_SCHEDULER: dask
       MSPASS_SCHEDULER_ADDRESS: mspass-scheduler
       MSPASS_DB_ADDRESS: mspass-dbmanager
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MSPASS_JUPYTER_PWD: mspass
       JUPYTER_PORT: 8888

--- a/data/yaml/docker-compose_spark.yaml
+++ b/data/yaml/docker-compose_spark.yaml
@@ -5,12 +5,15 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 27017:27017
+      - "127.0.0.1:27017:27017"
     environment:
       MSPASS_ROLE: db
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MONGODB_PORT: 27017
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet 
+      test: ["CMD-SHELL", "mongosh --host 127.0.0.1 --port 27017 admin --quiet --eval 'const enabled = [\"true\", \"1\", \"yes\"].includes((process.env.MSPASS_MONGO_AUTH || \"\").toLowerCase()); if (enabled && !db.auth(process.env.MONGO_INITDB_ROOT_USERNAME, process.env.MONGO_INITDB_ROOT_PASSWORD)) { quit(1); } if (!db.runCommand({ping: 1}).ok) { quit(1); }'"]
       interval: 10s
       timeout: 60s
       retries: 5
@@ -21,7 +24,7 @@ services:
     volumes:
       - "${PWD}:/home"
     ports:
-      - 7077:7077
+      - "127.0.0.1:7077:7077"
     environment:
       MSPASS_ROLE: scheduler
       MSPASS_SCHEDULER: spark
@@ -50,7 +53,7 @@ services:
     volumes:
       - "${PWD}:/home"
     ports:
-      - 8888:8888
+      - "127.0.0.1:8888:8888"
     depends_on:
       mspass-db:
         condition: service_healthy
@@ -61,5 +64,8 @@ services:
       MSPASS_SCHEDULER: spark
       MSPASS_SCHEDULER_ADDRESS: mspass-scheduler
       MSPASS_DB_ADDRESS: mspass-db
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MSPASS_JUPYTER_PWD: mspass
       JUPYTER_PORT: 8888

--- a/docs/source/getting_started/command_line_desktop.rst
+++ b/docs/source/getting_started/command_line_desktop.rst
@@ -335,14 +335,13 @@ sensitive files outside that directory, and use normal host backups.
 Network and credential safety
 -----------------------------
 
-The simple commands on this page and the shipped ``data/yaml/compose.yaml``
-publish their ports on the host interfaces.  The Compose example also uses
-the known Jupyter password ``mspass`` and does not configure MongoDB
-authentication.  Treat these as local or trusted-network examples.  On an
-untrusted network, bind published ports to loopback (for example,
-``127.0.0.1:8888:8888``) and choose a private Jupyter password.  The
-:ref:`Compose deployment guide <deploy_mspass_with_docker_compose>` explains
-those changes.
+The simple ``docker run`` commands on this page publish their ports on all host
+interfaces and should be treated as local or trusted-network examples.  The
+shipped ``data/yaml/compose.yaml`` instead binds every published port to
+``127.0.0.1``.  It retains the local research defaults: the Jupyter password is
+``mspass`` and MongoDB authentication is disabled.  The :ref:`Compose
+deployment guide <deploy_mspass_with_docker_compose>` documents how to opt in
+to MongoDB authentication when it is useful.
 
 Treat a Jupyter token or password as a credential.  Do not post a token-bearing
 URL in a shared log or expose the service ports through a firewall without an

--- a/docs/source/getting_started/deploy_mspass_with_docker_compose.rst
+++ b/docs/source/getting_started/deploy_mspass_with_docker_compose.rst
@@ -65,10 +65,13 @@ other important variables describe the scheduler and connect the services:
   to the cluster.  Each entry has the form ``name/host:port``.
 * ``MSPASS_SHARD_ID`` gives each shard a unique identity and keeps its data
   separate when shards share a mounted filesystem.
-* ``MSPASS_JUPYTER_PWD`` optionally sets the Jupyter password.  If it is
-  unset, Jupyter generates a login token and prints it in the frontend log.
-  An empty value permits access without a password and should be used only in
-  an appropriately protected environment.
+* ``MSPASS_MONGO_AUTH`` enables MongoDB authentication when set to ``true``.
+  It is ``false`` by default so existing local research workflows continue to
+  run without MongoDB credentials.
+* ``MONGO_INITDB_ROOT_USERNAME`` and ``MONGO_INITDB_ROOT_PASSWORD`` are
+  required only when ``MSPASS_MONGO_AUTH=true``.
+* ``MSPASS_JUPYTER_PWD`` optionally sets the Jupyter password.  The supplied
+  Compose files retain the historical ``mspass`` default.
 
 Several port variables are also available: ``JUPYTER_PORT`` defaults to
 ``8888``, ``DASK_SCHEDULER_PORT`` to ``8786``, ``SPARK_MASTER_PORT`` to
@@ -117,7 +120,8 @@ log with:
 
 Open ``http://127.0.0.1:8888/`` in a browser and enter the password
 ``mspass``.  The Dask dashboard is available at
-``http://127.0.0.1:8787/status``.
+``http://127.0.0.1:8787/status``.  All published service ports in the supplied
+files are bound to the host loopback interface.
 
 When finished, stop and remove the containers with:
 
@@ -132,16 +136,30 @@ scripts create ``db/`` for MongoDB data, ``logs/`` for service logs, and
 Common adjustments
 ------------------
 
-The supplied file is intended for local use.  It publishes service ports on
-all host interfaces, uses the known Jupyter password ``mspass``, and does not
-enable MongoDB authentication.  On an untrusted network, choose a private
-Jupyter password and bind published ports to loopback; for example, change
-``8888:8888`` to ``127.0.0.1:8888:8888``.
+The supplied files bind every published service port to ``127.0.0.1`` and do
+not enable MongoDB authentication by default.  This preserves the existing
+low-friction behavior for a local research workstation.  To opt in, define all
+three authentication variables before starting Compose:
+
+.. code-block:: bash
+
+   export MSPASS_MONGO_AUTH=true
+   export MONGO_INITDB_ROOT_USERNAME=mspass
+   read -r -s -p "MongoDB password: " MONGO_INITDB_ROOT_PASSWORD
+   echo
+   export MONGO_INITDB_ROOT_PASSWORD
+   docker compose up -d
+
+When authentication is enabled, the database, health checks, and frontend use
+the same credentials.  Keep them private.  Review firewall and authentication
+requirements separately before changing a binding to a non-loopback host
+address.
 
 Other common changes are:
 
 * Change the host side of a port mapping if a port is already in use.  For
-  example, ``9999:8888`` makes JupyterLab available on host port ``9999``.
+  example, ``127.0.0.1:9999:8888`` makes JupyterLab available on host port
+  ``9999`` without publishing it on other host interfaces.
 * Adjust ``MSPASS_WORKER_ARG`` to change the number of Dask worker processes.
   Do not request more CPU or memory than Docker has available.
 * Add the same bind mount to every service that needs access to waveform data

--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -35,6 +35,10 @@ else:
 from mspasspy.ccore.utility import MsPASSError
 
 
+def _env_flag_true(value):
+    return isinstance(value, str) and value.lower() in ("true", "1", "yes")
+
+
 def _require_pyspark():
     if _mspasspy_has_pyspark:
         return
@@ -222,6 +226,9 @@ class Client:
         # check env variables
         MSPASS_DB_ADDRESS = os.environ.get("MSPASS_DB_ADDRESS")
         MONGODB_PORT = os.environ.get("MONGODB_PORT")
+        MSPASS_MONGO_AUTH = os.environ.get("MSPASS_MONGO_AUTH", "false")
+        MONGO_INITDB_ROOT_USERNAME = os.environ.get("MONGO_INITDB_ROOT_USERNAME")
+        MONGO_INITDB_ROOT_PASSWORD = os.environ.get("MONGO_INITDB_ROOT_PASSWORD")
         MSPASS_SCHEDULER = os.environ.get("MSPASS_SCHEDULER")
         MSPASS_SCHEDULER_ADDRESS = os.environ.get("MSPASS_SCHEDULER_ADDRESS")
         DASK_SCHEDULER_PORT = os.environ.get("DASK_SCHEDULER_PORT")
@@ -243,6 +250,7 @@ class Client:
 
         # create a database client
         # priority: parameter -> env -> default
+        database_client_options = {}
         if database_host:
             database_address = database_host
         elif MSPASS_DB_ADDRESS:
@@ -250,9 +258,26 @@ class Client:
         else:
             database_address = "127.0.0.1"
         database_address = _build_database_address(database_address, MONGODB_PORT)
+        if (
+            _env_flag_true(MSPASS_MONGO_AUTH)
+            and MONGO_INITDB_ROOT_USERNAME
+            and MONGO_INITDB_ROOT_PASSWORD
+        ):
+            parsed_database_address = (
+                urlsplit(database_address) if "://" in database_address else None
+            )
+            if (
+                parsed_database_address is None
+                or parsed_database_address.username is None
+            ):
+                database_client_options = {
+                    "username": MONGO_INITDB_ROOT_USERNAME,
+                    "password": MONGO_INITDB_ROOT_PASSWORD,
+                    "authSource": "admin",
+                }
 
         try:
-            self._db_client = DBClient(database_address)
+            self._db_client = DBClient(database_address, **database_client_options)
             self._db_client.server_info()
         except Exception as err:
             raise MsPASSError(

--- a/python/tests/test_compose_security.py
+++ b/python/tests/test_compose_security.py
@@ -1,0 +1,722 @@
+import json
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPOSITORY_ROOT = Path(
+    os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
+)
+COMPOSE_FILES = (
+    REPOSITORY_ROOT / "data" / "yaml" / "compose.yaml",
+    REPOSITORY_ROOT / "data" / "yaml" / "docker-compose_spark.yaml",
+    REPOSITORY_ROOT / "data" / "yaml" / "docker-compose_sharding.yaml",
+    REPOSITORY_ROOT
+    / "scripts"
+    / "IU_examples"
+    / "python"
+    / "configuration_docker.yaml",
+)
+START_MSPASS = REPOSITORY_ROOT / "scripts" / "start-mspass.sh"
+COMPOSE_GUIDES = (
+    REPOSITORY_ROOT
+    / "docs"
+    / "source"
+    / "getting_started"
+    / "deploy_mspass_with_docker_compose.rst",
+    REPOSITORY_ROOT
+    / "docs"
+    / "source"
+    / "getting_started"
+    / "command_line_desktop.rst",
+)
+RUN_REAL_COMPOSE_TESTS = os.environ.get("MSPASS_RUN_COMPOSE_SECURITY_TESTS") == "1"
+
+
+def _compose_config(path, auth=False, username=None, password=None):
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("Docker Compose is required to resolve the configuration")
+    version = subprocess.run(
+        [docker, "compose", "version"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if version.returncode != 0:
+        pytest.skip("Docker Compose is not available in this environment")
+
+    env = os.environ.copy()
+    for key in (
+        "MSPASS_MONGO_AUTH",
+        "MONGO_INITDB_ROOT_USERNAME",
+        "MONGO_INITDB_ROOT_PASSWORD",
+    ):
+        env.pop(key, None)
+    if auth:
+        env["MSPASS_MONGO_AUTH"] = "true"
+    if username is not None:
+        env["MONGO_INITDB_ROOT_USERNAME"] = username
+    if password is not None:
+        env["MONGO_INITDB_ROOT_PASSWORD"] = password
+    return subprocess.run(
+        [docker, "compose", "-f", str(path), "config", "--format", "json"],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("compose_file", COMPOSE_FILES)
+def test_compose_default_preserves_passwordless_mongodb(compose_file):
+    result = _compose_config(compose_file)
+    assert result.returncode == 0, result.stderr
+    config = json.loads(result.stdout)
+
+    for service in config["services"].values():
+        for binding in service.get("ports", []):
+            assert binding["host_ip"] == "127.0.0.1"
+
+    mongo_services = [
+        service
+        for service in config["services"].values()
+        if service.get("environment", {}).get("MSPASS_ROLE")
+        in ("db", "dbmanager", "shard")
+    ]
+    assert mongo_services
+    for service in mongo_services:
+        environment = service["environment"]
+        assert environment["MSPASS_MONGO_AUTH"] == "false"
+        assert environment["MONGO_INITDB_ROOT_USERNAME"] == ""
+        assert environment["MONGO_INITDB_ROOT_PASSWORD"] == ""
+        healthcheck = " ".join(service["healthcheck"]["test"])
+        assert "MSPASS_MONGO_AUTH" in healthcheck
+        assert "db.auth(process.env.MONGO_INITDB_ROOT_USERNAME" in healthcheck
+
+    frontend = config["services"]["mspass-frontend"]["environment"]
+    assert frontend["MSPASS_MONGO_AUTH"] == "false"
+    assert frontend["MSPASS_JUPYTER_PWD"] == "mspass"
+
+
+@pytest.mark.parametrize("compose_file", COMPOSE_FILES)
+def test_compose_supports_explicit_mongodb_authentication(compose_file):
+    result = _compose_config(
+        compose_file,
+        auth=True,
+        username="root user",
+        password="p@ss:/ word",
+    )
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(result.stdout)
+    mongo_roles = ("db", "dbmanager", "shard")
+    for service in config["services"].values():
+        environment = service.get("environment", {})
+        if (
+            environment.get("MSPASS_ROLE") in mongo_roles
+            or environment.get("MSPASS_ROLE") == "frontend"
+        ):
+            assert environment["MSPASS_MONGO_AUTH"] == "true"
+            assert environment["MONGO_INITDB_ROOT_USERNAME"] == "root user"
+            assert environment["MONGO_INITDB_ROOT_PASSWORD"] == "p@ss:/ word"
+
+
+def test_start_script_uses_authentication_without_exposing_plaintext_password():
+    script = START_MSPASS.read_text()
+
+    assert "MONGO_SERVER_SECURITY_ARGS=(--auth)" in script
+    assert "process.env.MONGO_INITDB_ROOT_PASSWORD" in script
+    assert "${MONGO_INITDB_ROOT_PASSWORD}" not in script
+    assert '"${MONGO_CLIENT_AUTH_ARGS[@]}"' in script
+    assert '--password "$MONGO_INITDB_ROOT_PASSWORD"' not in script
+    assert 'quote(os.environ["MONGO_INITDB_ROOT_PASSWORD"]' in script
+
+
+def test_compose_guides_describe_default_and_opt_in_authentication():
+    combined = "\n".join(guide.read_text() for guide in COMPOSE_GUIDES)
+    assert "MSPASS_MONGO_AUTH" in combined
+    assert "MONGO_INITDB_ROOT_USERNAME" in combined
+    assert "MONGO_INITDB_ROOT_PASSWORD" in combined
+    for guide in COMPOSE_GUIDES:
+        text = guide.read_text()
+        assert "``mspass``" in text
+
+
+def _write_executable(path, content):
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def _require_client_dependencies():
+    pytest.importorskip("pymongo")
+    pytest.importorskip("mspasspy.ccore")
+
+
+def _run_start_script(tmp_path, role, extra_environment=None, user_exists=False):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "commands.log"
+    user_state = tmp_path / "root-user-created"
+    if user_exists:
+        user_state.touch()
+    _write_executable(
+        fake_bin / "mongod",
+        "#!/usr/bin/env bash\n"
+        "line=mongod\n"
+        "printf -v arguments ' <%s>' \"$@\"\n"
+        'printf \'%s\\n\' "${line}${arguments}" >> "$COMMAND_LOG"\n',
+    )
+    _write_executable(
+        fake_bin / "mongos",
+        "#!/usr/bin/env bash\n"
+        "line=mongos\n"
+        "printf -v arguments ' <%s>' \"$@\"\n"
+        'printf \'%s\\n\' "${line}${arguments}" >> "$COMMAND_LOG"\n',
+    )
+    _write_executable(
+        fake_bin / "mongosh",
+        """#!/usr/bin/env bash
+line=mongosh
+printf -v arguments ' <%s>' "$@"
+printf '%s\n' "${line}${arguments}" >> "$COMMAND_LOG"
+if [[ "$*" == *'db.createUser'* ]]; then
+  [[ "$MONGO_INITDB_ROOT_USERNAME" == 'root user' ]]
+  [[ "$MONGO_INITDB_ROOT_PASSWORD" == 'p@ss:/ word' ]]
+  [[ ! -f "$MONGO_USER_STATE" ]] || exit 1
+  touch "$MONGO_USER_STATE"
+  exit 0
+fi
+if [[ "$*" == *'connectionStatus'* || "$*" == *'adminCommand({ping: 1})'* ]]; then
+  attempts=0
+  if [[ -f "$MONGO_SERVER_PROBE_STATE" ]]; then
+    attempts=$(<"$MONGO_SERVER_PROBE_STATE")
+  fi
+  printf '%s\n' "$((attempts + 1))" > "$MONGO_SERVER_PROBE_STATE"
+  if ((attempts < ${MONGO_SERVER_FAILURES_BEFORE_READY:-0})); then
+    exit 1
+  fi
+fi
+if [[ "$*" == *'connectionStatus'* ]]; then
+  [[ -f "$MONGO_USER_STATE" ]]
+  exit $?
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "jupyter",
+        "#!/usr/bin/env bash\n"
+        "line=jupyter\n"
+        "printf -v arguments ' <%s>' \"$@\"\n"
+        'printf \'%s\\n\' "${line}${arguments}" >> "$COMMAND_LOG"\n',
+    )
+    _write_executable(
+        fake_bin / "pyspark",
+        "#!/usr/bin/env bash\n"
+        "previous=\n"
+        'for argument in "$@"; do\n'
+        '  if [[ "$previous" = --properties-file ]]; then\n'
+        '    cp -p -- "$argument" "$SPARK_PROPERTIES_CAPTURE"\n'
+        "  fi\n"
+        "  previous=$argument\n"
+        "done\n"
+        "line=pyspark\n"
+        "printf -v arguments ' <%s>' \"$@\"\n"
+        'printf \'%s\\n\' "${line}${arguments}" >> "$COMMAND_LOG"\n',
+    )
+    _write_executable(fake_bin / "tail", "#!/usr/bin/env bash\nexit 0\n")
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "COMMAND_LOG": str(command_log),
+            "HOME": str(tmp_path),
+            "JUPYTER_PORT": "8888",
+            "MONGODB_PORT": "27017",
+            "MONGO_INITDB_ROOT_PASSWORD": "p@ss:/ word",
+            "MONGO_INITDB_ROOT_USERNAME": "root user",
+            "MONGO_SERVER_PROBE_STATE": str(tmp_path / "mongo-server-probes"),
+            "MONGO_USER_STATE": str(user_state),
+            "MSPASS_DB_DIR": str(tmp_path / "db"),
+            "MSPASS_DB_PATH": "scratch",
+            "MSPASS_LOG_DIR": str(tmp_path / "logs"),
+            "MSPASS_MONGO_AUTH": "true",
+            "MSPASS_MONGO_KEYFILE": str(tmp_path / "mongo-keyfile"),
+            "MSPASS_ROLE": role,
+            "MSPASS_SCHEDULER": "dask",
+            "MSPASS_SCHEDULER_ADDRESS": "scheduler",
+            "MSPASS_SLEEP_TIME": "0",
+            "MSPASS_WORK_DIR": str(tmp_path / "work"),
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "SPARK_PROPERTIES_CAPTURE": str(tmp_path / "spark.properties"),
+        }
+    )
+    if extra_environment:
+        environment.update(extra_environment)
+    result = subprocess.run(
+        ["bash", str(START_MSPASS)],
+        capture_output=True,
+        env=environment,
+        text=True,
+        timeout=10,
+    )
+    commands = command_log.read_text().splitlines() if command_log.exists() else []
+    return result, commands, user_state
+
+
+def test_standalone_start_enables_auth_and_initializes_root_user(tmp_path):
+    result, commands, user_state = _run_start_script(tmp_path, "db")
+
+    assert result.returncode == 0, result.stderr
+    assert "p@ss:/ word" not in result.stdout
+    assert "p@ss:/ word" not in result.stderr
+    assert user_state.is_file()
+    mongod_command = next(
+        command for command in commands if command.startswith("mongod")
+    )
+    assert " <--auth>" in mongod_command
+    assert sum("db.createUser" in command for command in commands) == 1
+    authenticated = [command for command in commands if "connectionStatus" in command]
+    assert len(authenticated) == 2
+    assert all(
+        "getSiblingDB" in command and ".auth(process.env" in command
+        for command in authenticated
+    )
+    assert all(" <--password>" not in command for command in authenticated)
+    assert all("p@ss:/ word" not in command for command in authenticated)
+
+
+def test_standalone_restart_authenticates_without_recreating_root_user(tmp_path):
+    result, commands, user_state = _run_start_script(tmp_path, "db", user_exists=True)
+
+    assert result.returncode == 0, result.stderr
+    assert user_state.is_file()
+    assert all("db.createUser" not in command for command in commands)
+    assert sum("connectionStatus" in command for command in commands) == 1
+
+
+def test_standalone_restart_retries_authentication_after_server_becomes_ready(tmp_path):
+    result, commands, user_state = _run_start_script(
+        tmp_path,
+        "db",
+        {"MONGO_SERVER_FAILURES_BEFORE_READY": "2"},
+        user_exists=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert user_state.is_file()
+    assert sum("connectionStatus" in command for command in commands) == 2
+    assert all("db.createUser" not in command for command in commands)
+
+
+def test_start_rejects_missing_auth_credentials_before_mongod(tmp_path):
+    result, commands, _ = _run_start_script(
+        tmp_path,
+        "db",
+        {"MONGO_INITDB_ROOT_PASSWORD": ""},
+    )
+
+    assert result.returncode != 0
+    assert "MONGO_INITDB_ROOT_PASSWORD is required" in result.stderr
+    assert not commands
+
+
+def test_standalone_default_does_not_enable_authentication(tmp_path):
+    result, commands, user_state = _run_start_script(
+        tmp_path,
+        "db",
+        {"MSPASS_MONGO_AUTH": "false"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not user_state.exists()
+    mongod_command = next(
+        command for command in commands if command.startswith("mongod")
+    )
+    assert "--auth" not in mongod_command
+    assert "--keyFile" not in mongod_command
+    assert all("db.createUser" not in command for command in commands)
+
+
+@pytest.mark.parametrize("token", (None, "chosen-token"))
+def test_frontend_preserves_jupyter_password_and_optional_token(tmp_path, token):
+    extra_environment = {
+        "MSPASS_JUPYTER_PWD": "mspass",
+        "MSPASS_MONGO_AUTH": "false",
+    }
+    if token is not None:
+        extra_environment["MSPASS_JUPYTER_TOKEN"] = token
+    result, commands, _ = _run_start_script(tmp_path, "frontend", extra_environment)
+
+    assert result.returncode == 0, result.stderr
+    jupyter_command = next(
+        command for command in commands if command.startswith("jupyter")
+    )
+    if token is None:
+        assert "NotebookApp.token" not in jupyter_command
+    else:
+        assert " <--NotebookApp.token=chosen-token>" in jupyter_command
+    assert "NotebookApp.password" in jupyter_command
+
+
+def test_spark_frontend_keeps_encoded_mongo_credentials_out_of_arguments(tmp_path):
+    result, commands, _ = _run_start_script(
+        tmp_path,
+        "frontend",
+        {
+            "MSPASS_DB_ADDRESS": "mspass-db",
+            "MSPASS_SCHEDULER": "spark",
+            "MSPASS_SCHEDULER_ADDRESS": "scheduler",
+            "SPARK_MASTER_PORT": "7077",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    pyspark_command = next(
+        command for command in commands if command.startswith("pyspark")
+    )
+    expected_uri = (
+        "mongodb://root%20user:p%40ss%3A%2F%20word@mspass-db:27017/"
+        "test.misc?authSource=admin"
+    )
+    properties_file = tmp_path / "spark.properties"
+    assert properties_file.stat().st_mode & 0o777 == 0o600
+    properties = properties_file.read_text()
+    assert properties.count(expected_uri) == 2
+    assert "spark.redaction.regex" in properties
+    assert " <--properties-file>" in pyspark_command
+    assert expected_uri not in pyspark_command
+    assert "p@ss:/ word" not in pyspark_command
+    assert "p@ss:/ word" not in result.stdout
+    assert "p@ss:/ word" not in result.stderr
+
+
+def test_spark_frontend_preserves_passwordless_mongodb_arguments_by_default(tmp_path):
+    result, commands, _ = _run_start_script(
+        tmp_path,
+        "frontend",
+        {
+            "MSPASS_DB_ADDRESS": "mspass-db",
+            "MSPASS_MONGO_AUTH": "false",
+            "MSPASS_SCHEDULER": "spark",
+            "MSPASS_SCHEDULER_ADDRESS": "scheduler",
+            "SPARK_MASTER_PORT": "7077",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    pyspark_command = next(
+        command for command in commands if command.startswith("pyspark")
+    )
+    assert " <--properties-file>" not in pyspark_command
+    assert (
+        "spark.mongodb.input.uri=mongodb://mspass-db:27017/test.misc" in pyspark_command
+    )
+    assert (
+        "spark.mongodb.output.uri=mongodb://mspass-db:27017/test.misc"
+        in pyspark_command
+    )
+
+
+@pytest.mark.parametrize(
+    ("role", "extra_environment"),
+    (
+        (
+            "dbmanager",
+            {
+                "MSPASS_SHARD_LIST": "rs0/shard0:27017",
+            },
+        ),
+        (
+            "shard",
+            {
+                "MSPASS_SHARD_ID": "0",
+            },
+        ),
+    ),
+)
+def test_sharded_roles_use_a_shared_keyfile_and_authenticated_clients(
+    tmp_path, role, extra_environment
+):
+    result, commands, user_state = _run_start_script(tmp_path, role, extra_environment)
+
+    assert result.returncode == 0, result.stderr
+    assert user_state.is_file()
+    server_commands = [
+        command
+        for command in commands
+        if command.startswith("mongod <") or command.startswith("mongos <")
+    ]
+    assert server_commands
+    assert all(" <--keyFile>" in command for command in server_commands)
+    keyfile = tmp_path / "mongo-keyfile"
+    assert keyfile.is_file()
+    assert keyfile.stat().st_mode & 0o777 == 0o400
+    assert len(keyfile.read_text().strip()) == 64
+    authenticated = [command for command in commands if "getSiblingDB" in command]
+    assert authenticated
+    assert all(".auth(process.env" in command for command in authenticated)
+    assert all(" <--password>" not in command for command in authenticated)
+    if role == "dbmanager":
+        assert any("hello: 1" in command for command in authenticated)
+
+
+def test_client_uses_compose_mongo_credentials(monkeypatch):
+    _require_client_dependencies()
+    from mspasspy.client import Client
+    from mspasspy.db.client import DBClient
+
+    monkeypatch.setenv("MSPASS_DB_ADDRESS", "mspass-db")
+    monkeypatch.setenv("MSPASS_HOME", str(REPOSITORY_ROOT))
+    monkeypatch.setenv("MONGODB_PORT", "27017")
+    monkeypatch.setenv("MSPASS_MONGO_AUTH", "true")
+    monkeypatch.setenv("MONGO_INITDB_ROOT_USERNAME", "root user")
+    monkeypatch.setenv("MONGO_INITDB_ROOT_PASSWORD", "p@ss:/ word")
+    with (
+        mock.patch.object(DBClient, "server_info", return_value={}),
+        mock.patch("mspasspy.client.GlobalHistoryManager"),
+    ):
+        client = Client(scheduler="none")
+
+    assert client._db_client._mspass_db_host == "mspass-db:27017"
+    assert client._db_client._mspass_connection_kwargs == {
+        "username": "root user",
+        "password": "p@ss:/ word",
+        "authSource": "admin",
+    }
+
+
+def test_client_uses_compose_credentials_with_an_explicit_database_host(monkeypatch):
+    _require_client_dependencies()
+    from mspasspy.client import Client
+    from mspasspy.db.client import DBClient
+
+    monkeypatch.setenv("MSPASS_HOME", str(REPOSITORY_ROOT))
+    monkeypatch.setenv("MONGODB_PORT", "27017")
+    monkeypatch.setenv("MSPASS_MONGO_AUTH", "true")
+    monkeypatch.setenv("MONGO_INITDB_ROOT_USERNAME", "root user")
+    monkeypatch.setenv("MONGO_INITDB_ROOT_PASSWORD", "p@ss:/ word")
+    with (
+        mock.patch.object(DBClient, "server_info", return_value={}),
+        mock.patch("mspasspy.client.GlobalHistoryManager"),
+    ):
+        client = Client(database_host="mspass-db", scheduler="none")
+
+    assert client._db_client._mspass_db_host == "mspass-db:27017"
+    assert client._db_client._mspass_connection_kwargs == {
+        "username": "root user",
+        "password": "p@ss:/ word",
+        "authSource": "admin",
+    }
+
+
+def test_explicit_database_uri_credentials_take_priority_over_compose_credentials(
+    monkeypatch,
+):
+    _require_client_dependencies()
+    from mspasspy.client import Client
+    from mspasspy.db.client import DBClient
+
+    monkeypatch.setenv("MSPASS_HOME", str(REPOSITORY_ROOT))
+    monkeypatch.setenv("MSPASS_MONGO_AUTH", "true")
+    monkeypatch.setenv("MONGO_INITDB_ROOT_USERNAME", "root user")
+    monkeypatch.setenv("MONGO_INITDB_ROOT_PASSWORD", "p@ss:/ word")
+    with (
+        mock.patch.object(DBClient, "server_info", return_value={}),
+        mock.patch("mspasspy.client.GlobalHistoryManager"),
+    ):
+        client = Client(
+            database_host="mongodb://explicit:credential@mspass-db:27017",
+            scheduler="none",
+        )
+
+    assert client._db_client._mspass_connection_kwargs == {}
+
+
+def test_client_ignores_compose_credentials_by_default(monkeypatch):
+    _require_client_dependencies()
+    from mspasspy.client import Client
+    from mspasspy.db.client import DBClient
+
+    monkeypatch.setenv("MSPASS_DB_ADDRESS", "mspass-db")
+    monkeypatch.setenv("MSPASS_HOME", str(REPOSITORY_ROOT))
+    monkeypatch.setenv("MONGODB_PORT", "27017")
+    monkeypatch.setenv("MONGO_INITDB_ROOT_USERNAME", "root user")
+    monkeypatch.setenv("MONGO_INITDB_ROOT_PASSWORD", "p@ss:/ word")
+    with (
+        mock.patch.object(DBClient, "server_info", return_value={}),
+        mock.patch("mspasspy.client.GlobalHistoryManager"),
+    ):
+        client = Client(scheduler="none")
+
+    assert client._db_client._mspass_db_host == "mspass-db:27017"
+    assert client._db_client._mspass_connection_kwargs == {}
+
+
+def _real_compose_environment(tmp_path):
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "MSPASS_MONGO_AUTH": "true",
+            "MONGO_INITDB_ROOT_USERNAME": "mspass-compose-test",
+            "MONGO_INITDB_ROOT_PASSWORD": "compose-test-p@ss:/ word",
+            "PWD": str(tmp_path),
+        }
+    )
+    return environment
+
+
+def _run_real_compose(compose_file, project, environment, *arguments, timeout=600):
+    return subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-p",
+            project,
+            "-f",
+            str(compose_file),
+            *arguments,
+        ],
+        cwd=environment["PWD"],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _start_real_compose(compose_file, project, environment):
+    result = _run_real_compose(
+        compose_file,
+        project,
+        environment,
+        "up",
+        "-d",
+        "--wait",
+        "--wait-timeout",
+        "300",
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _stop_real_compose(compose_file, project, environment):
+    _run_real_compose(
+        compose_file,
+        project,
+        environment,
+        "down",
+        "--remove-orphans",
+        "--timeout",
+        "30",
+        timeout=120,
+    )
+
+
+def _real_compose_mongo_service(compose_file):
+    if compose_file.name == "docker-compose_sharding.yaml":
+        return "mspass-dbmanager"
+    return "mspass-db"
+
+
+def _run_authenticated_mongosh(compose_file, project, environment, expression):
+    return _run_real_compose(
+        compose_file,
+        project,
+        environment,
+        "exec",
+        "-T",
+        _real_compose_mongo_service(compose_file),
+        "mongosh",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "27017",
+        "admin",
+        "--quiet",
+        "--eval",
+        "if (!db.auth(process.env.MONGO_INITDB_ROOT_USERNAME, "
+        "process.env.MONGO_INITDB_ROOT_PASSWORD)) { quit(1); }",
+        "--eval",
+        expression,
+    )
+
+
+def _assert_real_compose_authentication(compose_file, project, environment):
+    mongo_service = _real_compose_mongo_service(compose_file)
+    unauthenticated = _run_real_compose(
+        compose_file,
+        project,
+        environment,
+        "exec",
+        "-T",
+        mongo_service,
+        "mongosh",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "27017",
+        "admin",
+        "--quiet",
+        "--eval",
+        "const result = db.adminCommand({listDatabases: 1}); quit(result.ok ? 0 : 13);",
+    )
+    assert unauthenticated.returncode != 0
+
+    authenticated = _run_authenticated_mongosh(
+        compose_file,
+        project,
+        environment,
+        "const result = db.adminCommand({listDatabases: 1}); quit(result.ok ? 0 : 13);",
+    )
+    assert authenticated.returncode == 0, authenticated.stderr
+
+    client = _run_real_compose(
+        compose_file,
+        project,
+        environment,
+        "exec",
+        "-T",
+        "mspass-frontend",
+        "python",
+        "-c",
+        "from mspasspy.client import Client; "
+        "client = Client(scheduler='none'); "
+        "assert client.get_database_client().admin.command('ping')['ok'] == 1",
+    )
+    assert client.returncode == 0, client.stderr
+
+
+@pytest.mark.skipif(
+    not RUN_REAL_COMPOSE_TESTS,
+    reason="set MSPASS_RUN_COMPOSE_SECURITY_TESTS=1 to start real topologies",
+)
+@pytest.mark.parametrize("compose_file", COMPOSE_FILES)
+def test_real_compose_authentication_survives_restart(tmp_path, compose_file):
+    project = "mspass794-" + uuid.uuid4().hex[:10]
+    environment = _real_compose_environment(tmp_path)
+    try:
+        _start_real_compose(compose_file, project, environment)
+        _assert_real_compose_authentication(compose_file, project, environment)
+        stored = _run_authenticated_mongosh(
+            compose_file,
+            project,
+            environment,
+            'db.getSiblingDB("mspass_issue_794").restore.insertOne({_id: "sentinel"})',
+        )
+        assert stored.returncode == 0, stored.stderr
+
+        _stop_real_compose(compose_file, project, environment)
+        _start_real_compose(compose_file, project, environment)
+        _assert_real_compose_authentication(compose_file, project, environment)
+        restored = _run_authenticated_mongosh(
+            compose_file,
+            project,
+            environment,
+            'const value = db.getSiblingDB("mspass_issue_794").restore.findOne({_id: "sentinel"}); quit(value ? 0 : 14)',
+        )
+        assert restored.returncode == 0, restored.stderr
+    finally:
+        _stop_real_compose(compose_file, project, environment)

--- a/scripts/IU_examples/python/configuration_docker.yaml
+++ b/scripts/IU_examples/python/configuration_docker.yaml
@@ -5,12 +5,15 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 27017:27017
+      - "127.0.0.1:27017:27017"
     environment:
       MSPASS_ROLE: db
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MONGODB_PORT: 27017
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet 
+      test: ["CMD-SHELL", "mongosh --host 127.0.0.1 --port 27017 admin --quiet --eval 'const enabled = [\"true\", \"1\", \"yes\"].includes((process.env.MSPASS_MONGO_AUTH || \"\").toLowerCase()); if (enabled && !db.auth(process.env.MONGO_INITDB_ROOT_USERNAME, process.env.MONGO_INITDB_ROOT_PASSWORD)) { quit(1); } if (!db.runCommand({ping: 1}).ok) { quit(1); }'"]
       interval: 10s
       timeout: 60s
       retries: 5
@@ -21,8 +24,8 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 8786:8786
-      - 8787:8787
+      - "127.0.0.1:8786:8786"
+      - "127.0.0.1:8787:8787"
     environment:
       MSPASS_ROLE: scheduler
       MSPASS_SCHEDULER: dask
@@ -56,7 +59,7 @@ services:
     volumes:
       - "${PWD}/:/home"
     ports:
-      - 8888:8888
+      - "127.0.0.1:8888:8888"
     depends_on:
       mspass-db:
         condition: service_started
@@ -67,5 +70,8 @@ services:
       MSPASS_SCHEDULER: dask
       MSPASS_SCHEDULER_ADDRESS: mspass-scheduler
       MSPASS_DB_ADDRESS: mspass-db
+      MSPASS_MONGO_AUTH: "${MSPASS_MONGO_AUTH:-false}"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-}"
       MSPASS_JUPYTER_PWD: mspass
       JUPYTER_PORT: 8888

--- a/scripts/start-mspass.sh
+++ b/scripts/start-mspass.sh
@@ -122,6 +122,103 @@ function build_dask_scheduler_uri {
   fi
 }
 
+function env_flag_true {
+  case "$1" in
+    true|TRUE|True|1|yes|YES|Yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+MONGO_CLIENT_AUTH_ARGS=()
+MONGO_SERVER_SECURITY_ARGS=()
+
+function prepare_mongo_security {
+  if ! env_flag_true "${MSPASS_MONGO_AUTH:-false}"; then
+    return
+  fi
+
+  : "${MONGO_INITDB_ROOT_USERNAME:?MONGO_INITDB_ROOT_USERNAME is required when MongoDB authentication is enabled}"
+  : "${MONGO_INITDB_ROOT_PASSWORD:?MONGO_INITDB_ROOT_PASSWORD is required when MongoDB authentication is enabled}"
+
+  MONGO_CLIENT_AUTH_ARGS=(
+    --eval 'if (!db.getSiblingDB("admin").auth(process.env.MONGO_INITDB_ROOT_USERNAME, process.env.MONGO_INITDB_ROOT_PASSWORD)) { quit(1); }'
+  )
+
+  if [[ "$MSPASS_ROLE" = "dbmanager" || "$MSPASS_ROLE" = "shard" ]]; then
+    local keyfile=${MSPASS_MONGO_KEYFILE:-/tmp/mspass-mongo-keyfile}
+    umask 077
+    printf '%s\0%s' "$MONGO_INITDB_ROOT_USERNAME" "$MONGO_INITDB_ROOT_PASSWORD" \
+      | sha256sum | awk '{print $1}' > "$keyfile"
+    chmod 400 "$keyfile"
+    MONGO_SERVER_SECURITY_ARGS=(--keyFile "$keyfile")
+  else
+    MONGO_SERVER_SECURITY_ARGS=(--auth)
+  fi
+}
+
+function initialize_mongo_root_user {
+  local port="$1"
+  local attempt
+  local max_attempts=20
+  if ! env_flag_true "${MSPASS_MONGO_AUTH:-false}"; then
+    return
+  fi
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if mongosh --host 127.0.0.1 --port "$port" admin \
+      "${MONGO_CLIENT_AUTH_ARGS[@]}" --quiet --eval \
+      'if (!db.runCommand({connectionStatus: 1}).authInfo.authenticatedUsers.length) { quit(1); }'; then
+      return
+    fi
+
+    if mongosh --host 127.0.0.1 --port "$port" --quiet --eval \
+      'if (!db.adminCommand({ping: 1}).ok) { quit(1); }' \
+      && mongosh --host 127.0.0.1 --port "$port" admin --quiet --eval \
+        'db.createUser({user: process.env.MONGO_INITDB_ROOT_USERNAME, pwd: process.env.MONGO_INITDB_ROOT_PASSWORD, roles: [{role: "root", db: "admin"}]})'; then
+      retry_mongosh_command "authenticate MongoDB root user on port ${port}" \
+        --host 127.0.0.1 --port "$port" admin \
+        "${MONGO_CLIENT_AUTH_ARGS[@]}" --quiet --eval \
+        'if (!db.runCommand({connectionStatus: 1}).authInfo.authenticatedUsers.length) { quit(1); }'
+      return
+    fi
+
+    if ((attempt < max_attempts)); then
+      echo "MongoDB authentication on port ${port} is not ready (attempt $attempt/$max_attempts); retrying in ${MSPASS_SLEEP_TIME}s"
+      sleep "$MSPASS_SLEEP_TIME"
+    fi
+  done
+
+  echo "ERROR: MongoDB authentication on port ${port} failed after $max_attempts attempts" >&2
+  return 1
+}
+
+function build_mongodb_spark_uri {
+  if env_flag_true "${MSPASS_MONGO_AUTH:-false}"; then
+    local encoded_credentials
+    encoded_credentials=$(python3 -c \
+      'import os; from urllib.parse import quote; print(quote(os.environ["MONGO_INITDB_ROOT_USERNAME"], safe="") + ":" + quote(os.environ["MONGO_INITDB_ROOT_PASSWORD"], safe="") + "@")')
+    printf 'mongodb://%s%s:%s/test.misc?authSource=admin' \
+      "$encoded_credentials" "$MSPASS_DB_ADDRESS" "$MONGODB_PORT"
+  else
+    printf 'mongodb://%s:%s/test.misc' "$MSPASS_DB_ADDRESS" "$MONGODB_PORT"
+  fi
+}
+
+function create_mongodb_spark_properties {
+  local properties_file
+  local mongodb_spark_uri
+  properties_file=$(mktemp "${TMPDIR:-/tmp}/mspass-spark-mongodb.XXXXXX")
+  mongodb_spark_uri=$(build_mongodb_spark_uri)
+  chmod 600 "$properties_file"
+  {
+    printf 'spark.mongodb.input.uri %s\n' "$mongodb_spark_uri"
+    printf 'spark.mongodb.output.uri %s\n' "$mongodb_spark_uri"
+    printf 'spark.redaction.regex %s\n' \
+      '(?i)secret|password|token|access[.]?key|spark[.]mongodb[.](input|output)[.]uri'
+  } > "$properties_file"
+  printf '%s' "$properties_file"
+}
+
 # define SLEEP_TIME
 if [[ -z $MSPASS_SLEEP_TIME ]]; then
   MSPASS_SLEEP_TIME=15
@@ -153,7 +250,7 @@ function ensure_shard_registered {
   local ensure_script
 
   if ! retry_mongosh_command "shard ${shard_name} primary" \
-    --host "$shard_connection" --quiet --eval \
+    --host "$shard_connection" "${MONGO_CLIENT_AUTH_ARGS[@]}" --quiet --eval \
     'const hello = db.adminCommand({hello: 1}); if (!(hello.isWritablePrimary || hello.ismaster)) { quit(1); }'; then
     return 1
   fi
@@ -174,7 +271,8 @@ function ensure_shard_registered {
     }
   "
   retry_mongosh_command "register shard ${shard_name}" \
-    --host "$HOSTNAME" --port "$MONGODB_PORT" --eval "$ensure_script"
+    --host "$HOSTNAME" --port "$MONGODB_PORT" \
+    "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval "$ensure_script"
 }
 
 # This sets defaults for this set of env variables
@@ -246,6 +344,20 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
       fi
 
       if [ "$MSPASS_SCHEDULER" = "spark" ]; then
+          local mongodb_spark_properties=""
+          local -a mongodb_spark_args
+          if env_flag_true "${MSPASS_MONGO_AUTH:-false}"; then
+              mongodb_spark_properties=$(create_mongodb_spark_properties)
+              if [[ "$RUN_JUPYTER_AS_NB_USER" = "true" ]]; then
+                  chown "${NB_UID:-${NB_USER:-mspass}}:${NB_GID:-100}" "$mongodb_spark_properties"
+              fi
+              mongodb_spark_args=(--properties-file "$mongodb_spark_properties")
+          else
+              mongodb_spark_args=(
+                  --conf "spark.mongodb.input.uri=mongodb://${MSPASS_DB_ADDRESS}:${MONGODB_PORT}/test.misc"
+                  --conf "spark.mongodb.output.uri=mongodb://${MSPASS_DB_ADDRESS}:${MONGODB_PORT}/test.misc"
+              )
+          fi
           if [ -z "$1" ]; then
               # Interactive Jupyter Lab mode for Spark
               export PYSPARK_DRIVER_PYTHON=jupyter
@@ -253,14 +365,12 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
               export PYSPARK_DRIVER_PYTHON_OPTS="lab ${NOTEBOOK_ARGS_STRING}"
               if [[ "$RUN_JUPYTER_AS_NB_USER" = "true" ]]; then
                   run_frontend_as_nb_user pyspark \
-                      --conf "spark.mongodb.input.uri=mongodb://${MSPASS_DB_ADDRESS}:${MONGODB_PORT}/test.misc" \
-                      --conf "spark.mongodb.output.uri=mongodb://${MSPASS_DB_ADDRESS}:${MONGODB_PORT}/test.misc" \
+                      "${mongodb_spark_args[@]}" \
                       --conf "spark.master=spark://${MSPASS_SCHEDULER_ADDRESS}:${SPARK_MASTER_PORT}" \
                       --packages org.mongodb.spark:mongo-spark-connector_2.12:3.0.0
               else
                   pyspark \
-                      --conf "spark.mongodb.input.uri=mongodb://${MSPASS_DB_ADDRESS}:${MONGODB_PORT}/test.misc" \
-                      --conf "spark.mongodb.output.uri=mongodb://${MSPASS_DB_ADDRESS}:${MONGODB_PORT}/test.misc" \
+                      "${mongodb_spark_args[@]}" \
                       --conf "spark.master=spark://${MSPASS_SCHEDULER_ADDRESS}:${SPARK_MASTER_PORT}" \
                       --packages org.mongodb.spark:mongo-spark-connector_2.12:3.0.0
               fi
@@ -275,11 +385,13 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
                   script_file="$input_file"
               fi
               spark-submit \
-                  --conf "spark.mongodb.input.uri=mongodb://${MSPASS_DB_ADDRESS}:${MONGODB_PORT}/test.misc" \
-                  --conf "spark.mongodb.output.uri=mongodb://${MSPASS_DB_ADDRESS}:${MONGODB_PORT}/test.misc" \
+                  "${mongodb_spark_args[@]}" \
                   --conf "spark.master=spark://${MSPASS_SCHEDULER_ADDRESS}:${SPARK_MASTER_PORT}" \
                   --packages org.mongodb.spark:mongo-spark-connector_2.12:3.0.0 \
                   "$script_file"
+          fi
+          if [[ -n "$mongodb_spark_properties" ]]; then
+              rm -f -- "$mongodb_spark_properties"
           fi
       elif [ "$MSPASS_SCHEDULER" = "none" ]; then
           if [ -z "$1" ]; then
@@ -329,7 +441,8 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
   function clean_up_single_node {
     # ---------------------- clean up workflow -------------------------
     # stop mongodb
-    mongosh --port $MONGODB_PORT admin --eval "db.shutdownServer({force:true})"
+    mongosh --port "$MONGODB_PORT" admin "${MONGO_CLIENT_AUTH_ARGS[@]}" \
+      --eval "db.shutdownServer({force:true})"
     sleep 5
     # copy shard data to scratch
     if [ "$MSPASS_DB_PATH" = "tmp" ]; then
@@ -345,7 +458,8 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
   function clean_up_multiple_nodes {
     # ---------------------- clean up workflow -------------------------
     # stop mongos routers
-    mongosh --port $MONGODB_PORT admin --eval "db.shutdownServer({force:true})"
+    mongosh --port "$MONGODB_PORT" admin "${MONGO_CLIENT_AUTH_ARGS[@]}" \
+      --eval "db.shutdownServer({force:true})"
     sleep 5
     # stop each shard replica set
     for i in ${MSPASS_SHARD_ADDRESS[@]}; do
@@ -353,7 +467,8 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
         sleep 5
     done
     # stop config servers
-    mongosh --port $(($MONGODB_PORT+1)) admin --eval "db.shutdownServer({force:true})"
+    mongosh --port $((MONGODB_PORT + 1)) admin \
+      "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval "db.shutdownServer({force:true})"
 
     # copy the shard data to scratch if the shards are deployed in /tmp
     if [ "$MSPASS_DB_PATH" = "tmp" ]; then
@@ -399,7 +514,9 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
 
   function start_db_scratch {
     [[ -d $MONGO_DATA ]] || mkdir -p $MONGO_DATA
-    mongod --port $MONGODB_PORT --dbpath $MONGO_DATA --logpath $MONGO_LOG --bind_ip_all &
+    mongod --port "$MONGODB_PORT" --dbpath "$MONGO_DATA" --logpath "$MONGO_LOG" \
+      --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
+    initialize_mongo_root_user "$MONGODB_PORT" || exit 1
   }
 
   function start_db_tmp {
@@ -417,14 +534,10 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
       cp -r $MSPASS_SCRATCH_DATA_DIR /tmp
     fi
     # start mongodb on /tmp
-    mongod --port $MONGODB_PORT --dbpath /tmp/db/data --logpath /tmp/logs/mongo_log --bind_ip_all &
-  }
-
-  function env_flag_true {
-    case "$1" in
-      true|TRUE|True|1|yes|YES|Yes) return 0 ;;
-      *) return 1 ;;
-    esac
+    mongod --port "$MONGODB_PORT" --dbpath /tmp/db/data \
+      --logpath /tmp/logs/mongo_log --bind_ip_all \
+      "${MONGO_SERVER_SECURITY_ARGS[@]}" &
+    initialize_mongo_root_user "$MONGODB_PORT" || exit 1
   }
 
   function local_scheduler_enabled_for_command {
@@ -467,6 +580,8 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
     MSPASS_WORKER_CMD='dask worker ${MSPASS_WORKER_ARG} --memory-limit=${MSPASS_DASK_WORKER_MEMORY_LIMIT:-0} --local-directory $MSPASS_WORKER_DIR "$(build_dask_scheduler_uri "$MSPASS_SCHEDULER_ADDRESS" "$DASK_SCHEDULER_PORT")" > ${MSPASS_LOG_DIR}/dask-worker_log_${MY_ID} 2>&1 &'
   fi
 
+  prepare_mongo_security
+
   if [ "$MSPASS_ROLE" = "db" ]; then
     if [ "$MSPASS_DB_PATH" = "tmp" ]; then
       start_db_tmp
@@ -482,11 +597,14 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
     if [ -d ${MONGO_DATA}_config ]; then
       echo "restore config server $HOSTNAME cluster"
       # start a mongod instance
-      mongod --port $MONGODB_CONFIG_PORT --dbpath ${MONGO_DATA}_config --logpath ${MONGO_LOG}_config --bind_ip_all &
+      mongod --port "$MONGODB_CONFIG_PORT" --dbpath "${MONGO_DATA}_config" \
+        --logpath "${MONGO_LOG}_config" --bind_ip_all \
+        "${MONGO_SERVER_SECURITY_ARGS[@]}" &
       sleep ${MSPASS_SLEEP_TIME}
       # drop the local database
       echo "drop local database for config server $HOSTNAME"
-      mongosh --port $MONGODB_CONFIG_PORT local --eval "db.dropDatabase()"
+      mongosh --port "$MONGODB_CONFIG_PORT" local \
+        "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval "db.dropDatabase()"
       sleep ${MSPASS_SLEEP_TIME}
       # update config.shards collections
       echo "update shard host names for config server $HOSTNAME"
@@ -494,38 +612,54 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
       ITER=0
       for i in ${MSPASS_SHARD_LIST[@]}; do
         echo "update rs${ITER} with host ${i}"
-        mongosh --port $MONGODB_CONFIG_PORT config --eval "db.shards.updateOne({\"_id\": \"rs${ITER}\"}, {\$set: {\"host\": \"${i}\"}})"
+        mongosh --port "$MONGODB_CONFIG_PORT" config \
+          "${MONGO_CLIENT_AUTH_ARGS[@]}" \
+          --eval "db.shards.updateOne({\"_id\": \"rs${ITER}\"}, {\$set: {\"host\": \"${i}\"}})"
         ((ITER++))
         sleep ${MSPASS_SLEEP_TIME}
       done
       echo "restart the config server $HOSTNAME as a replica set"
       # restart the mongod as a new single-node replica set
-      mongosh --port $MONGODB_CONFIG_PORT admin --eval "db.shutdownServer()"
+      mongosh --port "$MONGODB_CONFIG_PORT" admin \
+        "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval "db.shutdownServer()"
       sleep ${MSPASS_SLEEP_TIME}
-      mongod --port $MONGODB_CONFIG_PORT --configsvr --replSet configserver --dbpath ${MONGO_DATA}_config --logpath ${MONGO_LOG}_config --bind_ip_all &
+      mongod --port "$MONGODB_CONFIG_PORT" --configsvr --replSet configserver \
+        --dbpath "${MONGO_DATA}_config" --logpath "${MONGO_LOG}_config" \
+        --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
       sleep ${MSPASS_SLEEP_TIME}
       # initiate the new replica set
-      mongosh --port $MONGODB_CONFIG_PORT --eval \
+      mongosh --port "$MONGODB_CONFIG_PORT" \
+        "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval \
         "rs.initiate({_id: \"configserver\", configsvr: true, version: 1, members: [{ _id: 0, host : \"$HOSTNAME:$MONGODB_CONFIG_PORT\" }]})"
       sleep ${MSPASS_SLEEP_TIME}
 
       # start a mongos router server
-      mongos --port $MONGODB_PORT --configdb configserver/$HOSTNAME:$MONGODB_CONFIG_PORT --logpath ${MONGO_LOG}_router --bind_ip_all &
+      mongos --port "$MONGODB_PORT" \
+        --configdb "configserver/$HOSTNAME:$MONGODB_CONFIG_PORT" \
+        --logpath "${MONGO_LOG}_router" --bind_ip_all \
+        "${MONGO_SERVER_SECURITY_ARGS[@]}" &
       sleep ${MSPASS_SLEEP_TIME}
     else
       # create a config dir
       mkdir -p ${MONGO_DATA}_config
       echo "dbmanager config server $HOSTNAME replicaSet is initialized"
       # start a config server
-      mongod --port $MONGODB_CONFIG_PORT --configsvr --replSet configserver --dbpath ${MONGO_DATA}_config --logpath ${MONGO_LOG}_config --bind_ip_all &
+      mongod --port "$MONGODB_CONFIG_PORT" --configsvr --replSet configserver \
+        --dbpath "${MONGO_DATA}_config" --logpath "${MONGO_LOG}_config" \
+        --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
       sleep ${MSPASS_SLEEP_TIME}
-      mongosh --port $MONGODB_CONFIG_PORT --eval \
+      mongosh --port "$MONGODB_CONFIG_PORT" --eval \
         "rs.initiate({_id: \"configserver\", configsvr: true, version: 1, members: [{ _id: 0, host : \"$HOSTNAME:$MONGODB_CONFIG_PORT\" }]})"
       sleep ${MSPASS_SLEEP_TIME}
 
       # start a mongos router server
-      mongos --port $MONGODB_PORT --configdb configserver/$HOSTNAME:$MONGODB_CONFIG_PORT --logpath ${MONGO_LOG}_router --bind_ip_all &
+      mongos --port "$MONGODB_PORT" \
+        --configdb "configserver/$HOSTNAME:$MONGODB_CONFIG_PORT" \
+        --logpath "${MONGO_LOG}_router" --bind_ip_all \
+        "${MONGO_SERVER_SECURITY_ARGS[@]}" &
     fi
+
+    initialize_mongo_root_user "$MONGODB_PORT" || exit 1
 
     if [[ -z ${MSPASS_SHARD_LIST:-} ]]; then
       echo "ERROR: MSPASS_SHARD_LIST must contain at least one shard" >&2
@@ -542,14 +676,18 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
       # enable database sharding
       echo "enable database $MSPASS_SHARD_DATABASE sharding"
       if ! retry_mongosh_command "enable database $MSPASS_SHARD_DATABASE sharding" \
-        --host "$HOSTNAME" --port "$MONGODB_PORT" --eval "sh.enableSharding(\"${MSPASS_SHARD_DATABASE}\")"; then
+        --host "$HOSTNAME" --port "$MONGODB_PORT" \
+        "${MONGO_CLIENT_AUTH_ARGS[@]}" \
+        --eval "sh.enableSharding(\"${MSPASS_SHARD_DATABASE}\")"; then
         exit 1
       fi
       # shard collection(using hashed)
       for i in ${MSPASS_SHARD_COLLECTIONS[@]}; do
         echo "shard collection $MSPASS_SHARD_DATABASE.${i%%:*} and shard key is ${i##*:}"
         if ! retry_mongosh_command "shard collection $MSPASS_SHARD_DATABASE.${i%%:*}" \
-          --host "$HOSTNAME" --port "$MONGODB_PORT" --eval "sh.shardCollection(\"$MSPASS_SHARD_DATABASE.${i%%:*}\", {${i##*:}: \"hashed\"})"; then
+          --host "$HOSTNAME" --port "$MONGODB_PORT" \
+          "${MONGO_CLIENT_AUTH_ARGS[@]}" \
+          --eval "sh.shardCollection(\"$MSPASS_SHARD_DATABASE.${i%%:*}\", {${i##*:}: \"hashed\"})"; then
           exit 1
         fi
       done
@@ -562,6 +700,7 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
     tail -f /dev/null
   elif [ "$MSPASS_ROLE" = "shard" ]; then
     [[ -n $MSPASS_SHARD_ID ]] || MSPASS_SHARD_ID=$MY_ID
+    SHARD_WAS_RESTORED=false
     # Note that we have to create a one-member replica set here
     # because certain pymongo API will use "retryWrites=true"
     # and thus trigger an error.
@@ -578,57 +717,95 @@ if [ "$MSPASS_START_LOCAL_SERVICES" = "true" ]; then
       fi
       # reconfig the shard replica set
       if [ -d ${MONGO_DATA}_shard_${MSPASS_SHARD_ID} ]; then
+        SHARD_WAS_RESTORED=true
         # restore the shard replica set
-        mongod --port $MONGODB_PORT --dbpath /tmp/db/data_shard_${MSPASS_SHARD_ID} --logpath /tmp/logs/mongo_log_shard_${MSPASS_SHARD_ID} --bind_ip_all &
+        mongod --port "$MONGODB_PORT" \
+          --dbpath "/tmp/db/data_shard_${MSPASS_SHARD_ID}" \
+          --logpath "/tmp/logs/mongo_log_shard_${MSPASS_SHARD_ID}" \
+          --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
         sleep ${MSPASS_SLEEP_TIME}
         # drop local database
         echo "drop local database for shard server $HOSTNAME"
-        mongosh --port $MONGODB_PORT local --eval "db.dropDatabase()"
+        mongosh --port "$MONGODB_PORT" local \
+          "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval "db.dropDatabase()"
         sleep ${MSPASS_SLEEP_TIME}
         # update shard metadata in each shard's identity document
         echo "update config server host names for shard server $HOSTNAME"
-        mongosh --port $MONGODB_PORT admin --eval "db.system.version.updateOne({\"_id\": \"shardIdentity\"}, {\$set: {\"configsvrConnectionString\": \"${MSPASS_CONFIG_SERVER_ADDR}\"}})"
+        mongosh --port "$MONGODB_PORT" admin \
+          "${MONGO_CLIENT_AUTH_ARGS[@]}" \
+          --eval "db.system.version.updateOne({\"_id\": \"shardIdentity\"}, {\$set: {\"configsvrConnectionString\": \"${MSPASS_CONFIG_SERVER_ADDR}\"}})"
         sleep ${MSPASS_SLEEP_TIME}
         # restart the mongod as a new single-node replica set
         echo "restart the shard server $HOSTNAME as a replica set"
-        mongosh --port $MONGODB_PORT admin --eval "db.shutdownServer()"
+        mongosh --port "$MONGODB_PORT" admin \
+          "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval "db.shutdownServer()"
         sleep ${MSPASS_SLEEP_TIME}
-        mongod --port $MONGODB_PORT --shardsvr --replSet "rs${MSPASS_SHARD_ID}" --dbpath /tmp/db/data_shard_${MSPASS_SHARD_ID} --logpath /tmp/logs/mongo_log_shard_${MSPASS_SHARD_ID} --bind_ip_all &
+        mongod --port "$MONGODB_PORT" --shardsvr \
+          --replSet "rs${MSPASS_SHARD_ID}" \
+          --dbpath "/tmp/db/data_shard_${MSPASS_SHARD_ID}" \
+          --logpath "/tmp/logs/mongo_log_shard_${MSPASS_SHARD_ID}" \
+          --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
       else
         # store the shard data in the /tmp folder in local machine
-        mongod --port $MONGODB_PORT --shardsvr --replSet "rs${MSPASS_SHARD_ID}" --dbpath /tmp/db/data_shard_${MSPASS_SHARD_ID} --logpath /tmp/logs/mongo_log_shard_${MSPASS_SHARD_ID} --bind_ip_all &
+        mongod --port "$MONGODB_PORT" --shardsvr \
+          --replSet "rs${MSPASS_SHARD_ID}" \
+          --dbpath "/tmp/db/data_shard_${MSPASS_SHARD_ID}" \
+          --logpath "/tmp/logs/mongo_log_shard_${MSPASS_SHARD_ID}" \
+          --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
       fi
     else
       echo "store shard data in scratch for shard server $HOSTNAME"
       if [ -d ${MONGO_DATA}_shard_${MSPASS_SHARD_ID} ]; then
+        SHARD_WAS_RESTORED=true
         # restore the shard replica set
-        mongod --port $MONGODB_PORT --dbpath ${MONGO_DATA}_shard_${MSPASS_SHARD_ID} --logpath ${MONGO_LOG}_shard_${MSPASS_SHARD_ID} --bind_ip_all &
+        mongod --port "$MONGODB_PORT" \
+          --dbpath "${MONGO_DATA}_shard_${MSPASS_SHARD_ID}" \
+          --logpath "${MONGO_LOG}_shard_${MSPASS_SHARD_ID}" \
+          --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
         sleep ${MSPASS_SLEEP_TIME}
         # drop local database
         echo "drop local database for shard server $HOSTNAME"
-        mongosh --port $MONGODB_PORT local --eval "db.dropDatabase()"
+        mongosh --port "$MONGODB_PORT" local \
+          "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval "db.dropDatabase()"
         sleep ${MSPASS_SLEEP_TIME}
         # update shard metadata in each shard's identity document
         echo "update config server host names for shard server $HOSTNAME"
-        mongosh --port $MONGODB_PORT admin --eval "db.system.version.updateOne({\"_id\": \"shardIdentity\"}, {\$set: {\"configsvrConnectionString\": \"${MSPASS_CONFIG_SERVER_ADDR}\"}})"
+        mongosh --port "$MONGODB_PORT" admin \
+          "${MONGO_CLIENT_AUTH_ARGS[@]}" \
+          --eval "db.system.version.updateOne({\"_id\": \"shardIdentity\"}, {\$set: {\"configsvrConnectionString\": \"${MSPASS_CONFIG_SERVER_ADDR}\"}})"
         sleep ${MSPASS_SLEEP_TIME}
         # restart the mongod as a new single-node replica set
         echo "restart the shard server $HOSTNAME as a replica set"
-        mongosh --port $MONGODB_PORT admin --eval "db.shutdownServer()"
+        mongosh --port "$MONGODB_PORT" admin \
+          "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval "db.shutdownServer()"
         sleep ${MSPASS_SLEEP_TIME}
-        mongod --port $MONGODB_PORT --shardsvr --replSet "rs${MSPASS_SHARD_ID}" --dbpath ${MONGO_DATA}_shard_${MSPASS_SHARD_ID} --logpath ${MONGO_LOG}_shard_${MSPASS_SHARD_ID} --bind_ip_all &
+        mongod --port "$MONGODB_PORT" --shardsvr \
+          --replSet "rs${MSPASS_SHARD_ID}" \
+          --dbpath "${MONGO_DATA}_shard_${MSPASS_SHARD_ID}" \
+          --logpath "${MONGO_LOG}_shard_${MSPASS_SHARD_ID}" \
+          --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
       else
         # initialize the shard replica set
         mkdir -p ${MONGO_DATA}_shard_${MSPASS_SHARD_ID}
-        mongod --port $MONGODB_PORT --shardsvr --replSet "rs${MSPASS_SHARD_ID}" --dbpath ${MONGO_DATA}_shard_${MSPASS_SHARD_ID} --logpath ${MONGO_LOG}_shard_${MSPASS_SHARD_ID} --bind_ip_all &
+        mongod --port "$MONGODB_PORT" --shardsvr \
+          --replSet "rs${MSPASS_SHARD_ID}" \
+          --dbpath "${MONGO_DATA}_shard_${MSPASS_SHARD_ID}" \
+          --logpath "${MONGO_LOG}_shard_${MSPASS_SHARD_ID}" \
+          --bind_ip_all "${MONGO_SERVER_SECURITY_ARGS[@]}" &
       fi
     fi
     sleep ${MSPASS_SLEEP_TIME}
 
     # shard server configuration
     echo "shard server $HOSTNAME replicaSet is initialized"
-    mongosh --port $MONGODB_PORT --eval \
-      "rs.initiate({_id: \"rs${MSPASS_SHARD_ID}\", version: 1, members: [{ _id: 0, host : \"$HOSTNAME:$MONGODB_PORT\" }]})"
+    if [ "$SHARD_WAS_RESTORED" = "true" ]; then
+      mongosh --port "$MONGODB_PORT" "${MONGO_CLIENT_AUTH_ARGS[@]}" --eval \
+        "rs.initiate({_id: \"rs${MSPASS_SHARD_ID}\", version: 1, members: [{ _id: 0, host : \"$HOSTNAME:$MONGODB_PORT\" }]})"
+    else
+      mongosh --port "$MONGODB_PORT" --eval \
+        "rs.initiate({_id: \"rs${MSPASS_SHARD_ID}\", version: 1, members: [{ _id: 0, host : \"$HOSTNAME:$MONGODB_PORT\" }]})"
+    fi
+    initialize_mongo_root_user "$MONGODB_PORT" || exit 1
     tail -f /dev/null
   elif [ "$MSPASS_ROLE" = "scheduler" ]; then
     eval $MSPASS_SCHEDULER_CMD


### PR DESCRIPTION
## Valid security work
The PR reduces unauthenticated exposure, keeps secrets out of process arguments, and improves authenticated restart handling.

## Renewed deployment/security review — draft blocker
This PR remains draft.  It changes fresh/default Compose behavior, gives root Mongo credentials to application containers, derives an internal keyfile from those credentials, and leaves the real multi-topology security matrix opt-in/skipped in normal CI.  Those are deployment and credential-boundary choices, not merely implementation details.

A security/deployment owner must approve the credential model and fresh/restore migration behavior, and the real four-topology matrix must become a mandatory CI gate before merge.  Deterministic fake tests alone are insufficient.  The earlier “REVIEW PASS” conclusion is withdrawn.

Related to #794