### PR TITLE
Route clean deletions to the explicit source collection

### DIFF
--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -441,12 +441,15 @@ method of the Database class:
 
   def delete_data(self, object_id, object_type,
                   remove_unreferenced_files=False,
-                  clear_history=True, clear_elog=True):
+                  clear_history=True, clear_elog=True,
+                  collection=None):
 
 As with the read methods, :code:`object_id` is the ObjectId of the waveform
 document that references the data to be deleted.  :code:`object_type` must be
 either :code:`"TimeSeries"` or :code:`"Seismogram"` and selects the
-corresponding waveform collection.
+corresponding default waveform collection.  Set :code:`collection` to a
+schema-defined waveform collection of that type to delete from an explicit
+collection instead.
 Similarly, the idea of the :code:`clear_history` and :code:`clear_elog`
 may be apparent from the name.  When true all documents linked to the
 waveform data being deleted in the history and elog collections (respectively)

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1999,7 +1999,14 @@ class Database(pymongo.database.Database):
 
             # delete this document
             if delete_missing_required:
-                self.delete_data(doc["_id"], object_type.__name__, True, True, True)
+                self.delete_data(
+                    doc["_id"],
+                    object_type.__name__,
+                    True,
+                    True,
+                    True,
+                    collection=collection,
+                )
                 if verbose:
                     print("{}{} the document is deleted.".format(log_helper, error_msg))
                 return fixed_cnt
@@ -2037,7 +2044,14 @@ class Database(pymongo.database.Database):
 
             # delete this document
             if delete_missing_xref:
-                self.delete_data(doc["_id"], object_type.__name__, True, True, True)
+                self.delete_data(
+                    doc["_id"],
+                    object_type.__name__,
+                    True,
+                    True,
+                    True,
+                    collection=collection,
+                )
                 if verbose:
                     print("{}{} the document is deleted.".format(log_helper, error_msg))
                 return fixed_cnt
@@ -3938,6 +3952,7 @@ class Database(pymongo.database.Database):
         remove_unreferenced_files=False,
         clear_history=True,
         clear_elog=True,
+        collection=None,
     ):
         """
         Delete method for handling mspass data objects (TimeSeries and Seismograms).
@@ -3970,17 +3985,32 @@ class Database(pymongo.database.Database):
         :param remove_unreferenced_files: if ``True``, we will try to remove the file that no wf data is referencing. Default to be ``False``
         :param clear_history: if ``True``, we will clear the processing history of the associated wf object, default to be ``True``
         :param clear_elog: if ``True``, we will clear the elog entries of the associated wf object, default to be ``True``
+        :param collection: explicit waveform collection containing the object. If
+          omitted, use the default collection for ``object_type``.
         """
         if object_type not in ["TimeSeries", "Seismogram"]:
             raise TypeError("only TimeSeries and Seismogram are supported")
 
-        # get the wf collection name in the schema
-        schema = self.metadata_schema
-        if object_type == "TimeSeries":
-            detele_schema = schema.TimeSeries
+        if collection is None:
+            schema = self.metadata_schema
+            if object_type == "TimeSeries":
+                delete_schema = schema.TimeSeries
+            else:
+                delete_schema = schema.Seismogram
+            wf_collection_name = delete_schema.collection("_id")
         else:
-            detele_schema = schema.Seismogram
-        wf_collection_name = detele_schema.collection("_id")
+            wf_collection_name = self.database_schema.default_name(collection)
+            expected_type = TimeSeries if object_type == "TimeSeries" else Seismogram
+            if (
+                self.database_schema[wf_collection_name].data_type()
+                is not expected_type
+            ):
+                raise MsPASSError(
+                    "Collection {} is not a {} waveform collection".format(
+                        wf_collection_name, object_type
+                    ),
+                    ErrorSeverity.Invalid,
+                )
 
         # user might pass a mspass object by mistake
         try:

--- a/python/tests/db/test_clean_collection_routing_contract.py
+++ b/python/tests/db/test_clean_collection_routing_contract.py
@@ -1,0 +1,205 @@
+import copy
+import os
+import uuid
+
+import gridfs
+import pymongo
+import pytest
+from bson import ObjectId
+
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+from mspasspy.db.client import DBClient
+from mspasspy.db.database import Database
+
+
+@pytest.fixture
+def database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    probe = pymongo.MongoClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        probe.admin.command("ping")
+    except pymongo.errors.PyMongoError as error:
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    finally:
+        probe.close()
+    client = DBClient(uri, serverSelectionTimeoutMS=2000)
+    name = "test_clean_collection_routing_" + uuid.uuid4().hex
+    try:
+        database = Database(client, name)
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+CASES = [
+    ("TimeSeries", "wf_TimeSeries", "custom_TimeSeries"),
+    ("Seismogram", "wf_Seismogram", "custom_Seismogram"),
+]
+
+
+def register_custom_collection(database, default_collection, custom_collection):
+    database.database_schema[custom_collection] = copy.deepcopy(
+        database.database_schema[default_collection]
+    )
+
+
+@pytest.mark.parametrize("object_type,default_collection,custom_collection", CASES)
+@pytest.mark.parametrize("trigger", ["missing_required", "missing_xref"])
+def test_clean_collection_deletes_only_the_explicit_collection(
+    database, object_type, default_collection, custom_collection, trigger
+):
+    register_custom_collection(database, default_collection, custom_collection)
+    assert (
+        database.database_schema[custom_collection].data_type().__name__ == object_type
+    )
+    oid = ObjectId()
+    fs = gridfs.GridFS(database)
+    custom_gridfs_id = fs.put(b"custom waveform")
+    default_gridfs_id = fs.put(b"default waveform")
+    custom_document = {
+        "_id": oid,
+        "storage_mode": "gridfs",
+        "gridfs_id": custom_gridfs_id,
+        "marker": "custom",
+    }
+    default_document = {
+        "_id": oid,
+        "storage_mode": "gridfs",
+        "gridfs_id": default_gridfs_id,
+        "marker": "default",
+    }
+    database[custom_collection].insert_one(copy.deepcopy(custom_document))
+    database[default_collection].insert_one(copy.deepcopy(default_document))
+    custom_elog_id = (
+        database["elog"]
+        .insert_one({custom_collection + "_id": oid, "marker": "custom"})
+        .inserted_id
+    )
+    default_elog_id = (
+        database["elog"]
+        .insert_one({default_collection + "_id": oid, "marker": "default"})
+        .inserted_id
+    )
+
+    options = {"delete_missing_required": True}
+    if trigger == "missing_xref":
+        options = {
+            "required_xref_list": ["site_id"],
+            "delete_missing_xref": True,
+        }
+    result = database.clean_collection(custom_collection, **options)
+
+    assert result == {}
+    assert database[custom_collection].find_one({"_id": oid}) is None
+    assert database[default_collection].find_one({"_id": oid}) == default_document
+    assert not fs.exists(custom_gridfs_id)
+    assert fs.exists(default_gridfs_id)
+    assert database["elog"].find_one({"_id": custom_elog_id}) is None
+    assert database["elog"].find_one({"_id": default_elog_id}) is not None
+
+
+@pytest.mark.parametrize("object_type,default_collection,_custom_collection", CASES)
+def test_delete_data_keeps_default_collection_behavior(
+    database, object_type, default_collection, _custom_collection
+):
+    oid = ObjectId()
+    fs = gridfs.GridFS(database)
+    gridfs_id = fs.put(b"default waveform")
+    database[default_collection].insert_one(
+        {"_id": oid, "storage_mode": "gridfs", "gridfs_id": gridfs_id}
+    )
+
+    database.delete_data(oid, object_type)
+
+    assert database[default_collection].find_one({"_id": oid}) is None
+    assert not fs.exists(gridfs_id)
+
+
+@pytest.mark.parametrize(
+    "object_type,collection",
+    [
+        ("TimeSeries", "wf_Seismogram"),
+        ("Seismogram", "wf_TimeSeries"),
+        ("TimeSeries", "source"),
+        ("TimeSeries", "not_a_schema_collection"),
+    ],
+)
+def test_delete_data_rejects_an_explicit_nonmatching_waveform_collection(
+    database, object_type, collection
+):
+    oid = ObjectId()
+
+    with pytest.raises(MsPASSError) as error:
+        database.delete_data(oid, object_type, collection=collection)
+
+    assert error.value.severity == ErrorSeverity.Invalid
+
+
+def test_clean_collection_canonicalizes_a_custom_collection_alias(database):
+    default_collection = "wf_TimeSeries"
+    custom_collection = "custom_TimeSeries"
+    custom_alias = "custom_wf"
+    register_custom_collection(database, default_collection, custom_collection)
+    database.database_schema.set_default(custom_collection, custom_alias)
+    oid = ObjectId()
+    fs = gridfs.GridFS(database)
+    custom_gridfs_id = fs.put(b"custom waveform")
+    default_gridfs_id = fs.put(b"default waveform")
+    database[custom_collection].insert_one(
+        {"_id": oid, "storage_mode": "gridfs", "gridfs_id": custom_gridfs_id}
+    )
+    database[default_collection].insert_one(
+        {"_id": oid, "storage_mode": "gridfs", "gridfs_id": default_gridfs_id}
+    )
+
+    database.clean_collection(custom_alias, delete_missing_required=True)
+
+    assert database[custom_collection].find_one({"_id": oid}) is None
+    assert database[default_collection].find_one({"_id": oid}) is not None
+    assert not fs.exists(custom_gridfs_id)
+    assert fs.exists(default_gridfs_id)
+
+
+@pytest.mark.parametrize("object_type,default_collection,custom_collection", CASES)
+def test_clean_collection_counts_file_references_in_the_explicit_collection(
+    database, tmp_path, object_type, default_collection, custom_collection
+):
+    register_custom_collection(database, default_collection, custom_collection)
+    oid = ObjectId()
+    custom_file = tmp_path / "custom-waveforms"
+    default_file = tmp_path / "default-waveforms"
+    custom_file.write_bytes(b"shared custom waveform data")
+    default_file.write_bytes(b"default waveform data")
+    custom_document = {
+        "_id": oid,
+        "storage_mode": "file",
+        "dir": str(tmp_path),
+        "dfile": custom_file.name,
+    }
+    default_document = {
+        "_id": oid,
+        "storage_mode": "file",
+        "dir": str(tmp_path),
+        "dfile": default_file.name,
+    }
+    database[custom_collection].insert_one(copy.deepcopy(custom_document))
+    database[custom_collection].insert_one(
+        {
+            "storage_mode": "file",
+            "dir": str(tmp_path),
+            "dfile": custom_file.name,
+        }
+    )
+    database[default_collection].insert_one(copy.deepcopy(default_document))
+
+    database.clean_collection(
+        custom_collection,
+        query={"_id": oid},
+        delete_missing_required=True,
+    )
+
+    assert database[custom_collection].find_one({"_id": oid}) is None
+    assert database[default_collection].find_one({"_id": oid}) == default_document
+    assert custom_file.read_bytes() == b"shared custom waveform data"
+    assert default_file.read_bytes() == b"default waveform data"


### PR DESCRIPTION
Fixes #818

## Summary
- add a validated optional collection route to `delete_data`
- pass the scanned collection from both destructive `clean` paths
- derive parent lookup, file reference checks, and elog waveform keys from that canonical collection

## Verification
- independent agent review: PASS
- MongoDB 8.0.29 contract and neighboring regression tests: 16 passed
- exact audited baseline: 11 failed, 2 passed
- Black, Python 3.12/3.13 py_compile, and git diff checks: passed

This PR is ready for human review. It must not be merged automatically.