### PR TITLE
[P2][CI] Add deterministic Ruff and native sanitizer gates

### DIFF
--- a/.github/workflows/static-gates.yml
+++ b/.github/workflows/static-gates.yml
@@ -1,0 +1,139 @@
+name: Static gates
+
+"on":
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect native changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      native: ${{ steps.filter.outputs.native }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            native:
+              - 'cxx/**'
+
+  ruff:
+    name: Ruff fatal errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install Ruff
+        run: python -m pip install ruff==0.12.8
+      - name: Check fatal Python errors
+        run: ruff check --select E9,F63,F7,F82 python/mspasspy python/tests
+
+  asan:
+    name: Native ASan
+    needs: changes
+    if: ${{ needs.changes.outputs.native == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      BUILD_DIRECTORY: build-asan
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache Boost 1.86
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/mspass-boost-1.86.0
+          key: mspass-boost-1.86.0-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/boost-download.cmake') }}
+      - name: Configure Boost 1.86 cache
+        run: echo "MSPASS_BOOST_ROOT=${RUNNER_TEMP}/mspass-boost-1.86.0" >> "$GITHUB_ENV"
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -yq gfortran libgsl-dev liblapack-dev libyaml-cpp-dev
+      - name: Configure ASan
+        run: >-
+          cmake -S cxx -B "$BUILD_DIRECTORY"
+          -DBUILD_TESTING=ON
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+          -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+      - name: Build ASan
+        run: cmake --build "$BUILD_DIRECTORY" --config RelWithDebInfo --parallel 2
+      - name: Run full ASan test suite
+        working-directory: ${{ env.BUILD_DIRECTORY }}
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=1
+        run: ctest --output-on-failure
+
+  ubsan:
+    name: Native UBSan
+    needs: changes
+    if: ${{ needs.changes.outputs.native == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      BUILD_DIRECTORY: build-ubsan
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache Boost 1.86
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/mspass-boost-1.86.0
+          key: mspass-boost-1.86.0-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/boost-download.cmake') }}
+      - name: Configure Boost 1.86 cache
+        run: echo "MSPASS_BOOST_ROOT=${RUNNER_TEMP}/mspass-boost-1.86.0" >> "$GITHUB_ENV"
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -yq gfortran libgsl-dev liblapack-dev libyaml-cpp-dev
+      - name: Configure UBSan
+        run: >-
+          cmake -S cxx -B "$BUILD_DIRECTORY"
+          -DBUILD_TESTING=ON
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer"
+          -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer"
+      - name: Build UBSan
+        run: cmake --build "$BUILD_DIRECTORY" --config RelWithDebInfo --parallel 2
+      - name: Run full UBSan test suite
+        working-directory: ${{ env.BUILD_DIRECTORY }}
+        env:
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: ctest --output-on-failure
+
+  static-gates:
+    name: static-gates
+    if: ${{ always() }}
+    needs: [changes, ruff, asan, ubsan]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every applicable gate
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          NATIVE_CHANGED: ${{ needs.changes.outputs.native }}
+          RUFF_RESULT: ${{ needs.ruff.result }}
+          ASAN_RESULT: ${{ needs.asan.result }}
+          UBSAN_RESULT: ${{ needs.ubsan.result }}
+        run: |
+          set -euo pipefail
+          test "$CHANGES_RESULT" = success
+          test "$RUFF_RESULT" = success
+          if [[ "$NATIVE_CHANGED" == true ]]; then
+            test "$ASAN_RESULT" = success
+            test "$UBSAN_RESULT" = success
+          elif [[ "$NATIVE_CHANGED" == false ]]; then
+            test "$ASAN_RESULT" = skipped
+            test "$UBSAN_RESULT" = skipped
+          else
+            exit 1
+          fi

--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -107,7 +107,14 @@ elseif (NOT LAPACK_FOUND)
   set (LAPACK_LIBRARIES ${PROJECT_BINARY_DIR}/openblas/lib/libopenblas.a)
 endif ()
 
+# The mixed-language probe links with the Fortran driver, so C-only sanitizer
+# runtime flags must not leak into it.
+set (_mspass_c_flags "${CMAKE_C_FLAGS}")
+set (CMAKE_C_FLAGS "")
 include (FortranCInterface)
+if (NOT FortranCInterface_GLOBAL_FOUND)
+  message (FATAL_ERROR "Unable to detect the Fortran/C symbol interface")
+endif ()
 list (APPEND FORTRAN_FUNCTIONS ddot dscal daxpy dcopy dnrm2)
 list (APPEND FORTRAN_FUNCTIONS dgetrf dgetri)
 list (APPEND FORTRAN_FUNCTIONS dlamch dstebz dstein)
@@ -115,6 +122,8 @@ FortranCInterface_HEADER (include/FC.h
   MACRO_NAMESPACE "FC_"
   SYMBOLS ${FORTRAN_FUNCTIONS}
   )
+set (CMAKE_C_FLAGS "${_mspass_c_flags}")
+unset (_mspass_c_flags)
 
 message (STATUS "Building mseed")
 include (cmake/mseed.cmake)

--- a/cxx/test/bundle/test_bundle.cc
+++ b/cxx/test/bundle/test_bundle.cc
@@ -287,7 +287,7 @@ int main(int argc, char **argv)
   cout << "Test handling of incomplete bundles"<<endl;
   ens2=ens0;
   ens2.member.erase(ens2.member.begin());
-  ens2.member.erase(ens2.member.end());
+  ens2.member.erase(ens2.member.end()-1);
   ens3c=bundle_seed_data(ens2);
   print_output(ens3c);
   assert(compare_stas(ens3c,pattern));

--- a/cxx/test/md/test_md.cc
+++ b/cxx/test/md/test_md.cc
@@ -13,7 +13,7 @@ void print_metadata(Metadata& md)
 }
 int main(int argc, char **argv)
 {
-	char *pfname=strdup("test_md.pf");
+	const string pfname("test_md.pf");
 	try {
             cout << "Test program for Metadata object, AntelopePf, and ErrorLogger"
                 <<endl

--- a/docs/source/getting_started/static_gates_ci.rst
+++ b/docs/source/getting_started/static_gates_ci.rst
@@ -1,0 +1,15 @@
+Static analysis and sanitizer gates
+===================================
+
+Pull requests always run Ruff 0.12.8 over ``python/mspasspy`` and
+``python/tests`` with ``E9,F63,F7,F82`` selected.  Pull requests that change
+``cxx/**`` additionally run the complete native CTest suite in separate ASan
+and UBSan builds.  The stable ``static-gates`` job accepts only successful
+applicable jobs or two skipped sanitizer jobs when no native path changed.
+
+Branch protection must not require ``static-gates`` until this workflow has
+been merged into ``master`` and produced the check there.  Configuring it
+earlier could leave pull requests waiting for a context that the base branch
+cannot create.  After a successful run on ``master``, a repository
+administrator should add exactly ``static-gates`` to the required status
+checks and confirm it through the branch-protection API.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -126,6 +126,7 @@ Choose your path
    user_manual/FAQ
    user_manual/development_strategies
    CMake dependency maintenance <getting_started/cmake_dependency_maintenance>
+   Static analysis and sanitizer gates <getting_started/static_gates_ci>
 
 .. toctree::
    :maxdepth: 2

--- a/python/tests/test_static_gates_workflow.py
+++ b/python/tests/test_static_gates_workflow.py
@@ -1,0 +1,222 @@
+import os
+from pathlib import Path
+import shlex
+import subprocess
+
+import pytest
+import yaml
+
+REPOSITORY_ROOT = Path(
+    os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
+)
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github/workflows/static-gates.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _step(job, name):
+    return next(step for step in job["steps"] if step.get("name") == name)
+
+
+def test_ruff_gate_is_exact_and_has_no_waiver(workflow):
+    assert workflow["on"] == {
+        "push": {"branches": ["master"]},
+        "pull_request": {"branches": ["master"]},
+        "workflow_dispatch": None,
+    }
+    ruff = workflow["jobs"]["ruff"]
+    assert _step(ruff, "Install Ruff")["run"] == "python -m pip install ruff==0.12.8"
+
+    command = _step(ruff, "Check fatal Python errors")["run"]
+    assert shlex.split(command) == [
+        "ruff",
+        "check",
+        "--select",
+        "E9,F63,F7,F82",
+        "python/mspasspy",
+        "python/tests",
+    ]
+    assert "ignore" not in command.lower()
+    assert "noqa" not in command.lower()
+
+
+def test_native_path_filter_and_full_sanitizer_suites(workflow):
+    jobs = workflow["jobs"]
+    path_filter = next(
+        step for step in jobs["changes"]["steps"] if step.get("id") == "filter"
+    )
+    assert yaml.safe_load(path_filter["with"]["filters"]) == {"native": ["cxx/**"]}
+
+    expected = {
+        "asan": (
+            "address",
+            "Configure ASan",
+            "Run full ASan test suite",
+            {"ASAN_OPTIONS": "halt_on_error=1:abort_on_error=1:detect_leaks=1"},
+        ),
+        "ubsan": (
+            "undefined",
+            "Configure UBSan",
+            "Run full UBSan test suite",
+            {"UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1"},
+        ),
+    }
+    cache_keys = set()
+    for job_name, (
+        sanitizer,
+        configure_step_name,
+        test_step_name,
+        sanitizer_environment,
+    ) in expected.items():
+        job = jobs[job_name]
+        assert job["needs"] == "changes"
+        assert job["if"] == "${{ needs.changes.outputs.native == 'true' }}"
+        assert job["env"]["CC"] == "clang"
+        assert job["env"]["CXX"] == "clang++"
+        assert job["env"]["BUILD_DIRECTORY"] == f"build-{job_name}"
+        cache = _step(job, "Cache Boost 1.86")
+        assert cache["uses"] == "actions/cache@v5"
+        assert cache["with"]["path"] == "${{ runner.temp }}/mspass-boost-1.86.0"
+        cache_key = cache["with"]["key"]
+        assert "mspass-boost-1.86.0" in cache_key
+        assert "${{ runner.os }}" in cache_key
+        assert "${{ runner.arch }}" in cache_key
+        assert "${{ hashFiles('**/boost-download.cmake') }}" in cache_key
+        cache_keys.add(cache_key)
+        assert _step(job, "Configure Boost 1.86 cache")["run"] == (
+            'echo "MSPASS_BOOST_ROOT=${RUNNER_TEMP}/mspass-boost-1.86.0" '
+            '>> "$GITHUB_ENV"'
+        )
+        configure = _step(job, configure_step_name)["run"]
+        assert "-DBUILD_TESTING=ON" in configure
+        assert "-DCMAKE_BUILD_TYPE=RelWithDebInfo" in configure
+        assert configure.count(f"-fsanitize={sanitizer}") == 2
+        if job_name == "ubsan":
+            assert "-fno-sanitize-recover=undefined" in configure
+        build = _step(job, f"Build {configure_step_name.removeprefix('Configure ')}")[
+            "run"
+        ]
+        assert build == (
+            'cmake --build "$BUILD_DIRECTORY" --config RelWithDebInfo --parallel 2'
+        )
+        assert "--target" not in build
+        test_step = _step(job, test_step_name)
+        assert test_step["run"] == "ctest --output-on-failure"
+        assert test_step["env"] == sanitizer_environment
+        assert all("continue-on-error" not in step for step in job["steps"])
+    assert len(cache_keys) == 1
+    serialized = str(workflow).lower()
+    for forbidden in (
+        "suppressions=",
+        "sanitize-ignorelist",
+        "sanitize-blacklist",
+        "detect_leaks=0",
+    ):
+        assert forbidden not in serialized
+
+
+def _run_aggregate(script, **results):
+    environment = os.environ.copy()
+    environment.update(results)
+    return subprocess.run(
+        ["bash", "-c", script],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode
+
+
+def test_static_gates_accepts_only_complete_or_not_applicable_states(workflow):
+    aggregate = workflow["jobs"]["static-gates"]
+    assert aggregate["name"] == "static-gates"
+    assert aggregate["if"] == "${{ always() }}"
+    assert aggregate["needs"] == ["changes", "ruff", "asan", "ubsan"]
+    script = _step(aggregate, "Require every applicable gate")["run"]
+
+    assert (
+        _run_aggregate(
+            script,
+            CHANGES_RESULT="success",
+            NATIVE_CHANGED="true",
+            RUFF_RESULT="success",
+            ASAN_RESULT="success",
+            UBSAN_RESULT="success",
+        )
+        == 0
+    )
+    assert (
+        _run_aggregate(
+            script,
+            CHANGES_RESULT="success",
+            NATIVE_CHANGED="false",
+            RUFF_RESULT="success",
+            ASAN_RESULT="skipped",
+            UBSAN_RESULT="skipped",
+        )
+        == 0
+    )
+
+    failures = [
+        {"RUFF_RESULT": "failure"},
+        {"CHANGES_RESULT": "failure"},
+        {"ASAN_RESULT": "failure"},
+        {"UBSAN_RESULT": "failure"},
+    ]
+    for failure in failures:
+        results = {
+            "CHANGES_RESULT": "success",
+            "NATIVE_CHANGED": "true",
+            "RUFF_RESULT": "success",
+            "ASAN_RESULT": "success",
+            "UBSAN_RESULT": "success",
+        }
+        results.update(failure)
+        assert _run_aggregate(script, **results) != 0
+
+    assert (
+        _run_aggregate(
+            script,
+            CHANGES_RESULT="success",
+            NATIVE_CHANGED="false",
+            RUFF_RESULT="success",
+            ASAN_RESULT="success",
+            UBSAN_RESULT="success",
+        )
+        != 0
+    )
+    for invalid_native_state in ("", "unknown"):
+        assert (
+            _run_aggregate(
+                script,
+                CHANGES_RESULT="success",
+                NATIVE_CHANGED=invalid_native_state,
+                RUFF_RESULT="success",
+                ASAN_RESULT="skipped",
+                UBSAN_RESULT="skipped",
+            )
+            != 0
+        )
+
+
+def test_branch_protection_is_a_post_merge_admin_step(workflow):
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["jobs"]["changes"]["permissions"] == {
+        "contents": "read",
+        "pull-requests": "read",
+    }
+    serialized = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "branches/master/protection" not in serialized
+    assert "statuses:" not in serialized
+
+    guide = (
+        REPOSITORY_ROOT / "docs/source/getting_started/static_gates_ci.rst"
+    ).read_text(encoding="utf-8")
+    normalized = " ".join(guide.split())
+    assert "must not require ``static-gates`` until this workflow" in normalized
+    assert "merged into ``master``" in normalized
+    assert "add exactly ``static-gates``" in normalized
+    assert "branch-protection API" in normalized

--- a/python/tests/util/test_seispp.py
+++ b/python/tests/util/test_seispp.py
@@ -12,8 +12,8 @@ def setup_function(function):
 # FIXME: index_data will read the whole file to figure out the offset,
 # which is inefficient. i.e. junk=np.fromfile(fh,dtype=dtyp,count=ns3c)
 def backup_test_index_data():
-    index_data(test_index_data.data, test_index_data.db)
-    wfcol = test_index_data.db.wf
+    index_data(backup_test_index_data.data, backup_test_index_data.db)
+    wfcol = backup_test_index_data.db.wf
     assert wfcol.count_documents({}) == 3
     assert wfcol.count_documents({"sta": "ARV"}) == 1
     assert wfcol.count_documents({"sta": "BC3"}) == 1


### PR DESCRIPTION
## Summary

- add pinned Ruff 0.12.8 correctness checks
- build and run the full native CTest suite under Release, ASan, and UBSan
- add a stable aggregate check and strict policy regression tests
- repair the two baseline test defects exposed by the new gates, without changing production behavior

## Verification

- independent agent review: PASS
- Ruff exact full-tree command: PASS; baseline exposes 3 F821 errors
- Release, ASan, and UBSan full CTest: 12/12 each
- real ASan UAF/leak and UBSan overflow rejection: PASS
- policy tests, actionlint, strict Sphinx, Black, py_compile, and diff check: PASS

The `static-gates` required branch-protection context must be added by an administrator only after this workflow is merged and proven on master. Issue #798 remains open until that external step is verified. This PR is not merged.
