### PR TITLE
Fix normalization aliases and match-only cache columns

### DIFF
--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -1022,7 +1022,7 @@ class DataFrameCacheMatcher(BasicMatcher):
                                 mdkey = self.collection + "_" + key
                         else:
                             mdkey = key
-                        md[mdkey] = row[key]
+                        md[mdkey] = row[k]
                     else:
                         if elog is None:
                             elog = PyErrorLogger()
@@ -1047,7 +1047,7 @@ class DataFrameCacheMatcher(BasicMatcher):
                                 mdkey = self.collection + "_" + key
                         else:
                             mdkey = key
-                        md[mdkey] = row[key]
+                        md[mdkey] = row[k]
                 mdlist.append(md)
             return [mdlist, None]
 
@@ -2162,6 +2162,10 @@ class EqualityMatcher(DataFrameCacheMatcher):
         prepend_collection_name=False,
         custom_null_values=None,
     ):
+        if not isinstance(match_keys, dict):
+            raise TypeError(
+                "EqualityMatcher Constructor:  required argument 2 (matchkeys) must be a python dictionary"
+            )
         super().__init__(
             db_or_df,
             collection,
@@ -2171,41 +2175,37 @@ class EqualityMatcher(DataFrameCacheMatcher):
             require_unique_match=require_unique_match,
             prepend_collection_name=prepend_collection_name,
             custom_null_values=custom_null_values,
+            cache_columns=list(match_keys.values()),
         )
-        if isinstance(match_keys, dict):
-            self.match_keys = match_keys
-            for key in match_keys:
-                testkey = match_keys[key]
-                # this means no aliasing for key
-                if testkey == key:
-                    continue
-                if testkey in self.aliases:
-                    backtestkey = self.aliases[testkey]
-                    if backtestkey != key:
-                        error_message = (
-                            "EqualityMatcher constructor:  "
-                            + "match_keys and aliases are inconsistent.\n"
-                            + "match_keys="
-                            + str(match_keys)
-                            + "  aliases="
-                            + str(self.aliases)
-                        )
-                        raise MsPASSError(error_message, ErrorSeverity.Fatal)
-                else:
+        self.match_keys = match_keys
+        for key in match_keys:
+            testkey = match_keys[key]
+            # this means no aliasing for key
+            if testkey == key:
+                continue
+            if testkey in self.aliases:
+                backtestkey = self.aliases[testkey]
+                if backtestkey != key:
                     error_message = (
                         "EqualityMatcher constructor:  "
                         + "match_keys and aliases are inconsistent.\n"
-                        + "match_key defines key="
-                        + key
-                        + " to have alias name="
-                        + testkey
-                        + " but alias name is not defined by aliases parameter"
+                        + "match_keys="
+                        + str(match_keys)
+                        + "  aliases="
+                        + str(self.aliases)
                     )
                     raise MsPASSError(error_message, ErrorSeverity.Fatal)
-        else:
-            raise TypeError(
-                "EqualityMatcher Constructor:  required argument 2 (matchkeys) must be a python dictionary"
-            )
+            else:
+                error_message = (
+                    "EqualityMatcher constructor:  "
+                    + "match_keys and aliases are inconsistent.\n"
+                    + "match_key defines key="
+                    + key
+                    + " to have alias name="
+                    + testkey
+                    + " but alias name is not defined by aliases parameter"
+                )
+                raise MsPASSError(error_message, ErrorSeverity.Fatal)
 
     def subset(self, mspass_object) -> pd.DataFrame:
         """
@@ -2944,7 +2944,7 @@ class OriginTimeMatcher(DataFrameCacheMatcher):
                             mdkey = self.collection + "_" + key
                     else:
                         mdkey = key
-                    doc_out[mdkey] = row[key]
+                    doc_out[mdkey] = row[k]
                 else:
                     # land here if a required attribute is missing
                     # from the dataframe cache.  find logs
@@ -2968,7 +2968,7 @@ class OriginTimeMatcher(DataFrameCacheMatcher):
                             mdkey = self.collection + "_" + key
                     else:
                         mdkey = key
-                    doc_out[mdkey] = row[key]
+                    doc_out[mdkey] = row[k]
             return doc_out
         else:
             return None
@@ -3794,7 +3794,7 @@ def _extractData2Metadata(
                     mdkey = collection + "_" + key
             else:
                 mdkey = key
-            md[mdkey] = doc[key]
+            md[mdkey] = doc[k]
         else:
             message = "Required attribute {key} was not found".format(
                 key=k,
@@ -3816,5 +3816,5 @@ def _extractData2Metadata(
                     mdkey = collection + "_" + key
             else:
                 mdkey = key
-            md[mdkey] = doc[key]
+            md[mdkey] = doc[k]
     return md

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -77,17 +77,15 @@ class BasicMatcher(ABC):
           should be loaded only if they are defined. Default is None here,
           subclass should set their own default values.
 
-        :param aliases:   should be a python dictionary used to define
-          alternative keys to access a data object's Metadata from that
-          defining the same attribute in the collection/table being
-          matched.   Note carefully the key of the dictionary is the
-          collection/table attribute name and the value associated with
-          that key is the alias to use to fetch Metadata.  When matchers
-          scan the attributes_to_load and load_if_defined list they
-          should treat missing entries in alias as meaning the key in
-          the collection/table and Metadata are identical.  Default is
-          a None which is used as a signal to this constructor to
-          create an empty dictionary meaning there are no aliases.
+        :param aliases:   should be a python dictionary mapping source
+          collection/table attribute names to the keys returned in a data
+          object's Metadata.  Each dictionary key must appear in
+          attributes_to_load or load_if_defined.  Source values are always
+          read using the dictionary keys; the associated values only name
+          the returned Metadata keys.  A missing entry means the source and
+          returned keys are identical.  Default is None, which signals this
+          constructor to create an empty dictionary meaning there are no
+          aliases.
         :type aliases:  python dictionary
 
 
@@ -1171,12 +1169,11 @@ class ObjectIdDBMatcher(DatabaseMatcher):
       document retrieved in the query.
     :type load_if_defined:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-     when fetching from a data object's Metadata container.   The key sense
-     of the mapping is important to keep straight.  The key of this
-     dictionary should match one  of the attributes in attributes_to_load
-     or load_if_defined.  The value the key defines should be the alias
-     used to fetch the comparable attribute from the data.
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
     :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
@@ -1276,13 +1273,12 @@ class ObjectIdMatcher(DictionaryCacheMatcher):
       document retrieved in the query.
     :param type:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-     when fetching from a data object's Metadata container.   The key sense
-     of the mapping is important to keep straight.  The key of this
-     dictionary should match one  of the attributes in attributes_to_load
-     or load_if_defined.  The value the key defines should be the alias
-     used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when set true all attributes loaded
        from the normalizing collection will have the channel name prepended.
@@ -1463,13 +1459,12 @@ class MiniseedDBMatcher(DatabaseMatcher):
       addition here may be response data (see schema definition for keys)
     :type load_if_defined:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-     when fetching from a data object's Metadata container.   The key sense
-     of the mapping is important to keep straight.  The key of this
-     dictionary should match one  of the attributes in attributes_to_load
-     or load_if_defined.  The value the key defines should be the alias
-     used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
       Metadata containers by the find and find_one method will all have the
@@ -1732,13 +1727,12 @@ class MiniseedMatcher(DictionaryCacheMatcher):
       addition here may be response data (see schema definition for keys)
     :type load_if_defined:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-     when fetching from a data object's Metadata container.   The key sense
-     of the mapping is important to keep straight.  The key of this
-     dictionary should match one  of the attributes in attributes_to_load
-     or load_if_defined.  The value the key defines should be the alias
-     used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
       Metadata containers by the find and find_one method will all have the
@@ -2128,13 +2122,12 @@ class EqualityMatcher(DataFrameCacheMatcher):
       Note this parameter is ignored for DataFrame input.
     :type load_if_defined:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-     when fetching from a data object's Metadata container.   The key sense
-     of the mapping is important to keep straight.  The key of this
-     dictionary should match one  of the attributes in attributes_to_load
-     or load_if_defined.  The value the key defines should be the alias
-     used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
       Metadata containers by the find and find_one method will all have the
@@ -2292,13 +2285,12 @@ class EqualityDBMatcher(DatabaseMatcher):
       optional data.
     :param type:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-     when fetching from a data object's Metadata container.   The key sense
-     of the mapping is important to keep straight.  The key of this
-     dictionary should match one  of the attributes in attributes_to_load
-     or load_if_defined.  The value the key defines should be the alias
-     used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
       Metadata containers by find and find_one method will all have the
@@ -2432,13 +2424,12 @@ class OriginTimeDBMatcher(DatabaseMatcher):
       document retrieved in the query.  Default is ["magnitude"]
     :param type:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-       when fetching from a data object's Metadata container.   The key sense
-       of the mapping is important to keep straight.  The key of this
-       dictionary should match one  of the attributes in attributes_to_load
-       or load_if_defined.  The value the key defines should be the alias
-       used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
       Metadata containers by the find and find_one method will all have the
@@ -2633,13 +2624,12 @@ class OriginTimeMatcher(DataFrameCacheMatcher):
       document retrieved in the query.  Default is ["magnitude"]
     :param type:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-     when fetching from a data object's Metadata container.   The key sense
-     of the mapping is important to keep straight.  The key of this
-     dictionary should match one  of the attributes in attributes_to_load
-     or load_if_defined.  The value the key defines should be the alias
-     used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
       Metadata containers by the find and find_one method will all have the
@@ -3029,13 +3019,12 @@ class ArrivalDBMatcher(DatabaseMatcher):
       document retrieved in the query.  Default is None
     :param type:  list of strings defining collection keys
 
-    :param aliases:  python dictionary defining alias names to apply
-     when fetching from a data object's Metadata container.   The key sense
-     of the mapping is important to keep straight.  The key of this
-     dictionary should match one  of the attributes in attributes_to_load
-     or load_if_defined.  The value the key defines should be the alias
-     used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
       Metadata containers by the find and find_one method will all have the
@@ -3194,13 +3183,12 @@ class ArrivalMatcher(DataFrameCacheMatcher):
       document retrieved in the query.  Default is None
     :param type:  list of strings defining collection keyes
 
-    :param aliases:  python dictionary defining alias names to apply
-       when fetching from a data object's Metadata container.   The key sense
-       of the mapping is important to keep straight.  The key of this
-       dictionary should match one  of the attributes in attributes_to_load
-       or load_if_defined.  The value the key defines should be the alias
-       used to fetch the comparable attribute from the data.
-    :type aliaes:  python dictionary
+    :param aliases:  python dictionary mapping source collection/table keys
+     to keys returned in a Metadata container.  Each dictionary key should
+     match an attribute in attributes_to_load or load_if_defined.  Source
+     values are read using the dictionary keys; the associated values only
+     name the returned Metadata keys.
+    :type aliases:  python dictionary
 
     :param prepend_collection_name:  when True attributes returned in
       Metadata containers by the find and find_one method will all have the

--- a/python/tests/db/test_normalize_alias_cache.py
+++ b/python/tests/db/test_normalize_alias_cache.py
@@ -1,6 +1,8 @@
 import copy
 import os
+import subprocess
 import uuid
+from importlib.metadata import distribution, version
 from pathlib import Path
 
 import pandas as pd
@@ -19,10 +21,26 @@ from mspasspy.db.normalize import (
     OriginTimeMatcher,
 )
 
-SOURCE_PYTHON_ROOT = Path(
-    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
-)
-EXPECTED_NORMALIZE_MODULE = SOURCE_PYTHON_ROOT / "mspasspy" / "db" / "normalize.py"
+
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
 
 
 class _EqualityDictionaryMatcher(DictionaryCacheMatcher):
@@ -62,7 +80,9 @@ class _EqualityDictionaryMatcher(DictionaryCacheMatcher):
 
 @pytest.fixture
 def normalization_sources():
-    assert Path(normalize_module.__file__).resolve() == EXPECTED_NORMALIZE_MODULE
+    _assert_module_from_selected_build(
+        normalize_module, Path("mspasspy/db/normalize.py")
+    )
     client = DBClient("127.0.0.1")
     database_name = "issue_823_" + uuid.uuid4().hex
     database = Database(client, database_name)

--- a/python/tests/db/test_normalize_alias_cache.py
+++ b/python/tests/db/test_normalize_alias_cache.py
@@ -1,0 +1,315 @@
+import copy
+import os
+import uuid
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from bson import ObjectId
+
+import mspasspy.db.normalize as normalize_module
+from mspasspy.ccore.utility import Metadata
+from mspasspy.db.client import DBClient
+from mspasspy.db.database import Database
+from mspasspy.db.normalize import (
+    DataFrameCacheMatcher,
+    DictionaryCacheMatcher,
+    EqualityDBMatcher,
+    EqualityMatcher,
+    OriginTimeMatcher,
+)
+
+SOURCE_PYTHON_ROOT = Path(
+    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
+)
+EXPECTED_NORMALIZE_MODULE = SOURCE_PYTHON_ROOT / "mspasspy" / "db" / "normalize.py"
+
+
+class _EqualityDictionaryMatcher(DictionaryCacheMatcher):
+    """Concrete dictionary-cache matcher used to compare backend contracts."""
+
+    def __init__(
+        self,
+        source,
+        collection,
+        match_keys,
+        attributes_to_load,
+        load_if_defined,
+        aliases,
+    ):
+        self.match_keys = match_keys
+        super().__init__(
+            source,
+            collection,
+            attributes_to_load=attributes_to_load,
+            load_if_defined=load_if_defined,
+            aliases=aliases,
+            require_unique_match=True,
+            prepend_collection_name=False,
+        )
+
+    def cache_id(self, mspass_object):
+        if all(mspass_object.is_defined(key) for key in self.match_keys):
+            return repr(tuple(mspass_object[key] for key in self.match_keys))
+        return None
+
+    def db_make_cache_id(self, document):
+        source_keys = self.match_keys.values()
+        if all(key in document for key in source_keys):
+            return repr(tuple(document[key] for key in source_keys))
+        return None
+
+
+@pytest.fixture
+def normalization_sources():
+    assert Path(normalize_module.__file__).resolve() == EXPECTED_NORMALIZE_MODULE
+    client = DBClient("127.0.0.1")
+    database_name = "issue_823_" + uuid.uuid4().hex
+    database = Database(client, database_name)
+    client.admin.command("ping")
+    rows = [
+        {
+            "_id": ObjectId(),
+            "match_only": "A",
+            "version_only": 1,
+            "source_value": 11,
+            "optional_source": "first",
+        },
+        {
+            "_id": ObjectId(),
+            "match_only": "B",
+            "version_only": 2,
+            "source_value": 22,
+            "optional_source": "second",
+        },
+    ]
+    database["records"].insert_many(copy.deepcopy(rows))
+    yield database, rows
+    client.drop_database(database_name)
+    client.close()
+
+
+def _matcher_configuration():
+    match_keys = {"lookup": "match_only", "version": "version_only"}
+    attributes_to_load = ["source_value"]
+    load_if_defined = ["optional_source"]
+    aliases = {
+        "match_only": "lookup",
+        "version_only": "version",
+        "source_value": "target_value",
+        "optional_source": "target_optional",
+    }
+    return match_keys, attributes_to_load, load_if_defined, aliases
+
+
+def _make_matchers(database, rows):
+    match_keys, attributes_to_load, load_if_defined, aliases = _matcher_configuration()
+    frame = pd.DataFrame(copy.deepcopy(rows))
+    dataframe_matcher = EqualityMatcher(
+        frame,
+        "records",
+        match_keys,
+        attributes_to_load,
+        load_if_defined=load_if_defined,
+        aliases=aliases,
+        prepend_collection_name=False,
+    )
+    dictionary_matcher = _EqualityDictionaryMatcher(
+        database,
+        "records",
+        match_keys,
+        attributes_to_load,
+        load_if_defined,
+        aliases,
+    )
+    database_matcher = EqualityDBMatcher(
+        database,
+        "records",
+        match_keys,
+        attributes_to_load,
+        load_if_defined=load_if_defined,
+        aliases=aliases,
+        require_unique_match=True,
+        prepend_collection_name=False,
+    )
+    return frame, dataframe_matcher, dictionary_matcher, database_matcher
+
+
+def _dictionary_cache_snapshot(matcher):
+    return {
+        key: [dict(metadata) for metadata in values]
+        for key, values in matcher.normcache.items()
+    }
+
+
+def _database_snapshot(database):
+    return sorted(
+        [copy.deepcopy(document) for document in database["records"].find({})],
+        key=lambda document: str(document["_id"]),
+    )
+
+
+def test_match_only_columns_are_cached_but_not_returned(normalization_sources):
+    database, rows = normalization_sources
+    source_frame = pd.DataFrame(copy.deepcopy(rows))
+    frame_before = source_frame.copy(deep=True)
+    match_keys, attributes_to_load, load_if_defined, aliases = _matcher_configuration()
+    configuration_before = copy.deepcopy(
+        (match_keys, attributes_to_load, load_if_defined, aliases)
+    )
+    matcher = EqualityMatcher(
+        source_frame,
+        "records",
+        match_keys,
+        attributes_to_load,
+        load_if_defined=load_if_defined,
+        aliases=aliases,
+        prepend_collection_name=False,
+    )
+    caller = Metadata({"lookup": "A", "version": 1, "unchanged": True})
+    caller_before = dict(caller)
+
+    result, elog = matcher.find_one(caller)
+
+    assert elog is None
+    assert dict(result) == {"target_value": 11, "target_optional": "first"}
+    assert list(matcher.cache.columns) == [
+        "source_value",
+        "optional_source",
+        "match_only",
+        "version_only",
+    ]
+    assert "target_value" not in matcher.cache.columns
+    assert "match_only" not in result and "version_only" not in result
+    assert dict(caller) == caller_before
+    assert (match_keys, attributes_to_load, load_if_defined, aliases) == (
+        configuration_before
+    )
+    pd.testing.assert_frame_equal(source_frame, frame_before)
+    assert _database_snapshot(database) == sorted(
+        copy.deepcopy(rows), key=lambda document: str(document["_id"])
+    )
+
+
+def test_three_backends_return_identical_aliased_output(normalization_sources):
+    database, rows = normalization_sources
+    frame, dataframe_matcher, dictionary_matcher, database_matcher = _make_matchers(
+        database, rows
+    )
+    frame_before = frame.copy(deep=True)
+    dataframe_cache_before = dataframe_matcher.cache.copy(deep=True)
+    dictionary_before = _dictionary_cache_snapshot(dictionary_matcher)
+    database_before = _database_snapshot(database)
+    caller = Metadata({"lookup": "B", "version": 2, "unchanged": "caller"})
+    caller_before = dict(caller)
+
+    results = [
+        matcher.find_one(caller)
+        for matcher in (
+            dataframe_matcher,
+            dictionary_matcher,
+            database_matcher,
+        )
+    ]
+
+    assert all(elog is None for _, elog in results)
+    mappings = [dict(metadata) for metadata, _ in results]
+    assert (
+        mappings
+        == [
+            {"target_value": 22, "target_optional": "second"},
+        ]
+        * 3
+    )
+    assert dict(caller) == caller_before
+    pd.testing.assert_frame_equal(frame, frame_before)
+    pd.testing.assert_frame_equal(dataframe_matcher.cache, dataframe_cache_before)
+    assert _dictionary_cache_snapshot(dictionary_matcher) == dictionary_before
+    assert _database_snapshot(database) == database_before
+
+
+def test_missing_match_keys_leave_caller_and_backends_unchanged(
+    normalization_sources,
+):
+    database, rows = normalization_sources
+    frame, dataframe_matcher, dictionary_matcher, database_matcher = _make_matchers(
+        database, rows
+    )
+    dataframe_cache_before = dataframe_matcher.cache.copy(deep=True)
+    dictionary_before = _dictionary_cache_snapshot(dictionary_matcher)
+    database_before = _database_snapshot(database)
+    caller = Metadata({"lookup": "A", "unchanged": 7})
+    caller_before = dict(caller)
+
+    for matcher in (dataframe_matcher, dictionary_matcher, database_matcher):
+        result, elog = matcher.find_one(caller)
+        assert result is None
+        assert elog is not None
+
+    assert dict(caller) == caller_before
+    pd.testing.assert_frame_equal(dataframe_matcher.cache, dataframe_cache_before)
+    assert _dictionary_cache_snapshot(dictionary_matcher) == dictionary_before
+    assert _database_snapshot(database) == database_before
+    assert set(frame.columns) == set(rows[0])
+
+
+def test_invalid_match_keys_fail_before_cache_construction(monkeypatch):
+    frame = pd.DataFrame([{"source_value": 1, "match_only": "A"}])
+    frame_before = frame.copy(deep=True)
+    cache_load_calls = 0
+
+    def count_cache_load(*args, **kwargs):
+        nonlocal cache_load_calls
+        cache_load_calls += 1
+
+    monkeypatch.setattr(
+        DataFrameCacheMatcher, "_load_dataframe_cache", count_cache_load
+    )
+
+    with pytest.raises(TypeError, match="matchkeys.*python dictionary"):
+        EqualityMatcher(
+            frame,
+            "records",
+            ["match_only"],
+            ["source_value"],
+        )
+
+    assert cache_load_calls == 0
+    pd.testing.assert_frame_equal(frame, frame_before)
+
+
+def test_origin_time_find_doc_reads_values_from_source_keys():
+    sources = pd.DataFrame(
+        [
+            {
+                "source_time": 100.0,
+                "source_value": 41,
+                "optional_source": "present",
+            }
+        ]
+    )
+    sources_before = sources.copy(deep=True)
+    waveform_document = {"starttime": 100.0, "unchanged": True}
+    document_before = copy.deepcopy(waveform_document)
+    matcher = OriginTimeMatcher(
+        sources,
+        tolerance=1.0,
+        attributes_to_load=["source_time", "source_value"],
+        load_if_defined=["optional_source"],
+        aliases={
+            "source_value": "target_value",
+            "optional_source": "target_optional",
+        },
+        prepend_collection_name=False,
+        source_time_key="source_time",
+    )
+
+    result = matcher.find_doc(waveform_document)
+
+    assert result == {
+        "source_time": 100.0,
+        "target_value": 41,
+        "target_optional": "present",
+    }
+    assert waveform_document == document_before
+    pd.testing.assert_frame_equal(sources, sources_before)


### PR DESCRIPTION
Fixes #823

This PR makes all normalization backends read alias values from the source field while using aliases only for output names, and keeps match-only fields in EqualityMatcher caches without exposing them as output attributes.

Validation includes an independent agent review, MongoDB 8.0.29 backend parity, 33 normalization regressions, an exact baseline-red suite, Black, Python 3.12/3.13 py_compile, and diff checks.

This PR is ready for human review. It must not be merged automatically.