### PR TITLE
Repair the public CSS arrival interval matcher

### DIFF
--- a/python/mspasspy/db/matcher.py
+++ b/python/mspasspy/db/matcher.py
@@ -720,6 +720,7 @@ class css30_arrival_interval_matcher(NMF):
         :return: matching MongoDB document, or ``None`` when no match is found.
         :rtype: dict or None
         """
+
         stime = d.t0
         etime = d.endtime()
         query = {self.phasename_key: self.phasename}
@@ -731,39 +732,42 @@ class css30_arrival_interval_matcher(NMF):
             return self.dbhandle.find_one(query)
         else:
             cursor = self.dbhandle.find(query)
-            matchlist = []
-            # the key here perhaps should be set in constructor
-            # for now it is frozen as this constant
-            for doc in cursor:
-                # ignore any docs with the time attribute not set
-                if "time" in doc:
-                    dt = doc["time"] - (d.t0 + self.startime_offset)
-                    matchlist.append([abs(dt), doc])
-            # handle these special cases
-            n_to_test = len(matchlist)
-            if n_to_test == 0:
-                raise MsPASSError(
-                    "css30_arrival_interval_matcher.get_document:  no arrival docs found with phasename set as"
-                    + self.phasename
-                    + " with a time attribute defined.  This should not happen and indicates a serious database inconsistence.  Aborting",
-                    ErrorSeverity.Fatal,
-                )
-            elif n_to_test == 1:
-                # weird syntax but this returns to doc of the one and only
-                # tuple getting through the above loop.  Execution of this
-                # block should be very very rare
-                return matchlist[0][1]
-            else:
-                dtmin = matchlist[0][0]
-                imin = 0
-                for i in range(len(matchlist) - 1):
-                    ii = i + 1
-                    dt = matchlist[ii][0]
-                    # not dt values are stored as abs differences
-                    if dt < dtmin:
-                        imin = ii
-                        dtmin = dt
-                return matchlist[imin][1]
+            try:
+                matchlist = []
+                # the key here perhaps should be set in constructor
+                # for now it is frozen as this constant
+                for doc in cursor:
+                    # ignore any docs with the time attribute not set
+                    if "time" in doc:
+                        dt = doc["time"] - (d.t0 + self.startime_offset)
+                        matchlist.append([abs(dt), doc])
+                # handle these special cases
+                n_to_test = len(matchlist)
+                if n_to_test == 0:
+                    raise MsPASSError(
+                        "css30_arrival_interval_matcher.get_document:  no arrival docs found with phasename set as"
+                        + self.phasename
+                        + " with a time attribute defined.  This should not happen and indicates a serious database inconsistence.  Aborting",
+                        ErrorSeverity.Fatal,
+                    )
+                elif n_to_test == 1:
+                    # weird syntax but this returns to doc of the one and only
+                    # tuple getting through the above loop.  Execution of this
+                    # block should be very very rare
+                    return matchlist[0][1]
+                else:
+                    dtmin = matchlist[0][0]
+                    imin = 0
+                    for i in range(len(matchlist) - 1):
+                        ii = i + 1
+                        dt = matchlist[ii][0]
+                        # not dt values are stored as abs differences
+                        if dt < dtmin:
+                            imin = ii
+                            dtmin = dt
+                    return matchlist[imin][1]
+            finally:
+                cursor.close()
 
     def normalize(self, d):
         """

--- a/python/mspasspy/db/matcher.py
+++ b/python/mspasspy/db/matcher.py
@@ -699,6 +699,7 @@ class css30_arrival_interval_matcher(NMF):
     ):
         """ """
         super().__init__(kill_on_failure, verbose)
+        self.startime_offset = startime_offset
         self.phasename = phasename
         self.phasename_key = phasename_key
         for x in attributes_to_load:
@@ -707,7 +708,9 @@ class css30_arrival_interval_matcher(NMF):
         for x in load_if_defined:
             self.load_if_defined.append(x)
         self.prepend_collection_name = prepend_collection_name
-        self.dbhandle = db[arrival_collection_name]
+        self.arrival_collection_name = arrival_collection_name
+        self.collection = arrival_collection_name
+        self.dbhandle = db[self.arrival_collection_name]
 
     def get_document(self, d):
         """
@@ -720,7 +723,7 @@ class css30_arrival_interval_matcher(NMF):
         stime = d.t0
         etime = d.endtime()
         query = {self.phasename_key: self.phasename}
-        query["time"] = {"$ge": stime, "$le": etime}
+        query["time"] = {"$gte": stime, "$lte": etime}
         n = self.dbhandle.count_documents(query)
         if n == 0:
             return None
@@ -734,7 +737,7 @@ class css30_arrival_interval_matcher(NMF):
             for doc in cursor:
                 # ignore any docs with the time attribute not set
                 if "time" in doc:
-                    dt = doc["time"] - self.time_offset
+                    dt = doc["time"] - (d.t0 + self.startime_offset)
                     matchlist.append([abs(dt), doc])
             # handle these special cases
             n_to_test = len(matchlist)
@@ -800,7 +803,7 @@ class css30_arrival_interval_matcher(NMF):
                         # but it could create bloated elog collections
                         message = (
                             "No data for key="
-                            + self.mdkey
+                            + key
                             + " in document returned from collection="
                             + self.collection
                         )
@@ -822,8 +825,10 @@ class css30_arrival_interval_matcher(NMF):
                         d[mdkey] = doc[key]
                     elif self.verbose:
                         self.log_error(
+                            d,
                             "css30_arrival_interval_matcher",
                             "No data found with optional load key=" + key,
+                            False,
                             ErrorSeverity.Informational,
                         )
 

--- a/python/tests/db/test_css_arrival_matcher_contract.py
+++ b/python/tests/db/test_css_arrival_matcher_contract.py
@@ -15,12 +15,29 @@ from mspasspy.db import matcher as matcher_module
 from mspasspy.db.matcher import css30_arrival_interval_matcher
 
 
+class RecordingCursor:
+    def __init__(self, documents, error=None):
+        self.documents = documents
+        self.error = error
+        self.closed = False
+
+    def __iter__(self):
+        if self.error is not None:
+            raise self.error
+        return iter(self.documents)
+
+    def close(self):
+        self.closed = True
+
+
 class RecordingCollection:
-    def __init__(self, documents=()):
+    def __init__(self, documents=(), cursor_error=None):
         self.documents = copy.deepcopy(list(documents))
+        self.cursor_error = cursor_error
         self.count_queries = []
         self.find_one_queries = []
         self.find_queries = []
+        self.cursors = []
 
     @staticmethod
     def _matches(document, query):
@@ -46,11 +63,16 @@ class RecordingCollection:
 
     def find(self, query):
         self.find_queries.append(copy.deepcopy(query))
-        return [
-            copy.deepcopy(document)
-            for document in self.documents
-            if self._matches(document, query)
-        ]
+        cursor = RecordingCursor(
+            [
+                copy.deepcopy(document)
+                for document in self.documents
+                if self._matches(document, query)
+            ],
+            self.cursor_error,
+        )
+        self.cursors.append(cursor)
+        return cursor
 
 
 class RecordingDatabase:
@@ -141,6 +163,30 @@ def test_multiple_matches_select_nearest_to_start_plus_offset():
     assert len(database.collection.count_queries) == 1
     assert database.collection.find_one_queries == []
     assert len(database.collection.find_queries) == 1
+    assert len(database.collection.cursors) == 1
+    assert database.collection.cursors[0].closed
+
+
+def test_multiple_match_cursor_is_closed_when_iteration_raises():
+    expected_error = RuntimeError("cursor iteration failed")
+    documents = [
+        {"phase": "P", "time": 101.0},
+        {"phase": "P", "time": 104.0},
+    ]
+    database = RecordingDatabase(documents)
+    database.collection.cursor_error = expected_error
+    matcher = css30_arrival_interval_matcher(
+        database,
+        attributes_to_load=[],
+        load_if_defined=[],
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        matcher.get_document(make_datum())
+
+    assert error.value is expected_error
+    assert len(database.collection.cursors) == 1
+    assert database.collection.cursors[0].closed
 
 
 @pytest.mark.parametrize("kill_on_failure", [False, True])

--- a/python/tests/db/test_css_arrival_matcher_contract.py
+++ b/python/tests/db/test_css_arrival_matcher_contract.py
@@ -1,0 +1,257 @@
+import copy
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from pymongo import MongoClient
+from pymongo.errors import ServerSelectionTimeoutError
+
+from mspasspy.ccore.seismic import TimeSeries
+from mspasspy.ccore.utility import ErrorSeverity
+from mspasspy.db import matcher as matcher_module
+from mspasspy.db.matcher import css30_arrival_interval_matcher
+
+
+class RecordingCollection:
+    def __init__(self, documents=()):
+        self.documents = copy.deepcopy(list(documents))
+        self.count_queries = []
+        self.find_one_queries = []
+        self.find_queries = []
+
+    @staticmethod
+    def _matches(document, query):
+        for key, expected in query.items():
+            if isinstance(expected, dict):
+                value = document.get(key)
+                if not expected["$gte"] <= value <= expected["$lte"]:
+                    return False
+            elif document.get(key) != expected:
+                return False
+        return True
+
+    def count_documents(self, query):
+        self.count_queries.append(copy.deepcopy(query))
+        return sum(self._matches(document, query) for document in self.documents)
+
+    def find_one(self, query):
+        self.find_one_queries.append(copy.deepcopy(query))
+        for document in self.documents:
+            if self._matches(document, query):
+                return copy.deepcopy(document)
+        return None
+
+    def find(self, query):
+        self.find_queries.append(copy.deepcopy(query))
+        return [
+            copy.deepcopy(document)
+            for document in self.documents
+            if self._matches(document, query)
+        ]
+
+
+class RecordingDatabase:
+    def __init__(self, documents=(), collection="arrival"):
+        self.collection_name = collection
+        self.collection = RecordingCollection(documents)
+
+    def __getitem__(self, collection):
+        assert collection == self.collection_name
+        return self.collection
+
+
+def make_datum(starttime=100.0, npts=11, dt=1.0):
+    datum = TimeSeries(npts)
+    datum.t0 = starttime
+    datum.dt = dt
+    datum.set_live()
+    return datum
+
+
+def errors(datum):
+    return list(datum.elog.get_error_log())
+
+
+def test_contract_suite_loads_matcher_from_selected_source():
+    source_root = Path(
+        os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).parents[2])
+    )
+    expected = source_root / "mspasspy/db/matcher.py"
+    assert Path(matcher_module.__file__).resolve() == expected.resolve()
+
+
+def test_query_is_closed_waveform_interval_and_constructor_fields_exist():
+    document = {"phase": "P", "time": 100.0}
+    database = RecordingDatabase([document], collection="custom_arrival")
+    matcher = css30_arrival_interval_matcher(
+        database,
+        startime_offset=3.0,
+        attributes_to_load=[],
+        load_if_defined=[],
+        arrival_collection_name="custom_arrival",
+    )
+    datum = make_datum()
+
+    assert matcher.get_document(datum) == document
+
+    assert matcher.startime_offset == 3.0
+    assert matcher.arrival_collection_name == "custom_arrival"
+    assert matcher.collection == "custom_arrival"
+    expected = {"phase": "P", "time": {"$gte": 100.0, "$lte": 110.0}}
+    assert database.collection.count_queries == [expected]
+    assert database.collection.find_one_queries == [expected]
+
+
+def test_multiple_matches_select_nearest_to_start_plus_offset():
+    documents = [
+        {"phase": "P", "time": 101.0, "tag": "early"},
+        {"phase": "P", "time": 104.0, "tag": "target"},
+        {"phase": "P", "time": 109.0, "tag": "late"},
+    ]
+    database = RecordingDatabase(documents)
+    matcher = css30_arrival_interval_matcher(
+        database,
+        startime_offset=4.0,
+        attributes_to_load=[],
+        load_if_defined=[],
+    )
+
+    assert matcher.get_document(make_datum())["tag"] == "target"
+
+    assert len(database.collection.count_queries) == 1
+    assert database.collection.find_one_queries == []
+    assert len(database.collection.find_queries) == 1
+
+
+@pytest.mark.parametrize("kill_on_failure", [False, True])
+def test_zero_match_logs_one_invalid_and_honors_kill(kill_on_failure):
+    database = RecordingDatabase()
+    matcher = css30_arrival_interval_matcher(
+        database,
+        attributes_to_load=[],
+        load_if_defined=[],
+        kill_on_failure=kill_on_failure,
+    )
+    datum = make_datum()
+
+    assert matcher.normalize(datum) is datum
+
+    log = errors(datum)
+    assert len(log) == 1
+    assert log[0].badness == ErrorSeverity.Invalid
+    assert "arrival collection" in log[0].message
+    assert datum.dead() is kill_on_failure
+
+
+@pytest.mark.parametrize("kill_on_failure", [False, True])
+@pytest.mark.parametrize("prepend", [False, True])
+def test_required_fields_copy_or_log_exact_invalid(kill_on_failure, prepend):
+    document = {"phase": "P", "time": 102.0, "required": 7}
+    collection_name = "custom_arrival"
+    database = RecordingDatabase([document], collection=collection_name)
+    matcher = css30_arrival_interval_matcher(
+        database,
+        attributes_to_load=["required", "missing_required"],
+        load_if_defined=[],
+        kill_on_failure=kill_on_failure,
+        prepend_collection_name=prepend,
+        arrival_collection_name=collection_name,
+    )
+    datum = make_datum()
+
+    assert matcher.normalize(datum) is datum
+
+    output_key = "custom_arrival_required" if prepend else "required"
+    missing_output_key = (
+        "custom_arrival_missing_required" if prepend else "missing_required"
+    )
+    assert datum[output_key] == 7
+    assert not datum.is_defined(missing_output_key)
+    log = errors(datum)
+    assert len(log) == 1
+    assert log[0].badness == ErrorSeverity.Invalid
+    assert "key=missing_required" in log[0].message
+    assert "collection=custom_arrival" in log[0].message
+    assert datum.dead() is kill_on_failure
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+@pytest.mark.parametrize("prepend", [False, True])
+def test_optional_fields_copy_and_missing_are_informational_only(verbose, prepend):
+    document = {"phase": "P", "time": 102.0, "present_optional": 9}
+    collection_name = "custom_arrival"
+    database = RecordingDatabase([document], collection=collection_name)
+    matcher = css30_arrival_interval_matcher(
+        database,
+        attributes_to_load=[],
+        load_if_defined=["present_optional", "missing_optional"],
+        kill_on_failure=True,
+        prepend_collection_name=prepend,
+        verbose=verbose,
+        arrival_collection_name=collection_name,
+    )
+    datum = make_datum()
+
+    assert matcher.normalize(datum) is datum
+
+    output_key = "custom_arrival_present_optional" if prepend else "present_optional"
+    missing_output_key = (
+        "custom_arrival_missing_optional" if prepend else "missing_optional"
+    )
+    assert datum[output_key] == 9
+    assert not datum.is_defined(missing_output_key)
+    log = errors(datum)
+    assert len(log) == int(verbose)
+    if verbose:
+        assert log[0].badness == ErrorSeverity.Informational
+        assert "optional load key=missing_optional" in log[0].message
+    assert datum.live
+
+
+@pytest.fixture
+def mongo_database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    client = MongoClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        client.admin.command("ping")
+    except ServerSelectionTimeoutError as error:
+        client.close()
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    name = "test_css_arrival_matcher_" + uuid.uuid4().hex
+    database = client[name]
+    try:
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+def test_real_mongo_zero_one_and_multiple_selection(mongo_database):
+    matcher = css30_arrival_interval_matcher(
+        mongo_database,
+        startime_offset=4.0,
+        attributes_to_load=[],
+        load_if_defined=[],
+    )
+
+    assert matcher.get_document(make_datum()) is None
+
+    one_id = mongo_database.arrival.insert_one(
+        {"phase": "P", "time": 100.0}
+    ).inserted_id
+    assert matcher.get_document(make_datum())["_id"] == one_id
+
+    mongo_database.arrival.delete_many({})
+    upper_endpoint_id = mongo_database.arrival.insert_one(
+        {"phase": "P", "time": 110.0}
+    ).inserted_id
+    assert matcher.get_document(make_datum())["_id"] == upper_endpoint_id
+
+    mongo_database.arrival.delete_many({})
+
+    target_id = mongo_database.arrival.insert_one(
+        {"phase": "P", "time": 104.0}
+    ).inserted_id
+    mongo_database.arrival.insert_one({"phase": "P", "time": 109.0})
+    assert matcher.get_document(make_datum())["_id"] == target_id

--- a/python/tests/db/test_css_arrival_matcher_contract.py
+++ b/python/tests/db/test_css_arrival_matcher_contract.py
@@ -1,6 +1,8 @@
 import copy
 import os
+import subprocess
 import uuid
+from importlib.metadata import distribution, version
 from pathlib import Path
 
 import pytest
@@ -73,12 +75,29 @@ def errors(datum):
     return list(datum.elog.get_error_log())
 
 
-def test_contract_suite_loads_matcher_from_selected_source():
-    source_root = Path(
-        os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).parents[2])
-    )
-    expected = source_root / "mspasspy/db/matcher.py"
-    assert Path(matcher_module.__file__).resolve() == expected.resolve()
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
+
+
+def test_contract_suite_loads_matcher_from_selected_build():
+    _assert_module_from_selected_build(matcher_module, Path("mspasspy/db/matcher.py"))
 
 
 def test_query_is_closed_waveform_interval_and_constructor_fields_exist():


### PR DESCRIPTION
Fixes #832

Repairs the public CSS arrival interval matcher contracts, including inclusive MongoDB bounds, deterministic nearest-arrival selection, collection configuration, and error logging. Adds focused real-Mongo regression coverage for boundary, multi-match, missing-field, and custom-collection behavior.

## Renewed resource-lifecycle review

The first version materialized a PyMongo cursor for multi-match selection but returned or raised without closing it; its list-based test double hid that leak. Commit `a38586dd` wraps the complete multi-match selection in `try/finally`, closes the cursor on success and failure, and adds a real cursor-like test double that proves both paths. It does not change the arrival-selection formula or error policy.

Validation: focused contract `14 passed, 1 skipped` (the only skip was the absent local MongoDB service); Black 26.5.1, Python 3.12/3.13 `py_compile`, and `git diff --check` passed.

This PR is Ready: the renewed review found no unresolved data, API, or resource-lifecycle decision.