### PR TITLE
Align runtime and test dependency metadata

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install
       env:
         MSPASS_CMAKE_BUILD_TYPE: Debug
-      run: python -m pip install --no-cache-dir --no-build-isolation -v '.[seisbench]'
+      run: python -m pip install --no-cache-dir --no-build-isolation -v '.[seisbench,test]'
     - name: Test with pytest
       run: |
         export MSPASS_HOME=$(pwd)

--- a/Dockerfile
+++ b/Dockerfile
@@ -252,7 +252,7 @@ ADD pyproject.toml /mspass/pyproject.toml
 ADD python /mspass/python
 ADD .git /mspass/.git
 RUN ln -s /opt/conda/include/yaml-cpp /usr/include/yaml-cpp \
-	&& MSPASS_CMAKE_BUILD_TYPE=Debug pip3 install '/mspass[seisbench]' -v \
+	&& MSPASS_CMAKE_BUILD_TYPE=Debug pip3 install '/mspass[seisbench,test]' -v \
 	&& cmake --install /mspass/build/temp.* \
 	&& rm -rf /mspass/build /mspass/.git && docker-clean
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -59,7 +59,6 @@ requirements:
     - aiobotocore>=2.25.1,<2.26.0
     - boto3>=1.40.46,<1.40.62
     - botocore>=1.40.46,<1.40.62
-    - moto>=5.2.2,<5.3.0
     - requests
     - xarray
     - zarr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "aiobotocore[boto3]>=2.25.1,<2.26.0",
     "boto3>=1.40.46,<1.40.62",
     "botocore>=1.40.46,<1.40.62",
-    "moto>=5.2.2,<5.3.0",
     "requests",
     "earthscope-sdk>=1.6.1",
     "xarray",
@@ -53,6 +52,9 @@ Documentation = "https://www.mspass.org"
 Repository = "https://github.com/mspass-team/mspass"
 
 [project.optional-dependencies]
+test = [
+    "moto>=5.2.2,<5.3.0",
+]
 complete = [
     "scipy",
     "matplotlib",
@@ -61,8 +63,7 @@ seisbench = [
     "scipy",
     "matplotlib",
     "setuptools<82",
-    "seisbench==0.4.1; python_version < '3.9'",
-    "seisbench<=0.10.2; python_version >= '3.9'",
+    "seisbench<=0.10.2",
 ]
 
 [project.scripts]

--- a/python/tests/test_dependency_metadata.py
+++ b/python/tests/test_dependency_metadata.py
@@ -1,0 +1,140 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from packaging.markers import default_environment
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+import pytest
+import yaml
+
+REPOSITORY_ROOT = Path(
+    os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
+)
+SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12", "3.13")
+
+
+@pytest.fixture(scope="module")
+def distribution_requirements(tmp_path_factory):
+    report_path = tmp_path_factory.mktemp("dependency-metadata") / "pip-report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "--ignore-installed",
+            "--no-deps",
+            "--no-build-isolation",
+            "--report",
+            str(report_path),
+            ".[test,seisbench]",
+        ],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    packages = [
+        item
+        for item in report["install"]
+        if item["metadata"]["name"].lower() == "mspasspy"
+    ]
+    assert len(packages) == 1
+    return [Requirement(raw) for raw in packages[0]["metadata"]["requires_dist"]]
+
+
+def _applies(requirement, python_version, extra):
+    environment = default_environment()
+    environment.update(
+        python_version=python_version,
+        python_full_version=f"{python_version}.0",
+        extra=extra,
+    )
+    return requirement.marker is None or requirement.marker.evaluate(environment)
+
+
+def test_moto_is_exposed_only_by_the_test_extra(distribution_requirements):
+    moto_requirements = [
+        requirement
+        for requirement in distribution_requirements
+        if requirement.name.lower() == "moto"
+    ]
+    assert len(moto_requirements) == 1
+    moto = moto_requirements[0]
+    assert moto.specifier == SpecifierSet(">=5.2.2,<5.3.0")
+
+    for python_version in SUPPORTED_PYTHON_VERSIONS:
+        assert not _applies(moto, python_version, "")
+        assert _applies(moto, python_version, "test")
+        test_only = [
+            requirement
+            for requirement in distribution_requirements
+            if _applies(requirement, python_version, "test")
+            and not _applies(requirement, python_version, "")
+        ]
+        assert [requirement.name.lower() for requirement in test_only] == ["moto"]
+
+
+def test_seisbench_has_one_reachable_unconditional_branch(distribution_requirements):
+    seisbench_requirements = [
+        requirement
+        for requirement in distribution_requirements
+        if requirement.name.lower() == "seisbench"
+    ]
+    assert len(seisbench_requirements) == 1
+    requirement = seisbench_requirements[0]
+    assert requirement.specifier == SpecifierSet("<=0.10.2")
+    assert "python_version" not in str(requirement.marker)
+
+    for python_version in SUPPORTED_PYTHON_VERSIONS:
+        assert not _applies(requirement, python_version, "")
+        reachable = [
+            candidate
+            for candidate in seisbench_requirements
+            if _applies(candidate, python_version, "seisbench")
+        ]
+        assert reachable == [requirement]
+
+
+def test_generated_dependency_manifests_are_aligned():
+    result = subprocess.run(
+        [sys.executable, "scripts/sync_dependencies.py", "--check"],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "moto" not in (REPOSITORY_ROOT / "meta.yaml").read_text(encoding="utf-8")
+
+
+def test_test_runners_install_the_test_extra():
+    workflow = yaml.safe_load(
+        (REPOSITORY_ROOT / ".github/workflows/python-package.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    install_step = next(
+        step
+        for step in workflow["jobs"]["build"]["steps"]
+        if step.get("name") == "Install"
+    )
+    assert "'.[seisbench,test]'" in install_step["run"]
+
+    dockerfile = (REPOSITORY_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    runtime_package = dockerfile.split("FROM mspass-source AS runtime-package", 1)[
+        1
+    ].split("FROM mspass-source AS dev-package", 1)[0]
+    dev_package = dockerfile.split("FROM mspass-source AS dev-package", 1)[1].split(
+        "FROM runtime-package AS runtime-common", 1
+    )[0]
+    assert "pip3 install /mspass -v" in runtime_package
+    assert "/mspass[" not in runtime_package
+    assert "pip3 install '/mspass[seisbench,test]' -v" in dev_package


### PR DESCRIPTION
## Summary
- move Moto from runtime requirements into the test extra and keep generated Conda metadata synchronized
- collapse duplicate SeisBench markers into one supported requirement
- install `[seisbench,test]` in the Python test workflow and in the intentional branch-testing dev image stage, while leaving runtime images and dev image publishing behavior unchanged

## Verification
- independent agent review: PASS
- focused policy tests: 4 passed; exact baseline-red: 4 failed
- dependency synchronization check and Python 3.10–3.13 marker simulation: passed
- isolated resolver install selected Moto 5.2.2 with the pinned AWS dependency family; `pip check`, imports, and Moto S3 create/put/get round trip: passed
- Black, Python 3.12/3.13 `py_compile`, workflow YAML, rendered Conda YAML, and `git diff --check`: passed
- Mongo-backed S3 integration tests were collected but could not run locally because neither MongoDB nor a usable Docker daemon was available; the Python CI workflow now installs the test extra before the full suite

Closes #799