### PR TITLE
Add advertised support matrix gate

### DIFF
--- a/.github/workflows/support-matrix.yml
+++ b/.github/workflows/support-matrix.yml
@@ -1,0 +1,90 @@
+name: Advertised support matrix
+
+"on":
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  support:
+    name: CPython ${{ matrix.python-version }} / ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.10"
+            arch: amd64
+            runner: ubuntu-latest
+          - python-version: "3.11"
+            arch: amd64
+            runner: ubuntu-latest
+          - python-version: "3.12"
+            arch: amd64
+            runner: ubuntu-latest
+          - python-version: "3.13"
+            arch: amd64
+            runner: ubuntu-latest
+          - python-version: "3.10"
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - python-version: "3.11"
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - python-version: "3.12"
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - python-version: "3.13"
+            arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Cache Boost 1.86
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/mspass-boost-1.86.0
+          key: support-boost-1.86.0-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/boost-download.cmake') }}
+      - name: Configure Boost 1.86 cache
+        shell: bash
+        run: echo "MSPASS_BOOST_ROOT=${RUNNER_TEMP}/mspass-boost-1.86.0" >> "$GITHUB_ENV"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq gfortran libgsl-dev liblapack-dev libyaml-cpp-dev
+      - name: Build and install MsPASS
+        env:
+          MSPASS_CMAKE_BUILD_TYPE: Release
+        run: |
+          python -m pip install --upgrade pip setuptools setuptools_scm wheel numpy pytest
+          python -m pip install --no-cache-dir --no-build-isolation .
+      - name: Import installed package and native extension
+        run: python -c 'import mspasspy, mspasspy.ccore'
+      - name: Run workflow regression
+        run: pytest -q python/tests/test_workflow.py
+
+  support-matrix:
+    name: support-matrix
+    if: ${{ always() }}
+    needs: support
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all advertised combinations
+        env:
+          SUPPORT_RESULT: ${{ needs.support.result }}
+        run: test "$SUPPORT_RESULT" = success

--- a/.github/workflows/support-matrix.yml
+++ b/.github/workflows/support-matrix.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           MSPASS_CMAKE_BUILD_TYPE: Release
         run: |
-          python -m pip install --upgrade pip setuptools setuptools_scm wheel numpy pytest
+          python -m pip install --upgrade pip setuptools setuptools_scm wheel Cython numpy py-cpuinfo pytest
           python -m pip install --no-cache-dir --no-build-isolation .
       - name: Import installed package and native extension
         run: python -c 'import mspasspy, mspasspy.ccore'

--- a/python/tests/test_support_matrix_workflow.py
+++ b/python/tests/test_support_matrix_workflow.py
@@ -1,0 +1,104 @@
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPOSITORY_ROOT = Path(
+    os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
+)
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "support-matrix.yml"
+
+
+def _load_workflow():
+    with WORKFLOW_PATH.open(encoding="utf-8") as stream:
+        return yaml.safe_load(stream)
+
+
+def test_support_matrix_is_the_exact_advertised_cross_product():
+    workflow = _load_workflow()
+    assert workflow["on"] == {
+        "pull_request": {"branches": ["master"]},
+        "workflow_dispatch": None,
+    }
+    assert set(workflow["jobs"]) == {"support", "support-matrix"}
+
+    support = workflow["jobs"]["support"]
+    assert support["name"] == (
+        "CPython ${{ matrix.python-version }} / ${{ matrix.arch }}"
+    )
+    combinations = support["strategy"]["matrix"]["include"]
+    assert len(combinations) == 8
+    assert {
+        (entry["python-version"], entry["arch"], entry["runner"])
+        for entry in combinations
+    } == {
+        (version, arch, runner)
+        for version in ("3.10", "3.11", "3.12", "3.13")
+        for arch, runner in (
+            ("amd64", "ubuntu-latest"),
+            ("arm64", "ubuntu-24.04-arm"),
+        )
+    }
+    assert support["runs-on"] == "${{ matrix.runner }}"
+    assert support["strategy"]["fail-fast"] is False
+    assert "if" not in support
+    assert "continue-on-error" not in support
+
+
+def test_every_support_job_builds_imports_and_runs_the_workflow_test():
+    support = _load_workflow()["jobs"]["support"]
+    steps = support["steps"]
+    runs = [step.get("run") for step in steps]
+
+    install = next(
+        step for step in steps if step.get("name") == "Build and install MsPASS"
+    )
+    assert (
+        "python -m pip install --no-cache-dir --no-build-isolation ."
+        in install["run"].splitlines()
+    )
+    assert "python -c 'import mspasspy, mspasspy.ccore'" in runs
+    assert "pytest -q python/tests/test_workflow.py" in runs
+    assert all("if" not in step for step in steps)
+    assert all("continue-on-error" not in step for step in steps)
+    setup_python = next(
+        step for step in steps if step.get("name", "").startswith("Set up Python")
+    )
+    assert setup_python["uses"].startswith("actions/setup-python@")
+    assert setup_python["with"]["python-version"] == "${{ matrix.python-version }}"
+
+
+def test_support_matrix_aggregate_fails_unless_all_eight_jobs_succeed():
+    aggregate = _load_workflow()["jobs"]["support-matrix"]
+
+    assert aggregate == {
+        "name": "support-matrix",
+        "if": "${{ always() }}",
+        "needs": "support",
+        "runs-on": "ubuntu-latest",
+        "steps": [
+            {
+                "name": "Require all advertised combinations",
+                "env": {"SUPPORT_RESULT": "${{ needs.support.result }}"},
+                "run": 'test "$SUPPORT_RESULT" = success',
+            }
+        ],
+    }
+    command = aggregate["steps"][0]["run"]
+    for result in ("success", "failure", "cancelled", "skipped"):
+        completed = subprocess.run(
+            ["bash", "-c", command],
+            env={**os.environ, "SUPPORT_RESULT": result},
+            check=False,
+        )
+        assert completed.returncode == (0 if result == "success" else 1)
+
+
+def test_workflow_has_read_only_permissions_and_no_branch_protection_mutation():
+    workflow = _load_workflow()
+
+    assert workflow["permissions"] == {"contents": "read"}
+    serialized = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "branches/master/protection" not in serialized
+    assert "statuses:" not in serialized

--- a/python/tests/test_support_matrix_workflow.py
+++ b/python/tests/test_support_matrix_workflow.py
@@ -54,9 +54,13 @@ def test_every_support_job_builds_imports_and_runs_the_workflow_test():
     install = next(
         step for step in steps if step.get("name") == "Build and install MsPASS"
     )
+    bootstrap, project_install = install["run"].splitlines()
+    assert bootstrap == (
+        "python -m pip install --upgrade pip setuptools setuptools_scm wheel "
+        "Cython numpy py-cpuinfo pytest"
+    )
     assert (
-        "python -m pip install --no-cache-dir --no-build-isolation ."
-        in install["run"].splitlines()
+        "python -m pip install --no-cache-dir --no-build-isolation ." == project_install
     )
     assert "python -c 'import mspasspy, mspasspy.ccore'" in runs
     assert "pytest -q python/tests/test_workflow.py" in runs


### PR DESCRIPTION
## Valid implementation work
- defines the exact CPython 3.10–3.13 × Linux amd64/arm64 installation matrix
- imports the native package and runs the workflow regression in each combination
- exposes one aggregate that fails failed, cancelled, or skipped matrix results
- keeps workflow permissions read-only

## Renewed support-policy review — draft blocker
This PR remains draft.  The workflow is technically coherent, but committing to eight native runner combinations is a project support and recurring-cost decision, not something contract tests can approve.  A maintainer must decide which architectures/Python versions MsPASS promises, who owns the runner capacity, and whether every combination is a required merge gate.

Branch protection must also be changed only after the workflow exists and succeeds on `master`; requiring the context earlier would strand existing PRs.  Keep #800 open until a maintainer approves the matrix, merges the workflow, verifies it on `master`, and adds `support-matrix` without removing existing required contexts.  The earlier code-level PASS is not a merge-readiness conclusion.

## Evidence
- policy tests: 4 passed; exact baseline-red: 4 failed
- actionlint 1.7.12, Black, `py_compile`, YAML parse, and `git diff --check`: passed
- exact numcodecs build dependencies were independently reproduced

Related to #800