### PR TITLE
Support ensemble arrival database matching

### DIFF
--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -3068,6 +3068,14 @@ class ArrivalDBMatcher(DatabaseMatcher):
     :type query:  python dictionary or None.  None is equivalewnt to
       passing an empty dictionary.  A TypeError will be thrown if this
       argument is not None or a dict.
+
+    :param ensemble_starttime_key: Metadata key containing the inclusive
+      interval start for ensemble input.  Default is ``"starttime"``.
+    :type ensemble_starttime_key: string
+
+    :param ensemble_endtime_key: Metadata key containing the inclusive
+      interval end for ensemble input.  Default is ``"endtime"``.
+    :type ensemble_endtime_key: string
     """
 
     def __init__(
@@ -3080,6 +3088,8 @@ class ArrivalDBMatcher(DatabaseMatcher):
         require_unique_match=False,
         prepend_collection_name=True,
         query=None,
+        ensemble_starttime_key="starttime",
+        ensemble_endtime_key="endtime",
     ):
         super().__init__(
             db,
@@ -3099,6 +3109,8 @@ class ArrivalDBMatcher(DatabaseMatcher):
             raise TypeError(
                 "ArrivalDBMatcher constructor:  query arg must define a python dictionary"
             )
+        self.ensemble_starttime_key = ensemble_starttime_key
+        self.ensemble_endtime_key = ensemble_endtime_key
 
     def query_generator(self, mspass_object) -> dict:
         """
@@ -3109,8 +3121,8 @@ class ArrivalDBMatcher(DatabaseMatcher):
         class docstring.  That is, for atomic data the time span for
         the interval query is determined from the range of the waveform
         data received through mspass_object.   For ensembles the
-        algorithm fetches fields defined by self.startime_key and
-        self.endtime_key to define the time interval.
+        algorithm fetches fields defined by self.ensemble_starttime_key and
+        self.ensemble_endtime_key to define the time interval.
 
         The interval test is overlaid on the self.query input.  i.e.
         the query dict components derived are added to the self.query.
@@ -3132,8 +3144,27 @@ class ArrivalDBMatcher(DatabaseMatcher):
                 query["sta"] = sta
                 # intentionally ignore loc as option
                 return query
-        else:
-            return None
+        elif isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
+            if mspass_object.dead() or len(mspass_object.member) == 0:
+                return None
+            if not mspass_object.is_defined(
+                self.ensemble_starttime_key
+            ) or not mspass_object.is_defined(self.ensemble_endtime_key):
+                return None
+            sta = _get_with_readonly_recovery(mspass_object, "sta")
+            if sta is None:
+                return None
+            query = copy.deepcopy(self.query)
+            query["time"] = {
+                "$gte": mspass_object[self.ensemble_starttime_key],
+                "$lte": mspass_object[self.ensemble_endtime_key],
+            }
+            query["sta"] = sta
+            net = _get_with_readonly_recovery(mspass_object, "net")
+            if net is not None:
+                query["net"] = net
+            return query
+        return None
 
 
 class ArrivalMatcher(DataFrameCacheMatcher):

--- a/python/tests/db/test_arrival_db_ensemble_contract.py
+++ b/python/tests/db/test_arrival_db_ensemble_contract.py
@@ -1,0 +1,244 @@
+import copy
+
+import pytest
+
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+import mspasspy.db.normalize as normalize_module
+from mspasspy.db.normalize import ArrivalDBMatcher
+
+
+class FakeCursor(list):
+    def close(self):
+        self.closed = True
+
+
+class FakeCollection:
+    def __init__(self, documents):
+        self.documents = copy.deepcopy(documents)
+        self.count_queries = []
+        self.find_queries = []
+
+    @staticmethod
+    def _matches(document, query):
+        for key, expected in query.items():
+            if isinstance(expected, dict):
+                value = document.get(key)
+                if value is None:
+                    return False
+                if "$gte" in expected and value < expected["$gte"]:
+                    return False
+                if "$lte" in expected and value > expected["$lte"]:
+                    return False
+            elif document.get(key) != expected:
+                return False
+        return True
+
+    def _matching_documents(self, query):
+        return [doc for doc in self.documents if self._matches(doc, query)]
+
+    def count_documents(self, query):
+        self.count_queries.append(copy.deepcopy(query))
+        return len(self._matching_documents(query))
+
+    def find(self, query):
+        self.find_queries.append(copy.deepcopy(query))
+        return FakeCursor(copy.deepcopy(self._matching_documents(query)))
+
+
+@pytest.fixture(autouse=True)
+def patch_database_matcher_constructor(monkeypatch):
+    def initialize(
+        instance,
+        db,
+        collection,
+        attributes_to_load=None,
+        load_if_defined=None,
+        aliases=None,
+        require_unique_match=False,
+        prepend_collection_name=False,
+    ):
+        instance.dbhandle = db
+        instance.collection = collection
+        instance.attributes_to_load = list(attributes_to_load or [])
+        instance.load_if_defined = list(load_if_defined or [])
+        instance.aliases = dict(aliases or {})
+        instance.require_unique_match = require_unique_match
+        instance.prepend_collection_name = prepend_collection_name
+
+    monkeypatch.setattr(normalize_module.DatabaseMatcher, "__init__", initialize)
+
+
+def _ensemble(ensemble_class, *, start_key="starttime", end_key="endtime"):
+    ensemble = ensemble_class()
+    member = TimeSeries(1) if ensemble_class is TimeSeriesEnsemble else Seismogram(1)
+    member.set_live()
+    ensemble.member.append(member)
+    ensemble[start_key] = 100.0
+    ensemble[end_key] = 110.0
+    ensemble["sta"] = "AAA"
+    ensemble["net"] = "XX"
+    ensemble.set_live()
+    return ensemble
+
+
+def _atomic(ensemble_class):
+    datum = TimeSeries(11) if ensemble_class is TimeSeriesEnsemble else Seismogram(11)
+    datum.t0 = 100.0
+    datum.dt = 1.0
+    datum["sta"] = "AAA"
+    datum["net"] = "XX"
+    datum.set_live()
+    return datum
+
+
+def _ensemble_state(ensemble):
+    return {
+        "metadata": dict(ensemble),
+        "dead": ensemble.dead(),
+        "member_metadata": [dict(member) for member in ensemble.member],
+        "member_dead": [member.dead() for member in ensemble.member],
+        "member_sample_state": [
+            (member.npts, member.t0, member.dt) for member in ensemble.member
+        ],
+    }
+
+
+@pytest.mark.parametrize("ensemble_class", [TimeSeriesEnsemble, SeismogramEnsemble])
+def test_default_and_custom_interval_queries_are_exact_and_inclusive(ensemble_class):
+    collection = FakeCollection([])
+    default_matcher = ArrivalDBMatcher(collection, query={"phase": "P"})
+    default_ensemble = _ensemble(ensemble_class)
+    original_predicate = copy.deepcopy(default_matcher.query)
+    default_state = _ensemble_state(default_ensemble)
+
+    assert default_matcher.query_generator(default_ensemble) == {
+        "phase": "P",
+        "time": {"$gte": 100.0, "$lte": 110.0},
+        "sta": "AAA",
+        "net": "XX",
+    }
+    assert default_matcher.query == original_predicate
+    assert _ensemble_state(default_ensemble) == default_state
+
+    custom_matcher = ArrivalDBMatcher(
+        collection,
+        ensemble_starttime_key="window_open",
+        ensemble_endtime_key="window_close",
+    )
+    custom_ensemble = _ensemble(
+        ensemble_class, start_key="window_open", end_key="window_close"
+    )
+    custom_ensemble.erase("net")
+    custom_state = _ensemble_state(custom_ensemble)
+    assert custom_matcher.query_generator(custom_ensemble) == {
+        "time": {"$gte": 100.0, "$lte": 110.0},
+        "sta": "AAA",
+    }
+    assert _ensemble_state(custom_ensemble) == custom_state
+
+
+@pytest.mark.parametrize("ensemble_class", [TimeSeriesEnsemble, SeismogramEnsemble])
+@pytest.mark.parametrize("require_unique_match", [False, True])
+@pytest.mark.parametrize("match_count", [0, 1, 2])
+def test_find_one_uses_the_atomic_database_matcher_contract(
+    ensemble_class, require_unique_match, match_count
+):
+    documents = [
+        {"phase": "P", "time": 100.0, "sta": "AAA", "net": "XX"},
+        {"phase": "S", "time": 110.0, "sta": "AAA", "net": "XX"},
+    ][:match_count]
+    collection = FakeCollection(documents)
+    matcher = ArrivalDBMatcher(
+        collection,
+        require_unique_match=require_unique_match,
+        prepend_collection_name=True,
+    )
+    ensemble = _ensemble(ensemble_class)
+    ensemble_state = _ensemble_state(ensemble)
+    matcher_query = copy.deepcopy(matcher.query)
+
+    if match_count == 2 and require_unique_match:
+        with pytest.raises(MsPASSError) as exc:
+            matcher.find_one(ensemble)
+        assert exc.value.severity == ErrorSeverity.Fatal
+    else:
+        result, elog = matcher.find_one(ensemble)
+        if match_count == 0:
+            assert result is None
+            assert elog is not None
+        else:
+            assert dict(result) == {
+                "arrival_phase": documents[0]["phase"],
+                "arrival_time": documents[0]["time"],
+            }
+            assert (elog is not None) == (match_count == 2)
+
+    expected_query = {
+        "time": {"$gte": 100.0, "$lte": 110.0},
+        "sta": "AAA",
+        "net": "XX",
+    }
+    assert collection.count_queries == [expected_query]
+    assert collection.find_queries == ([] if match_count == 0 else [expected_query])
+    assert _ensemble_state(ensemble) == ensemble_state
+    assert matcher.query == matcher_query
+
+
+@pytest.mark.parametrize("ensemble_class", [TimeSeriesEnsemble, SeismogramEnsemble])
+def test_ensemble_and_atomic_paths_return_identical_output_mapping(ensemble_class):
+    documents = [{"phase": "P", "time": 105.0, "sta": "AAA", "net": "XX"}]
+    collection = FakeCollection(documents)
+    matcher = ArrivalDBMatcher(collection, prepend_collection_name=True)
+    ensemble = _ensemble(ensemble_class)
+    atomic = _atomic(ensemble_class)
+    ensemble_state = _ensemble_state(ensemble)
+    atomic_state = dict(atomic)
+
+    ensemble_result, ensemble_elog = matcher.find_one(ensemble)
+    atomic_result, atomic_elog = matcher.find_one(atomic)
+
+    assert dict(ensemble_result) == dict(atomic_result)
+    assert dict(ensemble_result) == {"arrival_phase": "P", "arrival_time": 105.0}
+    assert ensemble_elog is None
+    assert atomic_elog is None
+    assert _ensemble_state(ensemble) == ensemble_state
+    assert dict(atomic) == atomic_state
+
+
+@pytest.mark.parametrize("ensemble_class", [TimeSeriesEnsemble, SeismogramEnsemble])
+@pytest.mark.parametrize(
+    "invalid_state", ["dead", "empty", "missing_start", "missing_end", "missing_sta"]
+)
+def test_invalid_ensembles_return_before_any_database_query(
+    ensemble_class, invalid_state
+):
+    collection = FakeCollection(
+        [{"phase": "P", "time": 105.0, "sta": "AAA", "net": "XX"}]
+    )
+    matcher = ArrivalDBMatcher(collection)
+    ensemble = _ensemble(ensemble_class)
+    if invalid_state == "dead":
+        ensemble.kill()
+    elif invalid_state == "empty":
+        ensemble.member.clear()
+    elif invalid_state == "missing_start":
+        ensemble.erase("starttime")
+    elif invalid_state == "missing_end":
+        ensemble.erase("endtime")
+    else:
+        ensemble.erase("sta")
+    ensemble_state = _ensemble_state(ensemble)
+
+    result, _ = matcher.find(ensemble)
+
+    assert result is None
+    assert matcher.query_generator(ensemble) is None
+    assert collection.count_queries == []
+    assert collection.find_queries == []
+    assert _ensemble_state(ensemble) == ensemble_state


### PR DESCRIPTION
Fixes #827

This PR extends the public arrival database matcher to live, nonempty TimeSeries and Seismogram ensembles using configurable inclusive interval keys, required station metadata, and optional network metadata while preserving atomic matcher semantics.

Validation includes an independent agent review, 30 contract and neighboring regressions, exact baseline-red coverage, full state immutability on no-match/error paths, Black, pycompile, Ruff, and diff checks.

This PR is ready for human review. It must not be merged automatically.