### PR TITLE
Make Black a pinned read-only check

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -1,38 +1,28 @@
-name: code-format
+name: Black formatting
 
-on: [pull_request]
+"on":
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
-  build:
+  black-format:
+    name: black-format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check files using the black formatter
-        uses: psf/black@stable
-        id: action_black
+      - uses: actions/setup-python@v5
         with:
-          options: "--verbose"
-          jupyter: true
-          src: "./python"
-      - name: Check for formatting changes
-        id: check-changes
+          python-version: "3.13"
+          cache: pip
+      - name: Install pinned Black
+        run: python -m pip install 'black[jupyter]==25.1.0' pytest pyyaml
+      - name: Verify the formatting policy
+        run: pytest -q python/tests/test_black_workflow.py
+      - name: Check formatting without modifying files
+        shell: bash
         run: |
-          git diff --quiet || changed=true && echo "has_changes=${changed:-false}" >> $GITHUB_OUTPUT
-          echo "Detected changes: ${{ steps.check-changes.outputs.has_changes }}"
-      - name: Create Pull Request
-        if: steps.check-changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Format Python code with psf/black push"
-          commit-message: ":art: Format Python code with psf/black"
-          body: |
-            There appear to be some python formatting errors in ${{ github.sha }}. This pull request
-            uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
-          base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
-          branch: "black-formatting/${{ github.head_ref }}"
-      #- name: Annotate diff changes using reviewdog
-      #  if: steps.action_black.outputs.is_formatted == 'true'
-      #  uses: reviewdog/action-suggester@v1
-      #  with:
-      #    tool_name: blackfmt
+          shopt -s globstar nullglob
+          notebooks=(docs/**/*.ipynb)
+          black --workers 1 --check --diff python/mspasspy python/tests "${notebooks[@]}"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,25 @@ Before opening a pull request:
 2. Run relevant tests locally when possible.
 3. Keep documentation in sync with user-facing behavior changes.
 
+CI checks Python, test, and documentation-notebook formatting with Black
+25.1.0.  Run the same read-only check from the repository root with:
+
+```bash
+python -m pip install 'black[jupyter]==25.1.0'
+shopt -s globstar nullglob
+notebooks=(docs/**/*.ipynb)
+black --workers 1 --check --diff python/mspasspy python/tests "${notebooks[@]}"
+```
+
+To apply the corresponding formatting locally, run the final command without
+`--check --diff`:
+
+```bash
+shopt -s globstar nullglob
+notebooks=(docs/**/*.ipynb)
+black --workers 1 python/mspasspy python/tests "${notebooks[@]}"
+```
+
 ## License
 
 This project is licensed under the **BSD 3-Clause License**. See [LICENSE](LICENSE) for details.

--- a/python/tests/algorithms/test_decon_math_correctness.py
+++ b/python/tests/algorithms/test_decon_math_correctness.py
@@ -34,7 +34,8 @@ def _write_scalar_pf(
     if window_end is None:
         window_end = float(nfft - 1)
     pf = tmp_path / "scalar_decon.pf"
-    pf.write_text(f"""
+    pf.write_text(
+        f"""
 target_sample_interval 1.0
 operator_nfft {nfft}
 deconvolution_data_window_start {window_start:.12f}
@@ -43,7 +44,8 @@ damping_factor {damping:.12f}
 water_level {water_level:.12f}
 shaping_wavelet_dt 1.0
 shaping_wavelet_type none
-""")
+"""
+    )
     return pfread(str(pf))
 
 
@@ -62,7 +64,8 @@ def _write_time_domain_ls_pf(
     if model_length is not None:
         model_length_line = f"model_length {model_length}\n"
     pf = tmp_path / "time_domain_ls.pf"
-    pf.write_text(f"""
+    pf.write_text(
+        f"""
 target_sample_interval 1.0
 operator_nfft {nfft}
 deconvolution_data_window_start {window_start:.12f}
@@ -71,7 +74,8 @@ damping_factor {damping:.12f}
 {model_length_line}shaping_wavelet_dt 1.0
 shaping_wavelet_type {shaping_wavelet_type}
 shaping_wavelet_frequency {shaping_frequency:.12f}
-""")
+"""
+    )
     return pfread(str(pf))
 
 
@@ -86,7 +90,8 @@ def _write_multitaper_pf(
     shaping_frequency=1.0,
 ):
     pf = tmp_path / "multitaper_decon.pf"
-    pf.write_text(f"""
+    pf.write_text(
+        f"""
 target_sample_interval 0.05
 operator_nfft {nfft}
 deconvolution_data_window_start {window_start:.12f}
@@ -97,13 +102,15 @@ number_tapers 4
 shaping_wavelet_dt 0.05
 shaping_wavelet_type {shaping_wavelet_type}
 shaping_wavelet_frequency {shaping_frequency:.12f}
-""")
+"""
+    )
     return pfread(str(pf))
 
 
 def _write_noise_stable_pf(tmp_path, *, window_start=0.0, window_end=63.0, nfft=128):
     pf = tmp_path / "noise_stable_decon.pf"
-    pf.write_text(f"""
+    pf.write_text(
+        f"""
 target_sample_interval 1.0
 operator_nfft {nfft}
 deconvolution_data_window_start {window_start:.12f}
@@ -117,7 +124,8 @@ ns_gid_snr_taper_low 1.0
 ns_gid_snr_taper_high 3.0
 shaping_wavelet_dt 1.0
 shaping_wavelet_type none
-""")
+"""
+    )
     return pfread(str(pf))
 
 
@@ -261,7 +269,8 @@ def test_fft_window_sample_count_uses_rounding_near_integer_boundary(tmp_path):
     # value yields 32 samples, while rounding preserves the intended 33.
     window_end = np.nextafter((n - 1) * dt, 0.0)
     pf_file = tmp_path / "rounding_fft_length.pf"
-    pf_file.write_text(f"""
+    pf_file.write_text(
+        f"""
 target_sample_interval {dt:.17g}
 operator_nfft {n}
 deconvolution_data_window_start 0.0
@@ -270,7 +279,8 @@ damping_factor 1.0e-12
 water_level 1.0e-12
 shaping_wavelet_dt {dt:.17g}
 shaping_wavelet_type none
-""")
+"""
+    )
     pf = pfread(str(pf_file))
     engine = LeastSquareDecon(pf)
     wavelet = np.zeros(n)

--- a/python/tests/test_black_workflow.py
+++ b/python/tests/test_black_workflow.py
@@ -1,0 +1,200 @@
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+REPOSITORY_ROOT = Path(
+    os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
+)
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "code-format.yml"
+README_PATH = REPOSITORY_ROOT / "README.md"
+CHECK_SCRIPT = """\
+shopt -s globstar nullglob
+notebooks=(docs/**/*.ipynb)
+black --workers 1 --check --diff python/mspasspy python/tests "${notebooks[@]}"
+"""
+FORMAT_SCRIPT = """\
+shopt -s globstar nullglob
+notebooks=(docs/**/*.ipynb)
+black --workers 1 python/mspasspy python/tests "${notebooks[@]}"
+"""
+
+
+def _load_workflow():
+    with WORKFLOW_PATH.open(encoding="utf-8") as stream:
+        return yaml.safe_load(stream)
+
+
+def _run_black(black, *arguments, cwd):
+    return subprocess.run(
+        [black, "--workers", "1", *arguments],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_notebook(path, source):
+    path.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "execution_count": None,
+                        "metadata": {},
+                        "outputs": [],
+                        "source": [source],
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        )
+    )
+
+
+def test_black_workflow_is_pinned_read_only_and_stably_named():
+    workflow = _load_workflow()
+    assert workflow["permissions"] == {"contents": "read"}
+    assert set(workflow["jobs"]) == {"black-format"}
+
+    job = workflow["jobs"]["black-format"]
+    assert job["name"] == "black-format"
+    assert job["runs-on"] == "ubuntu-latest"
+    assert "permissions" not in job
+    assert all("continue-on-error" not in step for step in job["steps"])
+    assert [step.get("uses", step.get("name")) for step in job["steps"]] == [
+        "actions/checkout@v4",
+        "actions/setup-python@v5",
+        "Install pinned Black",
+        "Verify the formatting policy",
+        "Check formatting without modifying files",
+    ]
+
+    install = next(
+        step for step in job["steps"] if step.get("name") == "Install pinned Black"
+    )
+    assert (
+        install["run"] == "python -m pip install 'black[jupyter]==25.1.0' pytest pyyaml"
+    )
+    policy = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Verify the formatting policy"
+    )
+    assert policy["run"] == "pytest -q python/tests/test_black_workflow.py"
+    check = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Check formatting without modifying files"
+    )
+    assert check["shell"] == "bash"
+    assert check["run"] == CHECK_SCRIPT
+    assert "push" not in workflow["on"]
+    assert all(
+        "create-pull-request" not in str(step.get("uses", "")) for step in job["steps"]
+    )
+
+
+def test_readme_documents_the_exact_check_and_format_commands():
+    readme = README_PATH.read_text(encoding="utf-8")
+    assert "python -m pip install 'black[jupyter]==25.1.0'" in readme
+    assert CHECK_SCRIPT in readme
+    assert FORMAT_SCRIPT in readme
+
+
+def test_read_only_check_rejects_python_and_notebook_without_mutation(tmp_path):
+    black = shutil.which("black")
+    if not black:
+        pytest.skip("Black is installed by the black-format workflow")
+    version = subprocess.run(
+        [black, "--version"], capture_output=True, text=True, check=True
+    )
+    if "25.1.0" not in version.stdout:
+        pytest.skip("integration contract requires the workflow's Black 25.1.0")
+
+    package = tmp_path / "python" / "mspasspy"
+    tests = tmp_path / "python" / "tests"
+    notebooks = tmp_path / "docs" / "guide"
+    package.mkdir(parents=True)
+    tests.mkdir(parents=True)
+    notebooks.mkdir(parents=True)
+    (package / "good.py").write_text("answer = 42\n")
+    bad_python = tests / "bad.py"
+    bad_python.write_text("result=  [1,2,3]\n")
+    bad_notebook = notebooks / "demo.ipynb"
+    _write_notebook(bad_notebook, "result=  [1,2,3]\n")
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    before_status = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    before_python = bad_python.read_bytes()
+    before_notebook = bad_notebook.read_bytes()
+
+    rejected_python = _run_black(black, "--check", "--diff", bad_python, cwd=tmp_path)
+    rejected_notebook = _run_black(
+        black, "--check", "--diff", bad_notebook, cwd=tmp_path
+    )
+    assert rejected_python.returncode != 0
+    assert rejected_notebook.returncode != 0
+    diagnostics = (
+        rejected_python.stdout
+        + rejected_python.stderr
+        + rejected_notebook.stdout
+        + rejected_notebook.stderr
+    )
+    assert "bad.py" in diagnostics
+    assert "demo.ipynb" in diagnostics
+    assert bad_python.read_bytes() == before_python
+    assert bad_notebook.read_bytes() == before_notebook
+    assert (
+        subprocess.run(
+            ["git", "status", "--short"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        == before_status
+    )
+
+    for path in (bad_python, bad_notebook):
+        formatted = _run_black(black, path, cwd=tmp_path)
+        assert formatted.returncode == 0, formatted.stdout + formatted.stderr
+        accepted = _run_black(black, "--check", "--diff", path, cwd=tmp_path)
+        assert accepted.returncode == 0, accepted.stdout + accepted.stderr
+
+
+def test_read_only_check_accepts_formatted_tree_without_notebooks(tmp_path):
+    black = shutil.which("black")
+    if not black:
+        pytest.skip("Black is installed by the black-format workflow")
+    version = subprocess.run(
+        [black, "--version"], capture_output=True, text=True, check=True
+    )
+    if "25.1.0" not in version.stdout:
+        pytest.skip("integration contract requires the workflow's Black 25.1.0")
+
+    (tmp_path / "python" / "mspasspy").mkdir(parents=True)
+    (tmp_path / "python" / "tests").mkdir(parents=True)
+    (tmp_path / "python" / "mspasspy" / "good.py").write_text("answer = 42\n")
+    (tmp_path / "python" / "tests" / "good.py").write_text("assert True\n")
+
+    for path in (
+        tmp_path / "python" / "mspasspy" / "good.py",
+        tmp_path / "python" / "tests" / "good.py",
+    ):
+        accepted = _run_black(black, "--check", "--diff", path, cwd=tmp_path)
+        assert accepted.returncode == 0, accepted.stdout + accepted.stderr


### PR DESCRIPTION
## Summary
- replace the checkout-mutating formatter workflow with a stable read-only `black-format` job
- pin `black[jupyter]==25.1.0` and check exactly `python/mspasspy`, `python/tests`, and Bash-globbed `docs/**/*.ipynb`
- declare read-only permissions and remove every commit/branch/PR-writing path
- document the matching local check and format commands, and format the one existing target that failed the pinned release

## Verification before remote CI
- independent code review: PASS; only the post-merge branch-protection step remains
- Black policy and real Python/notebook behavior: 4 passed; exact baseline-red: 2 failed, 2 passed
- all 118 current Python targets pass Black 25.1.0 individually; the formatted decon test is AST-equivalent to baseline
- actionlint 1.7.12, Python 3.12/3.13 `py_compile`, YAML, and `git diff --check`: passed

## Required post-merge administration
This PR intentionally does **not** modify branch protection. The `black-format` context does not exist on `master` yet, and requiring it now would block all currently open PRs. After human merge, confirm a synchronized canary/PR receives a successful `black-format`, update remaining PRs so their latest SHA produces that context (or let the old queue clear), then add `black-format` to the existing required contexts without removing them or changing `strict=true`. Keep #801 open until the protection API confirms that final state.

Related to #801 (does not auto-close it yet).