### PR TITLE
Harden AWS Lambda invocation without breaking response compatibility

### DIFF
--- a/python/tests/test_aws_lambda_invoke_protocol.py
+++ b/python/tests/test_aws_lambda_invoke_protocol.py
@@ -1,0 +1,562 @@
+import base64
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from botocore.response import StreamingBody
+from botocore.stub import Stubber
+
+REPOSITORY_ROOT = Path(
+    os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
+)
+EXAMPLE_DIR = REPOSITORY_ROOT / "scripts" / "aws_lambda_examples"
+
+
+def _load_module(name, filename):
+    spec = importlib.util.spec_from_file_location(name, EXAMPLE_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def client_module():
+    return _load_module("mspass_aws_lambda_client_test", "AwsLambdaClient.py")
+
+
+@pytest.fixture
+def process_module(monkeypatch):
+    function_module = _load_module("aws_lambda_func_def", "aws_lambda_func_def.py")
+    monkeypatch.setitem(sys.modules, "aws_lambda_func_def", function_module)
+    return _load_module("mspass_aws_lambda_process_test", "process.py")
+
+
+class TrackingStream(io.BytesIO):
+    def __init__(self, value):
+        super().__init__(value)
+        self.was_closed = False
+
+    def close(self):
+        self.was_closed = True
+        super().close()
+
+
+class RaisingStream:
+    def __init__(self):
+        self.was_closed = False
+
+    def read(self):
+        raise OSError("read failed")
+
+    def close(self):
+        self.was_closed = True
+
+
+class LambdaClient:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def invoke(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.response
+
+
+def _client(client_module, response):
+    client = client_module.AwsLambdaClient(
+        "access",
+        "secret",
+        "upload-bucket",
+        "role",
+        "eu-central-1",
+    )
+    lambda_client = LambdaClient(response)
+    client.create_aws_client = lambda service: lambda_client
+    return client, lambda_client
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (
+            {"ret_type": "content", "ret_value": base64.b64encode(b"abc").decode()},
+            {"return_type": "content", "ret_value": b"abc"},
+        ),
+        (
+            {
+                "ret_type": "key",
+                "ret_value": "results::output.mseed",
+                "future_field": 1,
+            },
+            {"return_type": "key", "ret_value": "results::output.mseed"},
+        ),
+    ],
+)
+def test_client_accepts_required_response_protocol_and_closes_stream(
+    client_module, payload, expected
+):
+    stream = TrackingStream(json.dumps(payload).encode("utf-8"))
+    client, lambda_client = _client(client_module, {"Payload": stream})
+
+    assert client.call_lambda_function("window", {"duration": 10}) == expected
+    assert stream.was_closed
+    assert lambda_client.calls == [
+        {
+            "FunctionName": "window",
+            "InvocationType": "RequestResponse",
+            "LogType": "Tail",
+            "Payload": json.dumps({"duration": 10}),
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (
+            {"ret_type": "content", "ret_value": "YQ=="},
+            {"return_type": "content", "ret_value": b"a"},
+        ),
+        (
+            {"ret_type": "key", "ret_value": "outputs::a.mseed"},
+            {"return_type": "key", "ret_value": "outputs::a.mseed"},
+        ),
+    ],
+)
+def test_real_stubber_response_types_in_alternate_region(
+    client_module, payload, expected
+):
+    client = client_module.AwsLambdaClient(
+        "access", "secret", "bucket", "role", "ap-southeast-2"
+    )
+    lambda_client = client.create_aws_client("lambda")
+    assert lambda_client.meta.region_name == "ap-southeast-2"
+    request = {"duration": 10}
+    raw_payload = json.dumps(payload).encode("utf-8")
+    raw_stream = io.BytesIO(raw_payload)
+    stream = StreamingBody(raw_stream, len(raw_payload))
+    with Stubber(lambda_client) as stubber:
+        stubber.add_response(
+            "invoke",
+            {"StatusCode": 200, "Payload": stream},
+            {
+                "FunctionName": "window",
+                "InvocationType": "RequestResponse",
+                "LogType": "Tail",
+                "Payload": json.dumps(request),
+            },
+        )
+        client.create_aws_client = lambda service: lambda_client
+        assert client.call_lambda_function("window", request) == expected
+    assert raw_stream.closed
+
+
+@pytest.mark.parametrize(
+    ("response", "match"),
+    [
+        (
+            {
+                "Payload": TrackingStream(b'{"ret_type":"content","ret_value":"YQ=="}'),
+                "FunctionError": "Unhandled",
+            },
+            "FunctionError",
+        ),
+        ({"Payload": TrackingStream(b"\xff")}, "UTF-8/JSON"),
+        ({"Payload": TrackingStream(b"not json")}, "UTF-8/JSON"),
+        ({"Payload": TrackingStream(b"[]")}, "malformed response"),
+        (
+            {"Payload": TrackingStream(b'{"ret_type":"content"}')},
+            "malformed response",
+        ),
+        (
+            {
+                "Payload": TrackingStream(
+                    b'{"return_type":"content","ret_value":"YQ=="}'
+                )
+            },
+            "malformed response",
+        ),
+        (
+            {"Payload": TrackingStream(b'{"ret_type":"content","ret_value":1}')},
+            "non-string base64",
+        ),
+        (
+            {
+                "Payload": TrackingStream(
+                    b'{"ret_type":"content","ret_value":"not base64"}'
+                )
+            },
+            "invalid base64",
+        ),
+        (
+            {"Payload": TrackingStream(b'{"ret_type":"key","ret_value":""}')},
+            "invalid S3 key",
+        ),
+        (
+            {"Payload": TrackingStream(b'{"ret_type":"key","ret_value":1}')},
+            "invalid S3 key",
+        ),
+        (
+            {"Payload": TrackingStream(b'{"ret_type":"value","ret_value":"YQ=="}')},
+            "unknown ret_type",
+        ),
+    ],
+)
+def test_client_rejects_every_malformed_or_failed_response(
+    client_module, response, match
+):
+    client, _ = _client(client_module, response)
+    stream = response["Payload"]
+
+    with pytest.raises(RuntimeError, match=match):
+        client.call_lambda_function("window", {})
+    assert stream.was_closed
+
+
+def test_client_wraps_payload_read_failure_and_closes_stream(client_module):
+    stream = RaisingStream()
+    client, _ = _client(client_module, {"Payload": stream})
+
+    with pytest.raises(RuntimeError, match="Failed to read.*window"):
+        client.call_lambda_function("window", {})
+    assert stream.was_closed
+
+
+def test_client_rejects_missing_payload_stream(client_module):
+    client, _ = _client(client_module, {})
+
+    with pytest.raises(RuntimeError, match="no readable Payload"):
+        client.call_lambda_function("window", {})
+
+
+def test_client_uses_the_configured_session_region(client_module, monkeypatch):
+    calls = []
+
+    class Session:
+        def __init__(self, **kwargs):
+            calls.append(("session", kwargs))
+
+        def client(self, service):
+            calls.append(("client", service))
+            return object()
+
+    monkeypatch.setattr(client_module.boto3, "Session", Session)
+    client = client_module.AwsLambdaClient(
+        "access", "secret", "bucket", "role", "ap-southeast-2"
+    )
+
+    client.create_aws_client("s3")
+    assert calls == [
+        (
+            "session",
+            {
+                "aws_access_key_id": "access",
+                "aws_secret_access_key": "secret",
+                "region_name": "ap-southeast-2",
+            },
+        ),
+        ("client", "s3"),
+    ]
+
+
+def test_lambda_archive_stream_is_closed_after_upload(
+    client_module, monkeypatch, tmp_path
+):
+    archive = tmp_path / "base.zip"
+    with zipfile.ZipFile(archive, "w") as bundle:
+        bundle.writestr("process.py", "old process")
+        bundle.writestr("aws_lambda_func_def.py", "old function")
+        bundle.writestr("dependency.txt", "keep dependency")
+    (tmp_path / "process.py").write_text("new process", encoding="utf-8")
+    (tmp_path / "aws_lambda_func_def.py").write_text("new function", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    uploaded = {}
+
+    class S3:
+        def put_object(self, **kwargs):
+            uploaded.update(kwargs)
+            assert not kwargs["Body"].closed
+            uploaded["BodyBytes"] = kwargs["Body"].read()
+
+    class Lambda:
+        def create_function(self, **kwargs):
+            pass
+
+    archive_updates = []
+    client = client_module.AwsLambdaClient(
+        "access", "secret", "bucket", "role", "eu-central-1"
+    )
+    update_archive = client._updateZip
+
+    def tracked_update(zip_path, filename):
+        archive_updates.append((zip_path, filename))
+        update_archive(zip_path, filename)
+
+    client._updateZip = tracked_update
+    client.create_aws_client = lambda service: S3() if service == "s3" else Lambda()
+
+    client.create_lambda_function("window")
+    assert archive_updates == [
+        ("base.zip", "process.py"),
+        ("base.zip", "aws_lambda_func_def.py"),
+    ]
+    assert uploaded["Body"].closed
+    with zipfile.ZipFile(io.BytesIO(uploaded["BodyBytes"])) as uploaded_archive:
+        assert uploaded_archive.read("process.py") == b"new process"
+        assert uploaded_archive.read("aws_lambda_func_def.py") == b"new function"
+        assert uploaded_archive.read("dependency.txt") == b"keep dependency"
+
+    failed_upload = {}
+
+    class FailingS3:
+        def put_object(self, **kwargs):
+            failed_upload.update(kwargs)
+            raise RuntimeError("archive upload failed")
+
+    client.create_aws_client = lambda service: (
+        FailingS3() if service == "s3" else Lambda()
+    )
+    with pytest.raises(RuntimeError, match="archive upload failed"):
+        client.create_lambda_function("window")
+    assert failed_upload["Body"].closed
+
+
+class S3Client:
+    def __init__(self, source=b"source", failure=None):
+        self.source = source
+        self.failure = failure
+        self.download_paths = []
+        self.uploads = []
+
+    def download_file(self, bucket, key, path):
+        self.download_paths.append((bucket, key, path))
+        if self.failure == "download":
+            raise RuntimeError("download failed")
+        Path(path).write_bytes(self.source)
+
+    def upload_file(self, path, bucket, key):
+        self.uploads.append((path, bucket, key, Path(path).read_bytes()))
+        if self.failure == "upload":
+            raise RuntimeError("upload failed")
+
+
+class Session:
+    def __init__(self, s3, region="eu-west-3"):
+        self.s3 = s3
+        self.region_name = region
+        self.services = []
+
+    def client(self, service):
+        self.services.append(service)
+        return self.s3
+
+
+def _request(**updates):
+    request = {
+        "src_bucket": "source-bucket",
+        "dst_bucket": "destination-bucket",
+        "src_key": "input/source.mseed",
+        "dst_key": "output/result.mseed",
+    }
+    request.update(updates)
+    return request
+
+
+def _install_process_fakes(monkeypatch, process_module, s3, output, failure=None):
+    session = Session(s3)
+    output_paths = []
+
+    def lambda_function(input_path, event):
+        assert Path(input_path).read_bytes() == s3.source
+        if failure == "process":
+            raise RuntimeError("process failed")
+        handle = tempfile.NamedTemporaryFile(delete=False)
+        handle.write(output)
+        handle.close()
+        output_paths.append(handle.name)
+        return handle.name
+
+    monkeypatch.setattr(process_module.boto3, "Session", lambda: session)
+    monkeypatch.setattr(process_module, "lambda_func", lambda_function)
+    return session, output_paths
+
+
+def _assert_owned_files_removed(s3, output_paths):
+    assert s3.download_paths
+    assert not Path(s3.download_paths[0][2]).exists()
+    assert all(not Path(path).exists() for path in output_paths)
+
+
+def test_process_uses_session_region_returns_content_and_cleans_files(
+    process_module, monkeypatch
+):
+    s3 = S3Client()
+    session, output_paths = _install_process_fakes(
+        monkeypatch, process_module, s3, b"processed"
+    )
+
+    response = process_module.process(_request())
+    assert response == {
+        "ret_type": "content",
+        "ret_value": base64.b64encode(b"processed").decode("utf-8"),
+    }
+    assert session.region_name == "eu-west-3"
+    assert session.services == ["s3"]
+    assert s3.uploads == []
+    _assert_owned_files_removed(s3, output_paths)
+
+
+def test_process_uploads_oversized_final_json_and_returns_bucket_and_key(
+    process_module, monkeypatch
+):
+    s3 = S3Client()
+    session, output_paths = _install_process_fakes(
+        monkeypatch, process_module, s3, b"x" * 4_499_971
+    )
+
+    response = process_module.process(_request())
+    assert response == {
+        "ret_type": "key",
+        "ret_value": "destination-bucket::output/result.mseed",
+    }
+    assert session.services == ["s3"]
+    assert len(s3.uploads) == 1
+    assert s3.uploads[0][1:] == (
+        "destination-bucket",
+        "output/result.mseed",
+        b"x" * 4_499_971,
+    )
+    _assert_owned_files_removed(s3, output_paths)
+
+
+def test_process_keeps_largest_reachable_inline_content(process_module, monkeypatch):
+    s3 = S3Client()
+    _, output_paths = _install_process_fakes(
+        monkeypatch, process_module, s3, b"x" * 4_499_970
+    )
+
+    response = process_module.process(_request())
+    serialized = process_module._serialized_response(response)
+    assert len(serialized) == 6_000_000
+    assert response["ret_type"] == "content"
+    assert s3.uploads == []
+    _assert_owned_files_removed(s3, output_paths)
+
+
+@pytest.mark.parametrize(
+    ("size", "expected_type"),
+    [(5_999_999, "content"), (6_000_000, "content"), (6_000_001, "key")],
+)
+def test_final_serialized_invoke_boundaries(
+    process_module, monkeypatch, size, expected_type
+):
+    s3 = S3Client()
+    _, output_paths = _install_process_fakes(
+        monkeypatch, process_module, s3, b"processed"
+    )
+    monkeypatch.setattr(
+        process_module, "_serialized_response", lambda response: b"x" * size
+    )
+
+    response = process_module.process(_request())
+
+    assert response["ret_type"] == expected_type
+    assert len(s3.uploads) == (expected_type == "key")
+    _assert_owned_files_removed(s3, output_paths)
+
+
+def test_content_response_serialization_matches_runtime_json(process_module):
+    assert (
+        process_module._serialized_response(
+            {"ret_type": "content", "ret_value": "YQ=="}
+        )
+        == b'{"ret_type": "content", "ret_value": "YQ=="}'
+    )
+    assert process_module._serialized_response(
+        {"ret_type": "key", "ret_value": "r\N{LATIN SMALL LETTER E WITH ACUTE}sultat"}
+    ) == '{"ret_type": "key", "ret_value": "résultat"}'.encode("utf-8")
+
+
+def test_explicit_s3_response_skips_inline_serialization(process_module, monkeypatch):
+    s3 = S3Client()
+    _, output_paths = _install_process_fakes(
+        monkeypatch, process_module, s3, b"processed"
+    )
+    monkeypatch.setattr(
+        process_module,
+        "_serialized_response",
+        lambda response: (_ for _ in ()).throw(
+            AssertionError("explicit S3 output must not be serialized")
+        ),
+    )
+
+    response = process_module.process(_request(save_to_s3=True))
+
+    assert response == {
+        "ret_type": "key",
+        "ret_value": "destination-bucket::output/result.mseed",
+    }
+    assert len(s3.uploads) == 1
+    _assert_owned_files_removed(s3, output_paths)
+
+
+@pytest.mark.parametrize("failure", ["download", "process", "serialization", "upload"])
+def test_process_removes_owned_files_on_every_failure(
+    process_module, monkeypatch, failure
+):
+    s3 = S3Client(failure=failure if failure in {"download", "upload"} else None)
+    _, output_paths = _install_process_fakes(
+        monkeypatch,
+        process_module,
+        s3,
+        b"processed",
+        failure=failure,
+    )
+    request = _request(save_to_s3=failure == "upload")
+    if failure == "serialization":
+        monkeypatch.setattr(
+            process_module,
+            "_serialized_response",
+            lambda response: (_ for _ in ()).throw(
+                RuntimeError("serialization failed")
+            ),
+        )
+
+    with pytest.raises(RuntimeError, match=f"{failure} failed"):
+        process_module.process(request)
+    _assert_owned_files_removed(s3, output_paths)
+
+
+def test_process_removes_input_if_temporary_file_close_fails(
+    process_module, monkeypatch
+):
+    s3 = S3Client()
+    session = Session(s3)
+    real_named_temporary_file = tempfile.NamedTemporaryFile
+    input_paths = []
+
+    class CloseFailure:
+        def __init__(self, *args, **kwargs):
+            self._handle = real_named_temporary_file(*args, **kwargs)
+            self.name = self._handle.name
+            input_paths.append(self.name)
+
+        def close(self):
+            self._handle.close()
+            raise RuntimeError("temporary file close failed")
+
+    monkeypatch.setattr(process_module.boto3, "Session", lambda: session)
+    monkeypatch.setattr(process_module.tempfile, "NamedTemporaryFile", CloseFailure)
+
+    with pytest.raises(RuntimeError, match="temporary file close failed"):
+        process_module.process(_request())
+
+    assert len(input_paths) == 1
+    assert not Path(input_paths[0]).exists()

--- a/python/tests/test_aws_lambda_runtime_example.py
+++ b/python/tests/test_aws_lambda_runtime_example.py
@@ -57,6 +57,7 @@ def test_create_function_uses_python_313_bundle_contract(tmp_path, monkeypatch):
 
     with zipfile.ZipFile(tmp_path / "base.zip", "w") as archive:
         archive.writestr("process.py", "def handler(event, context): return event\n")
+    shutil.copy2(EXAMPLE_ROOT / "process.py", tmp_path)
     shutil.copy2(EXAMPLE_ROOT / "aws_lambda_func_def.py", tmp_path)
     monkeypatch.chdir(tmp_path)
 

--- a/scripts/aws_lambda_examples/AwsLambdaClient.py
+++ b/scripts/aws_lambda_examples/AwsLambdaClient.py
@@ -1,7 +1,6 @@
 import base64
-import io
+import binascii
 import boto3
-import sys
 import os
 import zipfile
 import tempfile
@@ -54,8 +53,7 @@ class AwsLambdaClient:
             aws_secret_access_key=self.aws_secret_access_key,
             region_name=self.region_name,
         )
-        client = aws_session.client(client_type, self.region_name)
-        return client
+        return aws_session.client(client_type)
 
     @staticmethod
     def _updateZip(zip_path, filename):
@@ -94,12 +92,14 @@ class AwsLambdaClient:
         """
 
         s3_client = self.create_aws_client("s3")
+        self._updateZip("base.zip", "process.py")
         self._updateZip("base.zip", "aws_lambda_func_def.py")
-        s3_client.put_object(
-            Key="base.zip",
-            Bucket=self.lambda_upload_bucket,
-            Body=open("base.zip", "rb"),
-        )
+        with open("base.zip", "rb") as archive:
+            s3_client.put_object(
+                Key="base.zip",
+                Bucket=self.lambda_upload_bucket,
+                Body=archive,
+            )
 
         lambda_client = self.create_aws_client("lambda")
         lambda_client.create_function(
@@ -118,16 +118,17 @@ class AwsLambdaClient:
         """
         Call an existing lambda function.
 
-        :param functionName: the name of the lambda function to call.
+        :param function_name: the name of the lambda function to call.
         :param request: an dictionary that contains all the arguments passed to the lambda function. It will be dumped as a json string and then used as the payload of request.
         It should at least contain four elements: ‘src_bucket’, ‘dst_bucket’, ‘src_key’, ‘dst_key’. They will indicate the input and output object of this lambda call.
         :return: a dict that contain two elements:
-            1) ret_type: two possible value: ‘key’ or ‘value’,
+            1) return_type: two possible values: ‘key’ or ‘content’,
                 ‘key’ means that the output object is saved to some place in s3.
-                ‘value’ means that the output object is directly returned through payload
+                ‘content’ means that the output object is directly returned through payload
             2) ret_value:
-                If ret_type=’key’, ret_value will be the key of the output object in s3.
-                If ret_type=’value’, ret_value will be the bytes of the returning object.
+                If return_type=’key’, ret_value will be the existing ``bucket::key``
+                location of the output object in s3.
+                If return_type=’content’, ret_value will be the decoded output bytes.
         """
 
         lambda_client = self.create_aws_client("lambda")
@@ -138,21 +139,72 @@ class AwsLambdaClient:
             Payload=json.dumps(request),
         )
 
-        response_payload = json.loads(response["Payload"].read())
-        ret_type = response_payload["ret_type"]
-        if (
-            ret_type == "key"
-        ):  #   The output file is saved to another bucket (s3_output_bucket).
-            ret_value = response_payload["ret_value"]
-            print(
-                "The window given is too large, can't be returned immediately,\nPlease check {}".format(
-                    ret_value
-                )
+        payload_stream = response.get("Payload")
+        if payload_stream is None or not hasattr(payload_stream, "read"):
+            raise RuntimeError(
+                f"Lambda {function_name!r} returned no readable Payload stream"
             )
-        elif ret_type == "content":
-            ret_value = base64.b64decode(response_payload["ret_value"].encode("utf-8"))
-        else:
-            raise Exception("Undefined return type when calling " + function, "Fatal")
+        try:
+            raw_payload = payload_stream.read()
+        except Exception as error:
+            raise RuntimeError(
+                f"Failed to read the response from Lambda {function_name!r}"
+            ) from error
+        finally:
+            close = getattr(payload_stream, "close", None)
+            if close is not None:
+                close()
 
-        ret_dict = {"return_type": ret_type, "ret_value": ret_value}
-        return ret_dict
+        if response.get("FunctionError"):
+            raise RuntimeError(
+                f"Lambda {function_name!r} failed with FunctionError "
+                f"{response['FunctionError']!r}"
+            )
+
+        try:
+            if isinstance(raw_payload, bytes):
+                decoded_payload = raw_payload.decode("utf-8")
+            elif isinstance(raw_payload, str):
+                decoded_payload = raw_payload
+            else:
+                raise TypeError(
+                    f"Payload.read() returned {type(raw_payload).__name__}, not bytes"
+                )
+            response_payload = json.loads(decoded_payload)
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError) as error:
+            raise RuntimeError(
+                f"Lambda {function_name!r} returned malformed UTF-8/JSON"
+            ) from error
+
+        if not isinstance(response_payload, dict) or not {
+            "ret_type",
+            "ret_value",
+        }.issubset(response_payload):
+            raise RuntimeError(
+                f"Lambda {function_name!r} returned a malformed response object"
+            )
+        ret_type = response_payload["ret_type"]
+        encoded_value = response_payload["ret_value"]
+        if ret_type == "key":
+            if not isinstance(encoded_value, str) or not encoded_value:
+                raise RuntimeError(
+                    f"Lambda {function_name!r} returned an invalid S3 key"
+                )
+            ret_value = encoded_value
+        elif ret_type == "content":
+            if not isinstance(encoded_value, str):
+                raise RuntimeError(
+                    f"Lambda {function_name!r} returned non-string base64 content"
+                )
+            try:
+                ret_value = base64.b64decode(encoded_value, validate=True)
+            except (binascii.Error, ValueError) as error:
+                raise RuntimeError(
+                    f"Lambda {function_name!r} returned invalid base64 content"
+                ) from error
+        else:
+            raise RuntimeError(
+                f"Lambda {function_name!r} returned unknown ret_type {ret_type!r}"
+            )
+
+        return {"return_type": ret_type, "ret_value": ret_value}

--- a/scripts/aws_lambda_examples/README.md
+++ b/scripts/aws_lambda_examples/README.md
@@ -42,7 +42,11 @@ the archive.  The build is fixed to `linux/amd64`, matching Lambda's default
 x86_64 architecture.
 
 ***Note:***
-* Because the size of response payload is limited, we can have two different API: 
-    * When the size of the object to return is small enough (Less than 5~6 MB), it can be dumped into the payload. In such a case, the return value of the call_lambda_function is a data object, which is directly obtained from the lambda function call.
-    * When the size of the object to return is larger than 5~6MB, it can’t be transmitted through the lambda payload. So we can just return the location of the output object, and let the user download it later. 
+* The Lambda response protocol has two required forms: `ret_type="content"`
+  carries base64 content in `ret_value`, while `ret_type="key"` carries the
+  existing `bucket::key` S3 location in `ret_value`.  `call_lambda_function`
+  continues to expose the public `return_type` and `ret_value` fields.
+* Inline content is selected only when the final UTF-8 JSON response,
+  including the base64 expansion and field syntax, is no larger than 6,000,000
+  bytes.  Larger results are uploaded to the configured destination bucket.
 * The maximum running time of one execution is 15 mins, so the lambda function can’t be used to do heavy work. The main point of  lambda function is to help do some trivial preprocessing on data on aws s3. If some heavy calculations are to be done, the better way is to download the data and do it locally.

--- a/scripts/aws_lambda_examples/aws_lambda_func_def.py
+++ b/scripts/aws_lambda_examples/aws_lambda_func_def.py
@@ -16,13 +16,8 @@ def lambda_func(input_path, event):
         "AwsLambdaClient.call_lambda_function". The user-specified parameters can be extracted as follows:
             arg1 = event['arg1']
             arg2 = event['arg2']
-    :return: a dict that contain two elements:
-        1) ret_type: two possible value: ‘key’ or ‘value’, 
-            ‘key’ means that the output object is saved to some place in s3.
-            ‘value’ means that the output object is directly returned through payload
-        2) ret_value:
-            If ret_type=’key’, ret_value will be the key of the output object in s3.
-            If ret_type=’value’, ret_value will be the bytes of the returning object.
+    :return: the path of the output file.  The process wrapper converts that
+        file to the ``content`` or ``key`` Invoke response protocol.
     """
 '''
 
@@ -38,7 +33,7 @@ def lambda_func(input_path, event):
         t0shift = event["t0shift"]
 
     basename = os.path.basename(input_path)
-    (filename, ext) = os.path.splitext(basename)
+    filename, ext = os.path.splitext(basename)
     filename = filename + "_{}_{}".format(duration, t0shift) + ext
     outfile = "/tmp/" + filename
 

--- a/scripts/aws_lambda_examples/process.py
+++ b/scripts/aws_lambda_examples/process.py
@@ -2,15 +2,33 @@
 
 import os
 import boto3
-import obspy
 import json
 import base64
-import shutil
+import tempfile
 from aws_lambda_func_def import lambda_func
 
-
 _DEBUG_FLAG_ = False  # When set to True, debugging log will be printed
-MAX_PAYLOAD = 6 * 1000000  # The maximum payload of lambda function is 6MB
+MAX_PAYLOAD = 6000000  # Maximum final UTF-8 JSON response size for synchronous Invoke
+
+
+def _serialized_response(response):
+    # Match the default separators used by the Python Lambda runtime's JSON
+    # response encoder.  The Invoke limit applies to these serialized bytes,
+    # not to the raw output file.
+    return json.dumps(response, ensure_ascii=False).encode("utf-8")
+
+
+def _fits_invoke_response(serialized_response):
+    return len(serialized_response) <= MAX_PAYLOAD
+
+
+def _remove_file(path):
+    if path is None:
+        return
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
 
 
 def process(event):
@@ -18,8 +36,9 @@ def process(event):
     A wrapper function for the user-defined aws lambda functions.
     First download the source object from s3 bucket.
     Then execute the lambda function defined by user.
-    Finally, return the content of the timewindow if the file size is less than 6MB,
-    Otherwise, dump that output file to another s3 bucket, and return the file location.
+    Finally, return the content when its UTF-8 JSON response is no larger than
+    6,000,000 bytes.  Otherwise, upload the output to S3 and return its existing
+    ``bucket::key`` location format.
     """
     if _DEBUG_FLAG_:
         print(event)
@@ -35,51 +54,60 @@ def process(event):
     src_key = event["src_key"]
     dst_key = event["dst_key"]
 
-    # Download file from the source S3 bucket.
     session = boto3.Session()
-    s3 = boto3.client("s3", region_name="us-west-2")  #   BY DEFAULT
-    tempfile = "/tmp/" + os.path.basename(src_key)
-    if _DEBUG_FLAG_:
-        print("Downloading {} to {}".format(src_key, tempfile))
-    s3.download_file(src_bucket, src_key, tempfile)
-
-    if not os.path.isfile(tempfile):
-        raise Exception(
-            "Could not download {} from {} to {}".format(src_key, src_bucket, tempfile)
+    s3 = session.client("s3")
+    suffix = os.path.splitext(os.path.basename(src_key))[1]
+    input_path = None
+    output_path = None
+    try:
+        input_handle = tempfile.NamedTemporaryFile(
+            prefix="mspass-lambda-input-", suffix=suffix, delete=False
         )
-
-    # Call user-defined function
-    outfile = lambda_func(tempfile, event)
-    if not os.path.isfile(outfile):
-        raise Exception("Could not write output file {}".format(outfile))
-
-    os.remove(tempfile)
-
-    # Check the size of output file
-    output_size = os.path.getsize(outfile)
-    if _DEBUG_FLAG_:
-        print("The size of {} is {}".format(outfile, output_size / 1000000.0))
-    if output_size > MAX_PAYLOAD:  #   We have to save that to another s3 bucket
-        save_to_s3 = True
-
-    # Save output to the output s3 bucket
-    if save_to_s3:
+        input_path = input_handle.name
+        input_handle.close()
         if _DEBUG_FLAG_:
-            print("Saving {} to {}".format(outfile, dst_key))
-        s3.upload_file(outfile, dst_bucket, dst_key)
+            print("Downloading {} to {}".format(src_key, input_path))
+        s3.download_file(src_bucket, src_key, input_path)
+        if not os.path.isfile(input_path):
+            raise RuntimeError(
+                "Could not download {} from {} to {}".format(
+                    src_key, src_bucket, input_path
+                )
+            )
 
-    ret_dict = {}
-    if save_to_s3:
-        ret_dict["ret_type"] = "key"
-        ret_dict["ret_value"] = dst_bucket + "::" + dst_key
-    else:
-        ret_dict["ret_type"] = "content"
-        outfile_bytes = open(outfile, "rb").read()
-        ret_dict["ret_value"] = base64.b64encode(outfile_bytes).decode("utf-8")
+        candidate_path = lambda_func(input_path, event)
+        if not isinstance(candidate_path, str) or not os.path.isfile(candidate_path):
+            raise RuntimeError(f"Could not write output file {candidate_path!r}")
+        output_path = candidate_path
 
-    os.remove(outfile)
+        if not save_to_s3:
+            with open(output_path, "rb") as output_stream:
+                output_bytes = output_stream.read()
+            content_response = {
+                "ret_type": "content",
+                "ret_value": base64.b64encode(output_bytes).decode("utf-8"),
+            }
+            serialized_content = _serialized_response(content_response)
+            if _fits_invoke_response(serialized_content):
+                return content_response
 
-    return ret_dict
+        if not isinstance(dst_bucket, str) or not dst_bucket:
+            raise RuntimeError("dst_bucket must be a nonempty S3 bucket")
+        if not isinstance(dst_key, str) or not dst_key:
+            raise RuntimeError("dst_key must be a nonempty S3 key")
+        if _DEBUG_FLAG_:
+            print("Saving {} to {}".format(output_path, dst_key))
+        s3.upload_file(output_path, dst_bucket, dst_key)
+        return {
+            "ret_type": "key",
+            "ret_value": dst_bucket + "::" + dst_key,
+        }
+    finally:
+        try:
+            _remove_file(output_path)
+        finally:
+            if output_path != input_path:
+                _remove_file(input_path)
 
 
 def handler(event, context):


### PR DESCRIPTION
Fixes #806.

## Summary
- preserve the existing Lambda wire protocol (`content` or `bucket::key`) and the public `return_type` client field
- keep otherwise valid responses forward-compatible when they contain additional fields
- use the configured AWS region, surface `FunctionError` and malformed payloads as contextual `RuntimeError`, and close response/archive streams
- size inline results from the final runtime-style UTF-8 JSON response and upload larger results to S3
- clean up every owned temporary file on success and failure; explicit S3 output skips unnecessary file reads and base64 serialization
- regenerate the deterministic Python 3.13 deployment bundle with the updated handler

## Verification
- AWS Invoke protocol tests: 32 passed
- Python 3.13 bundle/runtime tests: 4 passed
- bundle imports/native ABI and ObsPy miniSEED round trip passed
- embedded handler sources match the repository sources byte-for-byte
- Black, `py_compile`, and `git diff --check` passed

The PR remains draft only while the refreshed GitHub checks run.
