### PR TITLE
Fix MCXcor convergence and option handling

### DIFF
--- a/docs/source/user_manual/arrival_time_measurement.rst
+++ b/docs/source/user_manual/arrival_time_measurement.rst
@@ -366,23 +366,15 @@ show the full function signature for ``align_and_stack``:
     **kwargs,
     ) -> list:
 
-.. note::
-
-   The current implementation accepts ``use_median_initial_stack`` and
-   ``abort_irregular_sampling``, but does not forward either value to the
-   underlying stack or sampling-validation calls.  Consequently, the robust
-   stack currently always starts from a median stack, and irregularly sampled
-   members follow the default behavior of being logged and killed.  Do not rely
-   on setting either argument to change those behaviors until the implementation
-   is updated.
-
 The parameters of note are:
 
-#. The robust stack currently starts from the median stack of the ensemble
+#. By default the robust stack starts from the median stack of the ensemble
    aligned to the beam computed in the previous iteration.  This is a stable
-   starting estimate.  As noted above, ``use_median_initial_stack=False`` is
-   accepted by the API but does not currently select the previous beam as the
-   starting estimate.
+   starting estimate.  Set ``use_median_initial_stack=False`` to use the
+   supplied beam as the initial stack estimate instead.
+#. Set ``abort_irregular_sampling=True`` to abort processing when any live
+   member has an incompatible sample interval.  The default ``False`` logs and
+   kills only the incompatible members and continues while live members remain.
 #. *residual_norm_floor* implements a concept not recognized when
    we developed the original *dbxcor* program.
    It relates to a
@@ -418,7 +410,7 @@ the residual term makes the weighting more aggressively
 downweight any datum that differs significantly from the stack.
 That is desirable and a reason this algorithm can handle wildly variable
 quality data.  The dark side to recognize, however, is that it makes
-the result strongly history dependent.  The current median-started behavior
+the result strongly history dependent.  The default median-started behavior
 produces a stack that is close to the median stack.  How "close" is controlled by the
 setting of *residual_norm_floor*.   When *residual_norm_floor* is
 1.0 the residual weighting term is disabled.  As the floor becomes smaller,

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -23,7 +23,7 @@ from obspy.geodetics.base import gps2dist_azimuth, kilometers2degrees
 from obspy.taup import TauPyModel
 
 
-from mspasspy.ccore.utility import ErrorLogger, ErrorSeverity, Metadata
+from mspasspy.ccore.utility import ErrorLogger, ErrorSeverity, Metadata, MsPASSError
 from mspasspy.ccore.seismic import (
     TimeSeries,
     TimeSeriesEnsemble,
@@ -977,6 +977,16 @@ def robust_stack(
         )
 
 
+def _relative_stack_change(new_stack, previous_stack) -> float:
+    """Return the relative L2 change between two stack estimates."""
+    delta = new_stack - previous_stack
+    delta_norm = np.linalg.norm(delta.data)
+    previous_norm = np.linalg.norm(previous_stack.data)
+    if previous_norm == 0.0:
+        return 0.0 if delta_norm == 0.0 else np.inf
+    return delta_norm / previous_norm
+
+
 def _dbxcor_stacker(
     ensemble,
     stack0,
@@ -1005,13 +1015,15 @@ def _dbxcor_stacker(
     :type residual_norm_floor:   float (default 0.1)
     """
     stack = TimeSeries(stack0)
+    previous_stack = TimeSeries(stack0)
     # useful shorthands
     N = stack0.npts
     M = len(ensemble.member)
     wts = None  # needed to keep this symbol from going out of scope before return
     for i in range(maxiterations):
-        # this requires stack0 not be altered in this function
-        wts = dbxcor_weights(ensemble, stack0, residual_norm_floor=residual_norm_floor)
+        wts = dbxcor_weights(
+            ensemble, previous_stack, residual_norm_floor=residual_norm_floor
+        )
         # newstack = np.zeros(N)
         # this is just a fast way to initalize to 0s
         stack.set_npts(N)
@@ -1030,19 +1042,12 @@ def _dbxcor_stacker(
             stack.kill()
             return [stack, wts]
         # newstack /= sumwts
-        # order may matter here.  In this case delta becomes a numpy
-        # array which is cleaner in this context
-        # delta = newstack - stack.data
-        delta = stack - stack0
-        relative_delta = np.linalg.norm(delta.data) / np.linalg.norm(stack0.data)
-        # normalize by sample size or there is a window length dependency
-        relative_delta /= N
-        # update stack here so if we break loop we don't have to repeat
-        # this copying.  Force one iteration to make this a do-while loop
-        # newstack is a numpy vector so this cast is necesary
-        stack0 = stack
+        # Compare against the same immutable estimate used for the weights.
+        relative_delta = _relative_stack_change(stack, previous_stack)
+        # Force one iteration to make this a do-while loop.
         if i > 0 and relative_delta < eps:
             break
+        previous_stack = TimeSeries(stack)
     return [stack, wts]
 
 
@@ -1219,15 +1224,14 @@ def align_and_stack(
             stack that is defined.   Note recent experience has shown
             that with large, consistent ensembles the dbxcor robust
             estimate tends to focus on the signal closest to the median
-            stack.  The reason is that the median stack
-            is always used as the initial estimator.   Hence, it can
-            be thought of as a median stack that uses the full data
-            set more completely.
+            stack.  By default the median stack is used as the initial
+            estimator; ``use_median_initial_stack=False`` instead uses the
+            supplied beam.
         3.  dbxcor required the user to pick a seed signal to use as
-            the initial beam estimate.  That approach is NOT used here
-            but idea is to have some estimate passed to the algorithm
-            via the beam (arg1) argument.  In MsPASS the working model
-            is to apply the  broadband_snr_QC function to the data before
+            the initial beam estimate.  This function receives that estimate
+            through the beam (arg1) argument and uses it as the robust-stack
+            seed when ``use_median_initial_stack=False``.  In MsPASS the
+            working model is to apply the broadband_snr_QC function before
             running this function and select the initial seed (beam) from
             one or more of the computed snr metrics.   In addition,
             with this approach I envision a two-stage computation where
@@ -1336,9 +1340,9 @@ def align_and_stack(
         computing the robust stack.  Currently accepted value are:
         "dbxcor" (default) and "median".
     :type robust_stack_method:  string  - must be one of options listed above.
-    :param use_median_initial_stack: currently has no effect.  The implementation
-        always uses a median stack as the initial estimate, including when this
-        value is False.
+    :param use_median_initial_stack: when True, initialize robust stacking with
+        the member median.  When False, use the supplied beam as the initial
+        stack estimate.
     :type use_median_initial_stack: boolean (default True)
     :param time_shift_key:  the time shift applied relative to the starting
         point is posted to each live member with this key.  It is
@@ -1356,14 +1360,11 @@ def align_and_stack(
         this value will be truncated to this value with the sign
         of the shift preserved.
     :type time_shift_limit:  float
-    :param abort_irregular_sampling: currently has no effect.  This function uses
-        a generous test for sample rate mismatch.  A mismatch is
-        detected only if the computed time skew over the time span of
-        the input beam signal is more than half of the beam sample interval
-        (``beam.dt``).  Offending ensemble members are always killed and a
-        message is posted; setting this value to True does not currently raise
-        ``ValueError``.  The input ensemble can therefore return with fewer
-        live members.
+    :param abort_irregular_sampling: passed to ``regularize_sampling`` as
+        ``abort_on_error``.  When True, any irregular live member causes that
+        helper to abort; when False, offending members are killed and
+        processing continues if live members remain.  Exceptions use this
+        function's standard decorator error handling.
     :type abort_irregular_sampling: boolean (default False)
     :param residual_norm_floor: floor on residuals used to compute dbxcor weight
         function.  See docstring for `dbxcor_weights` for details.
@@ -1388,8 +1389,7 @@ def align_and_stack(
     # xcorens has function scope
     it0_key = "_initial_t0_value_"
     ensemble_index_key = "_ensemble_i0_"
-    # maximum iterations.  could be passed as an argument but I have
-    # never seen this algorithm not converge in 20 interation
+    # maximum iterations before the stack is returned dead
     MAXITERATION = 20
     # Enformce types of ensemble and beam
     if not isinstance(ensemble, TimeSeriesEnsemble):
@@ -1409,7 +1409,12 @@ def align_and_stack(
         ensemble.elog.log_error(alg, message, ErrorSeverity.Invalid)
         ensemble.kill()
         return [ensemble, beam]
-    ensemble = regularize_sampling(ensemble, beam.dt, Nsamp=beam.npts)
+    ensemble = regularize_sampling(
+        ensemble,
+        beam.dt,
+        Nsamp=beam.npts,
+        abort_on_error=abort_irregular_sampling,
+    )
     if ensemble.dead():
         return [ensemble, beam]
     # we need to make sure this is part of a valid set of algorithms
@@ -1588,7 +1593,7 @@ def align_and_stack(
 
     # above guarantees this cannot return a dead datum
     rbeam0 = WindowData(beam, rwin.start, rwin.end)
-    nrm_rbeam = np.linalg.norm(rbeam0.data)
+    converged = False
     for i in range(MAXITERATION):
         ensemble = beam_align(
             ensemble, beam, xcorwin, time_shift_limit=time_shift_limit
@@ -1601,16 +1606,14 @@ def align_and_stack(
         rbeam, wts = robust_stack(
             rens,
             method=robust_stack_method,
+            stack0=None if use_median_initial_stack else rbeam0,
             residual_norm_floor=residual_norm_floor,
             timespan_method="ensemble_median",
             stack_md=Metadata(rbeam0),
         )
-        delta_rbeam = rbeam - rbeam0
-        nrm_delta = np.linalg.norm(delta_rbeam.data)
-        if nrm_rbeam == 0.0:
-            if nrm_delta == 0.0:
-                break
-        elif nrm_delta / nrm_rbeam < convergence:
+        relative_change = _relative_stack_change(rbeam, rbeam0)
+        if relative_change < convergence:
+            converged = True
             break
         # this updates the always longer beam signal for correlation
         # use rbeam is used for convergence testing
@@ -1621,11 +1624,13 @@ def align_and_stack(
             beam.elog.log_error(alg, message, ErrorSeverity.Invalid)
             return [ensemble, beam]
         rbeam0 = rbeam
-        nrm_rbeam = np.linalg.norm(rbeam0.data)
-    if i >= MAXITERATION:
+    if not converged:
         beam.kill()
-        message = "robust_stack iterative loop did not converge"
-        beam.elog.log_error(alg, message, ErrorSeverity.Invalid)
+        message = (
+            "align_and_stack: robust_stack iterative loop did not converge "
+            "after 20 iterations"
+        )
+        beam.elog.log_error(MsPASSError(message, ErrorSeverity.Invalid))
         return [ensemble, beam]
 
     # apply time shifts to original ensemble that we will return
@@ -1643,8 +1648,6 @@ def align_and_stack(
                 tshift = ensemble.member[i].t0 - initial_starttime
                 allshifts.append(tshift)
         tshift_mean = np.average(allshifts)
-        # debug
-        print("Applying average time shift of ", tshift_mean)
         for i in range(len(ensemble.member)):
             if ensemble.member[i].live:
                 # this method alters the t0 values of the ensemble members

--- a/python/tests/algorithms/test_mcxcor_convergence_contract.py
+++ b/python/tests/algorithms/test_mcxcor_convergence_contract.py
@@ -1,0 +1,211 @@
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import mspasspy.algorithms.MCXcorStacking as mcxcor
+from mspasspy.ccore.algorithms.basic import TimeWindow
+from mspasspy.ccore.seismic import DoubleVector, TimeSeries, TimeSeriesEnsemble
+from mspasspy.ccore.utility import ErrorSeverity
+
+SOURCE_PYTHON_ROOT = Path(
+    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
+)
+
+
+def make_timeseries(values, t0=0.0, dt=1.0):
+    datum = TimeSeries(len(values))
+    datum.t0 = t0
+    datum.dt = dt
+    datum.data = DoubleVector(values)
+    datum.force_t0_shift(0.0)
+    datum.set_live()
+    return datum
+
+
+def make_ensemble(*members):
+    ensemble = TimeSeriesEnsemble()
+    for member in members:
+        ensemble.member.append(member)
+    ensemble.set_live()
+    return ensemble
+
+
+@pytest.fixture(scope="session", autouse=True)
+def assert_mcxcor_module_loaded_from_selected_worktree():
+    expected = SOURCE_PYTHON_ROOT / "mspasspy/algorithms/MCXcorStacking.py"
+    assert Path(mcxcor.__file__).resolve() == expected.resolve()
+
+
+def test_relative_stack_change_is_padding_invariant_and_handles_zero_denominator():
+    changes = []
+    for padding in (0, 50):
+        previous = make_timeseries([2.0, 0.0] + [0.0] * padding)
+        new = make_timeseries([3.0, 0.0] + [0.0] * padding)
+        changes.append(mcxcor._relative_stack_change(new, previous))
+    assert changes == pytest.approx([0.5, 0.5])
+
+    zeros = make_timeseries([0.0, 0.0])
+    assert mcxcor._relative_stack_change(zeros, zeros) == 0.0
+    assert np.isinf(mcxcor._relative_stack_change(make_timeseries([1.0, 0.0]), zeros))
+
+
+def test_dbxcor_convergence_uses_previous_stack_and_not_padding_length(monkeypatch):
+    def run_with_padding(padding):
+        first = make_timeseries([1.0, 0.0] + [0.0] * padding)
+        second = make_timeseries([3.0, 0.0] + [0.0] * padding)
+        ensemble = make_ensemble(first, second)
+        initial = make_timeseries([2.0, 0.0] + [0.0] * padding)
+        weight_sequence = (
+            np.array([1.0, 0.0]),
+            np.array([0.0, 1.0]),
+            np.array([0.0, 1.0]),
+        )
+        calls = []
+
+        def fake_weights(*args, **kwargs):
+            calls.append(np.array(args[1].data))
+            return weight_sequence[min(len(calls) - 1, len(weight_sequence) - 1)]
+
+        monkeypatch.setattr(mcxcor, "dbxcor_weights", fake_weights)
+        stack, _ = mcxcor._dbxcor_stacker(ensemble, initial, eps=0.75, maxiterations=10)
+        return calls, np.array(stack.data), np.array(initial.data)
+
+    short_calls, short_stack, short_initial = run_with_padding(0)
+    padded_calls, padded_stack, padded_initial = run_with_padding(50)
+
+    assert [call[0] for call in short_calls] == [2.0, 1.0, 3.0]
+    assert [call[0] for call in padded_calls] == [2.0, 1.0, 3.0]
+    assert short_stack[0] == padded_stack[0] == 3.0
+    assert np.array_equal(short_initial, np.array([2.0, 0.0]))
+    assert np.array_equal(padded_initial, np.array([2.0, 0.0] + [0.0] * 50))
+
+
+@pytest.mark.parametrize("abort_irregular_sampling", [False, True])
+def test_align_and_stack_forwards_regularization_option(
+    monkeypatch, abort_irregular_sampling, capsys
+):
+    ensemble = make_ensemble(make_timeseries([1.0, 1.0]))
+    beam = make_timeseries([1.0, 1.0])
+    calls = []
+
+    def fake_regularize(data, dt_expected, Nsamp, abort_on_error=None):
+        calls.append((data, dt_expected, Nsamp, abort_on_error))
+        data.kill()
+        return data
+
+    monkeypatch.setattr(mcxcor, "regularize_sampling", fake_regularize)
+    result = mcxcor.align_and_stack(
+        ensemble,
+        beam,
+        abort_irregular_sampling=abort_irregular_sampling,
+    )
+
+    assert len(result) == 2
+    assert calls == [(ensemble, beam.dt, beam.npts, abort_irregular_sampling)]
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    ("use_median_initial_stack", "expected_seed"),
+    [(True, [2.0, 2.0]), (False, [9.0, 9.0])],
+)
+def test_align_and_stack_honors_initial_stack_option_and_success_shape(
+    monkeypatch,
+    use_median_initial_stack,
+    expected_seed,
+    capsys,
+):
+    ensemble = make_ensemble(make_timeseries([1.0, 1.0]), make_timeseries([3.0, 3.0]))
+    beam = make_timeseries([9.0, 9.0])
+    window = TimeWindow(0.0, 1.0)
+    seeds = []
+
+    monkeypatch.setattr(mcxcor, "regularize_sampling", lambda data, *a, **k: data)
+    monkeypatch.setattr(mcxcor, "beam_align", lambda data, *a, **k: data)
+
+    def fake_stacker(data, stack0, **kwargs):
+        seeds.append(np.array(stack0.data))
+        return [TimeSeries(stack0), np.ones(len(data.member))]
+
+    monkeypatch.setattr(mcxcor, "_dbxcor_stacker", fake_stacker)
+    monkeypatch.setattr(
+        mcxcor,
+        "dbxcor_weights",
+        lambda data, stack, **kwargs: np.ones(len(data.member)),
+    )
+    monkeypatch.setattr(
+        mcxcor, "_update_xcor_beam", lambda data, output, method, weights: output
+    )
+
+    result = mcxcor.align_and_stack(
+        ensemble,
+        beam,
+        correlation_window=window,
+        robust_stack_window=window,
+        use_median_initial_stack=use_median_initial_stack,
+        convergence=np.inf,
+    )
+
+    assert len(result) == 2
+    assert result[0] is ensemble
+    assert result[1].live
+    assert len(seeds) == 1
+    assert np.array_equal(seeds[0], np.array(expected_seed))
+    assert all(
+        member.is_defined("arrival_time_correction") for member in ensemble.member
+    )
+    assert capsys.readouterr().out == ""
+
+
+def test_align_and_stack_iteration_exhaustion_is_dead_atomic_and_silent(
+    monkeypatch, capsys
+):
+    first = make_timeseries([1.0, 1.0])
+    second = make_timeseries([1.0, 1.0])
+    second["arrival_time_correction"] = 4.5
+    ensemble = make_ensemble(first, second)
+    beam = make_timeseries([1.0, 1.0])
+    window = TimeWindow(0.0, 1.0)
+    robust_stack_calls = []
+
+    monkeypatch.setattr(mcxcor, "regularize_sampling", lambda data, *a, **k: data)
+    monkeypatch.setattr(mcxcor, "beam_align", lambda data, *a, **k: data)
+
+    def never_converges(data, stack0=None, **kwargs):
+        robust_stack_calls.append(stack0)
+        next_stack = TimeSeries(beam)
+        next_stack *= 2.0 ** len(robust_stack_calls)
+        return [next_stack, np.ones(len(data.member))]
+
+    monkeypatch.setattr(mcxcor, "robust_stack", never_converges)
+    monkeypatch.setattr(
+        mcxcor, "_update_xcor_beam", lambda data, output, method, weights: output
+    )
+
+    result = mcxcor.align_and_stack(
+        ensemble,
+        beam,
+        correlation_window=window,
+        robust_stack_window=window,
+        use_median_initial_stack=False,
+        convergence=0.5,
+    )
+
+    assert len(result) == 2
+    assert result[0] is ensemble
+    dead_beam = result[1]
+    assert dead_beam.dead()
+    assert len(robust_stack_calls) == 20
+    assert not first.is_defined("arrival_time_correction")
+    assert second["arrival_time_correction"] == 4.5
+    errors = dead_beam.elog.get_error_log()
+    assert len(errors) == 1
+    assert errors[0].algorithm == "MsPASSError"
+    assert errors[0].message == (
+        "align_and_stack: robust_stack iterative loop did not converge "
+        "after 20 iterations"
+    )
+    assert errors[0].badness == ErrorSeverity.Invalid
+    assert capsys.readouterr().out == ""

--- a/python/tests/algorithms/test_mcxcor_convergence_contract.py
+++ b/python/tests/algorithms/test_mcxcor_convergence_contract.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+from importlib.metadata import distribution, version
 from pathlib import Path
 
 import numpy as np
@@ -9,9 +11,26 @@ from mspasspy.ccore.algorithms.basic import TimeWindow
 from mspasspy.ccore.seismic import DoubleVector, TimeSeries, TimeSeriesEnsemble
 from mspasspy.ccore.utility import ErrorSeverity
 
-SOURCE_PYTHON_ROOT = Path(
-    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
-)
+
+def _assert_module_from_selected_build(module, relative_path):
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(module.__file__).resolve() == Path(expected_module).resolve()
 
 
 def make_timeseries(values, t0=0.0, dt=1.0):
@@ -33,9 +52,10 @@ def make_ensemble(*members):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def assert_mcxcor_module_loaded_from_selected_worktree():
-    expected = SOURCE_PYTHON_ROOT / "mspasspy/algorithms/MCXcorStacking.py"
-    assert Path(mcxcor.__file__).resolve() == expected.resolve()
+def assert_mcxcor_module_loaded_from_selected_build():
+    _assert_module_from_selected_build(
+        mcxcor, Path("mspasspy/algorithms/MCXcorStacking.py")
+    )
 
 
 def test_relative_stack_change_is_padding_invariant_and_handles_zero_denominator():


### PR DESCRIPTION
Fixes #854

## What changed

- forward the irregular-sampling abort option exactly
- honor median and caller-supplied initial stack seeds
- compute convergence with a stable relative L2 norm without aliasing the prior stack
- define zero, non-finite, success, and 20-iteration exhaustion behavior
- return a dead beam with exactly one Invalid diagnostic on exhaustion and avoid writing final shifts
- remove unexpected stdout and correct the user manual's option status

## Root cause and impact

The convergence loop aliased stack state, had an unreachable exhaustion check, and ignored documented options. This could falsely report convergence, silently continue after exhaustion, or initialize from the wrong stack.

## Validation

- focused contract plus existing MCXcor tests: 23 passed
- exact audited baseline: 7/7 contract tests failed
- Black, Python 3.12/3.13 `py_compile`, `git diff --check`, and Sphinx dummy build: passed
- independent agent review: REVIEW PASS

This PR is ready for human review and is intentionally not merged.