### PR TITLE
Return logged dead MCXcor results for empty and all-dead ensembles

### DIFF
--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -708,7 +708,10 @@ def regularize_ensemble(
     Uses WindowData to assure all data are inside the common
     range starttime:endtime.  Dead data are dropped with one summary
     posted to the output ensemble.  Errors created while windowing a
-    dropped live member are copied back to that input member.
+    dropped live member are copied back to that input member, but this
+    helper does not change the member's pre-call live/dead state.  Dropping
+    some members is a nonfatal Complaint; the summary is Invalid only when
+    no member survives and the returned ensemble is dead.
     """
     ensout = TimeSeriesEnsemble(Metadata(ensemble), len(ensemble.member))
     if ensemble.elog.size() > 0:
@@ -736,7 +739,6 @@ def regularize_ensemble(
                             member.elog.log_error(
                                 error.algorithm, error.message, error.badness
                             )
-                    member.kill()
                     dropped_indices.append(i)
             else:
                 ensout.member.append(member)
@@ -746,7 +748,12 @@ def regularize_ensemble(
         message = "regularize_ensemble: dropped {} member(s) at indices {}".format(
             len(dropped_indices), ", ".join(str(i) for i in dropped_indices)
         )
-        ensout.elog.log_error(MsPASSError(message, ErrorSeverity.Invalid))
+        if ensout.member:
+            ensout.elog.log_error(
+                "regularize_ensemble", message, ErrorSeverity.Complaint
+            )
+        else:
+            ensout.elog.log_error(MsPASSError(message, ErrorSeverity.Invalid))
     if len(ensout.member) > 0:
         ensout.set_live()
     else:

--- a/python/mspasspy/algorithms/MCXcorStacking.py
+++ b/python/mspasspy/algorithms/MCXcorStacking.py
@@ -705,40 +705,61 @@ def regularize_ensemble(
     """
     Secondary function to regularize an ensemble for input to robust
     stacking algorithm.  ASsumes all data have the same sample rate.
-    Uses WindowData to assumre all data are inside the common
-    range startime:endtime.  Silently drops dead data.
+    Uses WindowData to assure all data are inside the common
+    range starttime:endtime.  Dead data are dropped with one summary
+    posted to the output ensemble.  Errors created while windowing a
+    dropped live member are copied back to that input member.
     """
     ensout = TimeSeriesEnsemble(Metadata(ensemble), len(ensemble.member))
     if ensemble.elog.size() > 0:
         ensout.elog = ensemble.elog
+    dropped_indices = []
     for i in range(len(ensemble.member)):
-        d = ensemble.member[i]
-        if d.live:
+        member = ensemble.member[i]
+        if member.live:
             if (
-                np.fabs((d.t0 - starttime)) > d.dt
-                or np.fabs(d.endtime() - endtime) > d.dt
+                np.fabs((member.t0 - starttime)) > member.dt
+                or np.fabs(member.endtime() - endtime) > member.dt
             ):
                 d = WindowData_autopad(
-                    d,
+                    member,
                     starttime,
                     endtime,
                     pad_fraction_cutoff=pad_fraction_cutoff,
                 )
                 if d.live:
-                    message = "Dropped member number {} because undefined data range exceeded limit of {}\n".format(
-                        i, pad_fraction_cutoff
-                    )
                     ensout.member.append(d)
+                else:
+                    if d is not member:
+                        member_error_count = member.elog.size()
+                        for error in d.elog.get_error_log()[member_error_count:]:
+                            member.elog.log_error(
+                                error.algorithm, error.message, error.badness
+                            )
+                    member.kill()
+                    dropped_indices.append(i)
             else:
-                ensout.member.append(d)
+                ensout.member.append(member)
         else:
-            message = "Dropped member number {} that was marked dead on input".format(i)
-            ensout.elog.log_error(
-                "regularize_ensemble", message, ErrorSeverity.Complaint
-            )
+            dropped_indices.append(i)
+    if dropped_indices:
+        message = "regularize_ensemble: dropped {} member(s) at indices {}".format(
+            len(dropped_indices), ", ".join(str(i) for i in dropped_indices)
+        )
+        ensout.elog.log_error(MsPASSError(message, ErrorSeverity.Invalid))
     if len(ensout.member) > 0:
         ensout.set_live()
+    else:
+        ensout.kill()
     return ensout
+
+
+def _logged_dead_timeseries(message) -> TimeSeries:
+    """Return an empty dead TimeSeries with one Invalid diagnostic."""
+    result = TimeSeries()
+    result.elog.log_error(MsPASSError(message, ErrorSeverity.Invalid))
+    result.kill()
+    return result
 
 
 def robust_stack(
@@ -855,7 +876,9 @@ def robust_stack(
         from the (optional) stack_md argument.   Component 1 is defined only
         for the dbxcor method in which case it is a numpy array containing the
         robust weights returned by the dbxcor algorithm.  If the method is
-        set to "median" component 1 will be returned as a None type.
+        set to "median" component 1 will be returned as a None type.  With no
+        live ensemble members, component 0 is a logged dead `TimeSeries`,
+        component 1 is `None`, and the input ensemble is marked dead and logged.
     """
     alg = "robust_stack"
     # if other values for method are added they need to be added here
@@ -863,14 +886,14 @@ def robust_stack(
         message = alg + ":  Illegal value for argument method={}\n".format(method)
         message += "Currently must be either median or dbxcor"
         raise ValueError(message)
-    # don't test type - if we get illegal type let it thro0w an exception
-    if ensemble.dead():
-        d_bad = TimeSeries()
-        message = "Received an input ensemble marked dead - cannot compute a stack"
-        d_bad.elog.log_error(alg, message, ErrorSeverity.Invalid)
-        # this isn't currently required by better to be explicit
-        d_bad.kill()
-        return [d_bad, None]
+    # don't test type - if we get illegal type let it throw an exception
+    M = number_live(ensemble)
+    if M == 0:
+        message = "robust_stack: input ensemble contains no live members"
+        ensemble.kill()
+        ensemble.elog.log_error(MsPASSError(message, ErrorSeverity.Invalid))
+        return [_logged_dead_timeseries(message), None]
+    live_member = next(d for d in ensemble.member if d.live)
     if timespan_method == "stack0":
         if stack0:
             # intentionally don't test type of stack0
@@ -895,9 +918,8 @@ def robust_stack(
         )
         raise ValueError(message)
 
-    # below we clone common stuff form member[0] if ensemble
-    # that is safe only because this function guarantees member 0 is not dead
-    # or irregular
+    # A live member supplies the common sampling attributes.  It need not be
+    # member 0 because dead members are allowed in the input.
     # TODO:   removing this for a test - I don't think this is needed with a
     # change in the algorithm.  If that proves true remove this function
     # from this module and remove this comment and the call to regularize_ensemble
@@ -905,11 +927,10 @@ def robust_stack(
     #    ensemble, timespan.start, timespan.end, pad_fraction_cutoff
     # )
     # the above can remove some members
-    M = number_live(ensemble)
     M_e = len(ensemble.member)
     # can now assume they are all the same length and don't need to worry about empty ensembles
     # N = ensemble.member[0].npts
-    dt = ensemble.member[0].dt
+    dt = live_member.dt
     N = int((timespan.end - timespan.start) / dt) + 1
 
     if stack0 and method == "dbxcor":
@@ -941,9 +962,9 @@ def robust_stack(
             stack = TimeSeries(stack, stack_md)
         stack.t0 = timespan.start
         # this works because we can assume ensemble is not empty and clean
-        stack.dt = ensemble.member[0].dt
+        stack.dt = live_member.dt
         # Make sure the stack has the same time base as the input
-        stack.tref = ensemble.member[0].tref
+        stack.tref = live_member.tref
         # Always compute the median stack as a starting point
         # that was the algorithm of dbxcor and there are good reasons for it
         data_matrix = np.zeros(shape=[M, N])
@@ -1381,7 +1402,8 @@ def align_and_stack(
         with positive final weight also have ``robust_weight_key``; members
         killed by sampling or windowing failures are marked dead.  Component 1
         is the computed stack windowed to the range defined by
-        ``output_stack_window``.
+        ``output_stack_window``.  Empty and all-dead inputs return the same
+        ensemble identity marked dead and a separately logged dead `TimeSeries`.
     """
     alg = "align_and_stack"
     # xcor ensemble has the initial start time posted to each
@@ -1402,8 +1424,11 @@ def align_and_stack(
         message = alg + ":  illegal type for arg1 (beam) = {}\n".format(str(type(beam)))
         message += "Must be a TimeSeries"
         raise TypeError(message)
-    if ensemble.dead():
-        return [ensemble, beam]
+    if number_live(ensemble) == 0:
+        message = "align_and_stack: input ensemble contains no live members"
+        ensemble.kill()
+        ensemble.elog.log_error(MsPASSError(message, ErrorSeverity.Invalid))
+        return [ensemble, _logged_dead_timeseries(message)]
     if beam.dead():
         message = "ensemble was marked live but beam input was marked dead - cannot process this ensemble"
         ensemble.elog.log_error(alg, message, ErrorSeverity.Invalid)
@@ -1416,7 +1441,8 @@ def align_and_stack(
         abort_on_error=abort_irregular_sampling,
     )
     if ensemble.dead():
-        return [ensemble, beam]
+        message = "align_and_stack: sampling regularization removed all live members"
+        return [ensemble, _logged_dead_timeseries(message)]
     # we need to make sure this is part of a valid set of algorithms
     if robust_stack_method not in ["dbxcor", "median"]:
         message = "Invalid value for robust_stack_method={}.  See docstring".format(
@@ -2557,6 +2583,11 @@ def _update_xcor_beam(xcorens, beam0, robust_stack_method, wts) -> TimeSeries:
     # A tricky but fast way to initialize the data vector to all zeros
     # warning this depends upon a special property of the C++ implementation
     beam.set_npts(beam0.npts)
+    if number_live(xcorens) == 0:
+        message = "_update_xcor_beam: input ensemble contains no live members"
+        beam.elog.log_error(MsPASSError(message, ErrorSeverity.Invalid))
+        beam.kill()
+        return beam
     # Cautioniously copy these to beam.   Maybe should log an error if they
     # aren't defined but for now do this silently.   Possible
     # maintenace issue if these keys ever change in MCXcorPPrep.

--- a/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
+++ b/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
@@ -1,5 +1,7 @@
 import os
+import subprocess
 from contextlib import ExitStack
+from importlib.metadata import distribution, version
 from numbers import Real
 from pathlib import Path
 from unittest.mock import patch
@@ -19,14 +21,26 @@ from mspasspy.ccore.utility import ErrorSeverity
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _verify_worktree_module():
+def _verify_selected_build_module():
     source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
-    assert source_root, "MSPASS_TEST_SOURCE_ROOT must identify the tree under test"
-    module_path = Path(mcx.__file__).resolve()
-    expected_root = (Path(source_root).resolve() / "mspasspy").resolve()
-    assert module_path.is_relative_to(
-        expected_root
-    ), f"loaded {module_path}, expected a module below {expected_root}"
+    relative_path = Path("mspasspy/algorithms/MCXcorStacking.py")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(mcx.__file__).resolve() == Path(expected_module).resolve()
 
 
 def _live_timeseries(data, *, t0=0.0, dt=1.0):

--- a/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
+++ b/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
@@ -253,10 +253,13 @@ def test_align_and_stack_regularization_drop_is_logged_once(monkeypatch, capsys)
     ensemble.set_live()
     beam = _live_timeseries([1.0, 2.0, 3.0])
 
-    def forced_regularization_drop(input_ensemble, dt, Nsamp):
+    def forced_regularization_drop(
+        input_ensemble, dt, Nsamp, abort_on_error=False
+    ):
         assert input_ensemble is ensemble
         assert dt == beam.dt
         assert Nsamp == beam.npts
+        assert abort_on_error is False
         dropped_member = input_ensemble.member[0]
         dropped_member.elog.log_error(
             "forced_regularization",

--- a/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
+++ b/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
@@ -1,0 +1,391 @@
+import os
+from contextlib import ExitStack
+from numbers import Real
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import mspasspy.algorithms.MCXcorStacking as mcx
+from mspasspy.ccore.algorithms.basic import TimeWindow
+from mspasspy.ccore.seismic import (
+    DoubleVector,
+    TimeReferenceType,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+from mspasspy.ccore.utility import ErrorSeverity
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _verify_worktree_module():
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    assert source_root, "MSPASS_TEST_SOURCE_ROOT must identify the tree under test"
+    module_path = Path(mcx.__file__).resolve()
+    expected_root = (Path(source_root).resolve() / "mspasspy").resolve()
+    assert module_path.is_relative_to(
+        expected_root
+    ), f"loaded {module_path}, expected a module below {expected_root}"
+
+
+def _live_timeseries(data, *, t0=0.0, dt=1.0):
+    datum = TimeSeries()
+    datum.t0 = t0
+    datum.dt = dt
+    datum.set_npts(len(data))
+    datum.data = DoubleVector(data)
+    datum.set_live()
+    return datum
+
+
+def _zero_live_ensemble(case):
+    ensemble = TimeSeriesEnsemble()
+    if case == "empty":
+        return ensemble
+    for values in ([1.0, 2.0], [3.0, 4.0]):
+        member = _live_timeseries(values)
+        member.kill()
+        ensemble.member.append(member)
+    # Exercise an inconsistent but representable container state: the
+    # container is live although every member is dead.
+    ensemble.set_live()
+    return ensemble
+
+
+def _error_snapshot(datum):
+    return [
+        (entry.algorithm, entry.message, entry.badness)
+        for entry in datum.elog.get_error_log()
+    ]
+
+
+def _member_snapshot(ensemble):
+    return [
+        {
+            "object": member,
+            "live": member.live,
+            "metadata": dict(member),
+            "data": np.array(member.data, dtype=float),
+            "errors": _error_snapshot(member),
+        }
+        for member in ensemble.member
+    ]
+
+
+def _assert_member_snapshot(ensemble, snapshot):
+    assert len(ensemble.member) == len(snapshot)
+    for member, expected in zip(ensemble.member, snapshot):
+        assert member is expected["object"]
+        assert member.live == expected["live"]
+        assert dict(member) == expected["metadata"]
+        assert np.array_equal(np.array(member.data), expected["data"])
+        assert _error_snapshot(member) == expected["errors"]
+
+
+def _assert_finite_timeseries(datum):
+    assert np.isfinite(datum.t0)
+    assert np.isfinite(datum.dt)
+    assert np.all(np.isfinite(np.array(datum.data, dtype=float)))
+    for value in dict(datum).values():
+        if isinstance(value, Real):
+            assert np.isfinite(value)
+
+
+def _assert_single_invalid(datum, expected_message):
+    errors = datum.elog.get_error_log()
+    assert len(errors) == 1
+    assert errors[0].algorithm == "MsPASSError"
+    assert errors[0].message == expected_message
+    assert errors[0].badness == ErrorSeverity.Invalid
+
+
+def _fail_if_called(name):
+    return AssertionError(f"{name} must not run for a zero-live ensemble")
+
+
+@pytest.mark.parametrize("case", ["empty", "all_dead"])
+def test_align_and_stack_zero_live_contract(case, capsys):
+    ensemble = _zero_live_ensemble(case)
+    members_before = _member_snapshot(ensemble)
+    input_beam = _live_timeseries([1.0, 2.0, 1.0])
+
+    patched_calls = [
+        (mcx, "regularize_sampling"),
+        (mcx, "ensemble_time_range"),
+        (mcx, "beam_align"),
+        (mcx, "robust_stack"),
+        (mcx, "_update_xcor_beam"),
+        (mcx, "dbxcor_weights"),
+        (mcx.np, "median"),
+        (mcx.np, "average"),
+        (mcx.np.linalg, "norm"),
+        (mcx.signal, "correlate"),
+    ]
+    with ExitStack() as patches:
+        for owner, name in patched_calls:
+            patches.enter_context(
+                patch.object(owner, name, side_effect=_fail_if_called(name))
+            )
+        result = mcx.align_and_stack(ensemble, input_beam)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    returned_ensemble, returned_beam = result
+    assert returned_ensemble is ensemble
+    assert returned_ensemble.dead()
+    assert returned_beam is not input_beam
+    assert input_beam.live
+    assert input_beam.elog.size() == 0
+    assert np.array_equal(np.array(input_beam.data), np.array([1.0, 2.0, 1.0]))
+    assert isinstance(returned_beam, TimeSeries)
+    assert returned_beam.dead()
+    _assert_member_snapshot(returned_ensemble, members_before)
+    message = "align_and_stack: input ensemble contains no live members"
+    _assert_single_invalid(returned_ensemble, message)
+    _assert_single_invalid(returned_beam, message)
+    _assert_finite_timeseries(returned_beam)
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize("case", ["empty", "all_dead"])
+def test_robust_stack_zero_live_short_circuit(case, capsys):
+    ensemble = _zero_live_ensemble(case)
+    members_before = _member_snapshot(ensemble)
+
+    patched_calls = [
+        (mcx, "ensemble_time_range"),
+        (mcx, "WindowData"),
+        (mcx, "_dbxcor_stacker"),
+        (mcx.np, "zeros"),
+        (mcx.np, "median"),
+    ]
+    with ExitStack() as patches:
+        for owner, name in patched_calls:
+            patches.enter_context(
+                patch.object(owner, name, side_effect=_fail_if_called(name))
+            )
+        stack, weights = mcx.robust_stack(ensemble)
+
+    assert stack.dead()
+    assert weights is None
+    assert ensemble.dead()
+    _assert_member_snapshot(ensemble, members_before)
+    message = "robust_stack: input ensemble contains no live members"
+    _assert_single_invalid(ensemble, message)
+    _assert_single_invalid(stack, message)
+    _assert_finite_timeseries(stack)
+    assert capsys.readouterr().out == ""
+
+
+def test_robust_stack_uses_live_member_sampling_when_member_zero_is_dead(capsys):
+    ensemble = TimeSeriesEnsemble()
+    dead_first = _live_timeseries([9.0, 9.0, 9.0])
+    dead_first.dt = float("nan")
+    dead_first.t0 = float("nan")
+    dead_first.kill()
+    ensemble.member.append(dead_first)
+    live_member = _live_timeseries([1.0, 2.0, 3.0], t0=10.0, dt=0.5)
+    ensemble.member.append(live_member)
+    ensemble.set_live()
+
+    stack, weights = mcx.robust_stack(ensemble, method="median")
+
+    assert stack.live
+    assert weights is None
+    assert stack.t0 == 10.0
+    assert stack.dt == 0.5
+    assert np.array_equal(np.array(stack.data), np.array([1.0, 2.0, 3.0]))
+    _assert_finite_timeseries(stack)
+    assert ensemble.member[0].dead()
+    assert ensemble.member[1].live
+    assert capsys.readouterr().out == ""
+
+
+def test_align_and_stack_one_live_control(capsys):
+    samples = [0.0, 1.0, 2.0, 1.0, 0.0]
+    ensemble = TimeSeriesEnsemble()
+    member = _live_timeseries(samples, t0=1000.0)
+    member.tref = TimeReferenceType.UTC
+    member.ator(1000.0)
+    ensemble.member.append(member)
+    ensemble.set_live()
+    beam = _live_timeseries(samples, t0=1000.0)
+    beam.tref = TimeReferenceType.UTC
+    beam.ator(1000.0)
+    window = TimeWindow(0.0, 4.0)
+
+    returned_ensemble, returned_beam = mcx.align_and_stack(
+        ensemble,
+        beam,
+        correlation_window=window,
+        robust_stack_window=window,
+        robust_stack_method="median",
+    )
+
+    assert returned_ensemble is ensemble
+    assert returned_ensemble.live
+    assert returned_ensemble.member[0].live
+    assert returned_beam.live
+    assert np.allclose(np.array(returned_beam.data), np.array(samples))
+    _assert_finite_timeseries(returned_beam)
+    assert capsys.readouterr().out == ""
+
+
+def test_align_and_stack_regularization_drop_is_logged_once(monkeypatch, capsys):
+    ensemble = TimeSeriesEnsemble()
+    member = _live_timeseries([1.0, 2.0, 3.0])
+    ensemble.member.append(member)
+    ensemble.set_live()
+    beam = _live_timeseries([1.0, 2.0, 3.0])
+
+    def forced_regularization_drop(input_ensemble, dt, Nsamp):
+        assert input_ensemble is ensemble
+        assert dt == beam.dt
+        assert Nsamp == beam.npts
+        dropped_member = input_ensemble.member[0]
+        dropped_member.elog.log_error(
+            "forced_regularization",
+            "forced lower-level member failure",
+            ErrorSeverity.Invalid,
+        )
+        dropped_member.kill()
+        input_ensemble.elog.log_error(
+            "forced_regularization",
+            "forced regularization summary",
+            ErrorSeverity.Invalid,
+        )
+        input_ensemble.kill()
+        return input_ensemble
+
+    monkeypatch.setattr(mcx, "regularize_sampling", forced_regularization_drop)
+    returned_ensemble, returned_beam = mcx.align_and_stack(ensemble, beam)
+
+    assert returned_ensemble is ensemble
+    assert returned_ensemble.dead()
+    assert _error_snapshot(returned_ensemble.member[0]) == [
+        (
+            "forced_regularization",
+            "forced lower-level member failure",
+            ErrorSeverity.Invalid,
+        )
+    ]
+    assert _error_snapshot(returned_ensemble) == [
+        (
+            "forced_regularization",
+            "forced regularization summary",
+            ErrorSeverity.Invalid,
+        )
+    ]
+    _assert_single_invalid(
+        returned_beam,
+        "align_and_stack: sampling regularization removed all live members",
+    )
+    assert returned_beam.dead()
+    _assert_finite_timeseries(returned_beam)
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    ("method", "weights"),
+    [("median", None), ("dbxcor", np.array([-1.0, -1.0]))],
+)
+def test_update_xcor_beam_zero_live_short_circuit(method, weights, capsys):
+    ensemble = _zero_live_ensemble("all_dead")
+    input_beam = _live_timeseries([1.0, 2.0, 3.0])
+
+    with (
+        patch.object(mcx, "WindowData", side_effect=_fail_if_called("WindowData")),
+        patch.object(mcx.np, "median", side_effect=_fail_if_called("median")),
+    ):
+        beam = mcx._update_xcor_beam(ensemble, input_beam, method, weights)
+
+    assert beam is not input_beam
+    assert input_beam.live
+    assert np.array_equal(np.array(input_beam.data), np.array([1.0, 2.0, 3.0]))
+    assert beam.dead()
+    assert np.array_equal(np.array(beam.data), np.zeros(3))
+    message = "_update_xcor_beam: input ensemble contains no live members"
+    _assert_single_invalid(beam, message)
+    _assert_finite_timeseries(beam)
+    assert capsys.readouterr().out == ""
+
+
+def test_regularize_ensemble_transfers_drop_diagnostics_once(capsys):
+    ensemble = TimeSeriesEnsemble()
+    failed_member = _live_timeseries([1.0, 2.0])
+    failed_member.elog.log_error(
+        "prior", "prior member message", ErrorSeverity.Complaint
+    )
+    ensemble.member.append(failed_member)
+    already_dead = _live_timeseries([3.0] * 11)
+    already_dead.elog.log_error(
+        "prior", "preexisting dead message", ErrorSeverity.Invalid
+    )
+    already_dead.kill()
+    ensemble.member.append(already_dead)
+    good_member = _live_timeseries([4.0] * 11)
+    ensemble.member.append(good_member)
+    ensemble.set_live()
+    output = mcx.regularize_ensemble(ensemble, 0.0, 10.0, pad_fraction_cutoff=0.05)
+
+    assert output.live
+    assert len(output.member) == 1
+    assert np.array_equal(np.array(output.member[0].data), np.array([4.0] * 11))
+    assert ensemble.member[0].dead()
+    failed_errors = ensemble.member[0].elog.get_error_log()
+    assert [entry.algorithm for entry in failed_errors] == [
+        "prior",
+        "WindowDataAtomic",
+        "WindowData_autopad",
+    ]
+    assert [entry.badness for entry in failed_errors] == [
+        ErrorSeverity.Complaint,
+        ErrorSeverity.Complaint,
+        ErrorSeverity.Invalid,
+    ]
+    assert failed_errors[0].message == "prior member message"
+    assert "Window end time is after data end time" in failed_errors[1].message
+    assert "time span of data is too short" in failed_errors[2].message
+    assert _error_snapshot(ensemble.member[1]) == [
+        ("prior", "preexisting dead message", ErrorSeverity.Invalid)
+    ]
+    summary = "regularize_ensemble: dropped 2 member(s) at indices 0, 1"
+    _assert_single_invalid(output, summary)
+    assert capsys.readouterr().out == ""
+
+
+def test_align_and_stack_all_dropped_by_sampling_regularization(capsys):
+    ensemble = TimeSeriesEnsemble()
+    for values in ([1.0] * 10, [2.0] * 10):
+        ensemble.member.append(_live_timeseries(values, dt=2.0))
+    ensemble.set_live()
+    member_objects = list(ensemble.member)
+    beam = _live_timeseries([1.0] * 10, dt=1.0)
+
+    returned_ensemble, returned_beam = mcx.align_and_stack(ensemble, beam)
+
+    assert returned_ensemble is ensemble
+    assert returned_ensemble.dead()
+    assert len(returned_ensemble.member) == 2
+    for returned_member, original_member in zip(
+        returned_ensemble.member, member_objects
+    ):
+        assert returned_member is original_member
+        assert returned_member.dead()
+        errors = returned_member.elog.get_error_log()
+        assert len(errors) == 1
+        assert errors[0].algorithm == "regularize_sampling"
+        assert errors[0].badness == ErrorSeverity.Invalid
+    ensemble_errors = returned_ensemble.elog.get_error_log()
+    assert len(ensemble_errors) == 1
+    assert ensemble_errors[0].algorithm == "regularize_sampling"
+    assert ensemble_errors[0].badness == ErrorSeverity.Invalid
+    assert returned_beam is not beam
+    assert returned_beam.dead()
+    _assert_single_invalid(
+        returned_beam,
+        "align_and_stack: sampling regularization removed all live members",
+    )
+    _assert_finite_timeseries(returned_beam)
+    assert capsys.readouterr().out == ""

--- a/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
+++ b/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
@@ -346,7 +346,7 @@ def test_regularize_ensemble_transfers_drop_diagnostics_once(capsys):
     assert output.live
     assert len(output.member) == 1
     assert np.array_equal(np.array(output.member[0].data), np.array([4.0] * 11))
-    assert ensemble.member[0].dead()
+    assert ensemble.member[0].live
     failed_errors = ensemble.member[0].elog.get_error_log()
     assert [entry.algorithm for entry in failed_errors] == [
         "prior",
@@ -365,7 +365,26 @@ def test_regularize_ensemble_transfers_drop_diagnostics_once(capsys):
         ("prior", "preexisting dead message", ErrorSeverity.Invalid)
     ]
     summary = "regularize_ensemble: dropped 2 member(s) at indices 0, 1"
-    _assert_single_invalid(output, summary)
+    assert _error_snapshot(output) == [
+        ("regularize_ensemble", summary, ErrorSeverity.Complaint)
+    ]
+    assert capsys.readouterr().out == ""
+
+
+def test_regularize_ensemble_all_dropped_is_invalid_without_killing_input(capsys):
+    ensemble = TimeSeriesEnsemble()
+    member = _live_timeseries([1.0, 2.0])
+    ensemble.member.append(member)
+    ensemble.set_live()
+
+    output = mcx.regularize_ensemble(ensemble, 0.0, 10.0, pad_fraction_cutoff=0.05)
+
+    assert output.dead()
+    assert len(output.member) == 0
+    assert member.live
+    _assert_single_invalid(
+        output, "regularize_ensemble: dropped 1 member(s) at indices 0"
+    )
     assert capsys.readouterr().out == ""
 
 


### PR DESCRIPTION
Fixes #855

## Summary

- short-circuit empty and all-dead MCXcor paths before numerical kernels
- return finite logged dead beams while preserving ensemble identity and members
- preserve lower-level diagnostics exactly once and remove stdout noise
- keep ordinary member dropping nonfatal when usable members remain

## Renewed scientific/error-policy review

The zero-live result is an Invalid condition, but the first version also promoted ordinary pre-dead/window-dropped members to an Invalid ensemble summary and killed an originally live input member. That widened the established `regularize_ensemble` behavior beyond the empty-result defect. Commit `32e62356` preserves transferred lower-level diagnostics without changing the member's pre-call life state; a partial drop now produces one `Complaint`, while an all-dropped dead result still produces one `MsPASSError(Invalid)`.

The public helper docstring now states that distinction explicitly instead of implying that every routine drop is fatal.

## Verification

- renewed contract plus adjacent complete MCXcor regression: `28 passed`
- partial drop, all-dropped result, input-member state, diagnostic order/severity, empty/all-dead short circuits, and stdout silence are covered
- Black 26.5.1, Python 3.12/3.13 `py_compile`, and `git diff --check`: passed

This PR intentionally remains draft pending human seismological/error-policy review.