### PR TITLE
Complete and harden S3 event index and read paths

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -4767,7 +4767,12 @@ class Database(pymongo.database.Database):
             with os.fdopen(descriptor, "wb") as output:
                 descriptor = None
                 obj = s3_client.get_object(Bucket=bucket, Key=key)
-                output.write(obj["Body"].read())
+                body = obj["Body"]
+                try:
+                    payload = body.read()
+                finally:
+                    body.close()
+                output.write(payload)
                 output.flush()
                 os.fsync(output.fileno())
             if replace_existing:
@@ -4841,7 +4846,7 @@ class Database(pymongo.database.Database):
                     aws_secret_access_key=aws_secret_access_key,
                 )
                 self._cache_s3_object(s3_client, BUCKET_NAME, KEY, fname)
-            except (botocore.exceptions.ClientError, urllib.error.HTTPError) as error:
+            except Exception as error:
                 if self._is_s3_not_found(error):
                     message = (
                         f"Could not find the object by the KEY: {KEY} "
@@ -4854,7 +4859,9 @@ class Database(pymongo.database.Database):
                     )
                     mspass_object.kill()
                     return mspass_object
-                raise
+                raise MsPASSError(
+                    "Error while read data from s3.", ErrorSeverity.Fatal
+                ) from error
 
         with open(fname, mode="rb") as fh:
             fh.seek(foff)
@@ -7107,8 +7114,9 @@ class Database(pymongo.database.Database):
             index data to.  The default is 'wf_miniseed'.  It should be rare
             to use anything but the default.
         :exception: This function returns without indexing if the S3 object does
-            not exist.  Other S3 and network exceptions are rethrown unchanged;
-            local indexing failures raise a fatal MsPASSError.
+            not exist.  Other S3, network, and local indexing failures raise a
+            fatal :class:`MsPASSError`; the original exception is retained as
+            its cause.
         """
 
         dbh = self[collection]
@@ -7146,14 +7154,16 @@ class Database(pymongo.database.Database):
                 fname,
                 replace_existing=True,
             )
-        except (botocore.exceptions.ClientError, urllib.error.HTTPError) as error:
+        except Exception as error:
             if self._is_s3_not_found(error):
                 print(
                     f"Could not find the object by the KEY: {KEY} "
                     f"from the BUCKET: {BUCKET_NAME} in s3"
                 )
                 return None
-            raise
+            raise MsPASSError(
+                "Error while index mseed file from s3.", ErrorSeverity.Fatal
+            ) from error
 
         try:
             # immediately read data from the file

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3,7 +3,9 @@ import io
 import copy
 import pathlib
 import pickle
+import tempfile
 import time
+import urllib.error
 import urllib.request
 from array import array
 from contextlib import contextmanager
@@ -4740,6 +4742,51 @@ class Database(pymongo.database.Database):
         except Exception as e:
             raise MsPASSError("Error while read data from s3_lambda.", "Fatal") from e
 
+    @staticmethod
+    def _is_s3_not_found(error):
+        if isinstance(error, urllib.error.HTTPError):
+            return error.code == 404
+        if isinstance(error, botocore.exceptions.ClientError):
+            response = error.response
+            code = str(response.get("Error", {}).get("Code", ""))
+            status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            return code in {"404", "NoSuchKey"} or status == 404
+        return False
+
+    @staticmethod
+    def _cache_s3_object(s3_client, bucket, key, fname, replace_existing=False):
+        """Publish one complete S3 object to a local cache path atomically."""
+        parent = os.path.dirname(fname) or "."
+        os.makedirs(parent, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=parent,
+            prefix=f".{os.path.basename(fname)}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as output:
+                descriptor = None
+                obj = s3_client.get_object(Bucket=bucket, Key=key)
+                output.write(obj["Body"].read())
+                output.flush()
+                os.fsync(output.fileno())
+            if replace_existing:
+                os.replace(temporary_name, fname)
+                temporary_name = None
+            else:
+                try:
+                    os.link(temporary_name, fname)
+                except FileExistsError:
+                    pass
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            if temporary_name is not None:
+                try:
+                    os.unlink(temporary_name)
+                except FileNotFoundError:
+                    pass
+
     def _read_data_from_s3_event(
         self,
         mspass_object,
@@ -4769,14 +4816,9 @@ class Database(pymongo.database.Database):
             raise TypeError("only TimeSeries and Seismogram are supported")
         fname = os.path.join(dir, dfile)
 
-        # check if fname exists
+        # Cache publication is atomic.  Concurrent readers either see no file
+        # or one complete download, never a partially written final path.
         if not os.path.exists(fname):
-            # fname might now exist, but could download from s3
-            s3_client = boto3.client(
-                "s3",
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
             BUCKET_NAME = "scedc-pds"
             year = mspass_object["year"]
             day_of_year = mspass_object["day_of_year"]
@@ -4792,25 +4834,27 @@ class Database(pymongo.database.Database):
                 + filename
                 + ".ms"
             )
-            # try to download the mseed file from s3 and save it locally
             try:
-                obj = s3_client.get_object(Bucket=BUCKET_NAME, Key=KEY)
-                mseed_content = obj["Body"].read()
-                # temporarily write data into a file
-                with open(fname, "wb") as f:
-                    f.write(mseed_content)
-
-            except botocore.exceptions.ClientError as e:
-                if e.response["Error"]["Code"] == "404":
-                    # the object does not exist
-                    print(
-                        "Could not find the object by the KEY: {} from the BUCKET: {} in s3"
-                    ).format(KEY, BUCKET_NAME)
-                else:
-                    raise
-
-            except Exception as e:
-                raise MsPASSError("Error while read data from s3.", "Fatal") from e
+                s3_client = boto3.client(
+                    "s3",
+                    aws_access_key_id=aws_access_key_id,
+                    aws_secret_access_key=aws_secret_access_key,
+                )
+                self._cache_s3_object(s3_client, BUCKET_NAME, KEY, fname)
+            except (botocore.exceptions.ClientError, urllib.error.HTTPError) as error:
+                if self._is_s3_not_found(error):
+                    message = (
+                        f"Could not find the object by the KEY: {KEY} "
+                        f"from the BUCKET: {BUCKET_NAME} in s3"
+                    )
+                    mspass_object.elog.log_error(
+                        "Database._read_data_from_s3_event",
+                        message,
+                        ErrorSeverity.Invalid,
+                    )
+                    mspass_object.kill()
+                    return mspass_object
+                raise
 
         with open(fname, mode="rb") as fh:
             fh.seek(foff)
@@ -4834,6 +4878,7 @@ class Database(pymongo.database.Database):
                 mspass_object.set_live()
             else:
                 mspass_object.kill()
+        return mspass_object
 
     @staticmethod
     def _read_data_from_fdsn(mspass_object):
@@ -7061,8 +7106,9 @@ class Database(pymongo.database.Database):
         :param collection:  is the mongodb collection name to write the
             index data to.  The default is 'wf_miniseed'.  It should be rare
             to use anything but the default.
-        :exception: This function will do nothing if the obejct does not exist. For other
-            exceptions, it would raise a MsPASSError.
+        :exception: This function returns without indexing if the S3 object does
+            not exist.  Other S3 and network exceptions are rethrown unchanged;
+            local indexing failures raise a fatal MsPASSError.
         """
 
         dbh = self[collection]
@@ -7084,20 +7130,32 @@ class Database(pymongo.database.Database):
             + ".ms"
         )
 
+        if dir is None:
+            odir = os.getcwd()
+        else:
+            odir = os.path.abspath(dir)
+        if dfile is None:
+            dfile = self._get_dfile_uuid("mseed")
+        fname = os.path.join(odir, dfile)
+
         try:
-            obj = s3_client.get_object(Bucket=BUCKET_NAME, Key=KEY)
-            mseed_content = obj["Body"].read()
-            # specify the file path
-            if dir is None:
-                odir = os.getcwd()
-            else:
-                odir = os.path.abspath(dir)
-            if dfile is None:
-                dfile = self._get_dfile_uuid("mseed")
-            fname = os.path.join(odir, dfile)
-            # temporarily write data into a file
-            with open(fname, "wb") as f:
-                f.write(mseed_content)
+            self._cache_s3_object(
+                s3_client,
+                BUCKET_NAME,
+                KEY,
+                fname,
+                replace_existing=True,
+            )
+        except (botocore.exceptions.ClientError, urllib.error.HTTPError) as error:
+            if self._is_s3_not_found(error):
+                print(
+                    f"Could not find the object by the KEY: {KEY} "
+                    f"from the BUCKET: {BUCKET_NAME} in s3"
+                )
+                return None
+            raise
+
+        try:
             # immediately read data from the file
             ind, elog = _mseed_file_indexer(fname)
             for i in ind:
@@ -7110,24 +7168,10 @@ class Database(pymongo.database.Database):
                 doc["day_of_year"] = day_of_year
                 doc["filename"] = filename
                 dbh.insert_one(doc)
-
-        except botocore.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "404":
-                # the object does not exist
-                print(
-                    "Could not find the object by the KEY: {} from the BUCKET: {} in s3"
-                ).format(KEY, BUCKET_NAME)
-            else:
-                print(
-                    "An ClientError occur when tyring to get the object by the KEY("
-                    + KEY
-                    + ")"
-                    + " with error: ",
-                    e,
-                )
-
-        except Exception as e:
-            raise MsPASSError("Error while index mseed file from s3.", "Fatal") from e
+        except Exception as error:
+            raise MsPASSError(
+                "Error while index mseed file from s3.", "Fatal"
+            ) from error
 
     def index_mseed_FDSN(
         self,
@@ -7301,6 +7345,17 @@ class Database(pymongo.database.Database):
         elif storage_mode == "s3_continuous":
             self._read_data_from_s3_continuous(
                 mspass_object, aws_access_key_id, aws_secret_access_key
+            )
+        elif storage_mode == "s3_event":
+            self._read_data_from_s3_event(
+                mspass_object,
+                md["dir"],
+                md["dfile"],
+                md["foff"],
+                nbytes=md["nbytes"],
+                format=None if "format" not in md else md["format"],
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
             )
         elif storage_mode == "s3_lambda":
             self._read_data_from_s3_lambda(

--- a/python/tests/db/test_s3_event_contract.py
+++ b/python/tests/db/test_s3_event_contract.py
@@ -16,7 +16,7 @@ import pytest
 
 import mspasspy.db.database as database_module
 from mspasspy.ccore.seismic import TimeSeries
-from mspasspy.ccore.utility import ErrorSeverity
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
 
@@ -54,6 +54,7 @@ class FakeBody:
         self.error = error
         self.barrier = barrier
         self.delay = delay
+        self.closed = False
 
     def read(self):
         if self.barrier is not None:
@@ -63,6 +64,9 @@ class FakeBody:
         if self.error is not None:
             raise self.error
         return self.payload
+
+    def close(self):
+        self.closed = True
 
 
 class FakeS3Client:
@@ -80,19 +84,20 @@ class FakeS3Client:
         self.barrier = barrier
         self.delay = delay
         self.calls = []
+        self.bodies = []
 
     def get_object(self, **kwargs):
         self.calls.append(kwargs)
         if self.error is not None:
             raise self.error
-        return {
-            "Body": FakeBody(
-                self.payload,
-                error=self.read_error,
-                barrier=self.barrier,
-                delay=self.delay,
-            )
-        }
+        body = FakeBody(
+            self.payload,
+            error=self.read_error,
+            barrier=self.barrier,
+            delay=self.delay,
+        )
+        self.bodies.append(body)
+        return {"Body": body}
 
 
 def make_event_timeseries(live=True):
@@ -219,7 +224,7 @@ def test_event_reader_not_found_returns_one_invalid_dead_datum(
     ],
 )
 @pytest.mark.parametrize("initially_live", [True, False])
-def test_event_reader_rethrows_original_error_without_mutation_or_cache_damage(
+def test_event_reader_wraps_non_not_found_error_without_mutation_or_cache_damage(
     monkeypatch,
     tmp_path,
     error_location,
@@ -253,7 +258,7 @@ def test_event_reader_rethrows_original_error_without_mutation_or_cache_damage(
         lambda path: False if os.fspath(path) == str(cache_path) else real_exists(path),
     )
 
-    with pytest.raises(type(error)) as raised:
+    with pytest.raises(MsPASSError, match="Error while read data from s3") as raised:
         Database._read_data_from_s3_event(
             Database,
             datum,
@@ -264,11 +269,15 @@ def test_event_reader_rethrows_original_error_without_mutation_or_cache_damage(
             format="mseed",
         )
 
-    assert raised.value is error
+    assert raised.value.severity == ErrorSeverity.Fatal
+    assert raised.value.__cause__ is error
     assert datum.live is initially_live
     assert datum.elog.size() == 0
     assert cache_path.read_bytes() == original_cache
     assert temporary_cache_files(cache_path) == []
+    if error_location == "body":
+        assert len(client.bodies) == 1
+        assert client.bodies[0].closed
 
 
 @pytest.mark.parametrize(
@@ -291,7 +300,7 @@ def test_event_reader_rethrows_original_error_without_mutation_or_cache_damage(
         ),
     ],
 )
-def test_event_index_rethrows_original_error_and_preserves_existing_cache(
+def test_event_index_wraps_non_not_found_error_and_preserves_existing_cache(
     database, tmp_path, error_location, error_factory
 ):
     error = error_factory()
@@ -303,7 +312,9 @@ def test_event_index_rethrows_original_error_and_preserves_existing_cache(
     else:
         client = FakeS3Client(read_error=error)
 
-    with pytest.raises(type(error)) as raised:
+    with pytest.raises(
+        MsPASSError, match="Error while index mseed file from s3"
+    ) as raised:
         database.index_mseed_s3_event(
             client,
             2017,
@@ -314,10 +325,14 @@ def test_event_index_rethrows_original_error_and_preserves_existing_cache(
             collection="wf_miniseed",
         )
 
-    assert raised.value is error
+    assert raised.value.severity == ErrorSeverity.Fatal
+    assert raised.value.__cause__ is error
     assert cache_path.read_bytes() == original_cache
     assert temporary_cache_files(cache_path) == []
     assert database["wf_miniseed"].count_documents({}) == 0
+    if error_location == "body":
+        assert len(client.bodies) == 1
+        assert client.bodies[0].closed
 
 
 def test_cache_download_fsyncs_same_directory_temp_before_publish(
@@ -333,13 +348,14 @@ def test_cache_download_fsyncs_same_directory_temp_before_publish(
         return real_fsync(descriptor)
 
     monkeypatch.setattr(database_module.os, "fsync", recording_fsync)
+    client = FakeS3Client(payload=payload)
 
-    Database._cache_s3_object(
-        FakeS3Client(payload=payload), "bucket", "key", str(cache_path)
-    )
+    Database._cache_s3_object(client, "bucket", "key", str(cache_path))
 
     assert cache_path.read_bytes() == payload
     assert len(fsync_calls) == 1
+    assert len(client.bodies) == 1
+    assert client.bodies[0].closed
     assert temporary_cache_files(cache_path) == []
 
 

--- a/python/tests/db/test_s3_event_contract.py
+++ b/python/tests/db/test_s3_event_contract.py
@@ -1,0 +1,458 @@
+import io
+import multiprocessing
+import os
+from pathlib import Path
+import time
+import urllib.error
+import uuid
+
+import botocore.exceptions
+import numpy as np
+import obspy
+import pymongo
+import pytest
+
+import mspasspy.db.database as database_module
+from mspasspy.ccore.seismic import TimeSeries
+from mspasspy.ccore.utility import ErrorSeverity
+from mspasspy.db.client import DBClient
+from mspasspy.db.database import Database
+
+
+SOURCE_PYTHON_ROOT = Path(
+    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
+)
+EXPECTED_DATABASE_MODULE = SOURCE_PYTHON_ROOT / "mspasspy" / "db" / "database.py"
+
+
+class FakeBody:
+    def __init__(
+        self,
+        payload=b"",
+        error=None,
+        barrier=None,
+        delay=0.0,
+    ):
+        self.payload = payload
+        self.error = error
+        self.barrier = barrier
+        self.delay = delay
+
+    def read(self):
+        if self.barrier is not None:
+            self.barrier.wait()
+        if self.delay:
+            time.sleep(self.delay)
+        if self.error is not None:
+            raise self.error
+        return self.payload
+
+
+class FakeS3Client:
+    def __init__(
+        self,
+        payload=b"",
+        error=None,
+        read_error=None,
+        barrier=None,
+        delay=0.0,
+    ):
+        self.payload = payload
+        self.error = error
+        self.read_error = read_error
+        self.barrier = barrier
+        self.delay = delay
+        self.calls = []
+
+    def get_object(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return {
+            "Body": FakeBody(
+                self.payload,
+                error=self.read_error,
+                barrier=self.barrier,
+                delay=self.delay,
+            )
+        }
+
+
+def make_event_timeseries(live=True):
+    datum = TimeSeries()
+    datum["year"] = "2017"
+    datum["day_of_year"] = "005"
+    datum["filename"] = "37780584"
+    if live:
+        datum.set_live()
+    else:
+        datum.kill()
+    return datum
+
+
+def s3_client_error(code, status):
+    return botocore.exceptions.ClientError(
+        {
+            "Error": {"Code": code, "Message": code},
+            "ResponseMetadata": {"HTTPStatusCode": status},
+        },
+        "GetObject",
+    )
+
+
+def http_error(status):
+    return urllib.error.HTTPError(
+        "https://example.invalid/object",
+        status,
+        "test response",
+        None,
+        None,
+    )
+
+
+def temporary_cache_files(cache_path):
+    return list(cache_path.parent.glob(f".{cache_path.name}.*.tmp"))
+
+
+@pytest.fixture
+def database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    probe = pymongo.MongoClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        probe.admin.command("ping")
+    except pymongo.errors.PyMongoError as error:
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    finally:
+        probe.close()
+
+    client = DBClient(uri, serverSelectionTimeoutMS=2000)
+    name = "test_s3_event_contract_" + uuid.uuid4().hex
+    try:
+        database = Database(client, name)
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def assert_database_module_loaded_from_selected_worktree():
+    assert Path(database_module.__file__).resolve() == EXPECTED_DATABASE_MODULE.resolve()
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        pytest.param(lambda: s3_client_error("NoSuchKey", 400), id="aws-nosuchkey"),
+        pytest.param(lambda: http_error(404), id="http-404"),
+    ],
+)
+@pytest.mark.parametrize("initially_live", [True, False])
+def test_event_reader_not_found_returns_one_invalid_dead_datum(
+    monkeypatch, tmp_path, error_factory, initially_live
+):
+    datum = make_event_timeseries(live=initially_live)
+    datum.elog.log_error("existing", "keep this entry", ErrorSeverity.Complaint)
+    initial_elog_size = datum.elog.size()
+    error = error_factory()
+    client = FakeS3Client(error=error)
+    monkeypatch.setattr(database_module.boto3, "client", lambda *args, **kwargs: client)
+    cache_path = tmp_path / "event.ms"
+
+    result = Database._read_data_from_s3_event(
+        Database,
+        datum,
+        str(tmp_path),
+        cache_path.name,
+        0,
+        nbytes=1,
+        format="mseed",
+    )
+
+    assert result is datum
+    assert result.dead()
+    assert result.elog.size() == initial_elog_size + 1
+    assert result.elog[0].algorithm == "existing"
+    entry = result.elog[initial_elog_size]
+    assert entry.algorithm == "Database._read_data_from_s3_event"
+    assert entry.badness == ErrorSeverity.Invalid
+    assert "event_waveforms/2017/2017_005/37780584.ms" in entry.message
+    assert not cache_path.exists()
+    assert temporary_cache_files(cache_path) == []
+
+
+@pytest.mark.parametrize(
+    "error_location,error_factory",
+    [
+        pytest.param(
+            "get_object",
+            lambda: s3_client_error("AccessDenied", 403),
+            id="aws-non-404",
+        ),
+        pytest.param(
+            "body",
+            lambda: urllib.error.URLError("network interrupted"),
+            id="network",
+        ),
+        pytest.param(
+            "client",
+            lambda: TimeoutError("client setup timed out"),
+            id="client-network-error",
+        ),
+    ],
+)
+@pytest.mark.parametrize("initially_live", [True, False])
+def test_event_reader_rethrows_original_error_without_mutation_or_cache_damage(
+    monkeypatch,
+    tmp_path,
+    error_location,
+    error_factory,
+    initially_live,
+):
+    datum = make_event_timeseries(live=initially_live)
+    error = error_factory()
+    if error_location == "get_object":
+        client = FakeS3Client(error=error)
+    else:
+        client = FakeS3Client(read_error=error)
+    if error_location == "client":
+
+        def raise_client_error(*args, **kwargs):
+            raise error
+
+        monkeypatch.setattr(database_module.boto3, "client", raise_client_error)
+    else:
+        monkeypatch.setattr(
+            database_module.boto3, "client", lambda *args, **kwargs: client
+        )
+    cache_path = tmp_path / "event.ms"
+    original_cache = b"existing complete cache"
+    cache_path.write_bytes(original_cache)
+
+    real_exists = os.path.exists
+    monkeypatch.setattr(
+        database_module.os.path,
+        "exists",
+        lambda path: False if os.fspath(path) == str(cache_path) else real_exists(path),
+    )
+
+    with pytest.raises(type(error)) as raised:
+        Database._read_data_from_s3_event(
+            Database,
+            datum,
+            str(tmp_path),
+            cache_path.name,
+            0,
+            nbytes=1,
+            format="mseed",
+        )
+
+    assert raised.value is error
+    assert datum.live is initially_live
+    assert datum.elog.size() == 0
+    assert cache_path.read_bytes() == original_cache
+    assert temporary_cache_files(cache_path) == []
+
+
+@pytest.mark.parametrize(
+    "error_location,error_factory",
+    [
+        pytest.param(
+            "get_object",
+            lambda: s3_client_error("AccessDenied", 403),
+            id="aws-non-404",
+        ),
+        pytest.param(
+            "body",
+            lambda: urllib.error.URLError("network interrupted"),
+            id="network",
+        ),
+        pytest.param(
+            "body",
+            lambda: TimeoutError("network stream timed out"),
+            id="generic-network-error",
+        ),
+    ],
+)
+def test_event_index_rethrows_original_error_and_preserves_existing_cache(
+    database, tmp_path, error_location, error_factory
+):
+    error = error_factory()
+    cache_path = tmp_path / "event.ms"
+    original_cache = b"previous complete cache"
+    cache_path.write_bytes(original_cache)
+    if error_location == "get_object":
+        client = FakeS3Client(error=error)
+    else:
+        client = FakeS3Client(read_error=error)
+
+    with pytest.raises(type(error)) as raised:
+        database.index_mseed_s3_event(
+            client,
+            2017,
+            5,
+            37780584,
+            cache_path.name,
+            dir=tmp_path,
+            collection="wf_miniseed",
+        )
+
+    assert raised.value is error
+    assert cache_path.read_bytes() == original_cache
+    assert temporary_cache_files(cache_path) == []
+    assert database["wf_miniseed"].count_documents({}) == 0
+
+
+def test_cache_download_fsyncs_same_directory_temp_before_publish(
+    monkeypatch, tmp_path
+):
+    cache_path = tmp_path / "event.ms"
+    payload = b"complete cache payload"
+    fsync_calls = []
+    real_fsync = os.fsync
+
+    def recording_fsync(descriptor):
+        fsync_calls.append(descriptor)
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(database_module.os, "fsync", recording_fsync)
+
+    Database._cache_s3_object(
+        FakeS3Client(payload=payload), "bucket", "key", str(cache_path)
+    )
+
+    assert cache_path.read_bytes() == payload
+    assert len(fsync_calls) == 1
+    assert temporary_cache_files(cache_path) == []
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        pytest.param(lambda: s3_client_error("404", 404), id="aws-404"),
+        pytest.param(lambda: http_error(404), id="http-404"),
+    ],
+)
+def test_event_index_not_found_returns_without_cache_or_documents(
+    database, tmp_path, error_factory
+):
+    client = FakeS3Client(error=error_factory())
+    cache_path = tmp_path / "event.ms"
+
+    result = database.index_mseed_s3_event(
+        client,
+        2017,
+        5,
+        37780584,
+        cache_path.name,
+        dir=tmp_path,
+        collection="wf_miniseed",
+    )
+
+    assert result is None
+    assert not cache_path.exists()
+    assert temporary_cache_files(cache_path) == []
+    assert database["wf_miniseed"].count_documents({}) == 0
+
+
+def test_public_event_index_then_read_dispatches_and_recaches(
+    database, monkeypatch, tmp_path
+):
+    source_path = SOURCE_PYTHON_ROOT / "tests" / "data" / "37780584.ms"
+    payload = source_path.read_bytes()
+    client = FakeS3Client(payload=payload)
+    cache_path = tmp_path / "event.ms"
+
+    database.index_mseed_s3_event(
+        client,
+        2017,
+        5,
+        37780584,
+        cache_path.name,
+        dir=tmp_path,
+        collection="wf_miniseed",
+    )
+    documents = list(database["wf_miniseed"].find({}).sort("foff", 1))
+    assert len(documents) == 344
+    assert documents[0]["foff"] == 0
+    assert documents[-1]["foff"] + documents[-1]["nbytes"] == len(payload)
+    assert all(document["storage_mode"] == "s3_event" for document in documents)
+    cache_path.unlink()
+    monkeypatch.setattr(database_module.boto3, "client", lambda *args, **kwargs: client)
+
+    for document in (documents[0], documents[-1]):
+        result = database.read_data(document, collection="wf_miniseed")
+
+        assert result.live
+        assert result["is_abortion"] is False
+        expected = obspy.read(
+            io.BytesIO(
+                payload[
+                    document["foff"] : document["foff"] + document["nbytes"]
+                ]
+            ),
+            format="MSEED",
+        )
+        expected.merge()
+        np.testing.assert_allclose(
+            np.asarray(result.data), expected[0].data.astype("float64")
+        )
+    assert cache_path.read_bytes() == payload
+    assert temporary_cache_files(cache_path) == []
+    expected_call = {
+        "Bucket": "scedc-pds",
+        "Key": "event_waveforms/2017/2017_005/37780584.ms",
+    }
+    assert client.calls == [expected_call, expected_call]
+
+
+def cache_worker(cache_path, payload, barrier, delay):
+    client = FakeS3Client(payload=payload, barrier=barrier, delay=delay)
+    Database._cache_s3_object(client, "bucket", "key", cache_path)
+
+
+def test_multiprocess_cache_publication_is_atomic_and_cleans_all_temps(tmp_path):
+    assert hasattr(Database, "_cache_s3_object")
+    context = multiprocessing.get_context("spawn")
+    cache_path = tmp_path / "event.ms"
+    payloads = [bytes([value]) * (256 * 1024) for value in range(1, 5)]
+    barrier = context.Barrier(len(payloads))
+    processes = [
+        context.Process(
+            target=cache_worker,
+            args=(str(cache_path), payload, barrier, 0.0 if index == 0 else 0.2),
+        )
+        for index, payload in enumerate(payloads)
+    ]
+    for process in processes:
+        process.start()
+
+    observations = []
+    deadline = time.monotonic() + 30.0
+    try:
+        while any(process.is_alive() for process in processes):
+            if time.monotonic() > deadline:
+                pytest.fail("S3 cache contention workers did not finish")
+            try:
+                observed = cache_path.read_bytes()
+            except FileNotFoundError:
+                time.sleep(0.001)
+                continue
+            observations.append(observed)
+            assert observed in payloads
+            time.sleep(0.001)
+    finally:
+        for process in processes:
+            process.join(timeout=1.0)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=1.0)
+
+    for process in processes:
+        assert process.exitcode == 0
+
+    assert observations
+    final_payload = cache_path.read_bytes()
+    assert final_payload in payloads
+    assert all(observed == final_payload for observed in observations)
+    assert temporary_cache_files(cache_path) == []

--- a/python/tests/db/test_s3_event_contract.py
+++ b/python/tests/db/test_s3_event_contract.py
@@ -375,7 +375,7 @@ def test_event_index_not_found_returns_without_cache_or_documents(
 def test_public_event_index_then_read_dispatches_and_recaches(
     database, monkeypatch, tmp_path
 ):
-    source_path = SOURCE_PYTHON_ROOT / "tests" / "data" / "37780584.ms"
+    source_path = Path(__file__).resolve().parents[2] / "tests" / "data" / "37780584.ms"
     payload = source_path.read_bytes()
     client = FakeS3Client(payload=payload)
     cache_path = tmp_path / "event.ms"

--- a/python/tests/db/test_s3_event_contract.py
+++ b/python/tests/db/test_s3_event_contract.py
@@ -18,7 +18,6 @@ from mspasspy.ccore.utility import ErrorSeverity
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
 
-
 SOURCE_PYTHON_ROOT = Path(
     os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
 )
@@ -137,7 +136,9 @@ def database():
 
 @pytest.fixture(scope="session", autouse=True)
 def assert_database_module_loaded_from_selected_worktree():
-    assert Path(database_module.__file__).resolve() == EXPECTED_DATABASE_MODULE.resolve()
+    assert (
+        Path(database_module.__file__).resolve() == EXPECTED_DATABASE_MODULE.resolve()
+    )
 
 
 @pytest.mark.parametrize(
@@ -387,9 +388,7 @@ def test_public_event_index_then_read_dispatches_and_recaches(
         assert result["is_abortion"] is False
         expected = obspy.read(
             io.BytesIO(
-                payload[
-                    document["foff"] : document["foff"] + document["nbytes"]
-                ]
+                payload[document["foff"] : document["foff"] + document["nbytes"]]
             ),
             format="MSEED",
         )

--- a/python/tests/db/test_s3_event_contract.py
+++ b/python/tests/db/test_s3_event_contract.py
@@ -1,10 +1,12 @@
 import io
 import multiprocessing
 import os
-from pathlib import Path
+import subprocess
 import time
 import urllib.error
 import uuid
+from importlib.metadata import distribution, version
+from pathlib import Path
 
 import botocore.exceptions
 import numpy as np
@@ -18,10 +20,26 @@ from mspasspy.ccore.utility import ErrorSeverity
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
 
-SOURCE_PYTHON_ROOT = Path(
-    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
-)
-EXPECTED_DATABASE_MODULE = SOURCE_PYTHON_ROOT / "mspasspy" / "db" / "database.py"
+
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
 
 
 class FakeBody:
@@ -135,10 +153,8 @@ def database():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def assert_database_module_loaded_from_selected_worktree():
-    assert (
-        Path(database_module.__file__).resolve() == EXPECTED_DATABASE_MODULE.resolve()
-    )
+def assert_database_module_loaded_from_selected_build():
+    _assert_module_from_selected_build(database_module, Path("mspasspy/db/database.py"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #822.

## Summary
- add the missing public `s3_event` read dispatch
- publish downloaded event files atomically from same-directory temporary files
- preserve the existing cache on failed replacement and clean every temporary file
- treat S3/HTTP not-found as the established no-data case
- close every S3 `StreamingBody` after reading
- preserve the public Fatal `MsPASSError` boundary for all other S3, network, stream, and local indexing failures, with the original exception available through `__cause__`

## Renewed API/error review
The first version changed non-404 failures to raw boto/network exceptions even though the indexing API documented `MsPASSError` and the prior generic read path wrapped operational failures as Fatal. It also read `StreamingBody` objects without closing them. Commit `06608978` restores that stable error boundary and resource lifecycle while retaining the valid 404, dispatch, and atomic-cache fixes.

## Verification
- full contract with temporary MongoDB 8.0.29 and fake S3: 18/18 passed
- existing Moto S3 event index/read regression: 1/1 passed
- success and body-read-error cases assert that the stream is closed
- multiprocess atomic publication and loser-temp cleanup remain covered
- Black 26.5.1, Python 3.12/3.13 `py_compile`, and `git diff --check`: passed

## Status
Ready for review after maintainer confirmation of the non-404 error policy.