### PR TITLE
Repair legacy ID matcher contracts

### DIFF
--- a/python/mspasspy/db/matcher.py
+++ b/python/mspasspy/db/matcher.py
@@ -66,7 +66,7 @@ class NMF(ABC):
         channel collection using id_matcher you can use
         d = id_matcher(d)  instead of d = id_matcher.normalize(d)
         """
-        self.normalize(d)
+        return self.normalize(d)
 
     @abstractmethod
     def get_document(self, d):
@@ -165,15 +165,18 @@ class ID_matcher(NMF):
             # Note this will return None if the query fails - callers should handle that condition
             return self.dbhandle.find_one(query)
         else:
-            # this is actually redundant with log_error usage but better to be clear
-            if self.kill_on_failure:
-                d.kill()
             message = (
                 "Normalizing ID with key="
                 + self.mdkey
                 + " is not defined in this object"
             )
-            self.log_error(d, "ID_matcher", message, True, ErrorSeverity.Invalid)
+            self.log_error(
+                d,
+                "ID_matcher",
+                message,
+                self.kill_on_failure,
+                ErrorSeverity.Invalid,
+            )
             return None
 
     def normalize(self, d):
@@ -189,19 +192,22 @@ class ID_matcher(NMF):
                 return d
             doc = self.get_document(d)
             if doc == None:
-                message = (
-                    "No matching _id found for "
-                    + self.mdkey
-                    + " in collection="
-                    + self.collection
-                )
-                self.log_error(
-                    d,
-                    "ID_matcher",
-                    message,
-                    self.kill_on_failure,
-                    ErrorSeverity.Invalid,
-                )
+                # get_document logs a missing ID field.  Log here only when
+                # an ID was present but did not match a document.
+                if d.is_defined(self.mdkey):
+                    message = (
+                        "No matching _id found for "
+                        + self.mdkey
+                        + " in collection="
+                        + self.collection
+                    )
+                    self.log_error(
+                        d,
+                        "ID_matcher",
+                        message,
+                        self.kill_on_failure,
+                        ErrorSeverity.Invalid,
+                    )
             else:
                 for key in self.attributes_to_load:
                     if key in doc:

--- a/python/tests/db/test_legacy_id_matcher_contract.py
+++ b/python/tests/db/test_legacy_id_matcher_contract.py
@@ -1,0 +1,141 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mspasspy.ccore.seismic import TimeSeries
+from mspasspy.ccore.utility import ErrorSeverity
+from mspasspy.db import matcher as matcher_module
+from mspasspy.db.matcher import ID_matcher, NMF
+
+
+SOURCE_PYTHON_ROOT = Path(
+    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
+)
+
+
+class ReturnProbe(NMF):
+    def __init__(self, result):
+        super().__init__()
+        self.result = result
+        self.normalize_calls = []
+
+    def get_document(self, datum):
+        return None
+
+    def normalize(self, datum):
+        self.normalize_calls.append(datum)
+        return self.result
+
+
+class FakeCollection:
+    def __init__(self, documents):
+        self.documents = documents
+        self.queries = []
+
+    def find_one(self, query):
+        self.queries.append(query)
+        return self.documents.get(query["_id"])
+
+
+class FakeDatabase:
+    def __init__(self, collection):
+        self.collection = collection
+
+    def __getitem__(self, name):
+        assert name == "source"
+        return self.collection
+
+
+def _live_datum(source_id=None):
+    datum = TimeSeries(1)
+    datum.set_live()
+    if source_id is not None:
+        datum["source_id"] = source_id
+    return datum
+
+
+def test_contract_suite_loads_matcher_from_selected_worktree():
+    expected = SOURCE_PYTHON_ROOT / "mspasspy/db/matcher.py"
+    assert Path(matcher_module.__file__).resolve() == expected.resolve()
+
+
+def test_nmf_callable_returns_the_distinct_normalize_result_once():
+    datum = object()
+    normalized = object()
+    matcher = ReturnProbe(normalized)
+
+    result = matcher(datum)
+
+    assert result is normalized
+    assert matcher.normalize_calls == [datum]
+
+
+def test_callable_returns_the_normalize_result_and_invokes_it_once():
+    collection = FakeCollection({1: {"_id": 1, "lat": 42.0}})
+    matcher = ID_matcher(FakeDatabase(collection), "source", ["lat"])
+    datum = _live_datum(1)
+
+    with patch.object(matcher, "normalize", wraps=matcher.normalize) as normalize_spy:
+        result = matcher(datum)
+
+    assert result is datum
+    normalize_spy.assert_called_once_with(datum)
+    assert datum["lat"] == 42.0
+    assert datum.elog.size() == 0
+    assert collection.queries == [{"_id": 1}]
+
+
+@pytest.mark.parametrize("kill_on_failure", [False, True])
+@pytest.mark.parametrize("failure", ["missing", "unmatched"])
+def test_callable_failures_log_once_and_honor_kill_policy(kill_on_failure, failure):
+    collection = FakeCollection({})
+    matcher = ID_matcher(
+        FakeDatabase(collection),
+        "source",
+        ["lat"],
+        kill_on_failure=kill_on_failure,
+    )
+    datum = _live_datum(None if failure == "missing" else 99)
+
+    with patch.object(matcher, "normalize", wraps=matcher.normalize) as normalize_spy:
+        result = matcher(datum)
+
+    assert result is datum
+    normalize_spy.assert_called_once_with(datum)
+    errors = datum.elog.get_error_log()
+    assert len(errors) == 1
+    assert errors[0].algorithm == "ID_matcher"
+    assert errors[0].badness == ErrorSeverity.Invalid
+    if failure == "missing":
+        assert "is not defined" in errors[0].message
+        assert collection.queries == []
+    else:
+        assert "No matching _id" in errors[0].message
+        assert collection.queries == [{"_id": 99}]
+    assert datum.dead() is kill_on_failure
+
+
+@pytest.mark.parametrize("kill_on_failure", [False, True])
+@pytest.mark.parametrize("failure", ["missing", "unmatched"])
+def test_normalize_failures_have_one_invalid_log_and_exact_life_state(
+    kill_on_failure, failure
+):
+    collection = FakeCollection({})
+    matcher = ID_matcher(
+        FakeDatabase(collection),
+        "source",
+        ["lat"],
+        kill_on_failure=kill_on_failure,
+    )
+    datum = _live_datum(None if failure == "missing" else 99)
+
+    result = matcher.normalize(datum)
+
+    assert result is datum
+    errors = datum.elog.get_error_log()
+    assert len(errors) == 1
+    assert errors[0].badness == ErrorSeverity.Invalid
+    assert datum.dead() is kill_on_failure
+    assert collection.queries == ([] if failure == "missing" else [{"_id": 99}])

--- a/python/tests/db/test_legacy_id_matcher_contract.py
+++ b/python/tests/db/test_legacy_id_matcher_contract.py
@@ -9,7 +9,6 @@ from mspasspy.ccore.utility import ErrorSeverity
 from mspasspy.db import matcher as matcher_module
 from mspasspy.db.matcher import ID_matcher, NMF
 
-
 SOURCE_PYTHON_ROOT = Path(
     os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
 )

--- a/python/tests/db/test_legacy_id_matcher_contract.py
+++ b/python/tests/db/test_legacy_id_matcher_contract.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+from importlib.metadata import distribution, version
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,9 +11,26 @@ from mspasspy.ccore.utility import ErrorSeverity
 from mspasspy.db import matcher as matcher_module
 from mspasspy.db.matcher import ID_matcher, NMF
 
-SOURCE_PYTHON_ROOT = Path(
-    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
-)
+
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
 
 
 class ReturnProbe(NMF):
@@ -55,9 +74,8 @@ def _live_datum(source_id=None):
     return datum
 
 
-def test_contract_suite_loads_matcher_from_selected_worktree():
-    expected = SOURCE_PYTHON_ROOT / "mspasspy/db/matcher.py"
-    assert Path(matcher_module.__file__).resolve() == expected.resolve()
+def test_contract_suite_loads_matcher_from_selected_build():
+    _assert_module_from_selected_build(matcher_module, Path("mspasspy/db/matcher.py"))
 
 
 def test_nmf_callable_returns_the_distinct_normalize_result_once():


### PR DESCRIPTION
Fixes #828

This PR makes the legacy callable matcher return its normalize result exactly once and makes missing/unmatched IDs produce one Invalid entry while honoring `kill_on_failure` without duplicate logs.

Validation includes an independent agent review, 11 contract tests, 29 neighboring normalization regressions, exact baseline-red coverage, query/identity/life-state assertions, Black, Python 3.12/3.13 py_compile, and diff checks.

This PR is ready for human review. It must not be merged automatically.