### PR TITLE
Fix distributed read sort validation and scratch materialization

### DIFF
--- a/python/mspasspy/io/distributed.py
+++ b/python/mspasspy/io/distributed.py
@@ -724,15 +724,23 @@ def read_distributed_data(
             if data_tag:
                 fullquery["data_tag"] = data_tag
             cursor = data[collection].find(fullquery)
+            try:
+                if scratchfile:
+                    # Store one Extended JSON document per line.  The scratch
+                    # file belongs to the caller and must remain available for
+                    # lazy and repeated computation of the returned bag/RDD.
+                    with open(scratchfile, "w") as outfile:
+                        for doc in cursor:
+                            outfile.write(json_util.dumps(doc))
+                            outfile.write("\n")
+                else:
+                    doclist = []
+                    for doc in cursor:
+                        doclist.append(doc)
+            finally:
+                cursor.close()
 
             if scratchfile:
-                # Store one Extended JSON document per line.  The scratch file
-                # belongs to the caller and must remain available for lazy and
-                # repeated computation of the returned bag/RDD.
-                with open(scratchfile, "w") as outfile:
-                    for doc in cursor:
-                        outfile.write(json_util.dumps(doc))
-                        outfile.write("\n")
                 if scheduler == "spark":
                     if npartitions is None:
                         plist = spark_context.textFile(scratchfile)
@@ -745,9 +753,6 @@ def read_distributed_data(
                     plist = dask.bag.read_text(scratchfile).map(json_util.loads)
 
             else:
-                doclist = []
-                for doc in cursor:
-                    doclist.append(doc)
                 if scheduler == "spark":
                     plist = spark_context.parallelize(doclist, numSlices=npartitions)
                 else:

--- a/python/mspasspy/io/distributed.py
+++ b/python/mspasspy/io/distributed.py
@@ -1,6 +1,6 @@
-import os
 import pandas as pd
-import json
+from bson import json_util
+from pymongo import ASCENDING, DESCENDING
 
 
 from mspasspy.db.database import (
@@ -94,6 +94,28 @@ def read_ensemble_parallel(
     if kill_me:
         ensemble.kill()
     return ensemble
+
+
+def _validate_sort_clause(sort_clause):
+    """Validate the list-of-pairs form accepted by PyMongo ``sort``."""
+    if not isinstance(sort_clause, list):
+        raise TypeError("sort_clause must be a list of (field_name, direction) pairs")
+    for item in sort_clause:
+        if not isinstance(item, tuple) or len(item) != 2:
+            raise TypeError(
+                "sort_clause must be a list of (field_name, direction) pairs"
+            )
+        field_name, direction = item
+        if not isinstance(field_name, str) or not field_name:
+            raise TypeError("sort_clause field names must be nonempty strings")
+        if (
+            isinstance(direction, bool)
+            or not isinstance(direction, int)
+            or direction not in (ASCENDING, DESCENDING)
+        ):
+            raise TypeError(
+                "sort_clause directions must be pymongo.ASCENDING or pymongo.DESCENDING"
+            )
 
 
 def post2metadata(mspass_object, doc):
@@ -338,8 +360,11 @@ def read_distributed_data(
       scalable to the largest conceivable seismic data sets.  When defined
       the documents retreived from the database are reformatted and pushed to
       a scratch file with the name defined by this argument.  The contents
-      of the file are then reloaded into a dask or spark DataFrame that
-      allow the same data to be handled within a more limited memory footprint.
+      of the file are then reloaded lazily into a Dask Bag or Spark RDD that
+      allows the same data to be handled within a more limited memory footprint.
+      The scratch file is owned by the caller:  this function never deletes it,
+      and the caller must retain it until all computations are complete before
+      removing it.
       Note use of this feature is rare and should never be necessary in an
       HPC or cloud cluster.   The default us None which means this that
       database input is loaded directly into memory to initiate construction
@@ -448,7 +473,7 @@ def read_distributed_data(
     :type sort_clause:  if None (default) no sorting is invoked when reading
       ensembles.   Other wise should be a python list of tuples
       defining a sort order.
-      e.g. [("sta",pymongo.ASCENDING),()"time",pymongo.ASCENDING)]
+      e.g. [("sta", pymongo.ASCENDING), ("time", pymongo.ASCENDING)]
 
     :param container_to_merge:  bag/RDD containing data packaged with
       one item per datum this reader is asked to read.   See above for
@@ -504,19 +529,7 @@ def read_distributed_data(
                 message += "list must contain only python dict defining queries that define each ensemble to be loaded"
                 raise TypeError(message)
         if sort_clause:
-            # TODO - conflicting examples of the type of this clause
-            # may have a hidden bug in TimeIntervalReader as it has usage
-            # differnt from this restricteion
-            if not isinstance(sort_clause, [list, str]):
-                message += "sort_clause argument is invalid\n"
-                message += "Must be either a list or a single string"
-                raise TypeError(message)
-            if isinstance(sort_clause, list):
-                for x in sort_clause:
-                    if not isinstance(x, dict):
-                        message += "sort_clause value = " + str(sort_clause)
-                        message += " is invalid input for MongoDB"
-                        raise TypeError(message)
+            _validate_sort_clause(sort_clause)
     elif isinstance(data, Database):
         ensemble_mode = False
         dataframe_input = False
@@ -713,26 +726,23 @@ def read_distributed_data(
             cursor = data[collection].find(fullquery)
 
             if scratchfile:
-                # here we write the documents all to a scratch file in
-                # json and immediately read them back to create a bag or RDD
+                # Store one Extended JSON document per line.  The scratch file
+                # belongs to the caller and must remain available for lazy and
+                # repeated computation of the returned bag/RDD.
                 with open(scratchfile, "w") as outfile:
                     for doc in cursor:
-                        json.dump(doc, outfile)
+                        outfile.write(json_util.dumps(doc))
+                        outfile.write("\n")
                 if scheduler == "spark":
-                    # the only way I could find to load json data in pyspark
-                    # is to use an intermediate dataframe.   This should
-                    # still parallelize, but will probably be slower
-                    # if there is a more direct solution should be done here.
-                    plist = spark_context.read.json(scratchfile)
-                    # this is wrong above also don't see how to do partitions
-                    # this section is broken until I (glp) can get help
-                    # plist = plist.map(to_dict,"records")
+                    if npartitions is None:
+                        plist = spark_context.textFile(scratchfile)
+                    else:
+                        plist = spark_context.textFile(
+                            scratchfile, minPartitions=npartitions
+                        )
+                    plist = plist.map(json_util.loads)
                 else:
-                    plist = dask.bag.read_text(scratchfile).map(json.loads)
-                # Intentionally omit error handler here.  Assume
-                # system will throw an error if file open files or write files
-                # that will be sufficient for user to understand the problem.
-                os.remove(scratchfile)
+                    plist = dask.bag.read_text(scratchfile).map(json_util.loads)
 
             else:
                 doclist = []

--- a/python/tests/io/test_distributed_read_contract.py
+++ b/python/tests/io/test_distributed_read_contract.py
@@ -13,27 +13,38 @@ import mspasspy.io.distributed as distributed
 
 
 class FakeCursor:
-    def __init__(self, collection, documents):
+    def __init__(self, collection, documents, iteration_error=None):
         self.collection = collection
         self.documents = documents
+        self.iteration_error = iteration_error
+        self.close_calls = 0
 
     def __iter__(self):
-        return iter(self.documents)
+        yield from self.documents
+        if self.iteration_error:
+            raise self.iteration_error
 
     def sort(self, sort_clause):
         self.collection.sort_clauses.append(sort_clause)
         return self
 
+    def close(self):
+        self.close_calls += 1
+
 
 class FakeCollection:
-    def __init__(self, documents):
+    def __init__(self, documents, iteration_error=None):
         self.documents = list(documents)
+        self.iteration_error = iteration_error
         self.find_queries = []
         self.sort_clauses = []
+        self.cursors = []
 
     def find(self, query):
         self.find_queries.append(query.copy())
-        return FakeCursor(self, self.documents)
+        cursor = FakeCursor(self, self.documents, self.iteration_error)
+        self.cursors.append(cursor)
+        return cursor
 
 
 class FakeDatum:
@@ -49,8 +60,8 @@ class FakeEnsemble:
 
 
 class FakeDatabase:
-    def __init__(self, documents, fail_on_read=False):
-        self.collection = FakeCollection(documents)
+    def __init__(self, documents, fail_on_read=False, iteration_error=None):
+        self.collection = FakeCollection(documents, iteration_error)
         self.fail_on_read = fail_on_read
         self.name = "fake_database"
 
@@ -178,6 +189,7 @@ def test_dask_scratch_is_extended_json_lines_lazy_and_caller_owned(
 
     assert isinstance(result, dask.bag.Bag)
     assert scratch.exists()
+    assert database.collection.cursors[-1].close_calls == 1
     lines = scratch.read_text().splitlines()
     assert len(lines) == 2
     assert [json_util.loads(line) for line in lines] == documents
@@ -186,6 +198,57 @@ def test_dask_scratch_is_extended_json_lines_lazy_and_caller_owned(
     assert scratch.exists()
     scratch.unlink()
     assert not scratch.exists()
+
+
+def test_database_cursor_closes_after_in_memory_materialization(monkeypatch):
+    documents = make_documents()
+    database = FakeDatabase(documents)
+    monkeypatch.setattr(distributed, "Database", FakeDatabase)
+
+    result = distributed.read_distributed_data(
+        database,
+        scheduler="dask",
+        npartitions=1,
+    )
+
+    assert database.collection.cursors[-1].close_calls == 1
+    assert result.compute(scheduler="synchronous") == documents
+
+
+@pytest.mark.parametrize("use_scratch", [False, True])
+def test_database_cursor_closes_when_iteration_fails(
+    monkeypatch, tmp_path, use_scratch
+):
+    database = FakeDatabase(
+        make_documents(), iteration_error=RuntimeError("controlled cursor failure")
+    )
+    monkeypatch.setattr(distributed, "Database", FakeDatabase)
+    scratch = str(tmp_path / "iteration-failure.jsonl") if use_scratch else None
+
+    with pytest.raises(RuntimeError, match="controlled cursor failure"):
+        distributed.read_distributed_data(
+            database,
+            scratchfile=scratch,
+            scheduler="dask",
+            npartitions=1,
+        )
+
+    assert database.collection.cursors[-1].close_calls == 1
+
+
+def test_database_cursor_closes_when_scratch_open_fails(monkeypatch, tmp_path):
+    database = FakeDatabase(make_documents())
+    monkeypatch.setattr(distributed, "Database", FakeDatabase)
+
+    with pytest.raises(IsADirectoryError):
+        distributed.read_distributed_data(
+            database,
+            scratchfile=str(tmp_path),
+            scheduler="dask",
+            npartitions=1,
+        )
+
+    assert database.collection.cursors[-1].close_calls == 1
 
 
 def test_dask_compute_failure_never_deletes_caller_scratch(monkeypatch, tmp_path):
@@ -202,6 +265,7 @@ def test_dask_compute_failure_never_deletes_caller_scratch(monkeypatch, tmp_path
     with pytest.raises(RuntimeError, match="controlled read failure"):
         result.compute(scheduler="synchronous")
 
+    assert database.collection.cursors[-1].close_calls == 1
     assert scratch.exists()
     scratch.unlink()
 
@@ -231,6 +295,7 @@ def test_spark_scratch_returns_repeatable_rdd_and_remains_caller_owned(
     from pyspark import RDD
 
     assert isinstance(result, RDD)
+    assert database.collection.cursors[-1].close_calls == 1
     assert result.collect() == documents
     assert result.collect() == documents
     assert scratch.exists()

--- a/python/tests/io/test_distributed_read_contract.py
+++ b/python/tests/io/test_distributed_read_contract.py
@@ -1,6 +1,8 @@
 import datetime
 import os
+import subprocess
 import sys
+from importlib.metadata import distribution, version
 from pathlib import Path
 
 import dask.bag
@@ -65,12 +67,29 @@ class FakeDatabase:
         return document
 
 
-def test_contract_suite_loads_distributed_from_selected_source():
-    source_root = Path(
-        os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).parents[2])
-    )
-    expected = source_root / "mspasspy/io/distributed.py"
-    assert Path(distributed.__file__).resolve() == expected.resolve()
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
+
+
+def test_contract_suite_loads_distributed_from_selected_build():
+    _assert_module_from_selected_build(distributed, Path("mspasspy/io/distributed.py"))
 
 
 @pytest.mark.parametrize(

--- a/python/tests/io/test_distributed_read_contract.py
+++ b/python/tests/io/test_distributed_read_contract.py
@@ -210,6 +210,7 @@ def test_dask_compute_failure_never_deletes_caller_scratch(monkeypatch, tmp_path
 @pytest.fixture(scope="module")
 def spark_context():
     pyspark = pytest.importorskip("pyspark")
+    active_context = pyspark.SparkContext._active_spark_context
     os.environ.setdefault("SPARK_LOCAL_IP", "127.0.0.1")
     previous_worker_python = os.environ.get("PYSPARK_PYTHON")
     previous_driver_python = os.environ.get("PYSPARK_DRIVER_PYTHON")
@@ -235,7 +236,8 @@ def spark_context():
     try:
         yield context
     finally:
-        context.stop()
+        if active_context is None:
+            context.stop()
         if previous_worker_python is None:
             os.environ.pop("PYSPARK_PYTHON", None)
         else:

--- a/python/tests/io/test_distributed_read_contract.py
+++ b/python/tests/io/test_distributed_read_contract.py
@@ -1,0 +1,256 @@
+import datetime
+import os
+import sys
+from pathlib import Path
+
+import dask.bag
+import pytest
+from bson import ObjectId, json_util
+from pymongo import ASCENDING, DESCENDING
+
+import mspasspy.io.distributed as distributed
+
+
+class FakeCursor:
+    def __init__(self, collection, documents):
+        self.collection = collection
+        self.documents = documents
+
+    def __iter__(self):
+        return iter(self.documents)
+
+    def sort(self, sort_clause):
+        self.collection.sort_clauses.append(sort_clause)
+        return self
+
+
+class FakeCollection:
+    def __init__(self, documents):
+        self.documents = list(documents)
+        self.find_queries = []
+        self.sort_clauses = []
+
+    def find(self, query):
+        self.find_queries.append(query.copy())
+        return FakeCursor(self, self.documents)
+
+
+class FakeDatum:
+    live = True
+
+
+class FakeEnsemble:
+    def __init__(self):
+        self.member = [FakeDatum()]
+
+    def kill(self):
+        raise AssertionError("an ensemble with a live member must not be killed")
+
+
+class FakeDatabase:
+    def __init__(self, documents, fail_on_read=False):
+        self.collection = FakeCollection(documents)
+        self.fail_on_read = fail_on_read
+        self.name = "fake_database"
+
+    def __getitem__(self, collection):
+        assert collection == "wf_TimeSeries"
+        return self.collection
+
+    def read_data(self, document, **kwargs):
+        if self.fail_on_read:
+            raise RuntimeError("controlled read failure")
+        if isinstance(document, FakeCursor):
+            return FakeEnsemble()
+        return document
+
+
+def test_contract_suite_loads_distributed_from_selected_source():
+    source_root = Path(
+        os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).parents[2])
+    )
+    expected = source_root / "mspasspy/io/distributed.py"
+    assert Path(distributed.__file__).resolve() == expected.resolve()
+
+
+@pytest.mark.parametrize(
+    "sort_clause",
+    [
+        ("starttime", ASCENDING),
+        "starttime",
+        {"starttime": ASCENDING},
+        [["starttime", ASCENDING]],
+        [("starttime",)],
+        [("starttime", ASCENDING, "extra")],
+        [(1, ASCENDING)],
+        [("", ASCENDING)],
+        [("starttime", True)],
+        [("starttime", 0)],
+        [("starttime", "ascending")],
+    ],
+)
+def test_invalid_truthy_sort_clauses_fail_before_query(monkeypatch, sort_clause):
+    database = FakeDatabase([])
+    monkeypatch.setattr(distributed, "Database", FakeDatabase)
+
+    with pytest.raises(TypeError):
+        distributed.read_distributed_data(
+            [{"sta": "AAA"}],
+            db=database,
+            scheduler="dask",
+            npartitions=1,
+            sort_clause=sort_clause,
+        )
+
+    assert database.collection.find_queries == []
+
+
+def test_valid_sort_pairs_reach_cursor_sort_after_lazy_compute(monkeypatch):
+    database = FakeDatabase([])
+    monkeypatch.setattr(distributed, "Database", FakeDatabase)
+    monkeypatch.setattr(distributed, "fetch_dbhandle", lambda _: database)
+    sort_clause = [("sta", ASCENDING), ("starttime", DESCENDING)]
+
+    result = distributed.read_distributed_data(
+        [{"sta": "AAA"}],
+        db=database,
+        scheduler="dask",
+        npartitions=1,
+        sort_clause=sort_clause,
+    )
+
+    assert isinstance(result, dask.bag.Bag)
+    assert database.collection.find_queries == []
+    computed = result.compute(scheduler="synchronous")
+    assert len(computed) == 1
+    assert isinstance(computed[0], FakeEnsemble)
+    assert database.collection.find_queries == [{"sta": "AAA"}]
+    assert database.collection.sort_clauses == [sort_clause]
+
+
+def make_documents():
+    return [
+        {
+            "_id": ObjectId("64b917ce9aa746564e8ecbfd"),
+            "starttime": datetime.datetime(2020, 1, 2, 3, 4, 5),
+            "value": 1,
+        },
+        {
+            "_id": ObjectId("64b917d69aa746564e8ecbfe"),
+            "starttime": datetime.datetime(2021, 2, 3, 4, 5, 6),
+            "value": 2,
+        },
+    ]
+
+
+def test_dask_scratch_is_extended_json_lines_lazy_and_caller_owned(
+    monkeypatch, tmp_path
+):
+    documents = make_documents()
+    database = FakeDatabase(documents)
+    monkeypatch.setattr(distributed, "Database", FakeDatabase)
+    scratch = tmp_path / "waveforms.jsonl"
+
+    result = distributed.read_distributed_data(
+        database,
+        scratchfile=str(scratch),
+        scheduler="dask",
+        npartitions=1,
+    )
+
+    assert isinstance(result, dask.bag.Bag)
+    assert scratch.exists()
+    lines = scratch.read_text().splitlines()
+    assert len(lines) == 2
+    assert [json_util.loads(line) for line in lines] == documents
+    assert result.compute(scheduler="synchronous") == documents
+    assert result.compute(scheduler="synchronous") == documents
+    assert scratch.exists()
+    scratch.unlink()
+    assert not scratch.exists()
+
+
+def test_dask_compute_failure_never_deletes_caller_scratch(monkeypatch, tmp_path):
+    database = FakeDatabase(make_documents(), fail_on_read=True)
+    monkeypatch.setattr(distributed, "Database", FakeDatabase)
+    scratch = tmp_path / "failing.jsonl"
+    result = distributed.read_distributed_data(
+        database,
+        scratchfile=str(scratch),
+        scheduler="dask",
+        npartitions=1,
+    )
+
+    with pytest.raises(RuntimeError, match="controlled read failure"):
+        result.compute(scheduler="synchronous")
+
+    assert scratch.exists()
+    scratch.unlink()
+
+
+@pytest.fixture(scope="module")
+def spark_context():
+    pyspark = pytest.importorskip("pyspark")
+    os.environ.setdefault("SPARK_LOCAL_IP", "127.0.0.1")
+    previous_worker_python = os.environ.get("PYSPARK_PYTHON")
+    previous_driver_python = os.environ.get("PYSPARK_DRIVER_PYTHON")
+    previous_pythonpath = os.environ.get("PYTHONPATH")
+    os.environ["PYSPARK_PYTHON"] = sys.executable
+    os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
+    test_module_directory = str(Path(__file__).parent)
+    os.environ["PYTHONPATH"] = (
+        test_module_directory
+        if previous_pythonpath is None
+        else test_module_directory + os.pathsep + previous_pythonpath
+    )
+    configuration = (
+        pyspark.SparkConf()
+        .setMaster("local[1]")
+        .setAppName("mspass-distributed-read-contract")
+        .set("spark.ui.enabled", "false")
+        .set("spark.driver.bindAddress", "127.0.0.1")
+    )
+    context = pyspark.SparkContext.getOrCreate(configuration)
+    context.setLogLevel("ERROR")
+    try:
+        yield context
+    finally:
+        context.stop()
+        if previous_worker_python is None:
+            os.environ.pop("PYSPARK_PYTHON", None)
+        else:
+            os.environ["PYSPARK_PYTHON"] = previous_worker_python
+        if previous_driver_python is None:
+            os.environ.pop("PYSPARK_DRIVER_PYTHON", None)
+        else:
+            os.environ["PYSPARK_DRIVER_PYTHON"] = previous_driver_python
+        if previous_pythonpath is None:
+            os.environ.pop("PYTHONPATH", None)
+        else:
+            os.environ["PYTHONPATH"] = previous_pythonpath
+
+
+def test_spark_scratch_returns_repeatable_rdd_and_remains_caller_owned(
+    monkeypatch, tmp_path, spark_context
+):
+    documents = make_documents()
+    database = FakeDatabase(documents)
+    monkeypatch.setattr(distributed, "Database", FakeDatabase)
+    scratch = tmp_path / "spark-waveforms.jsonl"
+
+    result = distributed.read_distributed_data(
+        database,
+        scratchfile=str(scratch),
+        scheduler="spark",
+        spark_context=spark_context,
+        npartitions=1,
+    )
+
+    from pyspark import RDD
+
+    assert isinstance(result, RDD)
+    assert result.collect() == documents
+    assert result.collect() == documents
+    assert scratch.exists()
+    scratch.unlink()
+    assert not scratch.exists()

--- a/python/tests/io/test_distributed_read_contract.py
+++ b/python/tests/io/test_distributed_read_contract.py
@@ -230,6 +230,7 @@ def spark_context():
         .set("spark.driver.bindAddress", "127.0.0.1")
     )
     context = pyspark.SparkContext.getOrCreate(configuration)
+    context.addPyFile(str(Path(__file__).resolve()))
     context.setLogLevel("ERROR")
     try:
         yield context

--- a/python/tests/io/test_distributed_read_contract.py
+++ b/python/tests/io/test_distributed_read_contract.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import subprocess
-import sys
 from importlib.metadata import distribution, version
 from pathlib import Path
 
@@ -208,52 +207,13 @@ def test_dask_compute_failure_never_deletes_caller_scratch(monkeypatch, tmp_path
 
 
 @pytest.fixture(scope="module")
-def spark_context():
-    pyspark = pytest.importorskip("pyspark")
-    active_context = pyspark.SparkContext._active_spark_context
-    os.environ.setdefault("SPARK_LOCAL_IP", "127.0.0.1")
-    previous_worker_python = os.environ.get("PYSPARK_PYTHON")
-    previous_driver_python = os.environ.get("PYSPARK_DRIVER_PYTHON")
-    previous_pythonpath = os.environ.get("PYTHONPATH")
-    os.environ["PYSPARK_PYTHON"] = sys.executable
-    os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
-    test_module_directory = str(Path(__file__).parent)
-    os.environ["PYTHONPATH"] = (
-        test_module_directory
-        if previous_pythonpath is None
-        else test_module_directory + os.pathsep + previous_pythonpath
-    )
-    configuration = (
-        pyspark.SparkConf()
-        .setMaster("local[1]")
-        .setAppName("mspass-distributed-read-contract")
-        .set("spark.ui.enabled", "false")
-        .set("spark.driver.bindAddress", "127.0.0.1")
-    )
-    context = pyspark.SparkContext.getOrCreate(configuration)
-    context.addPyFile(str(Path(__file__).resolve()))
-    context.setLogLevel("ERROR")
-    try:
-        yield context
-    finally:
-        if active_context is None:
-            context.stop()
-        if previous_worker_python is None:
-            os.environ.pop("PYSPARK_PYTHON", None)
-        else:
-            os.environ["PYSPARK_PYTHON"] = previous_worker_python
-        if previous_driver_python is None:
-            os.environ.pop("PYSPARK_DRIVER_PYTHON", None)
-        else:
-            os.environ["PYSPARK_DRIVER_PYTHON"] = previous_driver_python
-        if previous_pythonpath is None:
-            os.environ.pop("PYTHONPATH", None)
-        else:
-            os.environ["PYTHONPATH"] = previous_pythonpath
+def distributed_spark_context(spark_context):
+    spark_context.addPyFile(str(Path(__file__).resolve()))
+    return spark_context
 
 
 def test_spark_scratch_returns_repeatable_rdd_and_remains_caller_owned(
-    monkeypatch, tmp_path, spark_context
+    monkeypatch, tmp_path, distributed_spark_context
 ):
     documents = make_documents()
     database = FakeDatabase(documents)
@@ -264,7 +224,7 @@ def test_spark_scratch_returns_repeatable_rdd_and_remains_caller_owned(
         database,
         scratchfile=str(scratch),
         scheduler="spark",
-        spark_context=spark_context,
+        spark_context=distributed_spark_context,
         npartitions=1,
     )
 


### PR DESCRIPTION
## Summary

- Validate MongoDB sort clauses before issuing ensemble queries.
- Materialize internal cursors as one BSON Extended JSON document per scratch-file line and close each cursor on every path.
- Return working lazy Dask and Spark collections while leaving scratch-file lifetime under caller control, including repeated computation.
- Add focused Dask and real-Spark regression coverage.

Closes #834
