### PR TITLE
Normalize Python scale validation, metadata, and exception returns

### DIFF
--- a/cxx/src/lib/algorithms/amplitudes.cc
+++ b/cxx/src/lib/algorithms/amplitudes.cc
@@ -93,6 +93,8 @@ double PercAmplitude(const CoreTimeSeries &d, const double perc) {
   sort(amps.begin(), amps.end());
   size_t n = amps.size();
   size_t iperc = static_cast<size_t>(percfrac * static_cast<double>(n));
+  if (iperc >= amps.size())
+    iperc = amps.size() - 1;
   return amps[iperc];
 }
 double PercAmplitude(const CoreSeismogram &d, const double perc) {

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -96,6 +96,7 @@ def scale(
     handles_ensembles=True,
     checks_arg0_type=True,
     handles_dead_data=True,
+    propagate_exceptions=True,
     **kwargs,
 ):
     """
@@ -155,6 +156,9 @@ def scale(
       True.   The algorithm used in that case has an option to use the mean
       log amplitude for scaling the section instead of the default median
       amplitude.
+    :param propagate_exceptions: when True (default), unexpected Python
+      exceptions propagate without logging or killing input data.  Documented
+      MsPASSError data failures are still logged as Invalid and kill live data.
 
     :return: Data scaled to specified level.  Note the scaling always preserves
       absolute amplitude by adjusting the value of the calib attribute of the

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -34,7 +34,7 @@ def ensemble_error_post(d, alg, message, severity):
     This is a small helper function useful for error handlers in except
     blocks for ensemble objects.  If a function is called on an ensemble
     object that throws an exception this function will post the message
-    posted to all ensemble members.  It silently does nothing if the
+    to all live ensemble members.  It silently does nothing if the
     ensemble is empty.
 
     :param d: is the ensemble data to be handled.  It print and error message
@@ -49,7 +49,8 @@ def ensemble_error_post(d, alg, message, severity):
         if n <= 0:
             return
         for i in range(n):
-            d.member[i].elog.log_error(alg, str(message), severity)
+            if d.member[i].live:
+                d.member[i].elog.log_error(alg, str(message), severity)
     else:
         print(
             "Coding error - ensemble_error_post was passed an unexpected data type of",
@@ -64,11 +65,11 @@ def _post_amplitude(d, method, amp):
     computed amplitudes to metadata with a different key for each method
     used to compute amplitude.
     """
-    if method == "rms" or method == "RMS":
+    if method == ScalingMethod.RMS:
         d["rms_amplitude"] = amp
-    elif method == "perc":
+    elif method == ScalingMethod.ClipPerc:
         d["perc_amplitude"] = amp
-    elif method == "MAD" or method == "mad":
+    elif method == ScalingMethod.MAD:
         d["mad_amplitude"] = amp
     else:
         d["amplitude"] = amp
@@ -206,7 +207,7 @@ def scale(
                 ensemble_error_post(d, alg_name, message, ErrorSeverity.Complaint)
             else:
                 d.elog.log_error(alg_name, message, ErrorSeverity.Complaint)
-                level = 1.0
+            level = 1.0
     else:
         if level <= 0.0:
             message = "{meth} scaling method given illegal value={slevel}\nDefaulted to 1.0".format(
@@ -240,7 +241,7 @@ def scale(
     if method == "rms" or method == "RMS":
         method_to_use = ScalingMethod.RMS
     elif method == "perc":
-        method_to_use = ScalingMethod.perc
+        method_to_use = ScalingMethod.ClipPerc
     elif method == "MAD" or method == "mad":
         method_to_use = ScalingMethod.MAD
     try:
@@ -279,20 +280,26 @@ def scale(
         # if we add any other supported data objects we could have a
         # problem here.  This assumes what lands here is an ensemble
         else:
-            ensemble_error_post(d, alg_name, err)
+            ensemble_error_post(d, alg_name, err, ErrorSeverity.Invalid)
             for x in d.member:
-                x.kill()
+                if x.live:
+                    x.kill()
         return d
     # this is needed to handle an oddity recommended on this
     # web site:  http://effbot.org/zone/stupid-exceptions-keyboardinterrupt.htm
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, SystemExit):
         raise
-    except:
+    except Exception:
         message = "Something threw an unexpected exception\nThat is a bug that needs to be fixed - contact authors"
         if isinstance(d, Seismogram) or isinstance(d, TimeSeries):
             d.elog.log_error(alg_name, message, ErrorSeverity.Invalid)
+            d.kill()
         else:
             ensemble_error_post(d, alg_name, message, ErrorSeverity.Invalid)
+            for x in d.member:
+                if x.live:
+                    x.kill()
+        return d
 
 
 # not decorated for reasons given in docstring below

--- a/python/mspasspy/algorithms/window.py
+++ b/python/mspasspy/algorithms/window.py
@@ -285,21 +285,6 @@ def scale(
                 if x.live:
                     x.kill()
         return d
-    # this is needed to handle an oddity recommended on this
-    # web site:  http://effbot.org/zone/stupid-exceptions-keyboardinterrupt.htm
-    except (KeyboardInterrupt, SystemExit):
-        raise
-    except Exception:
-        message = "Something threw an unexpected exception\nThat is a bug that needs to be fixed - contact authors"
-        if isinstance(d, Seismogram) or isinstance(d, TimeSeries):
-            d.elog.log_error(alg_name, message, ErrorSeverity.Invalid)
-            d.kill()
-        else:
-            ensemble_error_post(d, alg_name, message, ErrorSeverity.Invalid)
-            for x in d.member:
-                if x.live:
-                    x.kill()
-        return d
 
 
 # not decorated for reasons given in docstring below

--- a/python/mspasspy/util/decorators.py
+++ b/python/mspasspy/util/decorators.py
@@ -57,6 +57,7 @@ def mspass_func_wrapper(
     handles_ensembles=True,
     checks_arg0_type=False,
     handles_dead_data=True,
+    propagate_exceptions=False,
     **kwargs,
 ):
     """
@@ -174,6 +175,9 @@ def mspass_func_wrapper(
       can hangle ensemble objects directly.   When False
       this decorator applies the atomic function to each ensemble member in
       a loop over membes.
+    :param propagate_exceptions: when True, RuntimeError and other unexpected
+      exceptions are re-raised without logging or killing arg0.  The default
+      False preserves the standard wrapper behavior.
     :param kwargs: extra kv arguments
     :return: modified seismic data object.  Can be a different type than
        the input.   If function_return_key is used only the Metadata
@@ -298,6 +302,8 @@ def mspass_func_wrapper(
     # On failure log arg0, kill it, and return it so callers never see implicit None.
     # Fatal MsPASSError is re-raised and does not use this handler.
     except RuntimeError as err:
+        if propagate_exceptions:
+            raise
         if isinstance(data, (Seismogram, TimeSeries)):
             data.elog.log_error(alg_name, str(err), ErrorSeverity.Invalid)
         else:
@@ -314,6 +320,8 @@ def mspass_func_wrapper(
         data.kill()
         return data
     except Exception as exc:
+        if propagate_exceptions:
+            raise
         if not isinstance(data, _MSPASS_WRAPPER_DATA_TYPES):
             raise exc
         if isinstance(data, (Seismogram, TimeSeries)):

--- a/python/tests/algorithms/test_scale_wrapper_contract.py
+++ b/python/tests/algorithms/test_scale_wrapper_contract.py
@@ -293,20 +293,14 @@ def test_percentile_validation_recovers_and_continues(
     "input_kind", ["atomic", "ensemble_members", "ensemble_section"]
 )
 @pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
-@pytest.mark.parametrize("error_kind", ["mspass", "generic"])
-def test_exceptions_kill_and_return_original_object(
-    input_kind, waveform_type, error_kind
-):
+def test_mspass_errors_kill_and_return_original_object(input_kind, waveform_type):
     data, target_name, scale_kwargs, live_members, dead_members = _input_and_target(
         input_kind, waveform_type=waveform_type
     )
     dead_snapshots = [
         (dict(member), np.asarray(member.data).copy()) for member in dead_members
     ]
-    if error_kind == "mspass":
-        error = MsPASSError("injected scale failure", ErrorSeverity.Complaint)
-    else:
-        error = RuntimeError("injected generic scale failure")
+    error = MsPASSError("injected scale failure", ErrorSeverity.Complaint)
 
     with patch.object(window_module, target_name, side_effect=error):
         result = window_module.scale(data, **scale_kwargs)
@@ -319,16 +313,53 @@ def test_exceptions_kill_and_return_original_object(
         assert len(errors) == 1
         assert errors[0].algorithm == "scale"
         assert errors[0].badness == ErrorSeverity.Invalid
-        if error_kind == "mspass":
-            assert "injected scale failure" in errors[0].message
-        else:
-            assert "unexpected exception" in errors[0].message
+        assert "injected scale failure" in errors[0].message
         assert _defined_amplitude_keys(member) == set()
     for member, (metadata, samples) in zip(dead_members, dead_snapshots):
         assert member.dead()
         assert _error_log(member) == []
         assert dict(member) == metadata
         assert np.array_equal(np.asarray(member.data), samples)
+
+
+@pytest.mark.parametrize(
+    "input_kind", ["atomic", "ensemble_members", "ensemble_section"]
+)
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+@pytest.mark.parametrize("exception_type", [RuntimeError, TypeError])
+def test_unexpected_exceptions_propagate_without_mutation(
+    input_kind, waveform_type, exception_type
+):
+    data, target_name, scale_kwargs, live_members, dead_members = _input_and_target(
+        input_kind, waveform_type=waveform_type
+    )
+    before = [
+        (dict(member), np.asarray(member.data).copy(), member.live)
+        for member in live_members + dead_members
+    ]
+
+    with patch.object(
+        window_module, target_name, side_effect=exception_type("injected failure")
+    ):
+        with pytest.raises(exception_type, match="injected failure"):
+            window_module.scale(data, **scale_kwargs)
+
+    current_live, current_dead = _current_members(data, input_kind)
+    for member, (metadata, samples, live) in zip(current_live + current_dead, before):
+        assert dict(member) == metadata
+        assert np.array_equal(np.asarray(member.data), samples)
+        assert member.live is live
+        assert _error_log(member) == []
+
+
+def test_timeseries_percentile_preserves_rank_and_caps_terminal_index():
+    median_rank = _atomic()
+    window_module.scale(median_rank, method="perc", level=0.5)
+    assert median_rank["perc_amplitude"] == pytest.approx(3.0)
+
+    terminal_rank = _atomic()
+    window_module.scale(terminal_rank, method="perc", level=1.0)
+    assert terminal_rank["perc_amplitude"] == pytest.approx(4.0)
 
 
 @pytest.mark.parametrize(

--- a/python/tests/algorithms/test_scale_wrapper_contract.py
+++ b/python/tests/algorithms/test_scale_wrapper_contract.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+from importlib.metadata import distribution, version
 from pathlib import Path
 from unittest.mock import patch
 
@@ -96,14 +98,26 @@ def _current_members(data, input_kind, include_dead=True):
     return live_members, dead_members
 
 
-def test_contract_module_is_loaded_from_selected_tree():
+def test_contract_module_is_loaded_from_selected_build():
     source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
-    assert source_root, "MSPASS_TEST_SOURCE_ROOT must identify the tree under test"
-    assert (
-        Path(window_module.__file__)
-        .resolve()
-        .is_relative_to(Path(source_root).resolve())
-    )
+    relative_path = Path("mspasspy/algorithms/window.py")
+    if source_root:
+        expected_module = Path(source_root) / relative_path
+    else:
+        expected_module = distribution("mspasspy").locate_file(relative_path)
+        installed_version = version("mspasspy")
+        installed_commit = installed_version.partition("+g")[2].partition(".")[0]
+        assert installed_commit, "installed mspasspy version lacks a source commit"
+        repository_root = next(
+            parent
+            for parent in Path(__file__).resolve().parents
+            if (parent / ".git").exists()
+        )
+        checkout_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True
+        ).strip()
+        assert checkout_commit.startswith(installed_commit)
+    assert Path(window_module.__file__).resolve() == Path(expected_module).resolve()
 
 
 @pytest.mark.parametrize(

--- a/python/tests/algorithms/test_scale_wrapper_contract.py
+++ b/python/tests/algorithms/test_scale_wrapper_contract.py
@@ -333,9 +333,10 @@ def test_unexpected_exceptions_propagate_without_mutation(
     data, target_name, scale_kwargs, live_members, dead_members = _input_and_target(
         input_kind, waveform_type=waveform_type
     )
+    members = list(live_members) + list(dead_members)
     before = [
         (dict(member), np.asarray(member.data).copy(), member.live)
-        for member in live_members + dead_members
+        for member in members
     ]
 
     with patch.object(
@@ -345,7 +346,8 @@ def test_unexpected_exceptions_propagate_without_mutation(
             window_module.scale(data, **scale_kwargs)
 
     current_live, current_dead = _current_members(data, input_kind)
-    for member, (metadata, samples, live) in zip(current_live + current_dead, before):
+    current_members = list(current_live) + list(current_dead)
+    for member, (metadata, samples, live) in zip(current_members, before):
         assert dict(member) == metadata
         assert np.array_equal(np.asarray(member.data), samples)
         assert member.live is live

--- a/python/tests/algorithms/test_scale_wrapper_contract.py
+++ b/python/tests/algorithms/test_scale_wrapper_contract.py
@@ -1,0 +1,373 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import mspasspy.algorithms.window as window_module
+from mspasspy.ccore.seismic import (
+    DoubleVector,
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+
+AMPLITUDE_KEYS = {
+    "amplitude",
+    "rms_amplitude",
+    "perc_amplitude",
+    "mad_amplitude",
+}
+
+
+def _atomic(multiplier=1.0, waveform_type="timeseries"):
+    samples = np.array([1.0, -2.0, 4.0, -3.0]) * multiplier
+    if waveform_type == "timeseries":
+        datum = TimeSeries(4)
+        datum.data = DoubleVector(samples)
+    else:
+        datum = Seismogram(4)
+        for sample_index, sample in enumerate(samples):
+            datum.data[0, sample_index] = sample
+            datum.data[1, sample_index] = 0.5 * sample
+            datum.data[2, sample_index] = -sample
+    datum.dt = 1.0
+    datum.t0 = 0.0
+    datum.set_live()
+    return datum
+
+
+def _ensemble(include_dead=True, waveform_type="timeseries"):
+    if waveform_type == "timeseries":
+        ensemble = TimeSeriesEnsemble()
+    else:
+        ensemble = SeismogramEnsemble()
+    ensemble.member.append(_atomic(1.0, waveform_type))
+    ensemble.member.append(_atomic(2.0, waveform_type))
+    if include_dead:
+        dead_member = _atomic(3.0, waveform_type)
+        dead_member.kill()
+        ensemble.member.append(dead_member)
+    ensemble.set_live()
+    return ensemble
+
+
+def _defined_amplitude_keys(datum):
+    return {key for key in AMPLITUDE_KEYS if datum.is_defined(key)}
+
+
+def _error_log(datum):
+    return datum.elog.get_error_log()
+
+
+def _input_and_target(input_kind, include_dead=True, waveform_type="timeseries"):
+    if input_kind == "atomic":
+        datum = _atomic(waveform_type=waveform_type)
+        return datum, "_scale", {}, [datum], []
+
+    ensemble = _ensemble(include_dead=include_dead, waveform_type=waveform_type)
+    live_members = ensemble.member[:2]
+    dead_members = ensemble.member[2:] if include_dead else []
+    if input_kind == "ensemble_members":
+        return (
+            ensemble,
+            "_scale_ensemble_members",
+            {"scale_by_section": False},
+            live_members,
+            dead_members,
+        )
+    return (
+        ensemble,
+        "_scale_ensemble",
+        {"scale_by_section": True},
+        live_members,
+        dead_members,
+    )
+
+
+def _current_members(data, input_kind, include_dead=True):
+    if input_kind == "atomic":
+        return [data], []
+    live_members = [data.member[0], data.member[1]]
+    dead_members = [data.member[2]] if include_dead else []
+    return live_members, dead_members
+
+
+def test_contract_module_is_loaded_from_selected_tree():
+    source_root = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    assert source_root, "MSPASS_TEST_SOURCE_ROOT must identify the tree under test"
+    assert (
+        Path(window_module.__file__)
+        .resolve()
+        .is_relative_to(Path(source_root).resolve())
+    )
+
+
+@pytest.mark.parametrize(
+    "method,expected_key",
+    [
+        ("peak", "amplitude"),
+        ("RMS", "rms_amplitude"),
+        ("rms", "rms_amplitude"),
+        ("perc", "perc_amplitude"),
+        ("MAD", "mad_amplitude"),
+        ("mad", "mad_amplitude"),
+    ],
+)
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+def test_atomic_methods_post_exact_amplitude_key(method, expected_key, waveform_type):
+    datum = _atomic(waveform_type=waveform_type)
+    level = 0.5 if method == "perc" else 1.0
+
+    result = window_module.scale(datum, method=method, level=level)
+
+    assert result is datum
+    assert datum.live
+    assert _defined_amplitude_keys(datum) == {expected_key}
+    assert datum[expected_key] > 0.0
+
+
+@pytest.mark.parametrize(
+    "method,expected_key",
+    [
+        ("peak", "amplitude"),
+        ("RMS", "rms_amplitude"),
+        ("rms", "rms_amplitude"),
+        ("perc", "perc_amplitude"),
+        ("MAD", "mad_amplitude"),
+        ("mad", "mad_amplitude"),
+    ],
+)
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+def test_section_methods_post_exact_amplitude_key(method, expected_key, waveform_type):
+    ensemble = _ensemble(waveform_type=waveform_type)
+    level = 0.5 if method == "perc" else 1.0
+
+    result = window_module.scale(
+        ensemble, method=method, level=level, scale_by_section=True
+    )
+
+    assert result is ensemble
+    assert _defined_amplitude_keys(ensemble) == {expected_key}
+    assert ensemble[expected_key] > 0.0
+    for member in ensemble.member:
+        assert _defined_amplitude_keys(member) == set()
+
+
+@pytest.mark.parametrize(
+    "method,expected_key",
+    [
+        ("peak", "amplitude"),
+        ("RMS", "rms_amplitude"),
+        ("rms", "rms_amplitude"),
+        ("perc", "perc_amplitude"),
+        ("MAD", "mad_amplitude"),
+        ("mad", "mad_amplitude"),
+    ],
+)
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+def test_ensemble_member_methods_post_exact_amplitude_key(
+    method, expected_key, waveform_type
+):
+    ensemble = _ensemble(include_dead=False, waveform_type=waveform_type)
+    level = 0.5 if method == "perc" else 1.0
+
+    result = window_module.scale(ensemble, method=method, level=level)
+
+    assert result is ensemble
+    assert _defined_amplitude_keys(ensemble) == set()
+    for member in ensemble.member:
+        assert member.live
+        assert _defined_amplitude_keys(member) == {expected_key}
+        assert member[expected_key] > 0.0
+
+
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+@pytest.mark.parametrize("scale_by_section", [False, True])
+def test_percentile_validation_posts_only_to_live_ensemble_members(
+    waveform_type, scale_by_section
+):
+    ensemble = _ensemble(waveform_type=waveform_type)
+    target_name = "_scale_ensemble" if scale_by_section else "_scale_ensemble_members"
+    return_value = 1.0 if scale_by_section else [1.0, 2.0, 0.0]
+    passed_levels = []
+
+    def record_level(*args, **kwargs):
+        passed_levels.append(args[2])
+        return return_value
+
+    with patch.object(window_module, target_name, side_effect=record_level):
+        result = window_module.scale(
+            ensemble,
+            method="perc",
+            level=0.0,
+            scale_by_section=scale_by_section,
+        )
+
+    assert result is ensemble
+    assert passed_levels == [1.0]
+    for member in ensemble.member[:2]:
+        errors = _error_log(member)
+        assert len(errors) == 1
+        assert errors[0].algorithm == "scale"
+        assert errors[0].badness == ErrorSeverity.Complaint
+        assert "Defaulted to 1.0" in errors[0].message
+    dead_member = ensemble.member[2]
+    assert dead_member.dead()
+    assert _error_log(dead_member) == []
+
+
+@pytest.mark.parametrize(
+    "input_kind", ["atomic", "ensemble_members", "ensemble_section"]
+)
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+@pytest.mark.parametrize(
+    "level,expected_level",
+    [(0.5, 0.5), (1.0, 1.0), (0.0, 1.0), (-0.25, 1.0), (1.25, 1.0)],
+)
+def test_percentile_validation_recovers_and_continues(
+    input_kind, waveform_type, level, expected_level
+):
+    data, target_name, scale_kwargs, live_members, dead_members = _input_and_target(
+        input_kind, include_dead=False, waveform_type=waveform_type
+    )
+    original_target = getattr(window_module, target_name)
+    passed_levels = []
+
+    def record_level(*args, **kwargs):
+        passed_levels.append(args[2])
+        if level == 0.5:
+            return original_target(*args, **kwargs)
+        if input_kind == "atomic":
+            return 4.0
+        if input_kind == "ensemble_section":
+            return 6.0
+        return [4.0, 8.0]
+
+    with patch.object(window_module, target_name, side_effect=record_level):
+        result = window_module.scale(data, method="perc", level=level, **scale_kwargs)
+
+    assert result is data
+    assert passed_levels == [expected_level]
+    live_members, dead_members = _current_members(data, input_kind, include_dead=False)
+    for member in live_members:
+        assert member.live
+    for member in dead_members:
+        assert member.dead()
+        assert _error_log(member) == []
+
+    if input_kind == "ensemble_section":
+        assert _defined_amplitude_keys(data) == {"perc_amplitude"}
+    else:
+        for member in live_members:
+            assert _defined_amplitude_keys(member) == {"perc_amplitude"}
+
+    expected_error_count = 0 if 0.0 < level <= 1.0 else 1
+    for member in live_members:
+        errors = _error_log(member)
+        assert len(errors) == expected_error_count
+        if errors:
+            assert errors[0].algorithm == "scale"
+            assert errors[0].badness == ErrorSeverity.Complaint
+            assert "Defaulted to 1.0" in errors[0].message
+
+
+@pytest.mark.parametrize(
+    "input_kind", ["atomic", "ensemble_members", "ensemble_section"]
+)
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+@pytest.mark.parametrize("error_kind", ["mspass", "generic"])
+def test_exceptions_kill_and_return_original_object(
+    input_kind, waveform_type, error_kind
+):
+    data, target_name, scale_kwargs, live_members, dead_members = _input_and_target(
+        input_kind, waveform_type=waveform_type
+    )
+    dead_snapshots = [
+        (dict(member), np.asarray(member.data).copy()) for member in dead_members
+    ]
+    if error_kind == "mspass":
+        error = MsPASSError("injected scale failure", ErrorSeverity.Complaint)
+    else:
+        error = RuntimeError("injected generic scale failure")
+
+    with patch.object(window_module, target_name, side_effect=error):
+        result = window_module.scale(data, **scale_kwargs)
+
+    assert result is data
+    live_members, dead_members = _current_members(data, input_kind)
+    for member in live_members:
+        assert member.dead()
+        errors = _error_log(member)
+        assert len(errors) == 1
+        assert errors[0].algorithm == "scale"
+        assert errors[0].badness == ErrorSeverity.Invalid
+        if error_kind == "mspass":
+            assert "injected scale failure" in errors[0].message
+        else:
+            assert "unexpected exception" in errors[0].message
+        assert _defined_amplitude_keys(member) == set()
+    for member, (metadata, samples) in zip(dead_members, dead_snapshots):
+        assert member.dead()
+        assert _error_log(member) == []
+        assert dict(member) == metadata
+        assert np.array_equal(np.asarray(member.data), samples)
+
+
+@pytest.mark.parametrize(
+    "input_kind", ["atomic", "ensemble_members", "ensemble_section"]
+)
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+@pytest.mark.parametrize("interrupt_type", [KeyboardInterrupt, SystemExit])
+def test_process_control_exceptions_propagate(
+    input_kind, waveform_type, interrupt_type
+):
+    data, target_name, scale_kwargs, live_members, dead_members = _input_and_target(
+        input_kind, waveform_type=waveform_type
+    )
+    before = [np.asarray(member.data).copy() for member in live_members]
+
+    with patch.object(window_module, target_name, side_effect=interrupt_type()):
+        with pytest.raises(interrupt_type):
+            window_module.scale(data, **scale_kwargs)
+
+    live_members, dead_members = _current_members(data, input_kind)
+    for member, original_samples in zip(live_members, before):
+        assert member.live
+        assert _error_log(member) == []
+        assert np.array_equal(np.asarray(member.data), original_samples)
+    for member in dead_members:
+        assert member.dead()
+        assert _error_log(member) == []
+
+
+@pytest.mark.parametrize("waveform_type", ["timeseries", "seismogram"])
+def test_dead_atomic_input_is_returned_unchanged(waveform_type):
+    datum = _atomic(waveform_type=waveform_type)
+    datum["sentinel"] = "unchanged"
+    datum.kill()
+    metadata = dict(datum)
+    samples = np.asarray(datum.data).copy()
+
+    result = window_module.scale(datum, method="perc", level=0.0)
+
+    assert result is datum
+    assert datum.dead()
+    assert dict(datum) == metadata
+    assert np.array_equal(np.asarray(datum.data), samples)
+    assert _error_log(datum) == []
+
+
+@pytest.mark.parametrize("ensemble_type", [TimeSeriesEnsemble, SeismogramEnsemble])
+def test_empty_ensemble_is_returned_unchanged(ensemble_type):
+    ensemble = ensemble_type()
+
+    result = window_module.scale(ensemble, method="perc", level=-1.0)
+
+    assert result is ensemble
+    assert ensemble.dead()
+    assert len(ensemble.member) == 0
+    assert dict(ensemble) == {}


### PR DESCRIPTION
Closes #861

## Summary
- Correct scale method and amplitude metadata-key mappings.
- Validate percentile levels while preserving object identity on documented data errors.
- Treat only MsPASSError as a documented data failure: log Invalid, kill live affected data, and return the original object.
- Propagate unexpected RuntimeError and TypeError unchanged, without mutation, logging, or life-state changes.
- Preserve the established percentile rank floor(p * n); cap only the terminal p = 1 index to the last sample.
- Keep native binding tests and Python wrapper tests in separate contract files.

## Maintainer decisions
The percentile definition remains the one used since this function was introduced. Unexpected programming/runtime errors are not reclassified as waveform-quality errors. The shared function wrapper gains an opt-in propagation flag whose default remains unchanged; scale enables it explicitly.

## Validation
- Isolated Release native scale contract: passed
- Native binding, Python wrapper, and adjacent window regressions: 135 passed
- Shared decorator regressions: 11 passed
- Black, Python byte compilation, and git diff --check: passed