### PR TITLE
Fix IU HPC launcher lifecycle

### DIFF
--- a/python/tests/test_iu_hpc_launcher_contract.py
+++ b/python/tests/test_iu_hpc_launcher_contract.py
@@ -1,0 +1,693 @@
+import importlib.util
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+REPOSITORY_ROOT = Path(
+    os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
+)
+LAUNCHER_PATH = REPOSITORY_ROOT / "scripts" / "IU_examples" / "python" / "launcher.py"
+
+
+@pytest.fixture
+def launcher_module():
+    spec = importlib.util.spec_from_file_location(
+        "mspass_iu_launcher_test", LAUNCHER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    assert Path(module.__file__).resolve() == LAUNCHER_PATH.resolve()
+    return module
+
+
+def _configuration(**cluster_updates):
+    cluster = {
+        "primary_host": "primary",
+        "database_host": "database:27017",
+        "scheduler_host": "tcp://scheduler:8786",
+        "worker_hosts": ["worker1", "worker2"],
+        "job_scheduler": "slurm",
+        "task_scheduler": "dask",
+        "container_run_command": "apptainer run",
+        "container_run_args": "-B /scratch --home /work",
+        "container_env_flag": "--env",
+        "worker_run_command": "mpiexec --label",
+        "setup_tunnel": False,
+        "tunnel_setup_command": "setup-tunnel --quiet",
+    }
+    cluster.update(cluster_updates)
+    return {
+        "container": "/containers/mspass.sif",
+        "working_directory": "/work",
+        "log_directory": "/work/logs",
+        "database_directory": "/work/db",
+        "worker_directory": "/work/worker",
+        "workers_per_node": 8,
+        "primary_node_workers": 2,
+        "cluster_subnet_name": "cluster.example",
+        "HPC_cluster": cluster,
+    }
+
+
+def _write_configuration(tmp_path, **cluster_updates):
+    path = tmp_path / "configuration.yaml"
+    path.write_text(yaml.safe_dump(_configuration(**cluster_updates)))
+    return path
+
+
+class Process:
+    def __init__(self, status=None):
+        self.status = status
+        self.poll_count = 0
+        self.terminate_count = 0
+        self.kill_count = 0
+        self.wait_calls = []
+
+    def poll(self):
+        self.poll_count += 1
+        return self.status
+
+    def terminate(self):
+        self.terminate_count += 1
+        self.status = 0
+
+    def kill(self):
+        self.kill_count += 1
+        self.status = -9
+
+    def wait(self, timeout):
+        self.wait_calls.append(timeout)
+        return self.status
+
+
+def _launcher(launcher_module, tmp_path, **cluster_updates):
+    return launcher_module.HPCClusterLauncher(
+        _write_configuration(tmp_path, **cluster_updates), auto_launch=False
+    )
+
+
+def _assert_process_handles_initialized(launcher):
+    assert launcher.scheduler_process is None
+    assert launcher.dbserver_process is None
+    assert launcher.primary_worker_process is None
+    assert launcher.remote_worker_process is None
+    assert launcher.jupyter_process is None
+
+
+def test_all_explicit_hosts_initialize_without_scheduler_discovery(
+    launcher_module, monkeypatch, tmp_path
+):
+    run_calls = []
+    monkeypatch.setattr(
+        launcher_module.subprocess,
+        "run",
+        lambda *args, **kwargs: run_calls.append((args, kwargs)),
+    )
+
+    launcher = _launcher(launcher_module, tmp_path)
+
+    assert launcher.primary_node == "primary"
+    assert launcher.database_host == "database:27017"
+    assert launcher.scheduler_host == "tcp://scheduler:8786"
+    assert launcher.worker_hosts == ["worker1", "worker2"]
+    assert run_calls == []
+    _assert_process_handles_initialized(launcher)
+
+
+def test_mixed_auto_hosts_use_exact_slurm_discovery(
+    launcher_module, monkeypatch, tmp_path
+):
+    calls = []
+
+    def run(args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(stdout="node1\nnode2\nnode3\n")
+
+    monkeypatch.setattr(launcher_module.subprocess, "run", run)
+    launcher = _launcher(
+        launcher_module,
+        tmp_path,
+        primary_host="auto",
+        database_host="mongo.example:27017",
+        scheduler_host="auto",
+        worker_hosts="auto",
+    )
+
+    assert calls == [
+        (
+            ["scontrol", "show", "hostname"],
+            {"capture_output": True, "text": True},
+        )
+    ]
+    assert launcher.primary_node == "node1"
+    assert launcher.database_host == "mongo.example:27017"
+    assert launcher.scheduler_host == "node1"
+    assert launcher.worker_hosts == ["node2", "node3"]
+    _assert_process_handles_initialized(launcher)
+
+
+def test_mixed_hosts_keep_explicit_primary_and_scheduler(
+    launcher_module, monkeypatch, tmp_path
+):
+    calls = []
+
+    def run(args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(stdout="node1\nnode2\nnode3\n")
+
+    monkeypatch.setattr(launcher_module.subprocess, "run", run)
+    launcher = _launcher(
+        launcher_module,
+        tmp_path,
+        primary_host="node2",
+        database_host="auto",
+        scheduler_host="tcp://explicit-scheduler:8786",
+        worker_hosts="auto",
+    )
+
+    assert calls == [
+        (
+            ["scontrol", "show", "hostname"],
+            {"capture_output": True, "text": True},
+        )
+    ]
+    assert launcher.primary_node == "node2"
+    assert launcher.database_host == "node2"
+    assert launcher.scheduler_host == "tcp://explicit-scheduler:8786"
+    assert launcher.worker_hosts == ["node1", "node3"]
+    _assert_process_handles_initialized(launcher)
+
+
+def test_all_auto_hosts_use_primary_and_remaining_allocated_nodes(
+    launcher_module, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        launcher_module.subprocess,
+        "run",
+        lambda args, **kwargs: SimpleNamespace(stdout="node1 node2"),
+    )
+    launcher = _launcher(
+        launcher_module,
+        tmp_path,
+        primary_host="auto",
+        database_host="auto",
+        scheduler_host="auto",
+        worker_hosts="auto",
+    )
+
+    assert launcher.primary_node == "node1"
+    assert launcher.database_host == "node1"
+    assert launcher.scheduler_host == "node1"
+    assert launcher.worker_hosts == ["node2"]
+    _assert_process_handles_initialized(launcher)
+
+
+def test_tunnel_executes_newly_constructed_argv(launcher_module, monkeypatch, tmp_path):
+    calls = []
+
+    def run(args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr(launcher_module.subprocess, "run", run)
+    _launcher(
+        launcher_module,
+        tmp_path,
+        setup_tunnel=True,
+        tunnel_setup_command="setup-tunnel --quiet",
+    )
+
+    assert calls == [
+        (
+            ["setup-tunnel", "--quiet", "primary"],
+            {"capture_output": True, "text": True, "check": True},
+        )
+    ]
+
+
+def test_repository_iu_configuration_is_valid_yaml():
+    configuration_path = (
+        REPOSITORY_ROOT / "scripts" / "IU_examples" / "python" / "configuration.yaml"
+    )
+    configuration = yaml.safe_load(configuration_path.read_text())
+    assert isinstance(configuration, dict)
+    assert isinstance(configuration["HPC_cluster"], dict)
+
+
+def test_worker_argv_contains_complete_endpoints_without_shell_syntax(
+    launcher_module, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    args = launcher._build_worker_run_args()
+
+    assert args == [
+        "mpiexec",
+        "--label",
+        "-n",
+        "2",
+        "-ppn",
+        "1",
+        "-hosts",
+        "worker1",
+        "worker2",
+        "apptainer",
+        "run",
+        "-B",
+        "/scratch",
+        "--home",
+        "/work",
+        "--env",
+        "MSPASS_ROLE=worker,MSPASS_WORK_DIR=/work,"
+        "MSPASS_SCHEDULER_ADDRESS=tcp://scheduler:8786,"
+        "MSPASS_DB_ADDRESS=database:27017,"
+        "MSPASS_WORKER_ARG=--nworkers=8 --nthreads 1",
+        "/containers/mspass.sif",
+    ]
+    assert "&" not in args
+
+
+def test_hpc_launcher_never_uses_shell_metacharacters_or_communicate(
+    launcher_module,
+):
+    source = LAUNCHER_PATH.read_text()
+    source = source[
+        source.index("class HPCClusterLauncher") : source.index("class DesktopLauncher")
+    ]
+    assert "shell=True" not in source
+    assert '.append("&")' not in source
+    assert ".communicate(" not in source
+
+
+def test_popen_executes_the_argv_list_without_a_shell(launcher_module, monkeypatch):
+    calls = []
+    process = Process(None)
+
+    def popen(*args, **kwargs):
+        calls.append((args, kwargs))
+        return process
+
+    monkeypatch.setattr(launcher_module.subprocess, "Popen", popen)
+    argv = ["program", "argument with spaces"]
+
+    assert launcher_module.HPCClusterLauncher._popen(argv) is process
+    assert calls == [
+        (
+            (argv,),
+            {
+                "stdin": launcher_module.subprocess.PIPE,
+                "stdout": launcher_module.subprocess.PIPE,
+                "stderr": launcher_module.subprocess.PIPE,
+                "close_fds": True,
+            },
+        )
+    ]
+
+
+def test_status_uses_none_as_only_running_value_and_skips_absent_handles(
+    launcher_module, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    running = Process(None)
+    successful_exit = Process(0)
+    failed_exit = Process(9)
+    launcher.dbserver_process = running
+    launcher.scheduler_process = successful_exit
+
+    assert launcher.status("db", verbose=False) == 1
+    assert launcher.status("scheduler", verbose=False) == 0
+    launcher.scheduler_process = failed_exit
+    assert launcher.status("scheduler", verbose=False) == 0
+    assert launcher.status("primary_worker", verbose=False) == 1
+    assert launcher.status("remote_worker", verbose=False) == 1
+    assert launcher.status("frontend", verbose=False) == 1
+    assert launcher.status("all", verbose=False) == 0
+    assert running.poll_count == 2
+    assert successful_exit.poll_count == 1
+    assert failed_exit.poll_count == 2
+    assert launcher.primary_worker_process is None
+
+
+def test_status_treats_absent_required_services_as_stopped(launcher_module, tmp_path):
+    launcher = _launcher(launcher_module, tmp_path)
+    assert launcher.status("db", verbose=False) == 0
+    assert launcher.status("scheduler", verbose=False) == 0
+
+
+def test_status_all_ignores_absent_optional_processes(launcher_module, tmp_path):
+    launcher = _launcher(launcher_module, tmp_path)
+    database = Process(None)
+    scheduler = Process(None)
+    launcher.dbserver_process = database
+    launcher.scheduler_process = scheduler
+
+    assert launcher.status("all", verbose=False) == 1
+    assert database.poll_count == 1
+    assert scheduler.poll_count == 1
+
+
+def test_launch_waits_for_both_services_before_any_worker(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    events = []
+    processes = []
+
+    def popen(args):
+        process = Process(None)
+        processes.append((args, process))
+        role = next(value for value in args if "MSPASS_ROLE=" in value)
+        events.append(("start", role))
+        return process
+
+    def ready():
+        assert len(processes) == 2
+        events.append(("ready",))
+
+    monkeypatch.setattr(launcher, "_popen", popen)
+    monkeypatch.setattr(launcher, "_wait_for_services", ready)
+    launcher.launch()
+
+    assert events[0][1].startswith("MSPASS_ROLE=scheduler")
+    assert events[1][1].startswith("MSPASS_ROLE=db")
+    assert events[2] == ("ready",)
+    assert events[3][1].startswith("MSPASS_ROLE=worker")
+    assert events[4][1].startswith("MSPASS_ROLE=worker")
+    assert len(processes) == 4
+    assert all("&" not in event[1] for event in events if event[0] == "start")
+    scheduler_args = processes[0][0]
+    database_args = processes[1][0]
+    remote_worker_args = processes[2][0]
+    primary_worker_args = processes[3][0]
+    assert scheduler_args == [
+        "apptainer",
+        "run",
+        "-B",
+        "/scratch",
+        "--home",
+        "/work",
+        "--env",
+        "MSPASS_ROLE=scheduler,MSPASS_WORK_DIR=/work,MSPASS_SCHEDULER=dask,MSPASS_SCHEDULER_ADDRESS=tcp://scheduler:8786",
+        "/containers/mspass.sif",
+    ]
+    assert database_args == [
+        "apptainer",
+        "run",
+        "-B",
+        "/scratch",
+        "--home",
+        "/work",
+        "--env",
+        "MSPASS_ROLE=db,MSPASS_WORK_DIR=/work,MSPASS_DB_DIR=/work/db",
+        "/containers/mspass.sif",
+    ]
+    assert remote_worker_args == launcher._build_worker_run_args()
+    assert primary_worker_args == [
+        "apptainer",
+        "run",
+        "-B",
+        "/scratch",
+        "--home",
+        "/work",
+        "--env",
+        "MSPASS_ROLE=worker,MSPASS_WORK_DIR=/work,"
+        "MSPASS_SCHEDULER_ADDRESS=tcp://scheduler:8786,"
+        "MSPASS_DB_ADDRESS=database:27017,"
+        "MSPASS_WORKER_ARG=--nworkers=2 --nthreads 1",
+        "/containers/mspass.sif",
+    ]
+
+
+def test_readiness_retries_closes_clients_and_uses_exact_endpoints(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    launcher.scheduler_process = Process(None)
+    launcher.dbserver_process = Process(None)
+    mongo_instances = []
+    dask_instances = []
+    attempts = {"mongo": 0, "dask": 0}
+
+    class Mongo:
+        def __init__(self, host, **kwargs):
+            assert host == "database:27017"
+            assert kwargs == {"serverSelectionTimeoutMS": 2000}
+            self.closed = False
+            self.admin = self
+            mongo_instances.append(self)
+
+        def command(self, command):
+            assert command == "ping"
+            attempts["mongo"] += 1
+            if attempts["mongo"] == 1:
+                raise RuntimeError("not ready")
+
+        def close(self):
+            self.closed = True
+
+    class Dask:
+        def __init__(self, endpoint, timeout):
+            assert endpoint == "tcp://scheduler:8786"
+            assert timeout == "2s"
+            self.closed = False
+            dask_instances.append(self)
+
+        def scheduler_info(self):
+            attempts["dask"] += 1
+            if attempts["dask"] == 1:
+                raise RuntimeError("not ready")
+
+        def close(self):
+            self.closed = True
+
+    clock = iter([0.0, 0.0, 0.1])
+    sleep_calls = []
+    monkeypatch.setenv("MSPASS_STARTUP_TIMEOUT_SECONDS", "3.5")
+    monkeypatch.setenv("MSPASS_STARTUP_POLL_SECONDS", "0.125")
+    monkeypatch.setattr(launcher_module, "MongoClient", Mongo)
+    monkeypatch.setattr(launcher_module, "Client", Dask)
+    monkeypatch.setattr(launcher_module.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(
+        launcher_module.time, "sleep", lambda delay: sleep_calls.append(delay)
+    )
+    launcher._wait_for_services()
+
+    assert attempts == {"mongo": 2, "dask": 2}
+    assert sleep_calls == [0.125]
+    assert all(instance.closed for instance in mongo_instances + dask_instances)
+
+
+def test_timeout_starts_no_workers_and_reaps_all_owned_children(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    started = []
+
+    def popen(args):
+        process = Process(None)
+        started.append(process)
+        return process
+
+    monotonic = iter([0.0, 1.0])
+    monkeypatch.setenv("MSPASS_STARTUP_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("MSPASS_STARTUP_POLL_SECONDS", "0.25")
+    monkeypatch.setattr(launcher, "_popen", popen)
+    monkeypatch.setattr(
+        launcher, "_probe_database", lambda: (_ for _ in ()).throw(RuntimeError())
+    )
+    monkeypatch.setattr(
+        launcher, "_probe_scheduler", lambda: (_ for _ in ()).throw(RuntimeError())
+    )
+    monkeypatch.setattr(launcher_module.time, "monotonic", lambda: next(monotonic))
+
+    with pytest.raises(launcher_module.MsPASSError) as error:
+        launcher.launch()
+
+    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
+    assert len(started) == 2
+    assert all(process.terminate_count == 1 for process in started)
+    assert all(process.wait_calls == [10] for process in started)
+    assert launcher.remote_worker_process is None
+    assert launcher.primary_worker_process is None
+
+
+def test_owned_child_early_exit_reaps_every_started_process(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    scheduler = Process(17)
+    started = []
+    monkeypatch.setattr(
+        launcher, "_popen", lambda args: started.append(scheduler) or scheduler
+    )
+
+    with pytest.raises(launcher_module.MsPASSError, match="scheduler.*17") as error:
+        launcher.launch()
+
+    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
+    assert started == [scheduler]
+    assert scheduler.wait_calls == [10]
+    assert scheduler.terminate_count == 0
+    assert launcher.dbserver_process is None
+    assert launcher.remote_worker_process is None
+    assert launcher.primary_worker_process is None
+
+
+@pytest.mark.parametrize("failed_role", ["database", "remote", "primary"])
+def test_each_other_owned_child_early_exit_reaps_every_started_process(
+    launcher_module, monkeypatch, tmp_path, failed_role
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    started = []
+
+    def popen(args):
+        environment = next(value for value in args if "MSPASS_ROLE=" in value)
+        if "MSPASS_ROLE=db" in environment:
+            role = "database"
+        elif "MSPASS_ROLE=scheduler" in environment:
+            role = "scheduler"
+        elif args[0] == "mpiexec":
+            role = "remote"
+        else:
+            role = "primary"
+        process = Process(23 if role == failed_role else None)
+        started.append((role, process))
+        return process
+
+    monkeypatch.setattr(launcher, "_popen", popen)
+    monkeypatch.setattr(launcher, "_wait_for_services", lambda: None)
+
+    with pytest.raises(launcher_module.MsPASSError, match="23") as error:
+        launcher.launch()
+
+    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
+    expected_roles = {
+        "database": ["scheduler", "database"],
+        "remote": ["scheduler", "database", "remote"],
+        "primary": ["scheduler", "database", "remote", "primary"],
+    }
+    assert [role for role, _ in started] == expected_roles[failed_role]
+    assert all(process.wait_calls == [10] for _, process in started)
+    assert all(
+        process.terminate_count == (0 if role == failed_role else 1)
+        for role, process in started
+    )
+
+
+def test_batch_and_interactive_frontends_include_both_endpoints_without_shell(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    ready_calls = []
+    run_calls = []
+    popen_calls = []
+    frontend = Process(None)
+    monkeypatch.setattr(
+        launcher, "_wait_for_services", lambda: ready_calls.append(True)
+    )
+    monkeypatch.setattr(
+        launcher_module.subprocess,
+        "run",
+        lambda args, **kwargs: run_calls.append((args, kwargs))
+        or SimpleNamespace(stdout="ok", stderr=""),
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_popen",
+        lambda args: popen_calls.append(args) or frontend,
+    )
+
+    launcher.run("analysis.py")
+    result = launcher.interactive_session()
+
+    assert ready_calls == [True, True]
+    frontend_args = [
+        "apptainer",
+        "run",
+        "-B",
+        "/scratch",
+        "--home",
+        "/work",
+        "--env",
+        "MSPASS_ROLE=frontend,MSPASS_WORK_DIR=/work,"
+        "MSPASS_DB_ADDRESS=database:27017,"
+        "MSPASS_SCHEDULER_ADDRESS=tcp://scheduler:8786",
+        "/containers/mspass.sif",
+    ]
+    assert run_calls[0][0] == frontend_args + ["--batch", "analysis.py"]
+    assert popen_calls == [frontend_args]
+    assert run_calls[0][1] == {"capture_output": True, "text": True}
+    assert result is frontend
+    assert launcher.jupyter_process is frontend
+    assert frontend.wait_calls == []
+
+
+def test_interactive_early_exit_reaps_all_owned_processes(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    services = [Process(None), Process(None), Process(None), Process(None)]
+    (
+        launcher.scheduler_process,
+        launcher.dbserver_process,
+        launcher.remote_worker_process,
+        launcher.primary_worker_process,
+    ) = services
+    frontend = Process(31)
+    monkeypatch.setattr(launcher, "_wait_for_services", lambda: None)
+    monkeypatch.setattr(launcher, "_popen", lambda args: frontend)
+
+    with pytest.raises(launcher_module.MsPASSError, match="frontend.*31") as error:
+        launcher.interactive_session()
+
+    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
+    assert frontend.terminate_count == 0
+    assert frontend.wait_calls == [10]
+    assert all(process.terminate_count == 1 for process in services)
+    assert all(process.wait_calls == [10] for process in services)
+    assert launcher.jupyter_process is None
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("MSPASS_STARTUP_TIMEOUT_SECONDS", "0"),
+        ("MSPASS_STARTUP_TIMEOUT_SECONDS", "nan"),
+        ("MSPASS_STARTUP_POLL_SECONDS", "-1"),
+        ("MSPASS_STARTUP_POLL_SECONDS", "invalid"),
+    ],
+)
+def test_startup_settings_have_fixed_defaults_and_reject_invalid_values(
+    launcher_module, monkeypatch, name, value
+):
+    monkeypatch.delenv("MSPASS_STARTUP_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("MSPASS_STARTUP_POLL_SECONDS", raising=False)
+    assert launcher_module.HPCClusterLauncher._startup_settings() == (120.0, 2.0)
+    monkeypatch.setenv(name, value)
+    with pytest.raises(launcher_module.MsPASSError) as error:
+        launcher_module.HPCClusterLauncher._startup_settings()
+    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
+
+
+def test_startup_settings_accept_valid_overrides(launcher_module, monkeypatch):
+    monkeypatch.setenv("MSPASS_STARTUP_TIMEOUT_SECONDS", "3.5")
+    monkeypatch.setenv("MSPASS_STARTUP_POLL_SECONDS", "0.125")
+    assert launcher_module.HPCClusterLauncher._startup_settings() == (3.5, 0.125)
+
+
+def test_invalid_startup_settings_start_no_children(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    started = []
+    monkeypatch.setenv("MSPASS_STARTUP_TIMEOUT_SECONDS", "invalid")
+    monkeypatch.setattr(launcher, "_popen", lambda args: started.append(args))
+
+    with pytest.raises(launcher_module.MsPASSError) as error:
+        launcher.launch()
+
+    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
+    assert started == []

--- a/python/tests/test_iu_hpc_launcher_contract.py
+++ b/python/tests/test_iu_hpc_launcher_contract.py
@@ -297,14 +297,35 @@ def test_popen_executes_the_argv_list_without_a_shell(launcher_module, monkeypat
     assert calls == [
         (
             (argv,),
-            {
-                "stdin": launcher_module.subprocess.PIPE,
-                "stdout": launcher_module.subprocess.PIPE,
-                "stderr": launcher_module.subprocess.PIPE,
-                "close_fds": True,
-            },
+            {"close_fds": True},
         )
     ]
+
+
+def test_auto_scheduler_host_uses_complete_default_endpoint(
+    launcher_module, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        launcher_module.subprocess,
+        "run",
+        lambda args, **kwargs: SimpleNamespace(stdout="node1 node2"),
+    )
+    launcher = _launcher(
+        launcher_module,
+        tmp_path,
+        primary_host="auto",
+        database_host="auto",
+        scheduler_host="auto",
+        worker_hosts="auto",
+    )
+
+    assert launcher.scheduler_host == "node1"
+    assert launcher._scheduler_endpoint(launcher.scheduler_host) == "tcp://node1:8786"
+    monkeypatch.setenv("DASK_SCHEDULER_PORT", "9876")
+    assert launcher._scheduler_endpoint(launcher.scheduler_host) == "tcp://node1:9876"
+    assert (
+        launcher._scheduler_endpoint("tcp://scheduler:8786") == "tcp://scheduler:8786"
+    )
 
 
 def test_status_uses_none_as_only_running_value_and_skips_absent_handles(
@@ -503,10 +524,9 @@ def test_timeout_starts_no_workers_and_reaps_all_owned_children(
     )
     monkeypatch.setattr(launcher_module.time, "monotonic", lambda: next(monotonic))
 
-    with pytest.raises(launcher_module.MsPASSError) as error:
+    with pytest.raises(RuntimeError):
         launcher.launch()
 
-    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
     assert len(started) == 2
     assert all(process.terminate_count == 1 for process in started)
     assert all(process.wait_calls == [10] for process in started)
@@ -524,10 +544,9 @@ def test_owned_child_early_exit_reaps_every_started_process(
         launcher, "_popen", lambda args: started.append(scheduler) or scheduler
     )
 
-    with pytest.raises(launcher_module.MsPASSError, match="scheduler.*17") as error:
+    with pytest.raises(RuntimeError, match="scheduler.*17"):
         launcher.launch()
 
-    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
     assert started == [scheduler]
     assert scheduler.wait_calls == [10]
     assert scheduler.terminate_count == 0
@@ -560,10 +579,9 @@ def test_each_other_owned_child_early_exit_reaps_every_started_process(
     monkeypatch.setattr(launcher, "_popen", popen)
     monkeypatch.setattr(launcher, "_wait_for_services", lambda: None)
 
-    with pytest.raises(launcher_module.MsPASSError, match="23") as error:
+    with pytest.raises(RuntimeError, match="23"):
         launcher.launch()
 
-    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
     expected_roles = {
         "database": ["scheduler", "database"],
         "remote": ["scheduler", "database", "remote"],
@@ -575,6 +593,58 @@ def test_each_other_owned_child_early_exit_reaps_every_started_process(
         process.terminate_count == (0 if role == failed_role else 1)
         for role, process in started
     )
+
+
+def test_launch_preserves_system_exception_identity_after_cleanup(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    scheduler = Process(None)
+    failure = OSError("container runtime unavailable")
+    calls = 0
+
+    def popen(args):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return scheduler
+        raise failure
+
+    monkeypatch.setattr(launcher, "_popen", popen)
+
+    with pytest.raises(OSError) as error:
+        launcher.launch()
+
+    assert error.value is failure
+    assert scheduler.terminate_count == 1
+    assert scheduler.wait_calls == [10]
+    assert launcher.scheduler_process is None
+
+
+def test_cleanup_failure_retains_process_handle_for_retry(
+    launcher_module, monkeypatch, tmp_path
+):
+    launcher = _launcher(launcher_module, tmp_path)
+    scheduler = Process(None)
+    database = Process(None)
+    launcher.scheduler_process = scheduler
+    launcher.dbserver_process = database
+    original_stop = launcher._stop_process
+
+    def stop(process):
+        if process is scheduler:
+            raise OSError("terminate failed")
+        original_stop(process)
+
+    monkeypatch.setattr(launcher, "_stop_process", stop)
+
+    with pytest.raises(OSError, match="terminate failed"):
+        launcher._cleanup_owned_processes()
+
+    assert launcher.scheduler_process is scheduler
+    assert launcher.dbserver_process is None
+    assert database.terminate_count == 1
+    assert database.wait_calls == [10]
 
 
 def test_batch_and_interactive_frontends_include_both_endpoints_without_shell(
@@ -640,10 +710,9 @@ def test_interactive_early_exit_reaps_all_owned_processes(
     monkeypatch.setattr(launcher, "_wait_for_services", lambda: None)
     monkeypatch.setattr(launcher, "_popen", lambda args: frontend)
 
-    with pytest.raises(launcher_module.MsPASSError, match="frontend.*31") as error:
+    with pytest.raises(RuntimeError, match="frontend.*31"):
         launcher.interactive_session()
 
-    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
     assert frontend.terminate_count == 0
     assert frontend.wait_calls == [10]
     assert all(process.terminate_count == 1 for process in services)
@@ -667,9 +736,8 @@ def test_startup_settings_have_fixed_defaults_and_reject_invalid_values(
     monkeypatch.delenv("MSPASS_STARTUP_POLL_SECONDS", raising=False)
     assert launcher_module.HPCClusterLauncher._startup_settings() == (120.0, 2.0)
     monkeypatch.setenv(name, value)
-    with pytest.raises(launcher_module.MsPASSError) as error:
+    with pytest.raises(ValueError):
         launcher_module.HPCClusterLauncher._startup_settings()
-    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
 
 
 def test_startup_settings_accept_valid_overrides(launcher_module, monkeypatch):
@@ -686,8 +754,7 @@ def test_invalid_startup_settings_start_no_children(
     monkeypatch.setenv("MSPASS_STARTUP_TIMEOUT_SECONDS", "invalid")
     monkeypatch.setattr(launcher, "_popen", lambda args: started.append(args))
 
-    with pytest.raises(launcher_module.MsPASSError) as error:
+    with pytest.raises(ValueError):
         launcher.launch()
 
-    assert error.value.severity == launcher_module.ErrorSeverity.Invalid
     assert started == []

--- a/scripts/IU_examples/python/launcher.py
+++ b/scripts/IU_examples/python/launcher.py
@@ -6,12 +6,17 @@ Created on Tue Jan 28 09:15:40 2025
 @author: pavlis
 """
 from abc import ABC, abstractmethod
-import yaml   
+import math
 import os
+import shlex
 import subprocess
-#import mock_subprocess as subprocess
-import copy
 import time
+
+from distributed import Client
+from pymongo import MongoClient
+import yaml
+
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
 
 
 class BasicMsPASSLauncher(ABC):
@@ -215,9 +220,9 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
           a new configuration to verify it is what you want. 
         
         """
-        message0="HPCClusterLauncher constructor:  "
+        message0 = "HPCClusterLauncher constructor:  "
         if verbose:
-            print("Loading configuration file=",configuration_file)
+            print("Loading configuration file=", configuration_file)
         super().__init__(configuration_file)
         # The base class constructor creates this image of the yaml 
         # file.  It only extracts common attributes.  Here we 
@@ -230,101 +235,95 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         # at present this is local version of mpiexec
         self.worker_run_command = cluster_config["worker_run_command"]
         self.task_scheduler = cluster_config["task_scheduler"]
-        
-        # This last complex block sets hostnames that 
-        # define the MsPASS frameworK;  database, scheduler, workers, and primary
-        # note primary as a minimum means the host to run the python/jupyter 
-        # script
-        js = cluster_config["job_scheduler"]
-        if js=="slurm":
-            if verbose:
-                print("job scheduler set as slurm")
-            ph=cluster_config["primary_host"]
-            dbh=cluster_config["database_host"]
-            sh=cluster_config["scheduler_host"]
-            wh=cluster_config["worker_hosts"]
-            if (ph=="auto") or (dbh=="auto") or (sh=="auto") or (wh=="auto"):
-                # this executes a slurm command to fetch nodes assigned to 
-                # this job
-                runline = ["scontrol","show","hostname"]
-                comout = subprocess.run(runline,
-                                        capture_output=True,
-                                        text=True,
-                                        )
-                hostlist = comout.stdout.split()
 
-                if len(hostlist)==0:
-                    if self.primary_node_workers==0:
-                        message = message0
-                        message += "scontrol command yielded an empty list of hostnames\n"
-                        message += "Cannot continue"
-                        raise RuntimeError(message)
-                    else:
-                        comout = subprocess.run(["hostname"],
-                                                 capture_output=True,
-                                                 text=True)
-                        hostlist=[comout.stdout]
-                # comout contans a list of host names. By default for 
-                # auto use the first in the list as primary
-                primary=hostlist[0].strip()   # needed because of appended newline
-                if ph=="auto":
-                    self.primary_node=copy.deepcopy(primary)
-                else:
-                    self.primary_node = ph
-                if dbh=="auto":
-                    self.database_host=copy.deepcopy(primary)
-                else:
-                    self.database_host = dbh
-                if sh=="auto":
-                    self.scheduler_host = copy.deepcopy(primary)
-                else:
-                    self.scheduler_list = sh
-                if wh=="auto":
-                    # note worker_hoss exclude primary
-                    self.worker_hosts = []
-                    for i in range(1,len(hostlist),1):
-                        self.worker_hosts.append(hostlist[i].strip())  # strip needed to remove newline
-                            
-                    if len(self.worker_hosts)<=0 and self.primary_node_workers==0:
-                        message = message0
-                        message += "Illegal configuration\n"
-                        message += "scontrol  returned only a single hostname "
-                        message += "but primary_node_workers was set to 0\n"
-                        message += "To run on a single node set primary_node_workers to a postive value\n"
-                        message += "To run on multiple nodes change your slurm commands at the top of this job"
-                        raise RuntimeError(message)
-                if verbose:
-                    print("Primary node name=",self.primary_node)
-                    print("database hostname=",self.database_host)
-                    print("scheduler hostname=",self.scheduler_host)
-                    print("Worker hostname(s)=",self.worker_hosts)
-            if cluster_config["setup_tunnel"]:
-                s = cluster_config["tunnel_setup_command"]
-                print("Attempting to set up ssh communication tunnel to node=",
-                      self.primary_node)
-                print("Using this command line: {} {}".format(s,self.primary_node))
-                # IMPORTANT:  actual implementation requires last arg 
-                # to be primary hostname 
-                arglist=s.split()
-                arglist.append(self.primary_node)
-                comout = subprocess.run(runline,
-                                        capture_output=True,
-                                        text=True)
-                print("Successfully created tunnels to allow connection to ",self.primary_node)
-            # these are set by the launch method but it is good practice 
-            # to initialize them here
-            self.scheduler_process = None
-            self.dbserver_process = None
-            self.primary_worker_process = None
-            self.remote_worker_process = None
-            self.jupyter_process=None
-            if auto_launch:
-                self.launch(verbose=verbose)
-        else:
+        self.scheduler_process = None
+        self.dbserver_process = None
+        self.primary_worker_process = None
+        self.remote_worker_process = None
+        self.jupyter_process = None
+
+        js = cluster_config["job_scheduler"]
+        if js != "slurm":
             message = message0
             message += "Cannot handle job_scheduler={}\n".format(js)
             message += "Currently only support slurm"
             raise ValueError(message)
+
+        if verbose:
+            print("job scheduler set as slurm")
+        primary_setting = cluster_config["primary_host"]
+        database_setting = cluster_config["database_host"]
+        scheduler_setting = cluster_config["scheduler_host"]
+        worker_setting = cluster_config["worker_hosts"]
+        needs_discovery = any(
+            value == "auto"
+            for value in (
+                primary_setting,
+                database_setting,
+                scheduler_setting,
+                worker_setting,
+            )
+        )
+        hostlist = []
+        if needs_discovery:
+            completed = subprocess.run(
+                ["scontrol", "show", "hostname"],
+                capture_output=True,
+                text=True,
+            )
+            hostlist = [
+                host.strip() for host in completed.stdout.split() if host.strip()
+            ]
+            if not hostlist:
+                if self.primary_node_workers == 0:
+                    raise RuntimeError(
+                        message0
+                        + "scontrol command yielded an empty list of hostnames\n"
+                        + "Cannot continue"
+                    )
+                completed = subprocess.run(["hostname"], capture_output=True, text=True)
+                hostname = completed.stdout.strip()
+                if not hostname:
+                    raise RuntimeError(
+                        message0 + "hostname command returned no hostname"
+                    )
+                hostlist = [hostname]
+
+        self.primary_node = (
+            hostlist[0] if primary_setting == "auto" else primary_setting
+        )
+        self.database_host = (
+            self.primary_node if database_setting == "auto" else database_setting
+        )
+        self.scheduler_host = (
+            self.primary_node if scheduler_setting == "auto" else scheduler_setting
+        )
+        if worker_setting == "auto":
+            self.worker_hosts = [host for host in hostlist if host != self.primary_node]
+        elif isinstance(worker_setting, str):
+            self.worker_hosts = [worker_setting] if worker_setting else []
+        else:
+            self.worker_hosts = list(worker_setting)
+
+        if not self.worker_hosts and self.primary_node_workers == 0:
+            raise RuntimeError(
+                message0
+                + "no remote workers were configured and primary_node_workers is 0"
+            )
+        if verbose:
+            print("Primary node name=", self.primary_node)
+            print("database hostname=", self.database_host)
+            print("scheduler hostname=", self.scheduler_host)
+            print("Worker hostname(s)=", self.worker_hosts)
+
+        if cluster_config["setup_tunnel"]:
+            tunnel_args = shlex.split(cluster_config["tunnel_setup_command"])
+            tunnel_args.append(self.primary_node)
+            subprocess.run(tunnel_args, capture_output=True, text=True, check=True)
+
+        if auto_launch:
+            self.launch(verbose=verbose)
+
     def __del__(self):
         """
         Class destructor. 
@@ -333,8 +332,148 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         This instance is little more than a call to self.shutdown()
         which shuts down all the containers as gracefully as possible.  
         """
-        self.shutdown()
-    def launch(self,verbose=False):
+        try:
+            self.shutdown()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _startup_settings():
+        try:
+            timeout = float(os.environ.get("MSPASS_STARTUP_TIMEOUT_SECONDS", "120"))
+            poll_interval = float(
+                os.environ.get("MSPASS_STARTUP_POLL_SECONDS", "2")
+            )
+        except ValueError as error:
+            raise MsPASSError(
+                "HPCClusterLauncher startup timeout and poll values must be numbers",
+                ErrorSeverity.Invalid,
+            ) from error
+        if (
+            not math.isfinite(timeout)
+            or timeout <= 0.0
+            or not math.isfinite(poll_interval)
+            or poll_interval <= 0.0
+        ):
+            raise MsPASSError(
+                "HPCClusterLauncher startup timeout and poll values must be finite and positive",
+                ErrorSeverity.Invalid,
+            )
+        return timeout, poll_interval
+
+    @staticmethod
+    def _popen(args):
+        return subprocess.Popen(
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            close_fds=True,
+        )
+
+    @staticmethod
+    def _stop_process(process):
+        if process is None:
+            return
+        if process.poll() is None:
+            process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+    def _cleanup_owned_processes(self):
+        first_error = None
+        for attribute in (
+            "jupyter_process",
+            "primary_worker_process",
+            "remote_worker_process",
+            "dbserver_process",
+            "scheduler_process",
+        ):
+            process = getattr(self, attribute, None)
+            try:
+                self._stop_process(process)
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+            finally:
+                setattr(self, attribute, None)
+        if first_error is not None:
+            raise first_error
+
+    def _raise_startup_error(self, message):
+        try:
+            self._cleanup_owned_processes()
+        except Exception as cleanup_error:
+            message += "; cleanup failed: {}".format(cleanup_error)
+        raise MsPASSError(message, ErrorSeverity.Invalid)
+
+    def _require_running(self, name, process):
+        if process is None:
+            self._raise_startup_error(
+                "HPCClusterLauncher: {} was not started".format(name)
+            )
+        status = process.poll()
+        if status is not None:
+            self._raise_startup_error(
+                "HPCClusterLauncher: {} exited during startup with code {}".format(
+                    name, status
+                )
+            )
+
+    def _probe_database(self):
+        client = MongoClient(self.database_host, serverSelectionTimeoutMS=2000)
+        try:
+            client.admin.command("ping")
+        finally:
+            client.close()
+
+    def _probe_scheduler(self):
+        client = Client(self.scheduler_host, timeout="2s")
+        try:
+            client.scheduler_info()
+        finally:
+            client.close()
+
+    def _wait_for_services(self):
+        timeout, poll_interval = self._startup_settings()
+        deadline = time.monotonic() + timeout
+        while True:
+            self._require_running("scheduler", self.scheduler_process)
+            self._require_running("database", self.dbserver_process)
+            database_ready = False
+            scheduler_ready = False
+            try:
+                self._probe_database()
+                database_ready = True
+            except Exception:
+                pass
+            try:
+                self._probe_scheduler()
+                scheduler_ready = True
+            except Exception:
+                pass
+            if database_ready and scheduler_ready:
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0.0:
+                self._raise_startup_error(
+                    "HPCClusterLauncher: services did not become ready within {} seconds".format(
+                        timeout
+                    )
+                )
+            time.sleep(min(poll_interval, remaining))
+
+    def _container_args(self, environment):
+        return self._initialize_container_runargs() + [
+            self.container_env_flag,
+            ",".join(environment),
+            self.container,
+        ]
+
+    def launch(self, verbose=False):
         """
         Call this method to launch all the MsPASS containized components.
         
@@ -350,146 +489,67 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         If workers are run on theh primary there will also be a defined 
         valued for "self.primary_worker_process".  
         """
-        runline = self._initialize_container_runargs()
-        runline.append(self.container_env_flag)
-        envlist = "MSPASS_ROLE=scheduler,MSPASS_WORK_DIR={}".format(self.working_directory)
-        envlist += ",MSPASS_SCHEDULER={}".format(self.task_scheduler)
-        envlist += ",MSPASS_SCHEDULER_ADDRESS={}".format(self.primary_node)
-        runline.append(envlist)
-        runline.append(self.container)
-        # We have to use this lower level function in subprocess 
-        # for two reason:  (a) nonblocking launch to run the container 
-        # from a new process and (b) keeping the output allows graceful 
-        # shutdown in the shutdown method
-        self.scheduler_process = subprocess.Popen(runline,
-                                    stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    close_fds=True,
-                                )
-        if verbose:
-            print("Successfully launched scheduler")
-        print("Debug:  launch line")
-        print(runline)
-        # now do a similar thing for database 
-        # note this implementation doesn't handle shrarding
-        runline = self._initialize_container_runargs()
-        runline.append(self.container_env_flag)
-        envlist = "MSPASS_ROLE=db,"
-        envlist += "MSPASS_WORK_DIR={},".format(self.working_directory)
-        envlist += "MSPASS_DB_DIR={}".format(self.database_directory)
-        runline.append(envlist)
-        runline.append(self.container)
-
-        self.dbserver_process = subprocess.Popen(runline,
-                                    stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    close_fds=True,
-                                )
-        if verbose:
-            print("Successfully launched db")
-        print("Debug:  launch line")
-        print(runline)
-        # Now launch workers on hosts that are not primaary host
-        worker_run_args=self._build_worker_run_args()
-        if len(worker_run_args)>0:
-            print("launching workers on remote hosts")
-            self.remote_worker_process = subprocess.Popen(worker_run_args,
-                                        stdin=subprocess.PIPE,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE,
-                                        close_fds=True,
-                                    )
-        # do not trap error of no worker nodes and no workers 
-        # assigned to primary - assume constructor traps that condition.
-        print("Launching worker container on primary node")
-        if self.primary_node_workers>0:
-            # we have to launch this container differently soo 
-            # we have to prepare a somewhat different run line
-            # could not make this work with worker_arg unless we used 
-            # shell=True.   In that case we build a command line instead of 
-            # a list like runline
-            runline = self._initialize_container_runargs()
-            srun =""
-            for s in runline:
-                srun += s
-                srun += " "
-            srun += self.container_env_flag
-            srun += " "
-            envlist = "MSPASS_ROLE=worker,"
-            envlist += "MSPASS_WORK_DIR={},".format(self.working_directory)
-            #envlist += "MSPASS_SCHEDULER_ADDRESS={}".format(self.scheduler_host)
-            envlist += "MSPASS_SCHEDULER_ADDRESS={},".format(self.scheduler_host)
-            #envlist += "MSPASS_DB_ADDRESS={},".format(self.database_host)
-            envlist += 'MSPASS_WORKER_ARG="--nworkers={} --nthreads 1"'.format(self.primary_node_workers)
-            srun += envlist + " " + self.container
-            print("command line sent to Popen")
-            print(srun)
-            #self.primary_worker_process = subprocess.Popen(runline,
-            self.primary_worker_process = subprocess.Popen(srun,shell=True,
-                                        stdin=subprocess.PIPE,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE,
-                                        close_fds=True,
-                                    )
-            print("Launched workers on primary node")
-            
-        # Exit immmeditaly if any of the contaienrs  have exited
-        if self.status(verbose=False) == 0:
-            def stat_message(c):
-                if self.status(container=c,verbose=False):
-                    m = c + " container is running\n"
-                else:
-                    m = c + "container is NOT running\n"
-                return m
-            message = "HPCClusterLauncher:  cluster initiation failed\n"
-            for con in ["db","scheduler","primary_worker"]:
-                m = stat_message(con)
-                message += m
-            raise RuntimeError(message)
+        # Validate these settings before starting any process.  Otherwise an
+        # invalid value would leave the scheduler and database children alive.
+        self._startup_settings()
+        try:
+            self.scheduler_process = self._popen(
+                self._container_args(
+                    [
+                        "MSPASS_ROLE=scheduler",
+                        "MSPASS_WORK_DIR={}".format(self.working_directory),
+                        "MSPASS_SCHEDULER={}".format(self.task_scheduler),
+                        "MSPASS_SCHEDULER_ADDRESS={}".format(self.scheduler_host),
+                    ]
+                )
+            )
+            self._require_running("scheduler", self.scheduler_process)
+            self.dbserver_process = self._popen(
+                self._container_args(
+                    [
+                        "MSPASS_ROLE=db",
+                        "MSPASS_WORK_DIR={}".format(self.working_directory),
+                        "MSPASS_DB_DIR={}".format(self.database_directory),
+                    ]
+                )
+            )
+            self._require_running("database", self.dbserver_process)
+            self._wait_for_services()
+            worker_args = self._build_worker_run_args()
+            if worker_args:
+                self.remote_worker_process = self._popen(worker_args)
+                self._require_running("remote worker", self.remote_worker_process)
+            if self.primary_node_workers > 0:
+                self.primary_worker_process = self._popen(
+                    self._container_args(
+                        [
+                            "MSPASS_ROLE=worker",
+                            "MSPASS_WORK_DIR={}".format(self.working_directory),
+                            "MSPASS_SCHEDULER_ADDRESS={}".format(self.scheduler_host),
+                            "MSPASS_DB_ADDRESS={}".format(self.database_host),
+                            "MSPASS_WORKER_ARG=--nworkers={} --nthreads 1".format(
+                                self.primary_node_workers
+                            ),
+                        ]
+                    )
+                )
+                self._require_running("primary worker", self.primary_worker_process)
+            if verbose:
+                print("Successfully launched MongoDB, scheduler, and workers")
+        except MsPASSError:
+            raise
+        except Exception as error:
+            message = "HPCClusterLauncher launch failed: {}".format(error)
+            try:
+                self._cleanup_owned_processes()
+            except Exception as cleanup_error:
+                message += "; cleanup failed: {}".format(cleanup_error)
+            raise MsPASSError(message, ErrorSeverity.Invalid) from error
 
     def shutdown(self):
-        # shutdown in reverse order to start
-        # first workers
-        # I think we only need to handle primary node container.  
-        # The contaners on other nodes have to be shut down by slurm
-        # unless here is an mpitrick I am unaware of
-        if self.jupyter_process:
-            try :
-                self.jupyter_process.terminate()
-                self.jupyter_process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                print("Jupyter notebook server (frontend) did not respond to terminate method")
-                print("Reverting to less graceful kill")
-                self.jupyter_process.kill()
-        if self.primary_worker_process:
-            try :
-                self.primary_worker_process.terminate()
-                self.primary_worker_process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                print("Worker container on primary node did not respond to terminate method")
-                print("Reverting to less graceful kill")
-                self.primary_worker_process.kill()
-        # now database - should always be running so no need for not None 
-        # test for the rest of these
-        try :
-            self.dbserver_process.terminate()
-            self.dbserver_process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            print("Database server container did not respond to terminate method")
-            print("Reverting to less graceful kill")
-            self.dbserver_process.kill()
-        # finally terminate the scheduler
-        try :
-            self.scheduler_process.terminate()
-            self.scheduler_process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            print("Scheduler container did not respond to terminate method")
-            print("Reverting to less graceful kill")
-            self.scheduler_process.kill()
+        self._cleanup_owned_processes()
 
-    def run(self,pyscript):
+    def run(self, pyscript):
         """
         Runs pyscript the primary node using this cluster.
         
@@ -500,32 +560,22 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         """
         # this can be made more elaborate.  Here I just run 
         # a script
-        print("Trying to run python script file=",pyscript)
-        runline=[]
-        # I am going to hard code this for now 
-        runline.append("apptainer")
-        runline.append("run")
-        crarg=self.container_run_args.split()
-        for arg in crarg:
-            runline.append(arg)
-        runline.append("--env")
-        envlist = "MSPASS_ROLE=frontend"
-        envlist += ",MSPASS_WORK_DIR={}".format(self.working_directory)
-        envlist += ",MSPASS_DB_ADDRESS={}".format(self.database_host)
-        envlist += ",MSPASS_SCHEDULER_ADDRESS={}".format(self.scheduler_host)
-        runline.append(envlist)
-        runline.append(self.container)
-        runline.append("--batch")
-        runline.append(pyscript)
-        print("running script")
-        print("Debug:  launch line")
-        print(runline)
-        
-        runout=subprocess.run(runline,capture_output=True,text=True)
+        print("Trying to run python script file=", pyscript)
+        self._wait_for_services()
+        runline = self._container_args(
+            [
+                "MSPASS_ROLE=frontend",
+                "MSPASS_WORK_DIR={}".format(self.working_directory),
+                "MSPASS_DB_ADDRESS={}".format(self.database_host),
+                "MSPASS_SCHEDULER_ADDRESS={}".format(self.scheduler_host),
+            ]
+        ) + ["--batch", pyscript]
+        runout = subprocess.run(runline, capture_output=True, text=True)
         print("stdout from this job")
         print(runout.stdout)
         print("stderr from this job")
         print(runout.stderr)
+
     def interactive_session(self):
         """
         Use this method to launch the jupyter server to initiate an 
@@ -535,18 +585,20 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         """
         print("Launching frontend container running juptyer server")
         print("Use cut-and-paste of url printed below to connect")
-        runline = self._initialize_container_runargs()
-        runline.append("--env")
-        envlist = "MSPASS_ROLE=frontend,"
-        envlist += "MSPASS_WORK_DIR={}".format(self.working_directory)
-        runline.append(envlist)
-        runline.append(self.container)
-        self.jupyter_process=subprocess.Popen(runline,stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = self.jupyter_process.communicate()
-        print(stdout)
-        print(stderr)
+        self._wait_for_services()
+        runline = self._container_args(
+            [
+                "MSPASS_ROLE=frontend",
+                "MSPASS_WORK_DIR={}".format(self.working_directory),
+                "MSPASS_DB_ADDRESS={}".format(self.database_host),
+                "MSPASS_SCHEDULER_ADDRESS={}".format(self.scheduler_host),
+            ]
+        )
+        self.jupyter_process = self._popen(runline)
+        self._require_running("frontend", self.jupyter_process)
+        return self.jupyter_process
 
-    def status(self,container="all",verbose=True)->int:
+    def status(self, container="all", verbose=True) -> int:
         """
         Check the status of one or more of the containers managed by this object.
         
@@ -560,14 +612,16 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
             "scheduler" - check only the contaner running the dask or
                 or spark scheduler
             "primary_worker" - check status of the worker container running on 
-                the primary node.  Note there is currently no support for 
-                workers spwaned on other nodes. 
+                the primary node.
+            "remote_worker" - check the worker launcher for remote nodes.
+            "frontend" - check the interactive frontend, when one was launched.
                 
         Any other values for arg0 will cause this method to throw a 
         ValueError exception.
         
         :param container: container keywords noted above for arg0.  i.e. 
-           must be one of "db","scheduler", "primary_worker", or "all" (default)
+           must be one of "db", "scheduler", "primary_worker", "remote_worker",
+           "frontend", or "all" (default)
         :type container:  string
         :param verbose:  boolean that when True (default) uses print to 
            post a status message for container(s) requested.  When false 
@@ -575,12 +629,18 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         :return:  int status.  1 means the container(s) tested were all 
            running.  0 means one or more have died.
         """
-        all_containers=["db","scheduler","primary_worker"]
-        if container=="all":
-            statlist=all_containers
+        all_containers = [
+            "db",
+            "scheduler",
+            "primary_worker",
+            "remote_worker",
+            "frontend",
+        ]
+        if container == "all":
+            statlist = all_containers
         else:
             if container in all_containers:
-                statlist=[container]
+                statlist = [container]
             else:
                 message = "HPCClusterLauncher.status:  component={}".format(container)
                 message += " invalid\n"
@@ -588,29 +648,39 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
                 for c in all_containers:
                     message += c + " "
                 raise ValueError(message)
-        def verbose_message(container_name,poll_return):
+
+        def verbose_message(container_name, poll_return):
             if poll_return is None:
-                print(container_name," is running")
+                print(container_name, " is running")
             else:
-                print(container_name, " has exited with code=",poll_return)
-        retval=1
+                print(container_name, " has exited with code=", poll_return)
+
+        retval = 1
         for container in statlist:
             match container:
                 case "db":
-                    stat = self.dbserver_process.poll()
+                    process = self.dbserver_process
                 case "scheduler":
-                    stat = self.scheduler_process.poll()
+                    process = self.scheduler_process
                 case "primary_worker":
-                    stat = self.primary_worker_process.poll()
+                    process = self.primary_worker_process
+                case "remote_worker":
+                    process = self.remote_worker_process
+                case "frontend":
+                    process = self.jupyter_process
+            if process is None:
+                if container in ("db", "scheduler"):
+                    retval = 0
+                continue
+            stat = process.poll()
             if verbose:
-                verbose_message(container,stat)
-            if stat:
+                verbose_message(container, stat)
+            if stat is not None:
                 retval = 0
-                
-        return retval
-                        
 
-    def _initialize_container_runargs(self)->list:
+        return retval
+
+    def _initialize_container_runargs(self) -> list:
         """
         This private method creates the initial list of args 
         used to run a container driven by two key-value pairs 
@@ -623,15 +693,16 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         Returns a list that is is the starting point for the list of 
         args used for subprocess.run and subprocess.Popen. 
         """
-        crargs=[]
-        rtmp=self.container_run_command.split()
+        crargs = []
+        rtmp = self.container_run_command.split()
         for arg in rtmp:
             crargs.append(arg)
-        rtmp=self.container_run_args.split()
+        rtmp = self.container_run_args.split()
         for arg in rtmp:
             crargs.append(arg)
         return crargs
-    def _build_worker_run_args(self)->list:
+
+    def _build_worker_run_args(self) -> list:
         """
         Private method that constructs the command to launch 
         workers on nodes other than the primary node.   Uses the 
@@ -645,11 +716,11 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         here are no workers assigned to primary.
         """
         nnodes = len(self.worker_hosts)
-        if nnodes==0:
-                return []
-        arglist=[]
-        #cthis allows args to be entered on teh run line in config file
-        tlist=self.worker_run_command.split()
+        if nnodes == 0:
+            return []
+        arglist = []
+        # cthis allows args to be entered on teh run line in config file
+        tlist = self.worker_run_command.split()
         for arg in tlist:
             arglist.append(arg)
         # these are actually locked to mpiexec so this isn't 
@@ -668,21 +739,24 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
             arglist.append(arg)
         # apptainer mthod for setting environment variables loaded 
         # in contaer
-        arglist.append("--env")
-        envlist = "MSPASS_ROLE=worker,"
-        envlist += "MSPASS_WORK_DIR={},".format(self.working_directory)
-        envlist += "MSPASS_SCHEDULER_ADDRESS={},".format(self.scheduler_host)
-        envlist += "MSPASS_DB_ADDRESS={}".format(self.database_host)
-        envlist += "MSPASS_WORKER_ARG=\"--nworkers={} --nthreads 1\"".format(self.workers_per_node)
-        arglist.append(envlist)
+        arglist.append(self.container_env_flag)
+        arglist.append(
+            ",".join(
+                [
+                    "MSPASS_ROLE=worker",
+                    "MSPASS_WORK_DIR={}".format(self.working_directory),
+                    "MSPASS_SCHEDULER_ADDRESS={}".format(self.scheduler_host),
+                    "MSPASS_DB_ADDRESS={}".format(self.database_host),
+                    "MSPASS_WORKER_ARG=--nworkers={} --nthreads 1".format(
+                        self.workers_per_node
+                    ),
+                ]
+            )
+        )
         arglist.append(self.container)
-        # also backgrounded 
-        arglist.append("&")
         return arglist
-            
-            
-            
-    
+
+
 class DesktopLauncher(BasicMsPASSLauncher):
     """
     Launcher for running MsPASS on a desktop in the all-in-one mode.

--- a/scripts/IU_examples/python/launcher.py
+++ b/scripts/IU_examples/python/launcher.py
@@ -11,13 +11,11 @@ import os
 import shlex
 import subprocess
 import time
+from urllib.parse import urlsplit
 
 from distributed import Client
 from pymongo import MongoClient
 import yaml
-
-from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
-
 
 class BasicMsPASSLauncher(ABC):
     """
@@ -341,13 +339,10 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
     def _startup_settings():
         try:
             timeout = float(os.environ.get("MSPASS_STARTUP_TIMEOUT_SECONDS", "120"))
-            poll_interval = float(
-                os.environ.get("MSPASS_STARTUP_POLL_SECONDS", "2")
-            )
+            poll_interval = float(os.environ.get("MSPASS_STARTUP_POLL_SECONDS", "2"))
         except ValueError as error:
-            raise MsPASSError(
-                "HPCClusterLauncher startup timeout and poll values must be numbers",
-                ErrorSeverity.Invalid,
+            raise ValueError(
+                "HPCClusterLauncher startup timeout and poll values must be numbers"
             ) from error
         if (
             not math.isfinite(timeout)
@@ -355,21 +350,23 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
             or not math.isfinite(poll_interval)
             or poll_interval <= 0.0
         ):
-            raise MsPASSError(
-                "HPCClusterLauncher startup timeout and poll values must be finite and positive",
-                ErrorSeverity.Invalid,
+            raise ValueError(
+                "HPCClusterLauncher startup timeout and poll values must be finite and positive"
             )
         return timeout, poll_interval
 
     @staticmethod
     def _popen(args):
-        return subprocess.Popen(
-            args,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            close_fds=True,
-        )
+        return subprocess.Popen(args, close_fds=True)
+
+    @staticmethod
+    def _scheduler_endpoint(address):
+        endpoint = address if "://" in address else "tcp://" + address
+        parsed = urlsplit(endpoint)
+        if parsed.port is None:
+            port = os.environ.get("DASK_SCHEDULER_PORT") or "8786"
+            parsed = parsed._replace(netloc=parsed.netloc + ":" + port)
+        return parsed.geturl()
 
     @staticmethod
     def _stop_process(process):
@@ -398,7 +395,7 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
             except Exception as error:
                 if first_error is None:
                     first_error = error
-            finally:
+            else:
                 setattr(self, attribute, None)
         if first_error is not None:
             raise first_error
@@ -408,7 +405,7 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
             self._cleanup_owned_processes()
         except Exception as cleanup_error:
             message += "; cleanup failed: {}".format(cleanup_error)
-        raise MsPASSError(message, ErrorSeverity.Invalid)
+        raise RuntimeError(message)
 
     def _require_running(self, name, process):
         if process is None:
@@ -431,7 +428,7 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
             client.close()
 
     def _probe_scheduler(self):
-        client = Client(self.scheduler_host, timeout="2s")
+        client = Client(self._scheduler_endpoint(self.scheduler_host), timeout="2s")
         try:
             client.scheduler_info()
         finally:
@@ -487,7 +484,15 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         object as self attibutes called "self.scheduler_process",
         "self.dbserver_process", and "self.remote_worker_process".  
         If workers are run on theh primary there will also be a defined 
-        valued for "self.primary_worker_process".  
+        valued for "self.primary_worker_process".
+
+        :raises ValueError: if the startup timeout or polling configuration is
+          not a finite positive number.  Validation happens before any child
+          is started.
+        :raises RuntimeError: if an owned child exits early, services do not
+          become ready before the deadline, or failure cleanup itself fails.
+          An underlying process-creation exception is re-raised unchanged
+          after already-started owned children have been cleaned up.
         """
         # Validate these settings before starting any process.  Otherwise an
         # invalid value would leave the scheduler and database children alive.
@@ -536,17 +541,26 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
                 self._require_running("primary worker", self.primary_worker_process)
             if verbose:
                 print("Successfully launched MongoDB, scheduler, and workers")
-        except MsPASSError:
+        except RuntimeError:
             raise
         except Exception as error:
-            message = "HPCClusterLauncher launch failed: {}".format(error)
             try:
                 self._cleanup_owned_processes()
             except Exception as cleanup_error:
-                message += "; cleanup failed: {}".format(cleanup_error)
-            raise MsPASSError(message, ErrorSeverity.Invalid) from error
+                raise RuntimeError(
+                    "HPCClusterLauncher launch failed: {}; cleanup failed: {}".format(
+                        error, cleanup_error
+                    )
+                ) from error
+            raise
 
     def shutdown(self):
+        """Stop every owned child.
+
+        A process handle is cleared only after that process is stopped.  If a
+        stop fails, cleanup continues for the other children, the first error
+        is re-raised, and the failed handle remains available for a retry.
+        """
         self._cleanup_owned_processes()
 
     def run(self, pyscript):
@@ -693,14 +707,9 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         Returns a list that is is the starting point for the list of 
         args used for subprocess.run and subprocess.Popen. 
         """
-        crargs = []
-        rtmp = self.container_run_command.split()
-        for arg in rtmp:
-            crargs.append(arg)
-        rtmp = self.container_run_args.split()
-        for arg in rtmp:
-            crargs.append(arg)
-        return crargs
+        return shlex.split(self.container_run_command) + shlex.split(
+            self.container_run_args
+        )
 
     def _build_worker_run_args(self) -> list:
         """
@@ -718,11 +727,8 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         nnodes = len(self.worker_hosts)
         if nnodes == 0:
             return []
-        arglist = []
         # cthis allows args to be entered on teh run line in config file
-        tlist = self.worker_run_command.split()
-        for arg in tlist:
-            arglist.append(arg)
+        arglist = shlex.split(self.worker_run_command)
         # these are actually locked to mpiexec so this isn't 
         # as flexible as it might look
         arglist.append("-n")
@@ -733,10 +739,7 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
         for hostname in self.worker_hosts:
             arglist.append(hostname)
         # simillar to launch method to generate run  line for container
-        for arg in self.container_run_command.split():
-            arglist.append(arg)
-        for arg in self.container_run_args.split():
-            arglist.append(arg)
+        arglist.extend(self._initialize_container_runargs())
         # apptainer mthod for setting environment variables loaded 
         # in contaer
         arglist.append(self.container_env_flag)


### PR DESCRIPTION
Related to #807

## Summary

- initialize explicit/auto/mixed host and every process-handle state
- execute exact tunnel/container/worker argv without shell metacharacters or `shell=True`
- probe the configured MongoDB and Dask endpoints before workers/frontends
- detect every owned-child early exit and startup timeout
- terminate and wait for already-started owned children before reporting failure
- retain a failed process handle when cleanup itself fails so shutdown can be retried
- keep frontend launch nonblocking and retain its process handle

## Renewed error-contract review

The issue text changed all startup failures to `MsPASSError(Invalid)`, but this class is an infrastructure launcher and its baseline public behavior uses ordinary Python runtime/configuration exceptions.  Commit `60be0795` restores that boundary:

- malformed timeout/poll settings raise `ValueError` before any child starts
- owned-child early exit/readiness timeout raises `RuntimeError`
- process-creation/system exceptions are re-raised with their original identity after cleanup
- if cleanup fails, that failure is explicit and the failed handle is retained rather than silently discarded

The long `launch` and `shutdown` docstrings now document these boundaries.

## Validation

- focused launcher lifecycle contract: 29/29 passed
- added original-exception identity and cleanup-retry-handle tests
- Python 3.12/3.13 `py_compile` and `git diff --check`: passed
- the new test file is Black 26.5.1 clean; the pre-existing launcher file has legacy whole-file formatting, so unrelated reformatting was deliberately excluded

This remains draft pending fresh CI and human infrastructure/API review.