### PR TITLE
Fix MCXcor phase search and coda timing fallbacks

### DIFF
--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -393,9 +393,9 @@ def MCXcorPrepP(
       members.  Each coda search, however, is constrained by the times of
       pP and/or PP.   As noted above the function uses the pP time for
       events with depths greater than 100 km but PP for shallow sources.
-      To allow for hypocenter errors  the duration defined by
-      P to pP or P to PP is multiplied by this factor to define the
-      search start for the coda estimation.
+      To allow for hypocenter errors the shortest duration defined by
+      P to pP or P to PP is multiplied by this factor once to cap the
+      final common correlation window.
     :type search_window_fraction: float (default 0.9)
     :param minimum_coda_duration: minimum accepted coda-duration estimate.
       Shorter estimates are excluded.  If no estimate exceeds this floor, the
@@ -527,7 +527,6 @@ def MCXcorPrepP(
     for d in enswork.member:
         if d.live:
             sr = _get_search_range(d)
-            sr *= search_window_fraction
             search_range.append(sr)
             # compute a noise estimate without being too dogmatic about
             # window range
@@ -1847,16 +1846,16 @@ def phase_time(
     (or any other algorithm that computes relative time shifts) and set with the
     Metadata key defined by the "time_shift_key" argment.  The defaults work for
     P phase times computed by `MCXcorPrepP` and shifts computed by
-    `align_and_stack`.   The computation here is trivial (just a difference) but
+    `align_and_stack`.   The computation here is trivial (just a sum) but
     the fluff is all the safeties in handling missing values.  Returns -1.0
     if any of the requried keys are missing.  Returns -2.0 if d is not defined
     as UTC.  That is basically a reminder this function only makes sense for
     data with a UTC time standard.
     """
-    phase_time = d.t0
+    if d.time_is_relative():
+        return -2.0
     if d.is_defined(phase_time_key) and d.is_defined(time_shift_key):
-        phase_time = d[phase_time_key] + d[time_shift_key]
-        return phase_time
+        return d[phase_time_key] + d[time_shift_key]
     else:
         return -1.0
 
@@ -2193,10 +2192,10 @@ def _coda_duration(ts, level, t0=0.0, search_start=None) -> TimeWindow:
     level of the envelope never exceeds the value defined by the level
     argument.
 
-    :param ts:  Datum to be processed.   The function will return a null
-      result (zero length window) if ts.t0> t0 (argument value).  The sample
-      data is assumed filtered to an appropriate band where the envelope will
-      properly define the coda.
+    :param ts:  Datum to be processed.  If ``t0`` precedes ``ts.t0``, the
+      returned window start and the search boundary are clipped to ``ts.t0``.
+      The sample data is assumed filtered to an appropriate band where the
+      envelope will properly define the coda.
     :type ts: `TimeSeries` is assumed.  There is not explicit type checking
       but a type mismatch will always cause an error.
     :param level:  amplitude of where the backward time search will be
@@ -2245,14 +2244,13 @@ def _coda_duration(ts, level, t0=0.0, search_start=None) -> TimeWindow:
         raise ValueError(message)
     httsd = signal.hilbert(ts.data)
     envelope = np.abs(httsd)
-    it0 = ts.sample_number(t0)
     i = itss
     while i > it0:
         if envelope[i] > level:
-            break
+            return TimeWindow(t0used, ts.time(i))
         i -= 1
     # A failed search will have start and end the same
-    return TimeWindow(t0used, ts.time(i))
+    return TimeWindow(t0used, t0used)
 
 
 def _set_phases(
@@ -2364,6 +2362,7 @@ def _set_phases(
         depth = d["source_depth"]
     else:
         depth = default_depth
+        d["source_depth"] = depth
         message = "source_depth value was not defined - using default value={}".format(
             depth
         )
@@ -2403,8 +2402,10 @@ def _get_search_range(
     range for P coda.   It returns a time duration to use as the search
     range relative to 0 (P time) based on a simple recipe to avoid interference
     from pP and PP phases.   Specifically, if the source depth is greater than
-    100 km the pP phase is used as the maximum duration of the coda.
-    For shallower sources PP is used.
+    100 km the pP phase is preferred as the maximum duration of the coda,
+    with PP as a fallback.  For sources at or below 100 km PP is preferred,
+    with pP as a fallback.  If neither phase is defined,
+    `duration_undefined` is used.
 
     This function should not normally be used except as a component of the
     MCXcorPrepP function.   It has no safeties and is pretty simple.
@@ -2413,16 +2414,22 @@ def _get_search_range(
     """
     if d.live:
         depth = d["source_depth"]
+        Ptime = d[Pkey]
         if depth > 100.0:
             if d.is_defined(pPkey):
                 tend = d[pPkey]
             elif d.is_defined(PPkey):
                 tend = d[PPkey]
             else:
-                d[Pkey] + duration_undefined
+                tend = Ptime + duration_undefined
         else:
-            tend = d[PPkey]
-        duration = tend - d[Pkey]
+            if d.is_defined(PPkey):
+                tend = d[PPkey]
+            elif d.is_defined(pPkey):
+                tend = d[pPkey]
+            else:
+                tend = Ptime + duration_undefined
+        duration = max(0.0, tend - Ptime)
     else:
         duration = 0.0
     return duration

--- a/python/tests/algorithms/test_MCXcorPrep_contract.py
+++ b/python/tests/algorithms/test_MCXcorPrep_contract.py
@@ -1,0 +1,194 @@
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import mspasspy.algorithms.MCXcorStacking as mcx
+from mspasspy.ccore.algorithms.basic import TimeWindow
+from mspasspy.ccore.seismic import (
+    DoubleVector,
+    TimeReferenceType,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+from mspasspy.ccore.utility import Metadata
+
+
+def test_contract_module_is_loaded_from_selected_tree():
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        assert Path(mcx.__file__).resolve().is_relative_to(Path(source_root).resolve())
+
+
+def _live_timeseries(npts=32, dt=1.0, t0=0.0):
+    datum = TimeSeries()
+    datum.set_npts(npts)
+    datum.dt = dt
+    datum.t0 = t0
+    datum.data = DoubleVector(np.ones(npts))
+    datum.set_live()
+    return datum
+
+
+def test_set_phases_posts_default_depth_before_model_selection():
+    datum = _live_timeseries()
+    datum["dist"] = 30.0
+    datum["source_time"] = 1000.0
+    default_depth = 42.5
+
+    class InspectingModel:
+        def get_travel_times(self, **kwargs):
+            assert datum["source_depth"] == default_depth
+            assert kwargs["source_depth_in_km"] == default_depth
+            return [SimpleNamespace(name="P", time=12.0)]
+
+    result = mcx._set_phases(datum, InspectingModel(), default_depth=default_depth)
+
+    assert result is datum
+    assert result["source_depth"] == default_depth
+    assert result["Ptime"] == 1012.0
+    assert result.elog.size() == 1
+    assert mcx._get_search_range(result) == 20.0
+
+
+@pytest.mark.parametrize("depth", [50.0, 150.0])
+@pytest.mark.parametrize(
+    "pPtime,PPtime,expected",
+    [
+        (112.0, None, {50.0: 12.0, 150.0: 12.0}),
+        (None, 130.0, {50.0: 30.0, 150.0: 30.0}),
+        (None, None, {50.0: 20.0, 150.0: 20.0}),
+    ],
+)
+def test_search_range_phase_fallbacks(depth, pPtime, PPtime, expected):
+    datum = _live_timeseries()
+    datum["source_depth"] = depth
+    datum["Ptime"] = 100.0
+    if pPtime is not None:
+        datum["pPtime"] = pPtime
+    if PPtime is not None:
+        datum["PPtime"] = PPtime
+
+    assert mcx._get_search_range(datum) == expected[depth]
+
+
+@pytest.mark.parametrize(
+    "depth,pPtime,PPtime,expected",
+    [
+        (150.0, 112.0, 130.0, 12.0),
+        (50.0, 112.0, 130.0, 30.0),
+        (150.0, 90.0, None, 0.0),
+        (50.0, None, 90.0, 0.0),
+    ],
+)
+def test_search_range_preference_and_nonnegative_duration(
+    depth, pPtime, PPtime, expected
+):
+    datum = _live_timeseries()
+    datum["source_depth"] = depth
+    datum["Ptime"] = 100.0
+    if pPtime is not None:
+        datum["pPtime"] = pPtime
+    if PPtime is not None:
+        datum["PPtime"] = PPtime
+
+    assert mcx._get_search_range(datum) == expected
+
+
+def test_search_range_treats_100_km_as_shallow():
+    datum = _live_timeseries()
+    datum["source_depth"] = 100.0
+    datum["Ptime"] = 100.0
+    datum["pPtime"] = 112.0
+    datum["PPtime"] = 130.0
+
+    assert mcx._get_search_range(datum) == 30.0
+
+
+@pytest.mark.parametrize("depth", [50.0, 150.0])
+@pytest.mark.parametrize("duration_undefined,expected", [(8.0, 8.0), (-8.0, 0.0)])
+def test_search_range_clamps_undefined_duration(depth, duration_undefined, expected):
+    datum = _live_timeseries()
+    datum["source_depth"] = depth
+    datum["Ptime"] = 100.0
+
+    assert (
+        mcx._get_search_range(datum, duration_undefined=duration_undefined) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "fraction,expected_end", [(0.0, 0.0), (0.5, 10.0), (1.0, 20.0)]
+)
+def test_prep_applies_search_fraction_once_to_common_window(fraction, expected_end):
+    datum = _live_timeseries(npts=101, t0=90.0)
+    datum.tref = TimeReferenceType.UTC
+    datum["Ptime"] = 100.0
+    datum["PPtime"] = 120.0
+    datum["source_depth"] = 10.0
+    datum["Parrival"] = {"bandwidth": 1.0}
+    ensemble = TimeSeriesEnsemble(Metadata(), 1)
+    ensemble.member.append(datum)
+    ensemble.set_live()
+    coda_search_starts = []
+
+    def record_coda_search(datum, level, search_start=None, **kwargs):
+        coda_search_starts.append(search_start)
+        return TimeWindow(0.0, 100.0)
+
+    with (
+        patch.object(mcx, "filter", side_effect=lambda value, **kwargs: value),
+        patch.object(mcx, "MADAmplitude", return_value=1.0),
+        patch.object(mcx, "_coda_duration", side_effect=record_coda_search),
+    ):
+        result, beam = mcx.MCXcorPrepP(
+            ensemble,
+            TimeWindow(-10.0, -1.0),
+            model=object(),
+            set_phases=False,
+            low_f_corner=0.1,
+            high_f_corner=1.0,
+            search_window_fraction=fraction,
+        )
+
+    assert result.live
+    assert beam.live
+    assert coda_search_starts == [20.0]
+    assert beam["correlation_window_end"] == expected_end
+
+
+def test_coda_duration_clips_negative_start_and_reports_no_crossing():
+    datum = _live_timeseries(npts=16)
+    datum.data = DoubleVector(np.zeros(datum.npts))
+
+    window = mcx._coda_duration(datum, level=1.0, t0=-10.0)
+
+    assert window.start == datum.t0
+    assert window.end == datum.t0
+    assert window.end - window.start == 0.0
+
+    off_grid_start = 0.25
+    window = mcx._coda_duration(datum, level=1.0, t0=off_grid_start)
+    assert window.start == off_grid_start
+    assert window.end == off_grid_start
+
+
+def test_phase_time_contract():
+    datum = _live_timeseries()
+    datum["Ptime"] = 1000.0
+    datum["arrival_time_correction"] = 1.25
+    assert mcx.phase_time(datum) == -2.0
+
+    datum.tref = TimeReferenceType.UTC
+    datum.erase("arrival_time_correction")
+    assert mcx.phase_time(datum) == -1.0
+
+    datum["arrival_time_correction"] = 1.25
+    datum.erase("Ptime")
+    assert mcx.phase_time(datum) == -1.0
+
+    datum["Ptime"] = 1000.0
+    assert mcx.phase_time(datum) == 1001.25

--- a/python/tests/algorithms/test_MCXcorStacking.py
+++ b/python/tests/algorithms/test_MCXcorStacking.py
@@ -700,7 +700,7 @@ def test_MCXcorPrepP():
         assert np.isclose(observed, expected)
     assert number_live(e) == N
     assert np.isclose(beam["correlation_window_start"], -2.0)
-    assert np.isclose(beam["correlation_window_end"], 154.65957854747774)
+    assert np.isclose(beam["correlation_window_end"], 171.84397616386414)
     for d in e.member:
         assert d.is_defined("Ptime")
         assert d.is_defined("PPtime")


### PR DESCRIPTION
Fixes #853

## What changed

- apply `search_window_fraction` exactly once to the final common phase-search range
- restore the documented default source depth before TauP phase selection
- make pP/PP search-range fallbacks complete at shallow, deep, and missing-phase boundaries
- preserve clipped coda indices and define the no-threshold-crossing result
- make `phase_time` return the documented relative/UTC sentinel values
- update the user-facing timing documentation and focused regression expectations

## Root cause and impact

Several independent fallback branches either reused already-scaled windows, read missing depth metadata, or left timing values undefined. The result was incorrect phase windows, crashes for incomplete metadata, and inconsistent coda timing.

## Validation

- focused contract plus full neighboring MCXcor tests: 38 passed
- exact audited baseline: 14 failed / 8 passed on the same contract suite
- Black, Ruff fatal checks, Python 3.12/3.13 `py_compile`, and `git diff --check`: passed
- independent agent review: REVIEW PASS

This PR is ready for human review and is intentionally not merged.