### PR TITLE
Repair DesktopLauncher configuration and Compose lifecycle

### DIFF
--- a/python/tests/test_iu_desktop_launcher_contract.py
+++ b/python/tests/test_iu_desktop_launcher_contract.py
@@ -1,0 +1,571 @@
+import importlib.util
+import inspect
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+
+REPOSITORY_ROOT = Path(
+    os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
+)
+LAUNCHER_PATH = REPOSITORY_ROOT / "scripts" / "IU_examples" / "python" / "launcher.py"
+
+
+@pytest.fixture
+def launcher_module():
+    spec = importlib.util.spec_from_file_location(
+        "mspass_iu_desktop_launcher_test", LAUNCHER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class BrowserProcess:
+    def __init__(self, status=None):
+        self.status = status
+        self.terminate_count = 0
+        self.wait_count = 0
+
+    def poll(self):
+        return self.status
+
+    def terminate(self):
+        self.terminate_count += 1
+        self.status = 0
+
+    def wait(self):
+        self.wait_count += 1
+        return self.status
+
+
+class PollFailureBrowser(BrowserProcess):
+    def poll(self):
+        raise OSError("browser poll failed")
+
+
+class SubprocessScript:
+    def __init__(self, results):
+        self.results = list(results)
+        self.run_calls = []
+        self.popen_calls = []
+        self.browser = BrowserProcess()
+        self.popen_error = None
+
+    def run(self, argv, **kwargs):
+        self.run_calls.append((argv, kwargs))
+        assert self.results, f"unexpected subprocess.run call: {argv}"
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    def popen(self, argv, **kwargs):
+        self.popen_calls.append((argv, kwargs))
+        if self.popen_error is not None:
+            raise self.popen_error
+        return self.browser
+
+
+def completed(stdout="", stderr="", returncode=0):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def install_subprocess_script(monkeypatch, launcher_module, results):
+    script = SubprocessScript(results)
+    monkeypatch.setattr(launcher_module.subprocess, "run", script.run)
+    monkeypatch.setattr(launcher_module.subprocess, "Popen", script.popen)
+    return script
+
+
+def compose(configuration, *arguments):
+    return ["docker", "compose", "-f", configuration, *arguments]
+
+
+def bare_launcher(launcher_module, *, owned=False):
+    launcher = launcher_module.DesktopLauncher.__new__(launcher_module.DesktopLauncher)
+    launcher.configuration_file = "custom.yaml"
+    launcher.host_os = "Linux"
+    launcher.browser = "browser"
+    launcher.verbose = False
+    launcher.browser_process = None
+    launcher._owns_stack = owned
+    launcher._url = None
+    launcher._startup_timeout = 120.0
+    launcher._startup_poll = 2.0
+    return launcher
+
+
+@pytest.mark.parametrize(
+    "host_os,browser_argv",
+    [
+        ("Linux", ["browser", "https://127.0.0.1:8888/lab?token=abc"]),
+        (
+            "Darwin",
+            ["open", "-a", "browser", "https://127.0.0.1:8888/lab?token=abc"],
+        ),
+        (
+            "Windows",
+            [
+                "cmd",
+                "/c",
+                "start",
+                "",
+                "browser",
+                "https://127.0.0.1:8888/lab?token=abc",
+            ],
+        ),
+    ],
+)
+def test_launch_uses_exact_compose_browser_and_timing_contract(
+    launcher_module, monkeypatch, host_os, browser_argv
+):
+    configuration = "data/yaml/compose.yaml"
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(),
+            completed(),
+            completed("starting\n"),
+            completed("mspass-frontend\n"),
+            completed("Jupyter: https://127.0.0.1:8888/lab?token=abc\n"),
+            completed("mspass-frontend\n"),
+            completed(),
+        ],
+    )
+    monotonic = iter([10.0, 10.5])
+    sleeps = []
+    monkeypatch.setattr(launcher_module.time, "monotonic", lambda: next(monotonic))
+    monkeypatch.setattr(launcher_module.time, "sleep", sleeps.append)
+
+    launcher = launcher_module.DesktopLauncher(
+        host_os=host_os, browser="browser", verbose=False
+    )
+
+    expected_url = "https://127.0.0.1:8888/lab?token=abc"
+    assert launcher.configuration_file == configuration
+    assert launcher._startup_timeout == 120.0
+    assert launcher._startup_poll == 2.0
+    assert launcher.url() == expected_url
+    assert launcher.launch() == expected_url
+    assert script.run_calls == [
+        (
+            compose(
+                configuration,
+                "ps",
+                "--status",
+                "running",
+                "--services",
+                "mspass-frontend",
+            ),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(configuration, "up", "-d", "mspass-frontend"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(configuration, "logs", "mspass-frontend"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(
+                configuration,
+                "ps",
+                "--status",
+                "running",
+                "--services",
+                "mspass-frontend",
+            ),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(configuration, "logs", "mspass-frontend"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(
+                configuration,
+                "ps",
+                "--status",
+                "running",
+                "--services",
+                "mspass-frontend",
+            ),
+            {"capture_output": True, "text": True},
+        ),
+    ]
+    assert script.popen_calls == [(browser_argv, {})]
+    assert sleeps == [2.0]
+    assert launcher._owns_stack is True
+
+    launcher.shutdown()
+    launcher.shutdown()
+    assert script.browser.terminate_count == 1
+    assert script.browser.wait_count == 1
+    assert script.run_calls[-1] == (
+        compose(configuration, "down"),
+        {"capture_output": True, "text": True},
+    )
+    assert script.results == []
+
+
+def test_default_os_comes_from_platform_system(launcher_module, monkeypatch):
+    monkeypatch.setattr(launcher_module.platform, "system", lambda: "Linux")
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed("mspass-frontend\n"),
+            completed("http://localhost:8888/lab?token=abc"),
+            completed("mspass-frontend\n"),
+        ],
+    )
+    launcher = launcher_module.DesktopLauncher(browser="browser", verbose=False)
+    assert launcher.host_os == "Linux"
+    assert script.popen_calls == [
+        (["browser", "http://localhost:8888/lab?token=abc"], {})
+    ]
+    launcher.shutdown()
+
+
+def test_unsupported_os_and_bad_timing_fail_before_compose(
+    launcher_module, monkeypatch
+):
+    run_calls = []
+    popen_calls = []
+    monkeypatch.setattr(
+        launcher_module.subprocess,
+        "run",
+        lambda *args, **kwargs: run_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        launcher_module.subprocess,
+        "Popen",
+        lambda *args, **kwargs: popen_calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(MsPASSError) as error:
+        launcher_module.DesktopLauncher(host_os="Plan9", verbose=False)
+    assert error.value.severity == ErrorSeverity.Invalid
+
+    for value in ("0", "-1", "nan", "inf", "not-a-number"):
+        monkeypatch.setenv("MSPASS_STARTUP_TIMEOUT_SECONDS", value)
+        with pytest.raises(MsPASSError) as error:
+            launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+        assert error.value.severity == ErrorSeverity.Invalid
+    assert run_calls == []
+    assert popen_calls == []
+
+
+def test_caller_owned_stack_is_preserved_and_launch_is_idempotent(
+    launcher_module, monkeypatch
+):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed("mspass-frontend\n"),
+            completed("http://localhost:8888/lab?token=caller"),
+            completed("mspass-frontend\n"),
+        ],
+    )
+    launcher = launcher_module.DesktopLauncher(
+        host_os="Linux", browser="browser", verbose=False
+    )
+    assert launcher._owns_stack is False
+    call_count = len(script.run_calls)
+    assert launcher.launch() == "http://localhost:8888/lab?token=caller"
+    assert len(script.run_calls) == call_count
+
+    launcher.shutdown()
+    launcher.shutdown()
+    assert all(call[0][-1] != "down" for call in script.run_calls)
+    assert script.browser.terminate_count == 1
+    assert script.browser.wait_count == 1
+
+
+def test_early_exit_and_timeout_clean_only_owned_stack(launcher_module, monkeypatch):
+    early = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(),
+            completed(),
+            completed("starting"),
+            completed(),
+            completed(),
+        ],
+    )
+    with pytest.raises(MsPASSError, match="exited") as error:
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert early.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+    assert early.popen_calls == []
+
+    timeout = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(),
+            completed(),
+            completed("still starting"),
+            completed("mspass-frontend\n"),
+            completed("still starting"),
+            completed("mspass-frontend\n"),
+            completed(),
+        ],
+    )
+    monkeypatch.setenv("MSPASS_STARTUP_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("MSPASS_STARTUP_POLL_SECONDS", "0.25")
+    monotonic = iter([0.0, 0.5, 1.0])
+    sleeps = []
+    monkeypatch.setattr(launcher_module.time, "monotonic", lambda: next(monotonic))
+    monkeypatch.setattr(launcher_module.time, "sleep", sleeps.append)
+    with pytest.raises(MsPASSError, match="timed out") as error:
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert timeout.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+    assert timeout.popen_calls == []
+    assert sleeps == [0.25]
+
+
+def test_failed_attach_preserves_caller_owned_stack(launcher_module, monkeypatch):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed("mspass-frontend\n"),
+            completed("still starting"),
+            completed(),
+        ],
+    )
+    with pytest.raises(MsPASSError, match="exited"):
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+    assert all(call[0][-1] != "down" for call in script.run_calls)
+    assert script.popen_calls == []
+
+
+@pytest.mark.parametrize("failure", [OSError("missing"), RuntimeError("broken")])
+def test_browser_failure_is_invalid_and_cleans_owned_stack(
+    launcher_module, monkeypatch, failure
+):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(),
+            completed(),
+            completed("http://localhost:8888/lab?token=abc"),
+            completed("mspass-frontend\n"),
+            completed(),
+        ],
+    )
+    script.popen_error = failure
+    with pytest.raises(MsPASSError, match="browser") as error:
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+
+
+@pytest.mark.parametrize("operation", ["ps", "up", "logs"])
+def test_compose_startup_failures_are_invalid(launcher_module, monkeypatch, operation):
+    failure = completed(stderr="compose failed", returncode=7)
+    if operation == "ps":
+        results = [failure]
+    elif operation == "up":
+        results = [completed(), failure]
+    else:
+        results = [completed(), completed(), failure, completed()]
+    script = install_subprocess_script(monkeypatch, launcher_module, results)
+
+    with pytest.raises(MsPASSError, match="command failed") as error:
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+    assert error.value.severity == ErrorSeverity.Invalid
+    if operation == "logs":
+        assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+    else:
+        assert all(call[0][-1] != "down" for call in script.run_calls)
+
+
+def test_post_up_status_failure_is_invalid_and_cleans_owned_stack(
+    launcher_module, monkeypatch
+):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(),
+            completed(),
+            completed("still starting"),
+            completed(stderr="ps failed", returncode=7),
+            completed(),
+        ],
+    )
+
+    with pytest.raises(MsPASSError, match="command failed") as error:
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+
+
+def test_status_run_and_shutdown_have_exact_result_contracts(
+    launcher_module, monkeypatch
+):
+    launcher = bare_launcher(launcher_module, owned=True)
+    browser = BrowserProcess()
+    launcher.browser_process = browser
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed("mspass-frontend\nother\n"),
+            completed("other\n"),
+            completed(stdout="ran"),
+            completed(),
+        ],
+    )
+
+    assert launcher.status() == 1
+    assert launcher.status() == 0
+    result = launcher.run("analysis.py")
+    assert result.stdout == "ran"
+    launcher.shutdown()
+    assert script.run_calls == [
+        (
+            compose(
+                "custom.yaml",
+                "ps",
+                "--status",
+                "running",
+                "--services",
+                "mspass-frontend",
+            ),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(
+                "custom.yaml",
+                "ps",
+                "--status",
+                "running",
+                "--services",
+                "mspass-frontend",
+            ),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(
+                "custom.yaml",
+                "exec",
+                "-T",
+                "mspass-frontend",
+                "python",
+                "analysis.py",
+            ),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose("custom.yaml", "down"),
+            {"capture_output": True, "text": True},
+        ),
+    ]
+    assert browser.terminate_count == 1
+    assert browser.wait_count == 1
+    assert launcher._owns_stack is False
+
+
+@pytest.mark.parametrize("operation", ["status", "run", "shutdown"])
+def test_public_compose_failures_are_invalid(launcher_module, monkeypatch, operation):
+    launcher = bare_launcher(launcher_module, owned=operation == "shutdown")
+    install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [completed(stderr=f"{operation} failed", returncode=9)],
+    )
+    with pytest.raises(MsPASSError) as error:
+        if operation == "status":
+            launcher.status()
+        elif operation == "run":
+            launcher.run("analysis.py")
+        else:
+            launcher.shutdown()
+    assert error.value.severity == ErrorSeverity.Invalid
+    if operation == "shutdown":
+        assert launcher._owns_stack is False
+
+
+def test_browser_nonzero_exit_is_waited_and_stack_is_cleaned(
+    launcher_module, monkeypatch
+):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(),
+            completed(),
+            completed("http://localhost:8888/lab?token=abc"),
+            completed("mspass-frontend\n"),
+            completed(),
+        ],
+    )
+    script.browser.status = 3
+    with pytest.raises(MsPASSError, match="browser"):
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+    assert script.browser.terminate_count == 0
+    assert script.browser.wait_count == 1
+    assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+
+
+def test_browser_poll_failure_terminates_waits_and_cleans_owned_stack(
+    launcher_module, monkeypatch
+):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(),
+            completed(),
+            completed("http://localhost:8888/lab?token=abc"),
+            completed("mspass-frontend\n"),
+            completed(),
+        ],
+    )
+    script.browser = PollFailureBrowser()
+
+    with pytest.raises(MsPASSError, match="browser poll failed") as error:
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert script.browser.terminate_count == 1
+    assert script.browser.wait_count == 1
+    assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+
+
+def test_url_parser_never_returns_a_fallback(launcher_module):
+    assert launcher_module.extract_jupyter_url("not ready") is None
+    assert launcher_module.extract_jupyter_url(None) is None
+    assert (
+        launcher_module.extract_jupyter_url(
+            "prefix http://127.0.0.1:8888/lab?token=one suffix"
+        )
+        == "http://127.0.0.1:8888/lab?token=one"
+    )
+    assert (
+        launcher_module.extract_jupyter_url("https://localhost:8888/tree?token=two")
+        == "https://localhost:8888/tree?token=two"
+    )
+
+
+def test_desktop_implements_base_method_signatures(launcher_module):
+    base = launcher_module.BasicMsPASSLauncher
+    desktop = launcher_module.DesktopLauncher
+    assert inspect.signature(desktop.launch) == inspect.signature(base.launch)
+    assert inspect.signature(desktop.status) == inspect.signature(base.status)
+    assert inspect.signature(desktop.run) == inspect.signature(base.run)

--- a/python/tests/test_iu_desktop_launcher_contract.py
+++ b/python/tests/test_iu_desktop_launcher_contract.py
@@ -6,12 +6,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
-
 REPOSITORY_ROOT = Path(
     os.environ.get("MSPASS_TEST_REPOSITORY_ROOT", Path(__file__).resolve().parents[2])
 )
 LAUNCHER_PATH = REPOSITORY_ROOT / "scripts" / "IU_examples" / "python" / "launcher.py"
+COMPOSE_SERVICES = (
+    "mspass-db\n" "mspass-scheduler\n" "mspass-worker\n" "mspass-frontend\n"
+)
 
 
 @pytest.fixture
@@ -38,14 +39,26 @@ class BrowserProcess:
         self.terminate_count += 1
         self.status = 0
 
-    def wait(self):
+    def wait(self, timeout=None):
         self.wait_count += 1
         return self.status
+
+    def kill(self):
+        self.terminate_count += 1
+        self.status = -9
 
 
 class PollFailureBrowser(BrowserProcess):
     def poll(self):
         raise OSError("browser poll failed")
+
+
+class RetryBrowser(BrowserProcess):
+    def terminate(self):
+        self.terminate_count += 1
+        if self.terminate_count == 1:
+            raise OSError("browser terminate failed")
+        self.status = 0
 
 
 class SubprocessScript:
@@ -129,12 +142,15 @@ def test_launch_uses_exact_compose_browser_and_timing_contract(
         monkeypatch,
         launcher_module,
         [
+            completed(COMPOSE_SERVICES),
             completed(),
             completed(),
             completed("starting\n"),
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed("Jupyter: https://127.0.0.1:8888/lab?token=abc\n"),
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed(),
         ],
     )
@@ -155,33 +171,15 @@ def test_launch_uses_exact_compose_browser_and_timing_contract(
     assert launcher.launch() == expected_url
     assert script.run_calls == [
         (
-            compose(
-                configuration,
-                "ps",
-                "--status",
-                "running",
-                "--services",
-                "mspass-frontend",
-            ),
+            compose(configuration, "config", "--services"),
             {"capture_output": True, "text": True},
         ),
         (
-            compose(configuration, "up", "-d", "mspass-frontend"),
+            compose(configuration, "ps", "--status", "running", "--services"),
             {"capture_output": True, "text": True},
         ),
         (
-            compose(configuration, "logs", "mspass-frontend"),
-            {"capture_output": True, "text": True},
-        ),
-        (
-            compose(
-                configuration,
-                "ps",
-                "--status",
-                "running",
-                "--services",
-                "mspass-frontend",
-            ),
+            compose(configuration, "up", "-d"),
             {"capture_output": True, "text": True},
         ),
         (
@@ -189,14 +187,23 @@ def test_launch_uses_exact_compose_browser_and_timing_contract(
             {"capture_output": True, "text": True},
         ),
         (
-            compose(
-                configuration,
-                "ps",
-                "--status",
-                "running",
-                "--services",
-                "mspass-frontend",
-            ),
+            compose(configuration, "config", "--services"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(configuration, "ps", "--status", "running", "--services"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(configuration, "logs", "mspass-frontend"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(configuration, "config", "--services"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose(configuration, "ps", "--status", "running", "--services"),
             {"capture_output": True, "text": True},
         ),
     ]
@@ -221,9 +228,11 @@ def test_default_os_comes_from_platform_system(launcher_module, monkeypatch):
         monkeypatch,
         launcher_module,
         [
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed("http://localhost:8888/lab?token=abc"),
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
         ],
     )
     launcher = launcher_module.DesktopLauncher(browser="browser", verbose=False)
@@ -250,15 +259,13 @@ def test_unsupported_os_and_bad_timing_fail_before_compose(
         lambda *args, **kwargs: popen_calls.append((args, kwargs)),
     )
 
-    with pytest.raises(MsPASSError) as error:
+    with pytest.raises(ValueError):
         launcher_module.DesktopLauncher(host_os="Plan9", verbose=False)
-    assert error.value.severity == ErrorSeverity.Invalid
 
     for value in ("0", "-1", "nan", "inf", "not-a-number"):
         monkeypatch.setenv("MSPASS_STARTUP_TIMEOUT_SECONDS", value)
-        with pytest.raises(MsPASSError) as error:
+        with pytest.raises(ValueError):
             launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
-        assert error.value.severity == ErrorSeverity.Invalid
     assert run_calls == []
     assert popen_calls == []
 
@@ -270,9 +277,11 @@ def test_caller_owned_stack_is_preserved_and_launch_is_idempotent(
         monkeypatch,
         launcher_module,
         [
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed("http://localhost:8888/lab?token=caller"),
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
         ],
     )
     launcher = launcher_module.DesktopLauncher(
@@ -295,16 +304,17 @@ def test_early_exit_and_timeout_clean_only_owned_stack(launcher_module, monkeypa
         monkeypatch,
         launcher_module,
         [
+            completed(COMPOSE_SERVICES),
             completed(),
             completed(),
             completed("starting"),
+            completed(COMPOSE_SERVICES),
             completed(),
             completed(),
         ],
     )
-    with pytest.raises(MsPASSError, match="exited") as error:
+    with pytest.raises(RuntimeError, match="exited"):
         launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
-    assert error.value.severity == ErrorSeverity.Invalid
     assert early.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
     assert early.popen_calls == []
 
@@ -312,12 +322,15 @@ def test_early_exit_and_timeout_clean_only_owned_stack(launcher_module, monkeypa
         monkeypatch,
         launcher_module,
         [
+            completed(COMPOSE_SERVICES),
             completed(),
             completed(),
             completed("still starting"),
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed("still starting"),
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed(),
         ],
     )
@@ -327,9 +340,8 @@ def test_early_exit_and_timeout_clean_only_owned_stack(launcher_module, monkeypa
     sleeps = []
     monkeypatch.setattr(launcher_module.time, "monotonic", lambda: next(monotonic))
     monkeypatch.setattr(launcher_module.time, "sleep", sleeps.append)
-    with pytest.raises(MsPASSError, match="timed out") as error:
+    with pytest.raises(RuntimeError, match="timed out"):
         launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
-    assert error.value.severity == ErrorSeverity.Invalid
     assert timeout.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
     assert timeout.popen_calls == []
     assert sleeps == [0.25]
@@ -340,78 +352,133 @@ def test_failed_attach_preserves_caller_owned_stack(launcher_module, monkeypatch
         monkeypatch,
         launcher_module,
         [
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed("still starting"),
+            completed(COMPOSE_SERVICES),
             completed(),
         ],
     )
-    with pytest.raises(MsPASSError, match="exited"):
+    with pytest.raises(RuntimeError, match="exited"):
         launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
     assert all(call[0][-1] != "down" for call in script.run_calls)
     assert script.popen_calls == []
 
 
-@pytest.mark.parametrize("failure", [OSError("missing"), RuntimeError("broken")])
-def test_browser_failure_is_invalid_and_cleans_owned_stack(
-    launcher_module, monkeypatch, failure
-):
-    script = install_subprocess_script(
-        monkeypatch,
-        launcher_module,
-        [
-            completed(),
-            completed(),
-            completed("http://localhost:8888/lab?token=abc"),
-            completed("mspass-frontend\n"),
-            completed(),
-        ],
-    )
-    script.popen_error = failure
-    with pytest.raises(MsPASSError, match="browser") as error:
-        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
-    assert error.value.severity == ErrorSeverity.Invalid
-    assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
-
-
-@pytest.mark.parametrize("operation", ["ps", "up", "logs"])
-def test_compose_startup_failures_are_invalid(launcher_module, monkeypatch, operation):
-    failure = completed(stderr="compose failed", returncode=7)
-    if operation == "ps":
-        results = [failure]
-    elif operation == "up":
-        results = [completed(), failure]
-    else:
-        results = [completed(), completed(), failure, completed()]
-    script = install_subprocess_script(monkeypatch, launcher_module, results)
-
-    with pytest.raises(MsPASSError, match="command failed") as error:
-        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
-    assert error.value.severity == ErrorSeverity.Invalid
-    if operation == "logs":
-        assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
-    else:
-        assert all(call[0][-1] != "down" for call in script.run_calls)
-
-
-def test_post_up_status_failure_is_invalid_and_cleans_owned_stack(
+def test_partial_caller_owned_stack_is_completed_but_never_brought_down(
     launcher_module, monkeypatch
 ):
     script = install_subprocess_script(
         monkeypatch,
         launcher_module,
         [
+            completed(COMPOSE_SERVICES),
+            completed("mspass-db\n"),
+            completed(),
+            completed("http://127.0.0.1:8888/lab"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
+        ],
+    )
+
+    launcher = launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+
+    assert any(call[0][-2:] == ["up", "-d"] for call in script.run_calls)
+    assert launcher._owns_stack is False
+    launcher.shutdown()
+    assert all(call[0][-1] != "down" for call in script.run_calls)
+
+
+def test_partial_caller_owned_stack_is_preserved_when_completion_fails(
+    launcher_module, monkeypatch
+):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(COMPOSE_SERVICES),
+            completed("mspass-db\n"),
+            completed(stderr="up failed", returncode=7),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="command failed"):
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+
+    assert all(call[0][-1] != "down" for call in script.run_calls)
+
+
+@pytest.mark.parametrize("failure", [OSError("missing"), RuntimeError("broken")])
+def test_browser_failure_raises_runtime_error_and_cleans_owned_stack(
+    launcher_module, monkeypatch, failure
+):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(COMPOSE_SERVICES),
+            completed(),
+            completed(),
+            completed("http://localhost:8888/lab?token=abc"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
+            completed(),
+        ],
+    )
+    script.popen_error = failure
+    with pytest.raises(RuntimeError, match="browser"):
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+    assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+
+
+@pytest.mark.parametrize("operation", ["config", "ps", "up", "logs"])
+def test_compose_startup_failures_raise_runtime_error(
+    launcher_module, monkeypatch, operation
+):
+    failure = completed(stderr="compose failed", returncode=7)
+    if operation == "config":
+        results = [failure]
+    elif operation == "ps":
+        results = [completed(COMPOSE_SERVICES), failure]
+    elif operation == "up":
+        results = [completed(COMPOSE_SERVICES), completed(), failure, completed()]
+    else:
+        results = [
+            completed(COMPOSE_SERVICES),
+            completed(),
+            completed(),
+            failure,
+            completed(),
+        ]
+    script = install_subprocess_script(monkeypatch, launcher_module, results)
+
+    with pytest.raises(RuntimeError, match="command failed"):
+        launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
+    if operation in ("up", "logs"):
+        assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+    else:
+        assert all(call[0][-1] != "down" for call in script.run_calls)
+
+
+def test_post_up_status_failure_raises_runtime_error_and_cleans_owned_stack(
+    launcher_module, monkeypatch
+):
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [
+            completed(COMPOSE_SERVICES),
             completed(),
             completed(),
             completed("still starting"),
+            completed(COMPOSE_SERVICES),
             completed(stderr="ps failed", returncode=7),
             completed(),
         ],
     )
 
-    with pytest.raises(MsPASSError, match="command failed") as error:
+    with pytest.raises(RuntimeError, match="command failed"):
         launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
-
-    assert error.value.severity == ErrorSeverity.Invalid
     assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
 
 
@@ -425,7 +492,9 @@ def test_status_run_and_shutdown_have_exact_result_contracts(
         monkeypatch,
         launcher_module,
         [
-            completed("mspass-frontend\nother\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES + "other\n"),
+            completed(COMPOSE_SERVICES),
             completed("other\n"),
             completed(stdout="ran"),
             completed(),
@@ -439,25 +508,19 @@ def test_status_run_and_shutdown_have_exact_result_contracts(
     launcher.shutdown()
     assert script.run_calls == [
         (
-            compose(
-                "custom.yaml",
-                "ps",
-                "--status",
-                "running",
-                "--services",
-                "mspass-frontend",
-            ),
+            compose("custom.yaml", "config", "--services"),
             {"capture_output": True, "text": True},
         ),
         (
-            compose(
-                "custom.yaml",
-                "ps",
-                "--status",
-                "running",
-                "--services",
-                "mspass-frontend",
-            ),
+            compose("custom.yaml", "ps", "--status", "running", "--services"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose("custom.yaml", "config", "--services"),
+            {"capture_output": True, "text": True},
+        ),
+        (
+            compose("custom.yaml", "ps", "--status", "running", "--services"),
             {"capture_output": True, "text": True},
         ),
         (
@@ -481,23 +544,49 @@ def test_status_run_and_shutdown_have_exact_result_contracts(
     assert launcher._owns_stack is False
 
 
+def test_status_requires_frontend_and_every_configured_service(
+    launcher_module, monkeypatch
+):
+    launcher = bare_launcher(launcher_module)
+    script = install_subprocess_script(
+        monkeypatch,
+        launcher_module,
+        [completed("mspass-db\nmspass-worker\n")],
+    )
+    with pytest.raises(RuntimeError, match="no mspass-frontend"):
+        launcher.status()
+    assert len(script.run_calls) == 1
+
+    script.results.extend(
+        [
+            completed(COMPOSE_SERVICES),
+            completed("mspass-db\nmspass-frontend\n"),
+        ]
+    )
+    assert launcher.status() == 0
+
+
 @pytest.mark.parametrize("operation", ["status", "run", "shutdown"])
-def test_public_compose_failures_are_invalid(launcher_module, monkeypatch, operation):
+def test_public_compose_failures_raise_runtime_error(
+    launcher_module, monkeypatch, operation
+):
     launcher = bare_launcher(launcher_module, owned=operation == "shutdown")
-    install_subprocess_script(
+    script = install_subprocess_script(
         monkeypatch,
         launcher_module,
         [completed(stderr=f"{operation} failed", returncode=9)],
     )
-    with pytest.raises(MsPASSError) as error:
+    with pytest.raises(RuntimeError):
         if operation == "status":
             launcher.status()
         elif operation == "run":
             launcher.run("analysis.py")
         else:
             launcher.shutdown()
-    assert error.value.severity == ErrorSeverity.Invalid
     if operation == "shutdown":
+        assert launcher._owns_stack is True
+        script.results.append(completed())
+        launcher.shutdown()
         assert launcher._owns_stack is False
 
 
@@ -508,15 +597,17 @@ def test_browser_nonzero_exit_is_waited_and_stack_is_cleaned(
         monkeypatch,
         launcher_module,
         [
+            completed(COMPOSE_SERVICES),
             completed(),
             completed(),
             completed("http://localhost:8888/lab?token=abc"),
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed(),
         ],
     )
     script.browser.status = 3
-    with pytest.raises(MsPASSError, match="browser"):
+    with pytest.raises(RuntimeError, match="browser"):
         launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
     assert script.browser.terminate_count == 0
     assert script.browser.wait_count == 1
@@ -530,22 +621,37 @@ def test_browser_poll_failure_terminates_waits_and_cleans_owned_stack(
         monkeypatch,
         launcher_module,
         [
+            completed(COMPOSE_SERVICES),
             completed(),
             completed(),
             completed("http://localhost:8888/lab?token=abc"),
-            completed("mspass-frontend\n"),
+            completed(COMPOSE_SERVICES),
+            completed(COMPOSE_SERVICES),
             completed(),
         ],
     )
     script.browser = PollFailureBrowser()
 
-    with pytest.raises(MsPASSError, match="browser poll failed") as error:
+    with pytest.raises(RuntimeError, match="browser poll failed"):
         launcher_module.DesktopLauncher(host_os="Linux", verbose=False)
-
-    assert error.value.severity == ErrorSeverity.Invalid
     assert script.browser.terminate_count == 1
     assert script.browser.wait_count == 1
     assert script.run_calls[-1][0] == compose("data/yaml/compose.yaml", "down")
+
+
+def test_browser_cleanup_failure_retains_handle_for_retry(launcher_module):
+    launcher = bare_launcher(launcher_module)
+    browser = RetryBrowser()
+    launcher.browser_process = browser
+
+    with pytest.raises(RuntimeError, match="browser terminate failed"):
+        launcher.shutdown()
+
+    assert launcher.browser_process is browser
+    launcher.shutdown()
+    assert launcher.browser_process is None
+    assert browser.terminate_count == 2
+    assert browser.wait_count == 1
 
 
 def test_url_parser_never_returns_a_fallback(launcher_module):
@@ -560,6 +666,13 @@ def test_url_parser_never_returns_a_fallback(launcher_module):
     assert (
         launcher_module.extract_jupyter_url("https://localhost:8888/tree?token=two")
         == "https://localhost:8888/tree?token=two"
+    )
+    assert (
+        launcher_module.extract_jupyter_url(
+            "http://container-id:8888/lab?token=three\n"
+            "or http://127.0.0.1:8888/lab?token=three"
+        )
+        == "http://127.0.0.1:8888/lab?token=three"
     )
 
 

--- a/scripts/IU_examples/python/launcher.py
+++ b/scripts/IU_examples/python/launcher.py
@@ -764,12 +764,22 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
 
 class DesktopLauncher(BasicMsPASSLauncher):
     """
-    Launcher for running MsPASS on a desktop in the all-in-one mode.
-    it differs from the cluster versions in multiple ways.  First assumes
-    docker rather than apptainer.  Second, it sets the scheduler
-    as a kwarg option in the constructor rather than defining a different
-    class for different scheulers.  That is appropriate because a single
-    container makes a lot of cluster baggage unnecessary.
+    Launch a complete Docker Compose MsPASS stack on a desktop.
+
+    This launcher manages the database, scheduler, worker, and frontend
+    services defined by the selected Compose file.  It differs from the HPC
+    launchers by using Docker Compose instead of Apptainer and by opening the
+    Jupyter frontend in a local browser.  Construction launches or attaches to
+    the stack, waits until every configured service is running and the
+    frontend publishes a real HTTP(S) URL, and then opens that URL.
+
+    The launcher records whether it started the Compose project.  ``shutdown``
+    brings down only a project started by this object; a project that was
+    already fully or partially running is treated as caller-owned.  Missing
+    services in a partial project are started without transferring ownership.
+    Browser processes started by this object are always reaped.  Compose
+    execution failures are reported as ``RuntimeError``; invalid constructor
+    arguments are reported as ``ValueError``.
     """
 
     _FRONTEND_SERVICE = "mspass-frontend"
@@ -784,14 +794,22 @@ class DesktopLauncher(BasicMsPASSLauncher):
         """
         Constructor for DesktopLauncher.
 
-        This implementation uses docker compose.  The constructor does little
-        more than run the docker ocmpose comand using the input configuration
-        file.
+        This implementation uses ``docker compose`` and immediately calls
+        :meth:`launch`.  Startup timeout and polling interval are controlled by
+        the positive finite environment values
+        ``MSPASS_STARTUP_TIMEOUT_SECONDS`` (default 120) and
+        ``MSPASS_STARTUP_POLL_SECONDS`` (default 2).
 
         :param configuration:  yaml file defining the docker compose
           configuration to launch containers.  See User Manual section
           title "Deply MsPASS with docker compose".
         :type configuration: string  (must be a file name ending in ".yaml" or ".yml")
+        :param host_os: canonical operating-system name used to construct the
+          browser command.  ``None`` selects ``platform.system()``.  Supported
+          values are ``Linux``, ``Darwin``, and ``Windows``.
+        :type host_os: string or None
+        :param browser: browser executable or macOS application name.
+        :type browser: string
         :param verbose:  boolean controling if the constructor print launch output.
           When False runs silently unless there is an exception.  When True the
           output of docker compose is captured and echoed to stdout of the
@@ -811,15 +829,11 @@ class DesktopLauncher(BasicMsPASSLauncher):
             "MSPASS_STARTUP_POLL_SECONDS", 2.0
         )
         if self.host_os not in ("Linux", "Darwin", "Windows"):
-            self._raise_invalid(
+            raise ValueError(
                 "DesktopLauncher does not support host operating system "
                 + repr(self.host_os)
             )
         self.launch()
-
-    @staticmethod
-    def _raise_invalid(message):
-        raise MsPASSError(message, ErrorSeverity.Invalid)
 
     @classmethod
     def _positive_environment_value(cls, name, default):
@@ -827,9 +841,9 @@ class DesktopLauncher(BasicMsPASSLauncher):
         try:
             value = float(value_string)
         except (TypeError, ValueError):
-            cls._raise_invalid(f"{name} must be a finite positive number")
+            raise ValueError(f"{name} must be a finite positive number")
         if not math.isfinite(value) or value <= 0.0:
-            cls._raise_invalid(f"{name} must be a finite positive number")
+            raise ValueError(f"{name} must be a finite positive number")
         return value
 
     def _compose_argv(self, *arguments):
@@ -846,9 +860,9 @@ class DesktopLauncher(BasicMsPASSLauncher):
         try:
             result = subprocess.run(argv, capture_output=True, text=True)
         except Exception as error:
-            self._raise_invalid(
+            raise RuntimeError(
                 "DesktopLauncher failed to execute " + " ".join(argv) + f": {error}"
-            )
+            ) from error
         if self.verbose:
             if result.stdout:
                 print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
@@ -856,7 +870,7 @@ class DesktopLauncher(BasicMsPASSLauncher):
                 print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
         if result.returncode != 0:
             message = result.stderr.strip() or result.stdout.strip()
-            self._raise_invalid(
+            raise RuntimeError(
                 "DesktopLauncher command failed: "
                 + " ".join(argv)
                 + (f": {message}" if message else "")
@@ -872,18 +886,20 @@ class DesktopLauncher(BasicMsPASSLauncher):
 
     def _stop_browser(self):
         process = self.browser_process
-        self.browser_process = None
         if process is None:
             return
         try:
             browser_running = process.poll() is None
         except Exception:
             browser_running = True
+        if browser_running:
+            process.terminate()
         try:
-            if browser_running:
-                process.terminate()
-        finally:
-            process.wait()
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+        self.browser_process = None
 
     def _cleanup_after_failed_launch(self):
         errors = []
@@ -896,7 +912,7 @@ class DesktopLauncher(BasicMsPASSLauncher):
                 self._run_compose("down")
             except BaseException as error:
                 errors.append(str(error))
-            finally:
+            else:
                 self._owns_stack = False
         self._url = None
         return errors
@@ -907,65 +923,138 @@ class DesktopLauncher(BasicMsPASSLauncher):
             logs = self._run_compose("logs", self._FRONTEND_SERVICE)
             url = extract_jupyter_url(logs.stdout)
             if self.status() != 1:
-                self._raise_invalid(
-                    f"DesktopLauncher detected that {self._FRONTEND_SERVICE} exited "
-                    "before publishing a Jupyter URL"
+                raise RuntimeError(
+                    "DesktopLauncher detected that one or more Compose services "
+                    "exited before the frontend published a Jupyter URL"
                 )
             if url is not None:
                 return url
             if time.monotonic() >= deadline:
-                self._raise_invalid(
+                raise RuntimeError(
                     "DesktopLauncher timed out waiting for a Jupyter HTTP(S) URL"
                 )
             time.sleep(self._startup_poll)
 
     def url(self):
-        """Return the Jupyter URL discovered by :meth:`launch`."""
+        """
+        Return the Jupyter URL discovered by :meth:`launch`.
+
+        The value is ``None`` before a successful launch and after shutdown.
+        No tokenless fallback URL is fabricated.
+        """
         return self._url
 
     def launch(self):
-        """Start or attach to the desktop stack and open its Jupyter URL."""
+        """
+        Start or attach to the desktop stack and open its Jupyter URL.
+
+        The method is idempotent after a successful launch.  A newly started
+        project is marked as owned and is brought down if readiness or browser
+        startup fails.  A fully or partially running project discovered on
+        entry is caller-owned: missing services are started, but the project
+        is never brought down by this object.
+
+        :return: the HTTP(S) Jupyter URL extracted from frontend logs.
+        :rtype: string
+        :raises RuntimeError: if Compose execution, service readiness, URL
+          discovery, or browser startup fails.
+        """
         if self._url is not None:
             return self._url
         try:
-            if self.status() == 0:
-                self._run_compose("up", "-d", self._FRONTEND_SERVICE)
-                self._owns_stack = True
+            expected_services, running_services = self._service_state()
+            if not expected_services.issubset(running_services):
+                # Start the complete configuration.  The worker is not a
+                # dependency of the frontend in the standard Compose file, so
+                # targeting only the frontend would create a scheduler with no
+                # worker capable of running user tasks.
+                self._owns_stack = not bool(expected_services & running_services)
+                self._run_compose("up", "-d")
             url = self._wait_for_url()
             try:
                 self.browser_process = subprocess.Popen(self._browser_argv(url))
                 browser_status = self.browser_process.poll()
             except Exception as error:
-                self._raise_invalid(
+                raise RuntimeError(
                     f"DesktopLauncher failed to launch browser: {error}"
-                )
+                ) from error
             if browser_status not in (None, 0):
-                self._raise_invalid(
+                raise RuntimeError(
                     "DesktopLauncher browser process exited with an error"
                 )
             self._url = url
             return url
         except BaseException as error:
             cleanup_errors = self._cleanup_after_failed_launch()
-            if cleanup_errors:
-                self._raise_invalid(
-                    f"{error}; cleanup failed: " + "; ".join(cleanup_errors)
+            if cleanup_errors and hasattr(error, "add_note"):
+                error.add_note(
+                    "DesktopLauncher cleanup failed: " + "; ".join(cleanup_errors)
                 )
             raise
 
+    def _service_state(self):
+        """Return the configured and running service-name sets."""
+        configured = self._run_compose("config", "--services")
+        expected_services = {
+            line.strip() for line in configured.stdout.splitlines() if line.strip()
+        }
+        if self._FRONTEND_SERVICE not in expected_services:
+            raise RuntimeError(
+                f"DesktopLauncher configuration has no {self._FRONTEND_SERVICE} service"
+            )
+        running = self._run_compose("ps", "--status", "running", "--services")
+        running_services = {
+            line.strip() for line in running.stdout.splitlines() if line.strip()
+        }
+        return expected_services, running_services
+
     def status(self):
-        result = self._run_compose(
-            "ps", "--status", "running", "--services", self._FRONTEND_SERVICE
-        )
-        services = {line.strip() for line in result.stdout.splitlines()}
-        return int(self._FRONTEND_SERVICE in services)
+        """
+        Test readiness of the complete configured Compose project.
+
+        Service names are read from ``docker compose config --services`` and
+        compared with ``docker compose ps --status running --services``.  This
+        prevents a running frontend from hiding a missing scheduler, worker,
+        or database.
+
+        :return: 1 when every configured service is running; otherwise 0.
+        :rtype: int
+        :raises RuntimeError: if Compose fails or the configuration has no
+          ``mspass-frontend`` service.
+        """
+        expected_services, running_services = self._service_state()
+        return int(expected_services.issubset(running_services))
 
     def run(self, python_file):
+        """
+        Run a Python script in the active frontend service.
+
+        The command is executed as ``docker compose exec -T
+        mspass-frontend python python_file`` and blocks until it exits.
+
+        :param python_file: path to a Python script visible in the frontend.
+        :type python_file: string
+        :return: the successful ``subprocess.CompletedProcess``.
+        :raises RuntimeError: if Compose cannot execute the command or the
+          command exits nonzero.
+        """
         return self._run_compose(
             "exec", "-T", self._FRONTEND_SERVICE, "python", python_file
         )
 
     def shutdown(self, verbose=False):
+        """
+        Reap the owned browser and stop an owned Compose project.
+
+        Calling this method repeatedly is safe.  A caller-owned Compose project
+        is never brought down.  Cleanup attempts continue after an individual
+        failure so that all owned resources have a chance to terminate.
+
+        :param verbose: print cleanup errors before raising them.
+        :type verbose: bool
+        :raises RuntimeError: after cleanup if one or more owned resources
+          could not be stopped.
+        """
         errors = []
         try:
             self._stop_browser()
@@ -976,13 +1065,13 @@ class DesktopLauncher(BasicMsPASSLauncher):
                 self._run_compose("down")
             except BaseException as error:
                 errors.append(str(error))
-            finally:
+            else:
                 self._owns_stack = False
         self._url = None
         if verbose and errors:
             print("DesktopLauncher shutdown errors: " + "; ".join(errors))
         if errors:
-            self._raise_invalid("DesktopLauncher shutdown failed: " + "; ".join(errors))
+            raise RuntimeError("DesktopLauncher shutdown failed: " + "; ".join(errors))
 
     def __del__(self):
         """
@@ -1012,7 +1101,11 @@ def extract_jupyter_url(outstr):
     """
     if not isinstance(outstr, str):
         return None
-    match = re.search(r"https?://[^\s\"']+", outstr)
-    if match is None:
+    matches = re.findall(r"https?://[^\s\"']+", outstr)
+    if not matches:
         return None
-    return match.group(0).rstrip(".,;)")
+    urls = [match.rstrip(".,;)") for match in matches]
+    for url in urls:
+        if urlsplit(url).hostname in ("127.0.0.1", "localhost", "::1"):
+            return url
+    return urls[0]

--- a/scripts/IU_examples/python/launcher.py
+++ b/scripts/IU_examples/python/launcher.py
@@ -8,6 +8,8 @@ Created on Tue Jan 28 09:15:40 2025
 from abc import ABC, abstractmethod
 import math
 import os
+import platform
+import re
 import shlex
 import subprocess
 import time
@@ -763,158 +765,254 @@ class HPCClusterLauncher(BasicMsPASSLauncher):
 class DesktopLauncher(BasicMsPASSLauncher):
     """
     Launcher for running MsPASS on a desktop in the all-in-one mode.
-    it differs from the cluster versions in multiple ways.  First assumes 
-    docker rather than apptainer.  Second, it sets the scheduler 
-    as a kwarg option in the constructor rather than defining a different 
-    class for different scheulers.  That is appropriate because a single 
+    it differs from the cluster versions in multiple ways.  First assumes
+    docker rather than apptainer.  Second, it sets the scheduler
+    as a kwarg option in the constructor rather than defining a different
+    class for different scheulers.  That is appropriate because a single
     container makes a lot of cluster baggage unnecessary.
     """
-    def __init__(self,
-                 configuration="configuration_docker.yaml",
-                 host_os="MacOS",
-                 browser="FireFox",
-                 verbose=True,
-                 ):
+
+    _FRONTEND_SERVICE = "mspass-frontend"
+
+    def __init__(
+        self,
+        configuration="data/yaml/compose.yaml",
+        host_os=None,
+        browser="FireFox",
+        verbose=True,
+    ):
         """
         Constructor for DesktopLauncher.
-        
+
         This implementation uses docker compose.  The constructor does little
-        more than run the docker ocmpose comand using the input configuration 
+        more than run the docker ocmpose comand using the input configuration
         file.
-        
-        :param configuration:  yaml file defining the docker compose 
-          configuration to launch containers.  See User Manual section 
+
+        :param configuration:  yaml file defining the docker compose
+          configuration to launch containers.  See User Manual section
           title "Deply MsPASS with docker compose".
         :type configuration: string  (must be a file name ending in ".yaml" or ".yml")
-        :param verbose:  boolean controling if the constructor print launch output. 
-          When False runs silently unless there is an exception.  When True the 
-          output of docker compose is captured and echoed to stdout of the 
+        :param verbose:  boolean controling if the constructor print launch output.
+          When False runs silently unless there is an exception.  When True the
+          output of docker compose is captured and echoed to stdout of the
           calling python script.
         """
         self.configuration_file = configuration
-        runline=[]
-        runline.append("docker-compose")
-        runline.append("-f")
-        # could test the type of configuration to be str but docker-compose 
-        # will fail if this is not a valid file name
-        runline.append(self.configuration_file)
-        runline.append("up")
-        runline.append("-d")
-        runout=subprocess.run(runline,capture_output=True,text=True)
-        if verbose:
-            print("stdout from DecktopLauncher constructor")
-            print(runout.stdout)
-            print("stderr from DesktopLauncher constructor")
-            print(runout.stderr)
-        url = self.url()
-        time.sleep(2)
-        match host_os:
-            case "MacOS":
-                launch_string = "open -a "+browser + " " + url
-            case "linux":
-                launch_string = browser + " " + url 
-            case "Window":
-                raise ValueError("DesktopLauncher constructor:  windows launcing not yet implemented")
+        self.host_os = platform.system() if host_os is None else host_os
+        self.browser = browser
+        self.verbose = verbose
+        self.browser_process = None
+        self._owns_stack = False
+        self._url = None
+        self._startup_timeout = self._positive_environment_value(
+            "MSPASS_STARTUP_TIMEOUT_SECONDS", 120.0
+        )
+        self._startup_poll = self._positive_environment_value(
+            "MSPASS_STARTUP_POLL_SECONDS", 2.0
+        )
+        if self.host_os not in ("Linux", "Darwin", "Windows"):
+            self._raise_invalid(
+                "DesktopLauncher does not support host operating system "
+                + repr(self.host_os)
+            )
+        self.launch()
 
-        self.browser_process = subprocess.Popen(launch_string,
-                                                shell=True,
-                                    stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    close_fds=True,
-                                )
-    def url(self)->str:
-        """
-        Runs docker-compos to extract url of jupyter server that is return.
-        """
-        runline=[]
-        runline.append("docker-compose")
-        runline.append("-f")
-        # could test the type of configuration to be str but docker-compose 
-        # will fail if this is not a valid file name
-        runline.append(self.configuration_file)
-        runline.append("logs")
-        runline.append("mspass-frontend")
-        frontend_query = subprocess.run(runline,capture_output=True,text=True)
-        query_out = frontend_query.stdout
-        url = extract_jupyter_url(query_out)
-        return url
-        
-           
+    @staticmethod
+    def _raise_invalid(message):
+        raise MsPASSError(message, ErrorSeverity.Invalid)
+
+    @classmethod
+    def _positive_environment_value(cls, name, default):
+        value_string = os.environ.get(name, str(default))
+        try:
+            value = float(value_string)
+        except (TypeError, ValueError):
+            cls._raise_invalid(f"{name} must be a finite positive number")
+        if not math.isfinite(value) or value <= 0.0:
+            cls._raise_invalid(f"{name} must be a finite positive number")
+        return value
+
+    def _compose_argv(self, *arguments):
+        return [
+            "docker",
+            "compose",
+            "-f",
+            self.configuration_file,
+            *arguments,
+        ]
+
+    def _run_compose(self, *arguments):
+        argv = self._compose_argv(*arguments)
+        try:
+            result = subprocess.run(argv, capture_output=True, text=True)
+        except Exception as error:
+            self._raise_invalid(
+                "DesktopLauncher failed to execute " + " ".join(argv) + f": {error}"
+            )
+        if self.verbose:
+            if result.stdout:
+                print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+            if result.stderr:
+                print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
+        if result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip()
+            self._raise_invalid(
+                "DesktopLauncher command failed: "
+                + " ".join(argv)
+                + (f": {message}" if message else "")
+            )
+        return result
+
+    def _browser_argv(self, url):
+        if self.host_os == "Linux":
+            return [self.browser, url]
+        if self.host_os == "Darwin":
+            return ["open", "-a", self.browser, url]
+        return ["cmd", "/c", "start", "", self.browser, url]
+
+    def _stop_browser(self):
+        process = self.browser_process
+        self.browser_process = None
+        if process is None:
+            return
+        try:
+            browser_running = process.poll() is None
+        except Exception:
+            browser_running = True
+        try:
+            if browser_running:
+                process.terminate()
+        finally:
+            process.wait()
+
+    def _cleanup_after_failed_launch(self):
+        errors = []
+        try:
+            self._stop_browser()
+        except BaseException as error:
+            errors.append(str(error))
+        if self._owns_stack:
+            try:
+                self._run_compose("down")
+            except BaseException as error:
+                errors.append(str(error))
+            finally:
+                self._owns_stack = False
+        self._url = None
+        return errors
+
+    def _wait_for_url(self):
+        deadline = time.monotonic() + self._startup_timeout
+        while True:
+            logs = self._run_compose("logs", self._FRONTEND_SERVICE)
+            url = extract_jupyter_url(logs.stdout)
+            if self.status() != 1:
+                self._raise_invalid(
+                    f"DesktopLauncher detected that {self._FRONTEND_SERVICE} exited "
+                    "before publishing a Jupyter URL"
+                )
+            if url is not None:
+                return url
+            if time.monotonic() >= deadline:
+                self._raise_invalid(
+                    "DesktopLauncher timed out waiting for a Jupyter HTTP(S) URL"
+                )
+            time.sleep(self._startup_poll)
+
+    def url(self):
+        """Return the Jupyter URL discovered by :meth:`launch`."""
+        return self._url
+
     def launch(self):
-        print("DesktopLauncher.lauch method is not needed")
-        print("constructor uses full construction is initialization concept")
+        """Start or attach to the desktop stack and open its Jupyter URL."""
+        if self._url is not None:
+            return self._url
+        try:
+            if self.status() == 0:
+                self._run_compose("up", "-d", self._FRONTEND_SERVICE)
+                self._owns_stack = True
+            url = self._wait_for_url()
+            try:
+                self.browser_process = subprocess.Popen(self._browser_argv(url))
+                browser_status = self.browser_process.poll()
+            except Exception as error:
+                self._raise_invalid(
+                    f"DesktopLauncher failed to launch browser: {error}"
+                )
+            if browser_status not in (None, 0):
+                self._raise_invalid(
+                    "DesktopLauncher browser process exited with an error"
+                )
+            self._url = url
+            return url
+        except BaseException as error:
+            cleanup_errors = self._cleanup_after_failed_launch()
+            if cleanup_errors:
+                self._raise_invalid(
+                    f"{error}; cleanup failed: " + "; ".join(cleanup_errors)
+                )
+            raise
+
     def status(self):
-        # this is a p rototype command line shows mspas_fronend and 
-        # mspass_db return something tut scheduler and worker 
-        # return nothing - needs a different approach
-        runline=[]
-        runline.append("docker-compose")
-        runline.append("-f")
-        runline.append(self.configuration_file)
-        runline.append("logs")
-        runline.append("mspass_frontend")
-        runout=subprocess.run(runline,capture_output=True,text=True)
-        print(runout.stdout)
-    def run(self):
-        print("Desktop run method is not implemented for this class")
-        print("Mismatch in concept as DesktopLauncher is for interactive use with jupyter")
-    def shutdown(self,verbose=False):
-        self.browser_process.terminate()
-        runline=[]
-        runline.append("docker-compose")
-        runline.append("-f")
-        runline.append(self.configuration_file)
-        runline.append("down")
-        runout=subprocess.run(runline,capture_output=True,text=True)
-        if verbose:
-            print("stdout from DecktopLauncher.shutdown")
-            print(runout.stdout)
-            print("stderr from DesktopLauncher.shutdown")
-            print(runout.stderr)
+        result = self._run_compose(
+            "ps", "--status", "running", "--services", self._FRONTEND_SERVICE
+        )
+        services = {line.strip() for line in result.stdout.splitlines()}
+        return int(self._FRONTEND_SERVICE in services)
+
+    def run(self, python_file):
+        return self._run_compose(
+            "exec", "-T", self._FRONTEND_SERVICE, "python", python_file
+        )
+
+    def shutdown(self, verbose=False):
+        errors = []
+        try:
+            self._stop_browser()
+        except BaseException as error:
+            errors.append(str(error))
+        if self._owns_stack:
+            try:
+                self._run_compose("down")
+            except BaseException as error:
+                errors.append(str(error))
+            finally:
+                self._owns_stack = False
+        self._url = None
+        if verbose and errors:
+            print("DesktopLauncher shutdown errors: " + "; ".join(errors))
+        if errors:
+            self._raise_invalid("DesktopLauncher shutdown failed: " + "; ".join(errors))
+
     def __del__(self):
         """
-        Class destructor. 
-        
-        The destrutor is called when an object goes out of scope. 
+        Class destructor.
+
+        The destrutor is called when an object goes out of scope.
         This instance is little more than a call to self.shutdown()
-        which shuts down all the containers as gracefully as possible.  
+        which shuts down all the containers as gracefully as possible.
         """
-        self.shutdown()
-        
+        try:
+            self.shutdown()
+        except BaseException:
+            pass
 
-def extract_jupyter_url(outstr)->str:
+
+def extract_jupyter_url(outstr):
     """
-    Parses output strng from launching jupyer lab to extract the url 
+    Parses output strng from launching jupyer lab to extract the url
     needed to connet to the jupyer server.
-    
-    Launchers can capture stdout from launching jupter with docker 
-    or aptainer and use this function to return the connection url 
-    to the jupyter server.  
-    
-    The algorithm used here is a simple search for the string "http://" 
-    that the current jupyter server posts.   Output has two options and 
-    the algorithm always selects the one with a ipv 4 address by veriying the 
-    line has three "." characters after http://.  
-    """
-    test_str="http://"
-    lines=outstr.splitlines()
-    url_lines=[]
-    for l in lines:
-        if test_str in l:
-            i = l.find(test_str)
-            url_lines.append(l[i:])
 
-    # select the first url with 3 or more "." symbols and assume 
-    # tha is a valid ipv4 address
-    for url in url_lines:
-        if url.count(".")>=3:
-            return url
-    
-    print("Error parsing jupyter server output:  returning default url with no token value")
-    return "http://localhost:8888"
-    
-            
-    
-            
-    
+    Launchers can capture stdout from launching jupter with docker
+    or aptainer and use this function to return the connection url
+    to the jupyter server.
+
+    Returns ``None`` when the output does not contain a URL.  In particular,
+    this function never fabricates a tokenless fallback URL.
+    """
+    if not isinstance(outstr, str):
+        return None
+    match = re.search(r"https?://[^\s\"']+", outstr)
+    if match is None:
+        return None
+    return match.group(0).rstrip(".,;)")


### PR DESCRIPTION
## Summary

- standardize `DesktopLauncher` on `data/yaml/compose.yaml`, canonical Linux/macOS/Windows browser argv, and argv-only subprocess execution
- start the complete Compose project rather than only `mspass-frontend`, and report ready only when every configured service is running
- wait for a real Jupyter HTTP(S) URL with configurable startup timing; never fabricate a tokenless fallback
- preserve caller-owned projects, make launch/shutdown idempotent, and deterministically terminate/wait (or kill) owned browser processes
- retain ordinary Python API boundaries: invalid arguments raise `ValueError`; Compose, readiness, and browser failures raise `RuntimeError`
- document topology, ownership, lifecycle, return values, and failure behavior in the public class and method docstrings

## Root cause

The prototype queried logs before readiness, mixed Compose configuration and service names, built platform-specific browser shell strings, ignored command return codes, and did not track stack/browser ownership consistently.

The first version of this PR followed an issue-authored contract too literally: it targeted and checked only the frontend service, which can leave a scheduler with no worker, and changed ordinary launcher failures to `MsPASSError(Invalid)` without a compatibility basis. The scientific/API re-audit corrected both expansions.

## Impact

Desktop launches now fail explicitly, require the database/scheduler/worker/frontend topology to be running, never fabricate a fallback URL, preserve caller-owned stacks, and clean up owned resources without replacing the original exception when cleanup itself also fails.

## Validation

- focused launcher contract: **24 passed**
- exact Compose/browser argv, delayed URL, full-service readiness, partial topology, every public failure path, ownership, idempotence, and browser poll cleanup covered
- Python byte compilation and `git diff --check`: passed
- test file formatted with Black; production changes are confined to `DesktopLauncher` in a legacy file whose unrelated HPC section is not Black-formatted

This PR remains draft pending the full renewed compatibility/scientific re-audit.

Fixes #808