### PR TITLE
Fix spectral SNR normalization and DC bandwidth semantics

### DIFF
--- a/cxx/include/mspass/algorithms/amplitudes.h
+++ b/cxx/include/mspass/algorithms/amplitudes.h
@@ -335,8 +335,8 @@ public:
     /* All these conditionals are necessary for handling unexpected
      * values.   0 is effectively and error return.  Without these
      * the function can return NaN or generate floating point exceptions. */
-    if ((f_range <= 0.0) || (high_edge_f<=low_edge_f)
-      || (high_edge_f < 0.0) || (low_edge_f < 0.0) )
+    if ((f_range <= 0.0) || (high_edge_f <= low_edge_f) ||
+        (high_edge_f < 0.0) || (low_edge_f <= 0.0))
       return 0.0;
     else {
       double ratio = high_edge_f / low_edge_f;
@@ -367,10 +367,8 @@ To avoid issues with lines in noise spectra snr must exceed the threshold
 by more than 2*tbw frequency bins for an edge to be defined.  The edge back is
 defined as 2*tbw*df from the first point satisfying that constraint.
 
-Note this function handles the calculation correctly if the signal and
-noise windows have a drastically different length.  A subtle feature of
-psd estimates of stationary processes is that the psd level scales by
-1/length of the analysis window.   snr estimates correct for this effect.
+Signal and noise spectra are normalized PSD estimates, so their values are
+compared directly even when the analysis windows have different lengths.
 
 \param signal_df is the expected signal frequency bin size.   An error will be
 thrown if that does not match the power spectrem s df.
@@ -427,10 +425,8 @@ with the following keys and the concepts they defines:
      condition.  When this is false it means the data have not detectable
      signal based on the computed spectra.
 
-This function handles the calculation correctly if the signal and
-noise windows have a drastically different length.  A subtle feature of
-psd estimates of stationary processes is that the psd level scales by
-1/length of the analysis window.   snr estimates correct for this effect.
+Signal and noise spectra are normalized PSD estimates, so their values are
+compared directly even when the analysis windows have different lengths.
 
 Note the function does attempt to avoid Inf and NaN values that are possible
 if the noise value at some frequency is zero (negative is treated like 0).

--- a/cxx/src/lib/algorithms/snr.cc
+++ b/cxx/src/lib/algorithms/snr.cc
@@ -19,12 +19,6 @@ BandwidthData EstimateBandwidth(const double signal_df, const PowerSpectrum &s,
                                 const double snr_threshold, const double tbp,
                                 const double fhs,
                                 const bool fix_high_edge_to_fhs) {
-  /* This number defines a scaling to correct for difference in window length
-  for signal and noise windows.   It assumes the noise process is stationary
-  which pretty is pretty much essential for this entire algorithm to make
-  sense anyway. */
-  double window_length_correction =
-      static_cast<double>(s.nf()) / static_cast<double>(n.nf());
   /* Set the starting search points at low (based on noise tbp) and high (80%
   fny) sides */
   double flow_start, fhigh_start;
@@ -54,7 +48,7 @@ BandwidthData EstimateBandwidth(const double signal_df, const PowerSpectrum &s,
     namp = n.power(f);
     namp = sqrt(namp);
     if (namp > 0.0)
-      snrnow = window_length_correction * sigamp / namp;
+      snrnow = sigamp / namp;
     else {
       if (sigamp > 0.0)
         snrnow = NOISE_FREE;
@@ -96,7 +90,7 @@ BandwidthData EstimateBandwidth(const double signal_df, const PowerSpectrum &s,
     sigamp = sqrt(s.power(fhigh_start));
     namp = sqrt(n.power(fhigh_start));
     if (namp > 0.0)
-      snrnow = window_length_correction * sigamp / namp;
+      snrnow = sigamp / namp;
     else {
       if (sigamp > 0.0)
         snrnow = NOISE_FREE;
@@ -112,7 +106,7 @@ BandwidthData EstimateBandwidth(const double signal_df, const PowerSpectrum &s,
       sigamp = sqrt(s.spectrum[i]);
       namp = sqrt(n.power(f));
       if (namp > 0.0)
-        snrnow = window_length_correction * sigamp / namp;
+        snrnow = sigamp / namp;
       else {
         if (sigamp > 0.0)
           snrnow = NOISE_FREE;
@@ -147,8 +141,8 @@ Metadata BandwidthStatistics(const PowerSpectrum &s, const PowerSpectrum &n,
   /* the algorithm below will fail if either of these conditions is true so
   we trap that and return a null result.   Caller must handle the null
   return correctly*/
-  if ((bwd.f_range <= 0.0) || ((bwd.high_edge_f - bwd.low_edge_f) < s.df())
-       || s.dead() || n.dead() || s.nf()<=0 || n.nf()<=0) {
+  if ((bwd.f_range <= 0.0) || ((bwd.high_edge_f - bwd.low_edge_f) < s.df()) ||
+      s.dead() || n.dead() || s.nf() <= 0 || n.nf() <= 0) {
     result.put_double("median_snr", 0.0);
     result.put_double("maximum_snr", 0.0);
     result.put_double("minimum_snr", 0.0);
@@ -158,9 +152,6 @@ Metadata BandwidthStatistics(const PowerSpectrum &s, const PowerSpectrum &n,
     result.put_bool("stats_are_valid", false);
     return result;
   }
-  /* As noted above this correction is needed for an irregular window size*/
-  double window_length_correction =
-      static_cast<double>(s.nf()) / static_cast<double>(n.nf());
   std::vector<double> bandsnr;
   double f;
   for (f = bwd.low_edge_f; f < bwd.high_edge_f && f < s.Nyquist();
@@ -174,7 +165,7 @@ Metadata BandwidthStatistics(const PowerSpectrum &s, const PowerSpectrum &n,
       else
         snr = INDETERMINATE;
     } else {
-      snr = window_length_correction * signal_amp / noise_amp;
+      snr = signal_amp / noise_amp;
     }
     bandsnr.push_back(snr);
   }

--- a/cxx/test/spectrum/CMakeLists.txt
+++ b/cxx/test/spectrum/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(test_spectrum test_spectrum.cc)
+add_executable(test_spectral_snr test_spectral_snr.cc)
 #configure_file(test_spectrum.out test_spectrum.out COPYONLY)
 include_directories(
     ${Boost_INCLUDE_DIRS}
@@ -8,3 +9,5 @@ include_directories(
     ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(test_spectrum PRIVATE mspass ${Boost_LIBRARIES} ${Python_LIBRARIES})
+target_link_libraries(test_spectral_snr PRIVATE mspass ${Boost_LIBRARIES} ${Python_LIBRARIES})
+add_test(NAME test_spectral_snr COMMAND test_spectral_snr)

--- a/cxx/test/spectrum/test_spectral_snr.cc
+++ b/cxx/test/spectrum/test_spectral_snr.cc
@@ -1,0 +1,90 @@
+#include "mspass/algorithms/amplitudes.h"
+#include "mspass/seismic/PowerSpectrum.h"
+#include "mspass/utility/Metadata.h"
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+using mspass::algorithms::amplitudes::BandwidthData;
+using mspass::algorithms::amplitudes::BandwidthStatistics;
+using mspass::algorithms::amplitudes::EstimateBandwidth;
+using mspass::seismic::PowerSpectrum;
+using mspass::utility::Metadata;
+
+void require(const bool condition, const std::string &message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
+
+PowerSpectrum constant_spectrum(const std::size_t length) {
+  return PowerSpectrum(Metadata(), std::vector<double>(length, 4.0), 1.0,
+                       "constant normalized PSD", 0.0, 0.05, 20);
+}
+
+void test_normalized_snr_is_independent_of_storage_length() {
+  const PowerSpectrum signal = constant_spectrum(11);
+  const PowerSpectrum noise = constant_spectrum(6);
+  const BandwidthData passband =
+      EstimateBandwidth(1.0, signal, noise, 0.5, 0.5, 4.0, true);
+
+  require(passband.low_edge_snr == 1.0,
+          "identical normalized PSDs must have unit low-edge SNR");
+  require(passband.high_edge_snr == 1.0,
+          "identical normalized PSDs must have unit high-edge SNR");
+
+  const Metadata stats = BandwidthStatistics(signal, noise, passband);
+  require(stats.get_bool("stats_are_valid"),
+          "the constant-spectrum passband statistics must be valid");
+  for (const std::string key : {"median_snr", "maximum_snr", "minimum_snr",
+                                "q1_4_snr", "q3_4_snr", "mean_snr"}) {
+    require(stats.get_double(key) == 1.0,
+            key + " must be exactly one for identical normalized PSDs");
+  }
+}
+
+void test_storage_length_does_not_create_a_false_passband() {
+  const PowerSpectrum signal = constant_spectrum(11);
+  const PowerSpectrum noise = constant_spectrum(6);
+  const BandwidthData result =
+      EstimateBandwidth(1.0, signal, noise, 1.1, 0.5, 4.0, true);
+
+  require(result.low_edge_f == 0.0 && result.high_edge_f == 0.0 &&
+              result.f_range == 0.0,
+          "unit SNR must not cross a threshold greater than one");
+}
+
+void test_nonpositive_low_edge_uses_bandwidth_error_sentinel() {
+  BandwidthData bandwidth;
+  bandwidth.f_range = 10.0;
+  bandwidth.high_edge_f = 10.0;
+
+  bandwidth.low_edge_f = -1.0;
+  require(bandwidth.bandwidth() == 0.0,
+          "a negative low edge must return the exact error sentinel");
+
+  bandwidth.low_edge_f = 0.0;
+  require(bandwidth.bandwidth() == 0.0,
+          "a DC low edge must return the exact error sentinel");
+
+  bandwidth.low_edge_f = 1.0;
+  const double positive_bandwidth = bandwidth.bandwidth();
+  require(std::isfinite(positive_bandwidth) &&
+              std::abs(positive_bandwidth - 20.0) < 1.0e-12,
+          "a positive low edge must retain the logarithmic bandwidth");
+}
+} // namespace
+
+int main() {
+  try {
+    test_normalized_snr_is_independent_of_storage_length();
+    test_storage_length_does_not_create_a_false_passband();
+    test_nonpositive_low_edge_uses_bandwidth_error_sentinel();
+  } catch (const std::exception &error) {
+    std::cerr << "test_spectral_snr failed: " << error.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/python/tests/algorithms/test_snr.py
+++ b/python/tests/algorithms/test_snr.py
@@ -216,17 +216,17 @@ def test_FD_snr_estimator():
 
     # optional metric validation
     tval = fd_snr_output[0]["mean_snr"]
-    assert np.isclose(tval, 19.319007409878544)
+    assert np.isclose(tval, 48.28786223975323)
     tval = fd_snr_output[0]["maximum_snr"]
-    assert np.isclose(tval, 116.20203792513581)
+    assert np.isclose(tval, 290.44701315453074)
     tval = fd_snr_output[0]["median_snr"]
-    assert np.isclose(tval, 11.0556385265721898)
+    assert np.isclose(tval, 27.63357033915945)
     tval = fd_snr_output[0]["minimum_snr"]
-    assert np.isclose(tval, 0.8505634189930033)
+    assert np.isclose(tval, 2.1259834074864954)
     tval = fd_snr_output[0]["q3_4_snr"]
-    assert np.isclose(tval, 36.014785627993845)
+    assert np.isclose(tval, 90.01896267763411)
     tval = fd_snr_output[0]["q1_4_snr"]
-    assert np.isclose(tval, 3.0112995924822457)
+    assert np.isclose(tval, 7.526743833125472)
     tval = fd_snr_output[0]["stats_are_valid"]
     assert tval
     tval = fd_snr_output[0]["snr_filtered_envelope_peak"]

--- a/python/tests/algorithms/test_spectral_snr_contract.py
+++ b/python/tests/algorithms/test_spectral_snr_contract.py
@@ -1,0 +1,80 @@
+import os
+from pathlib import Path
+
+import pytest
+
+import mspasspy.ccore.algorithms.amplitudes as amplitudes_module
+from mspasspy.ccore.algorithms.amplitudes import (
+    BandwidthData,
+    BandwidthStatistics,
+    EstimateBandwidth,
+)
+from mspasspy.ccore.seismic import DoubleVector, PowerSpectrum
+from mspasspy.ccore.utility import Metadata
+
+
+def _constant_spectrum(length):
+    return PowerSpectrum(
+        Metadata(),
+        DoubleVector([4.0] * length),
+        1.0,
+        "constant normalized PSD",
+        0.0,
+        0.05,
+        20,
+    )
+
+
+def test_contract_suite_loads_selected_native_binding():
+    binding_path = Path(amplitudes_module.__file__).resolve()
+    assert binding_path.suffix == ".so"
+
+    expected_root = os.environ.get("MSPASS_TEST_CCORE_ROOT")
+    if expected_root is not None:
+        assert binding_path.is_relative_to(Path(expected_root).resolve())
+
+
+def test_normalized_snr_is_independent_of_spectrum_storage_length():
+    signal = _constant_spectrum(11)
+    noise = _constant_spectrum(6)
+    passband = EstimateBandwidth(1.0, signal, noise, 0.5, 0.5, 4.0, True)
+
+    assert passband.low_edge_snr == 1.0
+    assert passband.high_edge_snr == 1.0
+
+    stats = BandwidthStatistics(signal, noise, passband)
+    assert stats["stats_are_valid"] is True
+    for key in (
+        "median_snr",
+        "maximum_snr",
+        "minimum_snr",
+        "q1_4_snr",
+        "q3_4_snr",
+        "mean_snr",
+    ):
+        assert stats[key] == 1.0
+
+
+def test_storage_length_does_not_create_false_passband():
+    signal = _constant_spectrum(11)
+    noise = _constant_spectrum(6)
+    result = EstimateBandwidth(1.0, signal, noise, 1.1, 0.5, 4.0, True)
+
+    assert result.low_edge_f == 0.0
+    assert result.high_edge_f == 0.0
+    assert result.f_range == 0.0
+
+
+def test_bandwidth_rejects_nonpositive_low_edge():
+    bandwidth = BandwidthData()
+    bandwidth.f_range = 10.0
+    bandwidth.high_edge_f = 10.0
+
+    bandwidth.low_edge_f = -1.0
+    assert bandwidth.bandwidth() == 0.0
+
+    bandwidth.low_edge_f = 0.0
+    assert bandwidth.bandwidth() == 0.0
+
+    bandwidth.low_edge_f = 1.0
+    assert bandwidth.bandwidth() == pytest.approx(20.0)


### PR DESCRIPTION
Fixes #849

## What changed

- remove the second `nf()` window-length scaling from already normalized signal/noise PSD ratios
- use the same normalized PSD semantics in `BandwidthStatistics`
- return the documented `0.0` bandwidth sentinel when the low edge is DC or negative
- update the API comments and focused SNR expectations
- add Release-safe native and real binding regression coverage

## Root cause and impact

The SNR code applied an extra spectrum-length ratio after both spectra had already been normalized. Unequal window lengths therefore produced biased ratios and false passbands. DC bandwidth also divided by a non-positive low edge and returned infinity.

## Validation

- Release full CTest: 13/13 passed
- rebuilt Python binding plus complete existing SNR tests: 8/8 passed, including local Mongo-backed coverage
- exact audited baseline: native contract failed; binding had 3 expected failures / 1 pass
- clang-format, Black, Python 3.12/3.13 `py_compile`, and `git diff --check`: passed
- independent agent review: REVIEW PASS

This PR is ready for human review and is intentionally not merged.