### PR TITLE
Make clean field updates precise and concurrency-safe

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -2043,28 +2043,40 @@ class Database(pymongo.database.Database):
             else:
                 print_messages.append("{}{}".format(log_helper, error_msg))
 
-        # 3. try to fix the mismtach errors in the doc
-        update_dict = {}
+        # 3. try to fix the mismtach errors in the doc.  Record only the
+        # fields this clean operation changes so an unrelated concurrent
+        # update cannot be overwritten by the scanned snapshot.
+        set_updates = {}
+        unset_updates = {}
         for k in doc:
             if k == "_id":
                 continue
             # if not the schema keys, ignore schema type check enforcement
             if not self.database_schema[collection].is_defined(k):
                 # delete undefined attributes in the doc if delete_undefined is True
-                if not delete_undefined:
+                if delete_undefined:
+                    unset_updates[k] = ""
+                else:
                     # try to rename the user specified keys
                     if k in rename_undefined:
-                        update_dict[rename_undefined[k]] = doc[k]
-                    else:
-                        update_dict[k] = doc[k]
+                        new_key = rename_undefined[k]
+                        if new_key != k:
+                            set_updates[new_key] = doc[k]
+                            unset_updates[k] = ""
+                        elif k in set_updates:
+                            set_updates[k] = doc[k]
+                    elif k in set_updates:
+                        set_updates[k] = doc[k]
                 continue
             # to remove aliases, get the unique key name defined in the schema
             unique_k = self.database_schema[collection].unique_name(k)
             if not isinstance(doc[k], self.database_schema[collection].type(unique_k)):
                 try:
-                    update_dict[unique_k] = self.database_schema[collection].type(
+                    set_updates[unique_k] = self.database_schema[collection].type(
                         unique_k
                     )(doc[k])
+                    if unique_k != k:
+                        unset_updates[k] = ""
                     print_messages.append(
                         "{}attribute {} conversion from {} to {} is done.".format(
                             log_helper,
@@ -2078,6 +2090,7 @@ class Database(pymongo.database.Database):
                     else:
                         fixed_cnt[k] = 1
                 except:
+                    unset_updates[k] = ""
                     print_messages.append(
                         "{}attribute {} conversion from {} to {} cannot be done.".format(
                             log_helper,
@@ -2087,13 +2100,25 @@ class Database(pymongo.database.Database):
                         )
                     )
             else:
-                # attribute values remain the same
-                update_dict[unique_k] = doc[k]
+                # Canonicalize aliases without rewriting an already-canonical
+                # field that did not change.
+                if unique_k != k:
+                    set_updates[unique_k] = doc[k]
+                    unset_updates[k] = ""
+                elif unique_k in set_updates:
+                    set_updates[unique_k] = doc[k]
 
         # 4. update the fixed attributes in the document in the collection
         filter_ = {"_id": doc["_id"]}
-        # use replace_one here because there may be some aliases in the document
-        col.replace_one(filter_, update_dict)
+        for key in set_updates:
+            unset_updates.pop(key, None)
+        update_document = {}
+        if set_updates:
+            update_document["$set"] = set_updates
+        if unset_updates:
+            update_document["$unset"] = unset_updates
+        if update_document:
+            col.update_one(filter_, update_document)
 
         if verbose:
             for msg in print_messages:
@@ -2392,12 +2417,15 @@ class Database(pymongo.database.Database):
             counts[k] = 0
         with _managed_collection_cursor(dbcol, query, no_cursor_timeout) as documents:
             for doc in documents:
-                id = doc.pop("_id")
-                n = 0
+                id = doc["_id"]
+                original_doc = dict(doc)
+                original_doc.pop("_id")
+                working_doc = dict(doc)
+                working_doc.pop("_id")
+                touched_keys = set()
                 for k in rename_map:
-                    n = 0
-                    if k in doc:
-                        val = doc.pop(k)
+                    if k in working_doc:
+                        val = working_doc.pop(k)
                         newkey = rename_map[k]
                         if verbose:
                             print("Document id=", id)
@@ -2408,10 +2436,26 @@ class Database(pymongo.database.Database):
                                 newkey,
                             )
                             print("Attribute value=", val)
-                        doc[newkey] = val
+                        working_doc[newkey] = val
+                        if newkey != k:
+                            touched_keys.update((k, newkey))
                         counts[k] += 1
-                        n += 1
-                dbcol.replace_one({"_id": id}, doc)
+                set_updates = {}
+                unset_updates = {}
+                for key in touched_keys:
+                    if key not in working_doc:
+                        unset_updates[key] = ""
+                    elif (
+                        key not in original_doc or working_doc[key] != original_doc[key]
+                    ):
+                        set_updates[key] = working_doc[key]
+                update_document = {}
+                if set_updates:
+                    update_document["$set"] = set_updates
+                if unset_updates:
+                    update_document["$unset"] = unset_updates
+                if update_document:
+                    dbcol.update_one({"_id": id}, update_document)
         return counts
 
     def _fix_attribute_types(

--- a/python/tests/db/test_clean_field_updates.py
+++ b/python/tests/db/test_clean_field_updates.py
@@ -1,0 +1,340 @@
+import copy
+import math
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from mspasspy.db.client import DBClient
+from mspasspy.db.collection import Collection
+from mspasspy.db.database import Database
+
+
+@pytest.fixture
+def database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    client = DBClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        client.admin.command("ping")
+    except Exception as error:
+        client.close()
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    name = "test_clean_field_updates_" + uuid.uuid4().hex
+    database = Database(client, name)
+    try:
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+def test_clean_uses_exact_field_updates_and_preserves_concurrent_field(database):
+    collection = database["wf_TimeSeries"]
+    document_id = collection.insert_one(
+        {
+            "npts": "7",
+            "calib": 1.0,
+            "old_undefined": "rename me",
+            "untouched": "keep me",
+        }
+    ).inserted_id
+    update_documents = []
+    original_update_one = Collection.update_one
+
+    def interleaved_update(self, query, update, *args, **kwargs):
+        if self.name == "wf_TimeSeries" and query == {"_id": document_id}:
+            original_update_one(self, query, {"$set": {"calib": 9.5}}, *args, **kwargs)
+            update_documents.append(copy.deepcopy(update))
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with (
+        patch.object(
+            Collection,
+            "replace_one",
+            side_effect=AssertionError("clean must not replace the whole document"),
+        ),
+        patch.object(Collection, "update_one", interleaved_update),
+    ):
+        fixed = database.clean(
+            document_id,
+            collection="wf_TimeSeries",
+            rename_undefined={"old_undefined": "new_undefined"},
+        )
+
+    assert fixed == {"npts": 1}
+    assert update_documents == [
+        {
+            "$set": {"npts": 7, "new_undefined": "rename me"},
+            "$unset": {"old_undefined": ""},
+        }
+    ]
+    result = collection.find_one({"_id": document_id})
+    assert result["npts"] == 7
+    assert result["new_undefined"] == "rename me"
+    assert "old_undefined" not in result
+    assert result["calib"] == 9.5
+    assert result["untouched"] == "keep me"
+
+
+def test_clean_delete_undefined_uses_only_unset(database):
+    collection = database["wf_TimeSeries"]
+    document_id = collection.insert_one(
+        {"npts": 7, "calib": 1.0, "remove_me": "undefined"}
+    ).inserted_id
+    update_documents = []
+    original_update_one = Collection.update_one
+
+    def capture_update(self, query, update, *args, **kwargs):
+        update_documents.append(copy.deepcopy(update))
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with (
+        patch.object(
+            Collection,
+            "replace_one",
+            side_effect=AssertionError("clean must not replace the whole document"),
+        ),
+        patch.object(Collection, "update_one", capture_update),
+    ):
+        database.clean(
+            document_id,
+            collection="wf_TimeSeries",
+            delete_undefined=True,
+        )
+
+    assert update_documents == [{"$unset": {"remove_me": ""}}]
+    result = collection.find_one({"_id": document_id})
+    assert "remove_me" not in result
+    assert result["npts"] == 7
+    assert result["calib"] == 1.0
+
+
+def test_rename_uses_exact_field_updates_and_preserves_concurrent_field(database):
+    collection = database["wf_TimeSeries"]
+    document_id = collection.insert_one(
+        {
+            "old_name": 1,
+            "middle_name": 2,
+            "calib": 1.0,
+            "untouched": "keep me",
+        }
+    ).inserted_id
+    update_documents = []
+    original_update_one = Collection.update_one
+
+    def interleaved_update(self, query, update, *args, **kwargs):
+        if self.name == "wf_TimeSeries" and query == {"_id": document_id}:
+            original_update_one(self, query, {"$set": {"calib": 8.5}}, *args, **kwargs)
+            update_documents.append(copy.deepcopy(update))
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with (
+        patch.object(
+            Collection,
+            "replace_one",
+            side_effect=AssertionError("rename must not replace the whole document"),
+        ),
+        patch.object(Collection, "update_one", interleaved_update),
+    ):
+        counts = database._rename_attributes(
+            "wf_TimeSeries",
+            {"old_name": "middle_name", "middle_name": "final_name"},
+            query={"_id": document_id},
+        )
+
+    assert counts == {"old_name": 1, "middle_name": 1}
+    assert update_documents == [
+        {
+            "$set": {"final_name": 1},
+            "$unset": {"old_name": "", "middle_name": ""},
+        }
+    ]
+    result = collection.find_one({"_id": document_id})
+    assert result["final_name"] == 1
+    assert "old_name" not in result
+    assert "middle_name" not in result
+    assert result["calib"] == 8.5
+    assert result["untouched"] == "keep me"
+
+
+def test_clean_preserves_canonical_value_when_it_follows_an_alias(database):
+    collection = database["wf_TimeSeries"]
+    document_id = collection.insert_one({"dt": 2.0, "delta": 1.0}).inserted_id
+    update_documents = []
+    original_update_one = Collection.update_one
+
+    def capture_update(self, query, update, *args, **kwargs):
+        update_documents.append(copy.deepcopy(update))
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with (
+        patch.object(
+            Collection,
+            "replace_one",
+            side_effect=AssertionError("clean must not replace the whole document"),
+        ),
+        patch.object(Collection, "update_one", capture_update),
+    ):
+        fixed = database.clean(document_id, collection="wf_TimeSeries")
+
+    assert fixed == {}
+    assert update_documents == [{"$set": {"delta": 1.0}, "$unset": {"dt": ""}}]
+    assert collection.find_one({"_id": document_id})["delta"] == 1.0
+
+
+def test_clean_preserves_existing_rename_target_and_identity_is_noop(database):
+    collection = database["wf_TimeSeries"]
+    collision_id = collection.insert_one(
+        {"old_name": "source", "target_name": "target"}
+    ).inserted_id
+    identity_id = collection.insert_one({"same_name": "same"}).inserted_id
+    updates_by_id = {}
+    original_update_one = Collection.update_one
+
+    def capture_update(self, query, update, *args, **kwargs):
+        updates_by_id[query["_id"]] = copy.deepcopy(update)
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with (
+        patch.object(
+            Collection,
+            "replace_one",
+            side_effect=AssertionError("clean must not replace the whole document"),
+        ),
+        patch.object(Collection, "update_one", capture_update),
+    ):
+        database.clean(
+            collision_id,
+            collection="wf_TimeSeries",
+            rename_undefined={"old_name": "target_name"},
+        )
+        database.clean(
+            identity_id,
+            collection="wf_TimeSeries",
+            rename_undefined={"same_name": "same_name"},
+        )
+
+    assert updates_by_id == {
+        collision_id: {
+            "$set": {"target_name": "target"},
+            "$unset": {"old_name": ""},
+        }
+    }
+    collision = collection.find_one({"_id": collision_id})
+    assert collision["target_name"] == "target"
+    assert "old_name" not in collision
+    assert collection.find_one({"_id": identity_id})["same_name"] == "same"
+
+
+def test_clean_failed_conversion_keeps_existing_unset_behavior(database):
+    collection = database["wf_TimeSeries"]
+    document_id = collection.insert_one({"npts": "not-an-integer"}).inserted_id
+    update_documents = []
+    original_update_one = Collection.update_one
+
+    def capture_update(self, query, update, *args, **kwargs):
+        update_documents.append(copy.deepcopy(update))
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with (
+        patch.object(
+            Collection,
+            "replace_one",
+            side_effect=AssertionError("clean must not replace the whole document"),
+        ),
+        patch.object(Collection, "update_one", capture_update),
+    ):
+        fixed = database.clean(document_id, collection="wf_TimeSeries")
+
+    assert fixed == {}
+    assert update_documents == [{"$unset": {"npts": ""}}]
+    assert "npts" not in collection.find_one({"_id": document_id})
+
+
+def test_rename_does_not_write_an_unselected_nan_field(database):
+    collection = database["wf_TimeSeries"]
+    document_id = collection.insert_one(
+        {"old_name": 1, "unselected_nan": float("nan")}
+    ).inserted_id
+    update_documents = []
+    original_update_one = Collection.update_one
+
+    def capture_update(self, query, update, *args, **kwargs):
+        update_documents.append(copy.deepcopy(update))
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with (
+        patch.object(
+            Collection,
+            "replace_one",
+            side_effect=AssertionError("rename must not replace the whole document"),
+        ),
+        patch.object(Collection, "update_one", capture_update),
+    ):
+        counts = database._rename_attributes(
+            "wf_TimeSeries",
+            {"old_name": "new_name"},
+            query={"_id": document_id},
+        )
+
+    assert counts == {"old_name": 1}
+    assert update_documents == [{"$set": {"new_name": 1}, "$unset": {"old_name": ""}}]
+    result = collection.find_one({"_id": document_id})
+    assert result["new_name"] == 1
+    assert math.isnan(result["unselected_nan"])
+
+
+def test_rename_target_collision_identity_and_id_source_behavior(database):
+    collection = database["wf_TimeSeries"]
+    collision_id = collection.insert_one({"old_name": 1, "target_name": 2}).inserted_id
+    identity_id = collection.insert_one({"same_name": "same"}).inserted_id
+    id_source_id = collection.insert_one({"value": "unchanged"}).inserted_id
+    updates_by_id = {}
+    original_update_one = Collection.update_one
+
+    def capture_update(self, query, update, *args, **kwargs):
+        updates_by_id[query["_id"]] = copy.deepcopy(update)
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with (
+        patch.object(
+            Collection,
+            "replace_one",
+            side_effect=AssertionError("rename must not replace the whole document"),
+        ),
+        patch.object(Collection, "update_one", capture_update),
+    ):
+        collision_counts = database._rename_attributes(
+            "wf_TimeSeries",
+            {"old_name": "target_name"},
+            query={"_id": collision_id},
+        )
+        identity_counts = database._rename_attributes(
+            "wf_TimeSeries",
+            {"same_name": "same_name"},
+            query={"_id": identity_id},
+        )
+        id_source_counts = database._rename_attributes(
+            "wf_TimeSeries",
+            {"_id": "moved_id"},
+            query={"_id": id_source_id},
+        )
+
+    assert collision_counts == {"old_name": 1}
+    assert identity_counts == {"same_name": 1}
+    assert id_source_counts == {"_id": 0}
+    assert updates_by_id == {
+        collision_id: {
+            "$set": {"target_name": 1},
+            "$unset": {"old_name": ""},
+        }
+    }
+    collision = collection.find_one({"_id": collision_id})
+    assert collision["target_name"] == 1
+    assert "old_name" not in collision
+    assert collection.find_one({"_id": identity_id})["same_name"] == "same"
+    assert collection.find_one({"_id": id_source_id}) == {
+        "_id": id_source_id,
+        "value": "unchanged",
+    }


### PR DESCRIPTION
Fixes #819

## Summary
- replace full-document rewrites in clean paths with exact `$set`/`$unset` updates
- preserve ordered alias and rename-target collision semantics
- avoid identity updates, `_id` renames, and unrelated `NaN` rewrites

## Verification
- independent agent review: PASS
- MongoDB 8.0.29 contract and neighboring regression tests: 11 passed
- exact audited baseline: 8 failed
- Black, Python 3.12/3.13 py_compile, and git diff checks: passed

This PR is ready for human review. It must not be merged automatically.