### PR TITLE
Fix inventory location grouping and lookup

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -5496,8 +5496,8 @@ class Database(pymongo.database.Database):
                     rec = geoJSON_doc(loc_lat, loc_lon, doc=rec, key="location")
                     rec["elev"] = loc_elev
                     rec["edepth"] = loc_edepth
-                    rec["starttime"] = starttime.timestamp
-                    rec["endtime"] = endtime.timestamp
+                    rec["starttime"] = loc_stime.timestamp
+                    rec["endtime"] = loc_etime.timestamp
                     if (
                         latitude != loc_lat
                         or longitude != loc_lon
@@ -5566,11 +5566,11 @@ class Database(pymongo.database.Database):
                     # done with site now handle channel
                     # Because many features are shared we can copy rec
                     # note this has to be a deep copy
-                    chanrec = copy.deepcopy(rec)
-                    # We don't want this baggage in the channel documents
-                    # keep them only in the site collection
-                    # del chanrec['serialized_inventory']
                     for chan in chans:
+                        if chan.location_code != loc:
+                            continue
+                        chanrec = copy.deepcopy(rec)
+                        chanrec.pop("_id", None)
                         chanrec["chan"] = chan.code
                         # the Dip attribute in a stationxml file
                         # is like strike-dip and relative to horizontal
@@ -5592,19 +5592,10 @@ class Database(pymongo.database.Database):
                             picklestr = pickle.dumps(chan)
                             chanrec["serialized_channel_data"] = picklestr
                             result = dbchannel.insert_one(chanrec)
-                            # insert_one has an obnoxious behavior in that it
-                            # inserts the ObjectId in chanrec.  In this loop
-                            # we reuse chanrec so we have to delete the id field
-                            # howeveer, we first want to update the record to
-                            # have chan_id provide an  alternate key to that id
-                            # object_id - that makes this consistent with site
-                            # we actually use the return instead of pulling from
-                            # chanrec
                             idobj = result.inserted_id
                             dbchannel.update_one(
                                 {"_id": idobj}, {"$set": {"chan_id": idobj}}
                             )
-                            del chanrec["_id"]
                             n_chan_saved += 1
                             if verbose:
                                 print(
@@ -5832,6 +5823,20 @@ class Database(pymongo.database.Database):
             return dbchannel.find_one(query)
         else:
             # Note we only land here when the above yields multiple matches
+            if loc is not None:
+                raise MsPASSError(
+                    "get_seed_channel: explicit location query returned "
+                    + str(matchsize)
+                    + " matches for "
+                    + net
+                    + ":"
+                    + sta
+                    + ":"
+                    + loc
+                    + ":"
+                    + chan,
+                    ErrorSeverity.Invalid,
+                )
             if loc == None:
                 # We could get here one of two ways.  There could
                 # be multiple loc codes and the user didn't specify

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -5780,13 +5780,21 @@ class Database(pymongo.database.Database):
         search though the list of docs returned for a match to
         loc being conscious of the null string oddity.
 
-        The (optional) time arg is used for a range match to find
-        period between the site startime and endtime.  If not used
-        the first occurence will be returned (usually ill adivsed)
+        The (optional) time arg is used for a range match to find the
+        period between the channel start time and end time.  If it is
+        omitted, the first occurrence may be returned (usually ill advised).
         Returns None if there is no match.  Although the time argument
-        is technically option it usually a bad idea to not include
-        a time stamp because most stations saved as seed data have
-        time variable channel metadata.
+        is technically optional, it is usually a bad idea to omit it because
+        most stations saved as SEED data have time-variable channel metadata.
+
+        An explicit ``loc`` makes the four SEED codes an exact selector.  If
+        more than one document still matches that selector, the channel
+        collection contains ambiguous duplicate metadata and this method
+        raises :class:`MsPASSError` with ``Invalid`` severity.  When ``loc``
+        is omitted, the legacy null/empty-location recovery described above
+        remains in effect; depending on whether ``time`` was supplied, that
+        path either returns the first documented recovery match or reports
+        the existing ambiguity error.
 
         Note this method may be DEPRICATED in the future as it has been
         largely superceded by BasicMatcher implementations in the
@@ -5802,8 +5810,12 @@ class Database(pymongo.database.Database):
            print warning message when the match is ambiguous - multiple
            docs match the specified keys.  The default is False.
 
-        :return: handle to query return
-        :rtype:  MondoDB Cursor object of query result.
+        :return: matching MongoDB channel document, or ``None`` when there is
+          no match.
+        :rtype: dict or None
+        :raises MsPASSError: if an explicit location query has multiple
+          matches, or if the legacy null-location recovery cannot select a
+          unique document without a time constraint.
         """
         dbchannel = self.channel
         query = {}

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -5222,23 +5222,14 @@ class Database(pymongo.database.Database):
     @staticmethod
     def _extract_locdata(chanlist):
         """
-        Parses the list returned by obspy channels attribute
-        for a Station object and returns a dict of unique
-        geographic location fields values keyed by loc code.  This algorithm
-        would be horribly inefficient for large lists with
-        many duplicates, but the assumption here is the list
-        will always be small
+        Group the channels of an ObsPy Station by location code.
+
+        Channel metadata remain attached to each Channel object so callers
+        can preserve channel-specific coordinates and validity intervals.
         """
         alllocs = {}
         for chan in chanlist:
-            alllocs[chan.location_code] = [
-                chan.start_date,
-                chan.end_date,
-                chan.latitude,
-                chan.longitude,
-                chan.elevation,
-                chan.depth,
-            ]
+            alllocs.setdefault(chan.location_code, []).append(chan)
         return alllocs
 
     def _site_is_not_in_db(self, record_to_test):
@@ -5384,8 +5375,15 @@ class Database(pymongo.database.Database):
 
         The channel collection can contain full response data
         that can be obtained by extracting the data with the key
-        "serialized_inventory" and running pickle loads on the returned
+        "serialized_channel_data" and running pickle loads on the returned
         string.
+
+        Channels are grouped by location code.  Each site document spans the
+        union of its channels' validity intervals.  When all channels in a
+        location have the same coordinates, those coordinates define the
+        site; otherwise the Station coordinates define the site and one
+        warning is printed.  Channel documents always retain their own
+        coordinates, depth, validity interval, orientation, and response.
 
         A final point of note is that not all Inventory objects are created
         equally.   Inventory objects appear to us to be designed as an image
@@ -5439,10 +5437,6 @@ class Database(pymongo.database.Database):
             stalist = x.stations
             for station in stalist:
                 sta = station.code
-                starttime = station.start_date
-                endtime = station.end_date
-                starttime = self._handle_null_starttime(starttime)
-                endtime = self._handle_null_endtime(endtime)
                 latitude = station.latitude
                 longitude = station.longitude
                 # stationxml files seen to put elevation in m. We
@@ -5460,8 +5454,7 @@ class Database(pymongo.database.Database):
                 # loc=_extract_loc_code(chanlist[0])
                 # TODO Delete when sure we don't need to keep the full thing
                 # picklestr = pickle.dumps(x)
-                all_locs = locdata.keys()
-                for loc in all_locs:
+                for loc, loc_channels in locdata.items():
                     # If multiple loc codes are present on the second pass
                     # rec will contain the ObjectId of the document inserted
                     # in the previous pass - an obnoxious property of insert_one
@@ -5470,21 +5463,30 @@ class Database(pymongo.database.Database):
                     rec["loc"] = loc
                     rec["net"] = net
                     rec["sta"] = sta
-                    lkey = loc
-                    loc_tuple = locdata[lkey]
-                    # We use these attributes linked to loc code rather than
-                    # the station data - experience shows they are not
-                    # consistent and we should use this set.
-                    loc_lat = loc_tuple[2]
-                    loc_lon = loc_tuple[3]
-                    loc_elev = loc_tuple[4]
-                    # for consistency convert this to km too
-                    loc_elev = loc_elev / 1000.0
-                    loc_edepth = loc_tuple[5]
-                    loc_stime = loc_tuple[0]
-                    loc_stime = self._handle_null_starttime(loc_stime)
-                    loc_etime = loc_tuple[1]
-                    loc_etime = self._handle_null_endtime(loc_etime)
+                    loc_stime = min(
+                        self._handle_null_starttime(chan.start_date)
+                        for chan in loc_channels
+                    )
+                    loc_etime = max(
+                        self._handle_null_endtime(chan.end_date)
+                        for chan in loc_channels
+                    )
+                    channel_geometry = {
+                        (chan.latitude, chan.longitude, chan.elevation)
+                        for chan in loc_channels
+                    }
+                    if len(channel_geometry) == 1:
+                        loc_lat, loc_lon, loc_elev_m = next(iter(channel_geometry))
+                        loc_elev = loc_elev_m / 1000.0
+                    else:
+                        loc_lat = latitude
+                        loc_lon = longitude
+                        loc_elev = elevation
+                        print(
+                            f"{net}:{sta}:{loc} (Warning): channels sharing this "
+                            "location code have conflicting coordinates; using "
+                            "Station coordinates for the site record"
+                        )
                     rec["lat"] = loc_lat
                     rec["lon"] = loc_lon
                     # save coordinates in both geoJSON and "legacy"
@@ -5495,35 +5497,11 @@ class Database(pymongo.database.Database):
                     # it indicates a problem datum
                     rec = geoJSON_doc(loc_lat, loc_lon, doc=rec, key="location")
                     rec["elev"] = loc_elev
-                    rec["edepth"] = loc_edepth
+                    location_depths = {chan.depth for chan in loc_channels}
+                    if len(location_depths) == 1:
+                        rec["edepth"] = next(iter(location_depths))
                     rec["starttime"] = loc_stime.timestamp
                     rec["endtime"] = loc_etime.timestamp
-                    if (
-                        latitude != loc_lat
-                        or longitude != loc_lon
-                        or elevation != loc_elev
-                    ):
-                        print(
-                            net,
-                            ":",
-                            sta,
-                            ":",
-                            loc,
-                            " (Warning):  station section position is not consistent with loc code position",
-                        )
-                        print("Data in loc code section overrides station section")
-                        print(
-                            "Station section coordinates:  ",
-                            latitude,
-                            longitude,
-                            elevation,
-                        )
-                        print(
-                            "loc code section coordinates:  ",
-                            loc_lat,
-                            loc_lon,
-                            loc_elev,
-                        )
                     if self._site_is_not_in_db(rec):
                         result = dbcol.insert_one(rec)
                         # Note this sets site_id to an ObjectId for the insertion
@@ -5542,9 +5520,9 @@ class Database(pymongo.database.Database):
                                 ":",
                                 loc,
                                 "for time span ",
-                                starttime,
+                                loc_stime,
                                 " to ",
-                                endtime,
+                                loc_etime,
                                 " added to site collection",
                             )
                     else:
@@ -5557,18 +5535,16 @@ class Database(pymongo.database.Database):
                                 ":",
                                 loc,
                                 "for time span ",
-                                starttime,
+                                loc_stime,
                                 " to ",
-                                endtime,
+                                loc_etime,
                                 " is already in site collection - ignored",
                             )
                     n_site_processed += 1
                     # done with site now handle channel
                     # Because many features are shared we can copy rec
                     # note this has to be a deep copy
-                    for chan in chans:
-                        if chan.location_code != loc:
-                            continue
+                    for chan in loc_channels:
                         chanrec = copy.deepcopy(rec)
                         chanrec.pop("_id", None)
                         chanrec["chan"] = chan.code
@@ -5579,6 +5555,16 @@ class Database(pymongo.database.Database):
                         # theta angle
                         chanrec["vang"] = chan.dip + 90.0
                         chanrec["hang"] = chan.azimuth
+                        chanrec["lat"] = chan.latitude
+                        chanrec["lon"] = chan.longitude
+                        chanrec["coords"] = [chan.longitude, chan.latitude]
+                        chanrec = geoJSON_doc(
+                            chan.latitude,
+                            chan.longitude,
+                            doc=chanrec,
+                            key="location",
+                        )
+                        chanrec["elev"] = chan.elevation / 1000.0
                         chanrec["edepth"] = chan.depth
                         st = chan.start_date
                         et = chan.end_date

--- a/python/tests/algorithms/test_calib.py
+++ b/python/tests/algorithms/test_calib.py
@@ -48,11 +48,11 @@ class TestApplyCalibEngine:
         """
         # this should be clean for the test data
         engine = ApplyCalibEngine(self.db)
-        # the actual test data have more entries than this
-        # many channels are dropped because they are ot velocity channels
-        # the test file creates 324 entries of which 192 are acceptible
-        # to this application
-        assert len(engine.calib) == 192  # number of entries in test file
+        # The inventory has 94 unique channels.  Many are dropped because
+        # they are not velocity channels, leaving 57 acceptable responses.
+        # Older save_inventory behavior created a channel-by-location
+        # Cartesian product and inflated this count.
+        assert len(engine.calib) == 57
 
         # These will all raise an exception from no data surviving
         # the first somewhat duplicates above but is worh doing

--- a/python/tests/db/test_inventory_location_contract.py
+++ b/python/tests/db/test_inventory_location_contract.py
@@ -1,0 +1,195 @@
+import copy
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from obspy import UTCDateTime
+from obspy.core.inventory import Channel, Inventory, Network, Response, Station
+from pymongo import MongoClient
+from pymongo.errors import ServerSelectionTimeoutError
+
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+from mspasspy.db.client import DBClient
+from mspasspy.db.database import Database
+
+
+@pytest.fixture
+def database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    probe = MongoClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        probe.admin.command("ping")
+    except ServerSelectionTimeoutError as error:
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    finally:
+        probe.close()
+    client = DBClient(uri, serverSelectionTimeoutMS=2000)
+    name = "test_inventory_locations_" + uuid.uuid4().hex
+    database = Database(client, name)
+    try:
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+def make_channel(code, location, latitude, longitude, elevation, depth, start, end):
+    return Channel(
+        code=code,
+        location_code=location,
+        latitude=latitude,
+        longitude=longitude,
+        elevation=elevation,
+        depth=depth,
+        azimuth=10.0,
+        dip=-90.0,
+        sample_rate=20.0,
+        response=Response(),
+        start_date=UTCDateTime(start),
+        end_date=UTCDateTime(end),
+    )
+
+
+def make_multi_location_inventory():
+    loc00 = {
+        "latitude": 30.0,
+        "longitude": -100.0,
+        "elevation": 100.0,
+        "depth": 1.0,
+        "start": "2020-01-01",
+        "end": "2021-01-01",
+    }
+    loc10 = {
+        "latitude": 31.0,
+        "longitude": -101.0,
+        "elevation": 200.0,
+        "depth": 2.0,
+        "start": "2022-01-01",
+        "end": "2023-01-01",
+    }
+    channels = [
+        make_channel("BHZ", "00", **loc00),
+        make_channel("BHN", "00", **loc00),
+        make_channel("HHZ", "10", **loc10),
+    ]
+    station = Station(
+        code="TEST",
+        latitude=35.0,
+        longitude=-105.0,
+        elevation=500.0,
+        channels=channels,
+        start_date=UTCDateTime("2010-01-01"),
+        end_date=UTCDateTime("2030-01-01"),
+    )
+    return Inventory(networks=[Network(code="XX", stations=[station])], source="test")
+
+
+def test_save_inventory_groups_channels_only_under_their_own_location(database):
+    inventory = make_multi_location_inventory()
+    source_channels = inventory.networks[0].stations[0].channels
+    source_state = [
+        (
+            id(channel),
+            id(channel.response),
+            channel.location_code,
+            channel.code,
+            channel.latitude,
+            channel.longitude,
+            channel.start_date,
+            channel.end_date,
+        )
+        for channel in source_channels
+    ]
+
+    def codec_boundary(channel):
+        return f"{channel.location_code}:{channel.code}:{id(channel.response)}".encode()
+
+    expected_payloads = {
+        (channel.location_code, channel.code): codec_boundary(channel)
+        for channel in source_channels
+    }
+
+    with patch("mspasspy.db.database.pickle.dumps", side_effect=codec_boundary):
+        counts = database.save_inventory(inventory, networks_to_exclude=None)
+
+    assert counts == (2, 3, 2, 3)
+    assert [
+        (
+            id(channel),
+            id(channel.response),
+            channel.location_code,
+            channel.code,
+            channel.latitude,
+            channel.longitude,
+            channel.start_date,
+            channel.end_date,
+        )
+        for channel in inventory.networks[0].stations[0].channels
+    ] == source_state
+    sites = list(database.site.find({"net": "XX", "sta": "TEST"}))
+    assert len(sites) == 2
+    sites_by_location = {document["loc"]: document for document in sites}
+    assert set(sites_by_location) == {"00", "10"}
+    expected_locations = {
+        "00": (30.0, -100.0, 0.1, 1.0, "2020-01-01", "2021-01-01"),
+        "10": (31.0, -101.0, 0.2, 2.0, "2022-01-01", "2023-01-01"),
+    }
+    for location, expected in expected_locations.items():
+        latitude, longitude, elevation, depth, start, end = expected
+        document = sites_by_location[location]
+        assert document["lat"] == latitude
+        assert document["lon"] == longitude
+        assert document["elev"] == elevation
+        assert document["edepth"] == depth
+        assert document["starttime"] == UTCDateTime(start).timestamp
+        assert document["endtime"] == UTCDateTime(end).timestamp
+
+    channels = list(database.channel.find({"net": "XX", "sta": "TEST"}))
+    assert len(channels) == 3
+    assert {(document["loc"], document["chan"]) for document in channels} == {
+        ("00", "BHZ"),
+        ("00", "BHN"),
+        ("10", "HHZ"),
+    }
+    assert len({document["serialized_channel_data"] for document in channels}) == 3
+    for document in channels:
+        expected = expected_locations[document["loc"]]
+        assert (
+            document["serialized_channel_data"]
+            == expected_payloads[(document["loc"], document["chan"])]
+        )
+        assert document["lat"] == expected[0]
+        assert document["lon"] == expected[1]
+        assert document["starttime"] == UTCDateTime(expected[4]).timestamp
+        assert document["endtime"] == UTCDateTime(expected[5]).timestamp
+
+
+@pytest.mark.parametrize("location", ["00", ""])
+def test_explicit_location_lookup_has_zero_one_and_ambiguous_results(
+    database, location
+):
+    query_document = {
+        "net": "XX",
+        "sta": "TEST",
+        "chan": "BHZ",
+        "loc": location,
+        "starttime": 0.0,
+        "endtime": 100.0,
+    }
+    distractor = copy.deepcopy(query_document)
+    distractor["loc"] = "10"
+    database.channel.insert_one(distractor)
+    assert database.get_seed_channel("XX", "TEST", "BHZ", location, time=50.0) is None
+
+    document_id = database.channel.insert_one(copy.deepcopy(query_document)).inserted_id
+    result = database.get_seed_channel("XX", "TEST", "BHZ", location, time=50.0)
+    assert result["_id"] == document_id
+
+    database.channel.insert_one(copy.deepcopy(query_document))
+    documents_before_error = list(database.channel.find().sort("_id"))
+    with pytest.raises(MsPASSError) as error:
+        database.get_seed_channel("XX", "TEST", "BHZ", location, time=50.0)
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert "explicit location query returned 2 matches" in str(error.value)
+    assert list(database.channel.find().sort("_id")) == documents_before_error

--- a/python/tests/db/test_inventory_location_contract.py
+++ b/python/tests/db/test_inventory_location_contract.py
@@ -85,6 +85,15 @@ def make_multi_location_inventory():
     return Inventory(networks=[Network(code="XX", stations=[station])], source="test")
 
 
+def test_extract_locdata_preserves_every_channel_in_its_location_group():
+    channels = make_multi_location_inventory().networks[0].stations[0].channels
+    grouped = Database._extract_locdata(channels)
+
+    assert set(grouped) == {"00", "10"}
+    assert grouped["00"] == channels[:2]
+    assert grouped["10"] == channels[2:]
+
+
 def test_save_inventory_groups_channels_only_under_their_own_location(database):
     inventory = make_multi_location_inventory()
     source_channels = inventory.networks[0].stations[0].channels
@@ -163,6 +172,65 @@ def test_save_inventory_groups_channels_only_under_their_own_location(database):
         assert document["lon"] == expected[1]
         assert document["starttime"] == UTCDateTime(expected[4]).timestamp
         assert document["endtime"] == UTCDateTime(expected[5]).timestamp
+
+
+def test_conflicting_channel_geometry_uses_station_site_and_exact_channels(
+    database, capsys
+):
+    channels = [
+        make_channel("BHZ", "00", 30.0, -100.0, 100.0, 1.0, "2020-01-01", "2021-01-01"),
+        make_channel("BHN", "00", 31.0, -101.0, 200.0, 2.0, "2019-01-01", "2022-01-01"),
+    ]
+    station = Station(
+        code="TEST",
+        latitude=35.0,
+        longitude=-105.0,
+        elevation=500.0,
+        channels=channels,
+    )
+    inventory = Inventory(
+        networks=[Network(code="XX", stations=[station])], source="test"
+    )
+
+    with patch(
+        "mspasspy.db.database.pickle.dumps",
+        side_effect=lambda channel: channel.code.encode(),
+    ):
+        counts = database.save_inventory(inventory, networks_to_exclude=None)
+
+    assert counts == (1, 2, 1, 2)
+    output = capsys.readouterr().out
+    assert output.count("channels sharing this location code have conflicting") == 1
+
+    site = database.site.find_one({"net": "XX", "sta": "TEST", "loc": "00"})
+    assert site["lat"] == 35.0
+    assert site["lon"] == -105.0
+    assert site["elev"] == 0.5
+    assert site["coords"] == [-105.0, 35.0]
+    assert site["location"]["coordinates"] == [-105.0, 35.0]
+    assert site["starttime"] == UTCDateTime("2019-01-01").timestamp
+    assert site["endtime"] == UTCDateTime("2022-01-01").timestamp
+    assert "edepth" not in site
+
+    documents = {
+        document["chan"]: document
+        for document in database.channel.find({"net": "XX", "sta": "TEST"})
+    }
+    assert set(documents) == {"BHZ", "BHN"}
+    for channel in channels:
+        document = documents[channel.code]
+        assert document["lat"] == channel.latitude
+        assert document["lon"] == channel.longitude
+        assert document["elev"] == channel.elevation / 1000.0
+        assert document["edepth"] == channel.depth
+        assert document["coords"] == [channel.longitude, channel.latitude]
+        assert document["location"]["coordinates"] == [
+            channel.longitude,
+            channel.latitude,
+        ]
+        assert document["starttime"] == channel.start_date.timestamp
+        assert document["endtime"] == channel.end_date.timestamp
+        assert document["serialized_channel_data"] == channel.code.encode()
 
 
 @pytest.mark.parametrize("location", ["00", ""])


### PR DESCRIPTION
## Summary

- Group each StationXML channel only under its own location code and preserve its exact coordinates, depth, validity interval, orientation, and response.
- Create one site per network/station/location with the union of its channel intervals. Use channel coordinates when they agree; otherwise use Station coordinates and emit one warning.
- Return `None` for zero explicit-location matches, the document for one match, and `MsPASSError(Invalid)` for ambiguous duplicates.

This PR does not define or migrate the persistent Inventory representation; #989 owns that codec and its backward-compatible readers.

## Validation

- Local contract result: 1 database-independent test passed; 4 MongoDB-backed tests were collected and skipped because no local MongoDB listener was available.
- Python compilation, Black formatting, and `git diff --check` pass.

Closes #824
