### PR TITLE
Persist miniSEED channel normalization and independent error logs

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -6006,21 +6006,19 @@ class Database(pymongo.database.Database):
           MongoDB document id with each elog entry)
         :param normalize_channel:  boolean controlling normalization with
           the channel collection.   When set True (default is false) the
-          method will call the Database.get_seed_channel method, extract
-          the id from the result, and set the result as "channel_id" before
-          writing the wf_miniseed document.  Set this argument true if
-          you have a relatively complete channel collection assembled
-          before running a workflow to index a set of miniseed files
-          (a common raw data starting point).
-        :param verbose:  boolean passed to get_seed_channel.  This
-          argument has no effect unless normalize_channel is set True.
-          It is necessary because the get_seed_channel function has no
-          way to log errors except calling print.  A very common metadata
-          error is duplicate and/or time overlaps in channel metadata.
-          Those are usually harmless so the default for this parameter is
-          False.  Set this True if you are using inline normalization
-          (normalize_channel set True) and you aren't certain your
-          channel collection has no serious inconsistencies.
+          method queries the channel collection with each segment's net,
+          sta, chan, optional loc, and start time.  It stores the matching
+          channel document id only when that query returns exactly one
+          document.  Set this argument true if you have a relatively complete
+          channel collection assembled before running a workflow to index a
+          set of miniseed files (a common raw data starting point).
+        :param verbose:  when True, print the query for any channel
+          normalization attempt that returns multiple documents.  This
+          argument has no effect unless normalize_channel is True.  Duplicate
+          or overlapping channel metadata are common and may be harmless, but
+          this method cannot choose one safely: it leaves ``channel_id`` unset
+          when the query is ambiguous.  Enable verbose output to identify and
+          clean those channel records before relying on inline normalization.
         :param sample_rate_tolerance: nonnegative relative tolerance used to
           decide whether packet sample rates belong to the same index entry.
           The default, ``1.0e-4``, matches libmseed's sample-rate tolerance.
@@ -6051,6 +6049,10 @@ class Database(pymongo.database.Database):
             elog.get_error_log()
         ):
             raise FileNotFoundError(str(elog.get_error_log()))
+        if len(ind) == 0:
+            if return_ids:
+                return [[], []]
+            return None
         ids_affected = []
         for i in ind:
             doc = self._convert_mseed_index(i, sample_rate_tolerance)
@@ -6060,26 +6062,28 @@ class Database(pymongo.database.Database):
             doc["dfile"] = dfile
             # mseed is dogmatically UTC so we always set it this way
             doc["time_standard"] = "UTC"
+            if normalize_channel:
+                channel_query = {
+                    "net": doc["net"],
+                    "sta": doc["sta"],
+                    "chan": doc["chan"],
+                    "starttime": {"$lt": doc["starttime"]},
+                    "endtime": {"$gt": doc["starttime"]},
+                }
+                if "loc" in doc:
+                    channel_query["loc"] = doc["loc"]
+                match_count = self.channel.count_documents(channel_query)
+                if match_count == 1:
+                    doc["channel_id"] = self.channel.find_one(channel_query)["_id"]
+                elif match_count > 1 and verbose:
+                    print(
+                        "index_mseed_file: channel normalization query returned",
+                        match_count,
+                        "documents; channel_id was not set for query",
+                        channel_query,
+                    )
             thisid = dbh.insert_one(doc).inserted_id
             ids_affected.append(thisid)
-        if normalize_channel:
-            # these quantities are always defined unless there was a read error
-            # and I don't think we can get here if we had a read error.
-            net = doc["net"]
-            sta = doc["sta"]
-            chan = doc["chan"]
-            stime = doc["starttime"]
-            if "loc" in doc:
-                loc = doc["loc"]
-                chandoc = self.get_seed_channel(
-                    net, sta, chan, loc, time=stime, verbose=verbose
-                )
-            else:
-                chandoc = self.get_seed_channel(
-                    net, sta, chan, time=stime, verbose=verbose
-                )
-            if chandoc != None:
-                doc["channel_id"] = chandoc["_id"]
 
         # log_ids is created here so it is defined but empty in
         # the tuple returned when return_ids is true
@@ -6100,13 +6104,12 @@ class Database(pymongo.database.Database):
                         "process_id": x.p_id,
                     }
                 )
-            docentry = {"logdata": logdata}
             # To mesh with the standard elog collection we add a copy of the
             # error messages with a tag for each id in the ids_affected list.
             # That should make elog connection to wf_miniseed records exactly
             # like wf_TimeSeries records but with a different collection link
             for wfid in ids_affected:
-                docentry["wf_miniseed_id"] = wfid
+                docentry = {"logdata": logdata, "wf_miniseed_id": wfid}
                 elogid = elog_col.insert_one(docentry).inserted_id
                 log_ids.append(elogid)
         if return_ids:

--- a/python/tests/db/test_index_mseed_file_contract.py
+++ b/python/tests/db/test_index_mseed_file_contract.py
@@ -1,0 +1,286 @@
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from bson import ObjectId
+from pymongo import MongoClient
+from pymongo.errors import ServerSelectionTimeoutError
+
+from mspasspy.db.client import DBClient
+from mspasspy.db.collection import Collection
+from mspasspy.db.database import Database
+
+
+class FakeErrorLogger:
+    def __init__(self, errors=()):
+        self._errors = list(errors)
+        self._job_id = ObjectId()
+
+    def get_error_log(self):
+        return self._errors
+
+    def get_job_id(self):
+        return self._job_id
+
+    def size(self):
+        return len(self._errors)
+
+
+def make_index(sta, starttime, loc="00"):
+    return SimpleNamespace(
+        sta=sta,
+        net="XX",
+        chan="BHZ",
+        loc=loc,
+        samprate=20.0,
+        starttime=starttime,
+        last_packet_time=starttime + 4.95,
+        foff=int(starttime),
+        nbytes=512,
+        npts=100,
+        endtime=starttime + 4.95,
+    )
+
+
+@pytest.fixture
+def database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    probe = MongoClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        probe.admin.command("ping")
+    except ServerSelectionTimeoutError as error:
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    finally:
+        probe.close()
+    client = DBClient(uri, serverSelectionTimeoutMS=2000)
+    name = "test_index_mseed_contract_" + uuid.uuid4().hex
+    database = Database(client, name)
+    try:
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+@pytest.mark.parametrize("return_ids,expected", [(False, None), (True, [[], []])])
+def test_empty_index_has_exact_return_and_performs_no_write(
+    database, tmp_path, return_ids, expected
+):
+    error = SimpleNamespace(
+        algorithm="mseed_file_indexer",
+        badness="Complaint",
+        message="empty input",
+        p_id=12,
+    )
+    with (
+        patch(
+            "mspasspy.db.database._mseed_file_indexer",
+            return_value=([], FakeErrorLogger([error])),
+        ),
+        patch.object(Collection, "insert_one") as insert_one,
+    ):
+        result = database.index_mseed_file(
+            tmp_path / "empty.mseed",
+            return_ids=return_ids,
+            normalize_channel=True,
+        )
+
+    assert result == expected
+    insert_one.assert_not_called()
+    assert database["wf_miniseed"].count_documents({}) == 0
+    assert database["elog"].count_documents({}) == 0
+
+
+def test_each_segment_persists_only_its_own_unique_channel_match(database, tmp_path):
+    unique_channel_id = (
+        database["channel"]
+        .insert_one(
+            {
+                "net": "XX",
+                "sta": "ONE",
+                "chan": "BHZ",
+                "loc": "00",
+                "starttime": 0.0,
+                "endtime": 1000.0,
+            }
+        )
+        .inserted_id
+    )
+    database["channel"].insert_one(
+        {
+            "net": "XX",
+            "sta": "ONE",
+            "chan": "BHZ",
+            "loc": "99",
+            "starttime": 0.0,
+            "endtime": 1000.0,
+        }
+    )
+    database["channel"].insert_one(
+        {
+            "net": "XX",
+            "sta": "ONE",
+            "chan": "BHZ",
+            "loc": "00",
+            "starttime": 100.0,
+            "endtime": 1000.0,
+        }
+    )
+    for marker in (1, 2):
+        database["channel"].insert_one(
+            {
+                "net": "XX",
+                "sta": "MANY",
+                "chan": "BHZ",
+                "loc": "00",
+                "starttime": 0.0,
+                "endtime": 1000.0,
+                "marker": marker,
+            }
+        )
+    no_loc_channel_id = (
+        database["channel"]
+        .insert_one(
+            {
+                "net": "XX",
+                "sta": "NOLOC",
+                "chan": "BHZ",
+                "loc": "99",
+                "starttime": 0.0,
+                "endtime": 1000.0,
+            }
+        )
+        .inserted_id
+    )
+    database["channel"].insert_one(
+        {
+            "net": "XX",
+            "sta": "BOUNDARY",
+            "chan": "BHZ",
+            "loc": "00",
+            "starttime": 400.0,
+            "endtime": 1000.0,
+        }
+    )
+
+    indexes = [
+        make_index("ONE", 100.0),
+        make_index("ZERO", 200.0),
+        make_index("MANY", 300.0),
+        make_index("NOLOC", 350.0, loc=""),
+        make_index("BOUNDARY", 400.0),
+    ]
+    with (
+        patch(
+            "mspasspy.db.database._mseed_file_indexer",
+            return_value=(indexes, FakeErrorLogger()),
+        ),
+        patch("builtins.print") as print_mock,
+    ):
+        waveform_ids, elog_ids = database.index_mseed_file(
+            tmp_path / "segments.mseed",
+            return_ids=True,
+            normalize_channel=True,
+            verbose=True,
+        )
+
+    assert len(waveform_ids) == 5
+    assert elog_ids == []
+    documents = [
+        database["wf_miniseed"].find_one({"_id": waveform_id})
+        for waveform_id in waveform_ids
+    ]
+    assert documents[0]["channel_id"] == unique_channel_id
+    assert "channel_id" not in documents[1]
+    assert "channel_id" not in documents[2]
+    assert documents[3]["channel_id"] == no_loc_channel_id
+    assert "loc" not in documents[3]
+    assert "channel_id" not in documents[4]
+    assert [document["sta"] for document in documents] == [
+        "ONE",
+        "ZERO",
+        "MANY",
+        "NOLOC",
+        "BOUNDARY",
+    ]
+    print_mock.assert_called_once()
+    print_args = print_mock.call_args.args
+    assert print_args[1] == 2
+    assert print_args[3] == {
+        "net": "XX",
+        "sta": "MANY",
+        "chan": "BHZ",
+        "loc": "00",
+        "starttime": {"$lt": 300.0},
+        "endtime": {"$gt": 300.0},
+    }
+
+
+def test_each_segment_is_normalized_before_its_insert(database, tmp_path):
+    indexes = [make_index("FIRST", 100.0), make_index("SECOND", 200.0)]
+    failure = RuntimeError("injected second-segment normalization failure")
+    original_count_documents = Collection.count_documents
+
+    def fail_second_segment(self, query, *args, **kwargs):
+        if self.name == "channel":
+            if query["sta"] == "SECOND":
+                raise failure
+            return 0
+        return original_count_documents(self, query, *args, **kwargs)
+
+    with (
+        patch(
+            "mspasspy.db.database._mseed_file_indexer",
+            return_value=(indexes, FakeErrorLogger()),
+        ),
+        patch.object(Collection, "count_documents", fail_second_segment),
+    ):
+        with pytest.raises(RuntimeError) as error:
+            database.index_mseed_file(
+                tmp_path / "normalization-failure.mseed",
+                normalize_channel=True,
+            )
+
+    assert error.value is failure
+    documents = list(database["wf_miniseed"].find({}))
+    assert len(documents) == 1
+    assert documents[0]["sta"] == "FIRST"
+    assert database["elog"].count_documents({}) == 0
+
+
+def test_each_affected_waveform_gets_a_fresh_elog_document(database, tmp_path):
+    error = SimpleNamespace(
+        algorithm="mseed_file_indexer",
+        badness="Complaint",
+        message="recoverable packet error",
+        p_id=34,
+    )
+    indexes = [make_index("FIRST", 100.0), make_index("SECOND", 200.0)]
+    logger = FakeErrorLogger([error])
+    with patch(
+        "mspasspy.db.database._mseed_file_indexer",
+        return_value=(indexes, logger),
+    ):
+        waveform_ids, elog_ids = database.index_mseed_file(
+            tmp_path / "errors.mseed",
+            return_ids=True,
+        )
+
+    assert len(waveform_ids) == 2
+    assert len(elog_ids) == 2
+    assert len(set(elog_ids)) == 2
+    assert database["elog"].count_documents({}) == 2
+    for waveform_id, elog_id in zip(waveform_ids, elog_ids):
+        document = database["elog"].find_one({"_id": elog_id})
+        assert document["wf_miniseed_id"] == waveform_id
+        assert document["logdata"] == [
+            {
+                "job_id": logger.get_job_id(),
+                "algorithm": "mseed_file_indexer",
+                "badness": "Complaint",
+                "error_message": "recoverable packet error",
+                "process_id": 34,
+            }
+        ]


### PR DESCRIPTION
Fixes #821

## Dependency resolution

PR #994 was squash-merged first. This branch was then rebased onto that exact master commit so its diff now contains only the #821 persistence changes; it does not duplicate the miniSEED recovery implementation.

## Summary

- return exact empty-index results without database writes
- normalize every indexed segment independently and persist `channel_id` only for one exact channel match
- allocate a fresh elog document for every affected waveform
- retain the detailed warning that duplicate/overlapping channel metadata can be harmless but are ambiguous for inline normalization

## Verification

- final diff against master: exactly `database.py` plus the #821 contract test
- combined #994 gap plus in-tolerance rate-drift reader contract: passed
- #821 contract: real MongoDB 8.0.29 evidence 5/5 passed
- Black, Python 3.12/3.13 `py_compile`, and `git diff --check`: passed

## Review

The resolved stack preserves both #994's gap/rate contract and #821's per-segment normalization guidance. No scientific behavior was discarded.