### PR TITLE
Replace elog records in place

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -4405,7 +4405,8 @@ class Database(pymongo.database.Database):
     ):
         """
         Save error log for a data object. Data objects in MsPASS contain an error log object used to post any
-        errors handled by processing functions. This function will delete the old elog entry if `elog_id` is given.
+        errors handled by processing functions.  If `elog_id` identifies an
+        existing record, that record is replaced atomically in place.
 
         :param mspass_object: the target object.
         :type mspass_object: either :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`
@@ -4467,7 +4468,11 @@ class Database(pymongo.database.Database):
                             elog_doc["logdata"].append(x)
 
                     docentry["logdata"] = elog_doc["logdata"]
-                    self[collection].delete_one({"_id": elog_id})
+                    if wf_id_name not in docentry and wf_id_name in elog_doc:
+                        docentry[wf_id_name] = elog_doc[wf_id_name]
+                    docentry["_id"] = elog_id
+                    self[collection].replace_one({"_id": elog_id}, docentry)
+                    return elog_id
                 # note that is should be impossible for the old elog to have tombstone entry
                 # so we ignore the handling of that attribute here.
                 ret_elog_id = self[collection].insert_one(docentry).inserted_id

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -951,7 +951,7 @@ class TestDatabase:
         assert "storage_mode" in ts and ts["storage_mode"] == "gridfs"
         assert not ts["gridfs_id"] == old_gridfs_id
         assert not ts["history_object_id"] == old_history_object_id
-        assert not ts["elog_id"] == old_elog_id
+        assert ts["elog_id"] == old_elog_id
         # Changes for V2 modified the output of this test due to
         # an implementation detail.  V1 had the following:
         # should add 3 more elog entries(one in update_metadata, two in update_data)

--- a/python/tests/db/test_elog_replacement_contract.py
+++ b/python/tests/db/test_elog_replacement_contract.py
@@ -1,0 +1,125 @@
+import copy
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from bson import ObjectId
+
+from mspasspy.ccore.seismic import Seismogram, TimeSeries
+from mspasspy.ccore.utility import ErrorSeverity
+from mspasspy.db.client import DBClient
+from mspasspy.db.collection import Collection
+from mspasspy.db.database import Database
+
+
+@pytest.fixture
+def database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    client = DBClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        client.admin.command("ping")
+    except Exception as error:
+        client.close()
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    name = "test_elog_replacement_" + uuid.uuid4().hex
+    database = Database(client, name)
+    try:
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+def make_timeseries():
+    datum = TimeSeries(1)
+    datum.set_live()
+    return datum
+
+
+def make_seismogram():
+    datum = Seismogram(1)
+    datum.set_live()
+    return datum
+
+
+CASES = [
+    (make_timeseries, "wf_TimeSeries_id"),
+    (make_seismogram, "wf_Seismogram_id"),
+]
+
+
+@pytest.mark.parametrize("factory,waveform_id_key", CASES)
+def test_existing_elog_is_replaced_in_place_with_stable_reference(
+    database, factory, waveform_id_key
+):
+    datum = factory()
+    waveform_id = ObjectId()
+    datum["_id"] = waveform_id
+    datum.elog.log_error("first", "first message", ErrorSeverity.Informational)
+    elog_id = database._save_elog(datum)
+    datum.erase("_id")
+    datum.elog.log_error("second", "second message", ErrorSeverity.Complaint)
+
+    with patch.object(
+        Collection,
+        "delete_one",
+        side_effect=AssertionError("delete_one must not be used for replacement"),
+    ):
+        returned_id = database._save_elog(datum, elog_id=elog_id)
+
+    assert returned_id == elog_id
+    assert database["elog"].count_documents({}) == 1
+    document = database["elog"].find_one({"_id": elog_id})
+    assert document["_id"] == elog_id
+    assert document[waveform_id_key] == waveform_id
+    assert [entry["algorithm"] for entry in document["logdata"]] == [
+        "first",
+        "second",
+    ]
+    assert [entry["error_message"] for entry in document["logdata"]] == [
+        "first message",
+        "second message",
+    ]
+
+
+@pytest.mark.parametrize("factory,waveform_id_key", CASES)
+def test_replace_failure_preserves_previous_elog_document(
+    database, factory, waveform_id_key
+):
+    datum = factory()
+    waveform_id = ObjectId()
+    datum["_id"] = waveform_id
+    datum.elog.log_error("first", "first message", ErrorSeverity.Informational)
+    elog_id = database._save_elog(datum)
+    previous_document = copy.deepcopy(database["elog"].find_one({"_id": elog_id}))
+    assert previous_document[waveform_id_key] == waveform_id
+    datum.elog.log_error("second", "second message", ErrorSeverity.Complaint)
+    failure = RuntimeError("injected elog replacement failure")
+
+    with patch.object(Collection, "replace_one", side_effect=failure):
+        with pytest.raises(RuntimeError) as error:
+            database._save_elog(datum, elog_id=elog_id)
+
+    assert error.value is failure
+    assert database["elog"].count_documents({}) == 1
+    assert database["elog"].find_one({"_id": elog_id}) == previous_document
+
+
+@pytest.mark.parametrize("factory,_waveform_id_key", CASES)
+@pytest.mark.parametrize("pass_missing_id", [False, True])
+def test_no_existing_elog_inserts_exactly_one_new_record(
+    database, factory, _waveform_id_key, pass_missing_id
+):
+    datum = factory()
+    datum.elog.log_error("new", "new message", ErrorSeverity.Informational)
+    missing_id = ObjectId() if pass_missing_id else None
+
+    elog_id = database._save_elog(datum, elog_id=missing_id)
+
+    assert isinstance(elog_id, ObjectId)
+    assert elog_id != missing_id
+    assert database["elog"].count_documents({}) == 1
+    document = database["elog"].find_one({"_id": elog_id})
+    assert document["logdata"][0]["algorithm"] == "new"
+    assert document["logdata"][0]["error_message"] == "new message"


### PR DESCRIPTION
## Summary

- replace an existing elog document atomically at its current `_id`
- preserve the existing waveform cross-reference when the in-memory datum no longer carries `_id`
- keep new-elog insertion behavior unchanged and update the public regression expectation to the stable-ID contract

## Root cause

`Database._save_elog` previously deleted the old document and inserted a replacement.  If insertion failed, the prior audit log was already gone and the waveform could still reference its obsolete ID.

## Validation

- MongoDB 8.0.29: 8 TimeSeries/Seismogram contract cases passed
- neighboring `test_save_elogs` and public `test_update_data`: passed; 10 focused tests total
- exact baseline: 4 contract failures and the updated public stable-ID assertion fails as expected
- independent agent review: passed
- Black, Python 3.12/3.13 `py_compile`, and diff checks: passed

Fixes #816
