### PR TITLE
Make waveform deletion retry-safe

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3968,9 +3968,12 @@ class Database(pymongo.database.Database):
         waveform data.  If the data are stored in gridfs the deletion of
         the waveform data will be immediate.  If the data are stored in
         disk files the file will be deleted when there are no more references
-        in the wf collection for the exact combination of dir and dfile associated
-        an atomic deletion.  Error log and history data deletion linked to
-        a datum is optional.  Note this is an expensive operation as it
+        in any schema-defined waveform collection for the exact combination
+        of dir and dfile associated with an atomic deletion.  Requested
+        history and error-log cleanup precedes sample deletion, and the
+        waveform document is removed last so a partial failure can be retried.
+        Error log and history data deletion linked to a datum is optional.
+        Note this is an expensive operation as it
         involves extensive database interactions.   It is best used for
         surgical solutions.   Deletion of large components of a data set
         (e.g. all data with a given data_tag value) are best done with
@@ -4041,8 +4044,20 @@ class Database(pymongo.database.Database):
         elog_id_name = elog_collection + "_id"
         elog_id = object_doc.get(elog_id_name)
 
-        # Delete gridfs/file samples first.  Missing children are the expected
-        # state when retrying after a later child cleanup failed.
+        # Clear database-owned auxiliary records before removing samples.  If
+        # one of these operations fails, the parent still identifies every
+        # remaining child and its waveform samples are still readable.
+        if clear_history and history_obj_id is not None:
+            self[history_collection].delete_one({"_id": history_obj_id})
+
+        if clear_elog:
+            if elog_id is not None:
+                self[elog_collection].delete_one({"_id": elog_id})
+            self[elog_collection].delete_many({wf_id_name: oid})
+
+        # Remove samples only after the requested history and elog cleanup.
+        # Missing children are the expected state when retrying a partially
+        # completed deletion.
         if storage_mode == "gridfs" and gridfs_id is not None:
             gfsh = gridfs.GridFS(self)
             if gfsh.exists(gridfs_id):
@@ -4055,12 +4070,13 @@ class Database(pymongo.database.Database):
             and dfile_name is not None
         ):
             # The parent is deliberately still present, so exclude it while
-            # checking both supported waveform collections for another
+            # checking every schema-defined waveform collection for another
             # reference to the same file.
             file_is_referenced = False
             waveform_collections = {
-                schema.TimeSeries.collection("_id"),
-                schema.Seismogram.collection("_id"),
+                collection_name
+                for collection_name, definition in self.database_schema._attr_dict.items()
+                if definition.data_type() in (TimeSeries, Seismogram)
             }
             for collection_name in waveform_collections:
                 reference_query = {"dir": dir_name, "dfile": dfile_name}
@@ -4075,18 +4091,6 @@ class Database(pymongo.database.Database):
                     os.remove(fname)
                 except FileNotFoundError:
                     pass
-
-        # clear history
-        if clear_history and history_obj_id is not None:
-            self[history_collection].delete_one({"_id": history_obj_id})
-
-        # clear elog
-        if clear_elog:
-            # delete the one by elog_id in mspass object
-            if elog_id is not None:
-                self[elog_collection].delete_one({"_id": elog_id})
-            # delete the documents with the wf_id equals to obejct['_id']
-            self[elog_collection].delete_many({wf_id_name: oid})
 
         # Remove the durable retry record only after all requested child
         # cleanup operations have completed successfully.

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -4026,47 +4026,71 @@ class Database(pymongo.database.Database):
                 "Invalid",
             )
 
-        # delete the document just retrieved from the database
-        self[wf_collection_name].delete_one({"_id": oid})
+        # Resolve every child reference before starting cleanup.  The waveform
+        # document remains the durable retry record until all referenced
+        # children have been removed or confirmed absent.
+        storage_mode = object_doc.get("storage_mode")
+        gridfs_id = object_doc.get("gridfs_id")
+        dir_name = object_doc.get("dir")
+        dfile_name = object_doc.get("dfile")
+        history_collection = self.database_schema.default_name("history_object")
+        history_obj_id_name = history_collection + "_id"
+        history_obj_id = object_doc.get(history_obj_id_name)
+        wf_id_name = wf_collection_name + "_id"
+        elog_collection = self.database_schema.default_name("elog")
+        elog_id_name = elog_collection + "_id"
+        elog_id = object_doc.get(elog_id_name)
 
-        # delete gridfs/file depends on storage mode, and unreferenced files
-        storage_mode = object_doc["storage_mode"]
-        if storage_mode == "gridfs":
+        # Delete gridfs/file samples first.  Missing children are the expected
+        # state when retrying after a later child cleanup failed.
+        if storage_mode == "gridfs" and gridfs_id is not None:
             gfsh = gridfs.GridFS(self)
-            if gfsh.exists(object_doc["gridfs_id"]):
-                gfsh.delete(object_doc["gridfs_id"])
+            if gfsh.exists(gridfs_id):
+                gfsh.delete(gridfs_id)
 
-        elif storage_mode in ["file"] and remove_unreferenced_files:
-            dir_name = object_doc["dir"]
-            dfile_name = object_doc["dfile"]
-            # find if there are any remaining matching documents with dir and dfile
-            match_doc_cnt = self[wf_collection_name].count_documents(
-                {"dir": dir_name, "dfile": dfile_name}
-            )
-            # delete this file
-            if match_doc_cnt == 0:
+        elif (
+            storage_mode == "file"
+            and remove_unreferenced_files
+            and dir_name is not None
+            and dfile_name is not None
+        ):
+            # The parent is deliberately still present, so exclude it while
+            # checking both supported waveform collections for another
+            # reference to the same file.
+            file_is_referenced = False
+            waveform_collections = {
+                schema.TimeSeries.collection("_id"),
+                schema.Seismogram.collection("_id"),
+            }
+            for collection_name in waveform_collections:
+                reference_query = {"dir": dir_name, "dfile": dfile_name}
+                if collection_name == wf_collection_name:
+                    reference_query["_id"] = {"$ne": oid}
+                if self[collection_name].count_documents(reference_query) > 0:
+                    file_is_referenced = True
+                    break
+            if not file_is_referenced:
                 fname = os.path.join(dir_name, dfile_name)
-                os.remove(fname)
+                try:
+                    os.remove(fname)
+                except FileNotFoundError:
+                    pass
 
         # clear history
-        if clear_history:
-            history_collection = self.database_schema.default_name("history_object")
-            history_obj_id_name = history_collection + "_id"
-            if history_obj_id_name in object_doc:
-                self[history_collection].delete_one(
-                    {"_id": object_doc[history_obj_id_name]}
-                )
+        if clear_history and history_obj_id is not None:
+            self[history_collection].delete_one({"_id": history_obj_id})
 
         # clear elog
         if clear_elog:
-            wf_id_name = wf_collection_name + "_id"
-            elog_collection = self.database_schema.default_name("elog")
-            elog_id_name = elog_collection + "_id"
             # delete the one by elog_id in mspass object
-            if elog_id_name in object_doc:
-                self[elog_collection].delete_one({"_id": object_doc[elog_id_name]})
+            if elog_id is not None:
+                self[elog_collection].delete_one({"_id": elog_id})
             # delete the documents with the wf_id equals to obejct['_id']
             self[elog_collection].delete_many({wf_id_name: oid})
+
+        # Remove the durable retry record only after all requested child
+        # cleanup operations have completed successfully.
+        self[wf_collection_name].delete_one({"_id": oid})
 
     def _load_collection_metadata(
         self, mspass_object, exclude_keys, include_undefined=False, collection=None

--- a/python/tests/db/test_delete_data_cleanup_order.py
+++ b/python/tests/db/test_delete_data_cleanup_order.py
@@ -168,12 +168,16 @@ def test_child_cleanup_failure_keeps_parent_and_retry_finishes_deletion(
     assert (
         database[collection].find_one({"_id": graph.parent_id}) == graph.parent_document
     )
-    assert sample_exists(database, graph) is (failure_stage in {"file", "gridfs"})
+    assert sample_exists(database, graph)
     assert bool(database["history_object"].find_one({"_id": graph.history_id})) is (
-        failure_stage in {"file", "gridfs", "history"}
+        failure_stage == "history"
     )
-    assert database["elog"].find_one({"_id": graph.elog_id})
-    assert database["elog"].find_one({"_id": graph.linked_elog_id})
+    assert bool(database["elog"].find_one({"_id": graph.elog_id})) is (
+        failure_stage in {"history", "elog"}
+    )
+    assert bool(database["elog"].find_one({"_id": graph.linked_elog_id})) is (
+        failure_stage in {"history", "elog"}
+    )
     assert_unrelated_resources_exist(database, graph)
 
     database.delete_data(
@@ -338,3 +342,34 @@ def test_shared_file_across_waveform_types_is_removed_only_after_the_last_parent
 
     database.delete_data(second_id, "Seismogram", remove_unreferenced_files=True)
     assert not shared_file.exists()
+
+
+def test_schema_defined_waveform_collection_preserves_a_shared_file(database, tmp_path):
+    shared_file = tmp_path / "shared-with-archive.bin"
+    shared_file.write_bytes(b"shared samples")
+    parent_id = (
+        database["wf_TimeSeries"]
+        .insert_one(
+            {
+                "storage_mode": "file",
+                "dir": str(tmp_path),
+                "dfile": shared_file.name,
+            }
+        )
+        .inserted_id
+    )
+    archive_collection = "wf_TimeSeries_archive"
+    database.database_schema[archive_collection] = copy.deepcopy(
+        database.database_schema["wf_TimeSeries"]
+    )
+    database[archive_collection].insert_one(
+        {
+            "storage_mode": "file",
+            "dir": str(tmp_path),
+            "dfile": shared_file.name,
+        }
+    )
+
+    database.delete_data(parent_id, "TimeSeries", remove_unreferenced_files=True)
+
+    assert shared_file.exists()

--- a/python/tests/db/test_delete_data_cleanup_order.py
+++ b/python/tests/db/test_delete_data_cleanup_order.py
@@ -1,0 +1,340 @@
+import copy
+import os
+import uuid
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import gridfs
+import pytest
+from bson import ObjectId
+from pymongo import MongoClient
+from pymongo.errors import ServerSelectionTimeoutError
+
+from mspasspy.db.client import DBClient
+from mspasspy.db.collection import Collection
+from mspasspy.db.database import Database
+
+
+@pytest.fixture
+def database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    probe = MongoClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        probe.admin.command("ping")
+    except ServerSelectionTimeoutError as error:
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    finally:
+        probe.close()
+    client = DBClient(uri, serverSelectionTimeoutMS=2000)
+    name = "test_delete_cleanup_order_" + uuid.uuid4().hex
+    database = Database(client, name)
+    try:
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+OBJECT_CASES = [
+    ("TimeSeries", "wf_TimeSeries"),
+    ("Seismogram", "wf_Seismogram"),
+]
+
+
+def make_resource_graph(database, tmp_path, collection, storage_mode):
+    parent_id = ObjectId()
+    history_id = database["history_object"].insert_one({"target": True}).inserted_id
+    waveform_id_key = collection + "_id"
+    elog_id = (
+        database["elog"]
+        .insert_one({"logdata": [], waveform_id_key: parent_id, "explicit": True})
+        .inserted_id
+    )
+    linked_elog_id = (
+        database["elog"]
+        .insert_one({"logdata": [], waveform_id_key: parent_id, "linked": True})
+        .inserted_id
+    )
+
+    document = {
+        "_id": parent_id,
+        "storage_mode": storage_mode,
+        "history_object_id": history_id,
+        "elog_id": elog_id,
+    }
+    target_file = tmp_path / f"target-{parent_id}.bin"
+    target_gridfs_id = None
+    if storage_mode == "file":
+        target_file.write_bytes(b"target samples")
+        document.update({"dir": str(tmp_path), "dfile": target_file.name})
+    else:
+        target_gridfs_id = gridfs.GridFS(database).put(b"target samples")
+        document["gridfs_id"] = target_gridfs_id
+    database[collection].insert_one(document)
+
+    unrelated_parent_id = (
+        database[collection]
+        .insert_one({"storage_mode": "none", "unrelated": True})
+        .inserted_id
+    )
+    unrelated_history_id = (
+        database["history_object"].insert_one({"unrelated": True}).inserted_id
+    )
+    unrelated_elog_id = (
+        database["elog"]
+        .insert_one({"logdata": [], waveform_id_key: unrelated_parent_id})
+        .inserted_id
+    )
+    unrelated_gridfs_id = gridfs.GridFS(database).put(b"unrelated samples")
+    unrelated_file = tmp_path / f"unrelated-{parent_id}.bin"
+    unrelated_file.write_bytes(b"unrelated samples")
+
+    return SimpleNamespace(
+        collection=collection,
+        parent_id=parent_id,
+        parent_document=copy.deepcopy(document),
+        history_id=history_id,
+        elog_id=elog_id,
+        linked_elog_id=linked_elog_id,
+        target_file=target_file,
+        target_gridfs_id=target_gridfs_id,
+        unrelated_parent_id=unrelated_parent_id,
+        unrelated_history_id=unrelated_history_id,
+        unrelated_elog_id=unrelated_elog_id,
+        unrelated_gridfs_id=unrelated_gridfs_id,
+        unrelated_file=unrelated_file,
+    )
+
+
+def sample_exists(database, graph):
+    if graph.target_gridfs_id is not None:
+        return gridfs.GridFS(database).exists(graph.target_gridfs_id)
+    return graph.target_file.exists()
+
+
+def assert_unrelated_resources_exist(database, graph):
+    assert database[graph.collection].find_one({"_id": graph.unrelated_parent_id})
+    assert database["history_object"].find_one({"_id": graph.unrelated_history_id})
+    assert database["elog"].find_one({"_id": graph.unrelated_elog_id})
+    assert gridfs.GridFS(database).exists(graph.unrelated_gridfs_id)
+    assert graph.unrelated_file.exists()
+
+
+@pytest.mark.parametrize("object_type,collection", OBJECT_CASES)
+@pytest.mark.parametrize(
+    "failure_stage,storage_mode",
+    [
+        ("file", "file"),
+        ("gridfs", "gridfs"),
+        ("history", "gridfs"),
+        ("elog", "gridfs"),
+    ],
+)
+def test_child_cleanup_failure_keeps_parent_and_retry_finishes_deletion(
+    database, tmp_path, object_type, collection, failure_stage, storage_mode
+):
+    graph = make_resource_graph(database, tmp_path, collection, storage_mode)
+    failure = RuntimeError(f"injected {failure_stage} cleanup failure")
+    original_delete_one = Collection.delete_one
+    failed_collection = (
+        "history_object" if failure_stage == "history" else failure_stage
+    )
+
+    def fail_selected_collection(self, *args, **kwargs):
+        if self.name == failed_collection:
+            raise failure
+        return original_delete_one(self, *args, **kwargs)
+
+    with ExitStack() as stack:
+        if failure_stage == "file":
+            stack.enter_context(patch("os.remove", side_effect=failure))
+        elif failure_stage == "gridfs":
+            stack.enter_context(
+                patch.object(gridfs.GridFS, "delete", side_effect=failure)
+            )
+        else:
+            stack.enter_context(
+                patch.object(Collection, "delete_one", fail_selected_collection)
+            )
+        with pytest.raises(RuntimeError) as error:
+            database.delete_data(
+                graph.parent_id,
+                object_type,
+                remove_unreferenced_files=True,
+            )
+
+    assert error.value is failure
+    assert (
+        database[collection].find_one({"_id": graph.parent_id}) == graph.parent_document
+    )
+    assert sample_exists(database, graph) is (failure_stage in {"file", "gridfs"})
+    assert bool(database["history_object"].find_one({"_id": graph.history_id})) is (
+        failure_stage in {"file", "gridfs", "history"}
+    )
+    assert database["elog"].find_one({"_id": graph.elog_id})
+    assert database["elog"].find_one({"_id": graph.linked_elog_id})
+    assert_unrelated_resources_exist(database, graph)
+
+    database.delete_data(
+        graph.parent_id,
+        object_type,
+        remove_unreferenced_files=True,
+    )
+
+    assert database[collection].find_one({"_id": graph.parent_id}) is None
+    assert not sample_exists(database, graph)
+    assert database["history_object"].find_one({"_id": graph.history_id}) is None
+    assert database["elog"].find_one({"_id": graph.elog_id}) is None
+    assert database["elog"].find_one({"_id": graph.linked_elog_id}) is None
+    assert_unrelated_resources_exist(database, graph)
+
+
+@pytest.mark.parametrize("object_type,collection", OBJECT_CASES)
+@pytest.mark.parametrize("storage_mode", ["file", "gridfs"])
+def test_already_missing_referenced_children_are_retry_safe(
+    database, tmp_path, object_type, collection, storage_mode
+):
+    graph = make_resource_graph(database, tmp_path, collection, storage_mode)
+    if graph.target_gridfs_id is not None:
+        gridfs.GridFS(database).delete(graph.target_gridfs_id)
+    else:
+        graph.target_file.unlink()
+    database["history_object"].delete_one({"_id": graph.history_id})
+    database["elog"].delete_one({"_id": graph.elog_id})
+
+    database.delete_data(
+        graph.parent_id,
+        object_type,
+        remove_unreferenced_files=True,
+    )
+
+    assert database[collection].find_one({"_id": graph.parent_id}) is None
+    assert database["elog"].find_one({"_id": graph.linked_elog_id}) is None
+    assert_unrelated_resources_exist(database, graph)
+
+
+@pytest.mark.parametrize(
+    "object_type,collection,parent_fields",
+    [
+        ("TimeSeries", "wf_TimeSeries", {"storage_mode": "gridfs"}),
+        (
+            "Seismogram",
+            "wf_Seismogram",
+            {"storage_mode": "file", "dir": "unused"},
+        ),
+    ],
+)
+def test_missing_sample_reference_metadata_does_not_delete_unrelated_resources(
+    database, tmp_path, object_type, collection, parent_fields
+):
+    parent_id = ObjectId()
+    database[collection].insert_one({"_id": parent_id, **parent_fields})
+    linked_elog_id = (
+        database["elog"]
+        .insert_one({collection + "_id": parent_id, "logdata": []})
+        .inserted_id
+    )
+    unrelated_gridfs_id = gridfs.GridFS(database).put(b"unrelated")
+    unrelated_file = tmp_path / "unrelated.bin"
+    unrelated_file.write_bytes(b"unrelated")
+    unrelated_history_id = (
+        database["history_object"].insert_one({"unrelated": True}).inserted_id
+    )
+    unrelated_elog_id = (
+        database["elog"].insert_one({"unrelated": True, "logdata": []}).inserted_id
+    )
+
+    database.delete_data(
+        parent_id,
+        object_type,
+        remove_unreferenced_files=True,
+    )
+
+    assert database[collection].find_one({"_id": parent_id}) is None
+    assert database["elog"].find_one({"_id": linked_elog_id}) is None
+    assert gridfs.GridFS(database).exists(unrelated_gridfs_id)
+    assert unrelated_file.exists()
+    assert database["history_object"].find_one({"_id": unrelated_history_id})
+    assert database["elog"].find_one({"_id": unrelated_elog_id})
+
+
+@pytest.mark.parametrize(
+    "clear_history,clear_elog",
+    [(False, True), (True, False), (False, False)],
+)
+def test_optional_cleanup_flags_preserve_unrequested_children(
+    database, clear_history, clear_elog
+):
+    parent_id = ObjectId()
+    history_id = database["history_object"].insert_one({"target": True}).inserted_id
+    explicit_elog_id = (
+        database["elog"]
+        .insert_one({"wf_TimeSeries_id": parent_id, "explicit": True})
+        .inserted_id
+    )
+    linked_elog_id = (
+        database["elog"]
+        .insert_one({"wf_TimeSeries_id": parent_id, "linked": True})
+        .inserted_id
+    )
+    database["wf_TimeSeries"].insert_one(
+        {
+            "_id": parent_id,
+            "storage_mode": "file",
+            "history_object_id": history_id,
+            "elog_id": explicit_elog_id,
+        }
+    )
+
+    database.delete_data(
+        parent_id,
+        "TimeSeries",
+        clear_history=clear_history,
+        clear_elog=clear_elog,
+    )
+
+    assert database["wf_TimeSeries"].find_one({"_id": parent_id}) is None
+    assert bool(database["history_object"].find_one({"_id": history_id})) is (
+        not clear_history
+    )
+    assert bool(database["elog"].find_one({"_id": explicit_elog_id})) is (
+        not clear_elog
+    )
+    assert bool(database["elog"].find_one({"_id": linked_elog_id})) is (not clear_elog)
+
+
+def test_shared_file_across_waveform_types_is_removed_only_after_the_last_parent(
+    database, tmp_path
+):
+    shared_file = tmp_path / "shared.bin"
+    shared_file.write_bytes(b"shared samples")
+    first_id = (
+        database["wf_TimeSeries"]
+        .insert_one(
+            {
+                "storage_mode": "file",
+                "dir": str(tmp_path),
+                "dfile": shared_file.name,
+            }
+        )
+        .inserted_id
+    )
+    second_id = (
+        database["wf_Seismogram"]
+        .insert_one(
+            {
+                "storage_mode": "file",
+                "dir": str(tmp_path),
+                "dfile": shared_file.name,
+            }
+        )
+        .inserted_id
+    )
+
+    database.delete_data(first_id, "TimeSeries", remove_unreferenced_files=True)
+    assert shared_file.exists()
+    assert database["wf_Seismogram"].find_one({"_id": second_id})
+
+    database.delete_data(second_id, "Seismogram", remove_unreferenced_files=True)
+    assert not shared_file.exists()


### PR DESCRIPTION
Fixes #817

## Summary
- keep the waveform document as the durable retry record until requested sample, history, and elog cleanup succeeds
- make already-missing child resources retry-safe
- preserve files referenced by either waveform collection and remove them only after the final parent is deleted

## Verification
- independent agent review: PASS
- MongoDB 8.0.29 contract and neighboring regression tests: 19 passed
- exact audited baseline: 13 failed, 5 passed
- Black, py_compile, and git diff --check: passed

This PR is ready for human review. It must not be merged automatically.