### PR TITLE
Fix BasicGather backend axes, append, and partition behavior

### DIFF
--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -828,10 +828,10 @@ class BasicGather(ABC):
 
     def append(self, mspass_object):
         """
-        Append one member along axis zero and install the returned backend array.
+        Append one member along axis zero.
 
-        The stored array contains only active members.  ``capacity`` remains a
-        reservation hint and grows when the appended size exceeds it.
+        ``capacity`` is the allocated axis-zero length.  Unused rows are retained
+        until the array is full, then the backend grows to fit the new member.
         """
         if not isinstance(mspass_object, (TimeSeries, Seismogram)):
             raise TypeError("only TimeSeries and Seismogram are supported")
@@ -855,18 +855,39 @@ class BasicGather(ABC):
                 new_data = new_data.transpose()
             new_data = new_data.reshape((1,) + new_data.shape)
 
-        current_data = self.member_data[: self.size]
+        metadata = deepcopy(dict(mspass_object))
+        metadata.setdefault("starttime", mspass_object.t0)
+        metadata.setdefault("delta", mspass_object.dt)
+        metadata.setdefault("npts", mspass_object.npts)
+        metadata["is_live"] = mspass_object.live
+        new_member_metadata = pd.concat(
+            [self.member_metadata, pd.DataFrame([metadata])],
+            ignore_index=True,
+            sort=False,
+        )
+
         new_size = self.size + 1
         new_capacity = max(self.capacity, new_size)
         if self.array_type == "numpy":
-            self.member_data = np.concatenate((current_data, new_data), axis=0)
+            if new_capacity > self.capacity:
+                expanded = np.empty(
+                    (new_capacity,) + self.member_data.shape[1:],
+                    dtype=self.member_data.dtype,
+                )
+                expanded[: self.size] = self.member_data[: self.size]
+                self.member_data = expanded
+            self.member_data[self.size] = new_data[0]
         else:
+            current_data = self.member_data
             if self.array_type == "xarray":
-                current_data = current_data.data
-            appended = da.concatenate(
-                (current_data, da.from_array(new_data, chunks=new_data.shape)),
-                axis=0,
-            )
+                current_data = self.member_data.data
+            pieces = [
+                current_data[: self.size],
+                da.from_array(new_data, chunks=new_data.shape),
+            ]
+            if new_size < new_capacity:
+                pieces.append(current_data[new_size:new_capacity])
+            appended = da.concatenate(pieces, axis=0)
             appended = appended.rechunk(
                 _dask_chunks(appended.shape, new_capacity, self.npartitions)
             )
@@ -874,15 +895,7 @@ class BasicGather(ABC):
                 xr.DataArray(appended) if self.array_type == "xarray" else appended
             )
 
-        metadata = dict(mspass_object)
-        metadata.setdefault("starttime", mspass_object.t0)
-        metadata.setdefault("delta", mspass_object.dt)
-        metadata.setdefault("npts", mspass_object.npts)
-        metadata["is_live"] = mspass_object.live
-        if self.member_metadata.empty and len(self.member_metadata.columns) == 0:
-            self.member_metadata = pd.DataFrame([metadata])
-        else:
-            self.member_metadata.loc[len(self.member_metadata.index)] = metadata
+        self.member_metadata = new_member_metadata
         self.size = new_size
         self.capacity = new_capacity
 

--- a/python/mspasspy/seismic/gather.py
+++ b/python/mspasspy/seismic/gather.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 import math
-from numbers import Real
+from numbers import Integral, Real
 
 import xarray as xr
 import dask.array as da
@@ -66,6 +66,31 @@ def isOldEnsembleObject(obj):
 
 def isMsPassObject(obj):
     return isinstance(obj, (TimeSeries, Seismogram))
+
+
+def _array_dimensions(shape, is_compact):
+    if len(shape) != 3:
+        raise ValueError("Gather sample arrays must be three-dimensional")
+    if is_compact:
+        return shape[0], shape[1], shape[2]
+    return shape[0], shape[2], shape[1]
+
+
+def _validate_partitions(array_type, npartitions):
+    if array_type in ("dask", "xarray") and (
+        isinstance(npartitions, bool)
+        or not isinstance(npartitions, Integral)
+        or npartitions < 1
+    ):
+        raise ValueError("npartitions must be a positive integer for Dask arrays")
+
+
+def _dask_chunks(shape, capacity, npartitions):
+    return (
+        max(1, math.ceil(capacity / npartitions)),
+        shape[1],
+        shape[2],
+    )
 
 
 def extractDataFromMsPassObject(mspass_object):
@@ -314,6 +339,25 @@ class BasicGather(ABC):
             self._column_values,
         )
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        elog = state.pop("elog")
+        state["_serialized_elog_job_id"] = elog.get_job_id()
+        state["_serialized_elog"] = [
+            (entry.algorithm, entry.message, entry.badness)
+            for entry in elog.get_error_log()
+        ]
+        return state
+
+    def __setstate__(self, state):
+        job_id = state.pop("_serialized_elog_job_id")
+        entries = state.pop("_serialized_elog")
+        self.__dict__.update(state)
+        self.elog = ErrorLogger()
+        self.elog.set_job_id(job_id)
+        for algorithm, message, severity in entries:
+            self.elog.log_error(algorithm, message, severity)
+
     def __default_constructor__(
         self,
         capacity,
@@ -366,6 +410,8 @@ class BasicGather(ABC):
         :param npartitions: The number of desired partitions for Dask or xarray.
         :type npartitions: :class:`int`
         """
+        _validate_partitions(array_type, npartitions)
+
         self.capacity = capacity
         self.npts = npts
         self.size = 0
@@ -392,26 +438,26 @@ class BasicGather(ABC):
                 )
             )
 
-        if (
-            num_components == 1
-        ):  # For the scalar data, we don't need to do rearrangement
-            is_compact = False
-
         shape = (
-            [capacity, num_components, npts]
+            (capacity, num_components, npts)
             if is_compact
-            else [capacity, npts, num_components]
+            else (capacity, npts, num_components)
         )
 
         if array_type == "xarray":
-            self.member_data = xr.DataArray()
-            chunksize = [shape[0] // npartitions, shape[1], shape[2]]
-            self.member_data.data = da.empty(shape=shape, chunks=chunksize)
+            self.member_data = xr.DataArray(
+                da.empty(
+                    shape=shape,
+                    chunks=_dask_chunks(shape, capacity, npartitions),
+                )
+            )
         elif array_type == "numpy":
             self.member_data = np.empty(shape)
         elif array_type == "dask":
-            chunksize = [shape[0] // npartitions, shape[1], shape[2]]
-            self.member_data = da.empty(shape=shape, chunks=chunksize)
+            self.member_data = da.empty(
+                shape=shape,
+                chunks=_dask_chunks(shape, capacity, npartitions),
+            )
 
     def __constructor_from_input_data(
         self,
@@ -447,6 +493,8 @@ class BasicGather(ABC):
         :param npartitions: The number of desired partitions for Dask or xarray.
         :type npartitions: :class:`int`
         """
+        _validate_partitions(array_type, npartitions)
+
         self.capacity = 0
         self.npts = 0
         self.size = 0
@@ -460,13 +508,15 @@ class BasicGather(ABC):
         self.elog = ErrorLogger()
         self._column_values = None
 
-        supported_types = (da.Array, np.ndarray)
+        supported_types = (xr.DataArray, da.Array, np.ndarray)
         if not isinstance(input_data, supported_types):
             raise TypeError(
                 "The array type should be one of the follows: {}".format(
                     supported_types
                 )
             )
+        if isinstance(input_data, xr.DataArray):
+            input_data = input_data.data
 
         supported_array_types = [
             "numpy",
@@ -481,45 +531,31 @@ class BasicGather(ABC):
                 )
             )
 
+        size, num_components, npts = _array_dimensions(input_data.shape, is_compact)
+        shape = tuple(input_data.shape)
+
         if array_type == "numpy":
             if isinstance(input_data, da.Array):
                 self.member_data = input_data.compute()
             elif isinstance(input_data, np.ndarray):
                 self.member_data = input_data
         elif array_type == "xarray":
-            self.member_data = xr.DataArray()
-            chunksize = [
-                input_data.shape[0] // self.npartitions,
-                input_data.shape[1],
-                input_data.shape[2],
-            ]
+            chunksize = _dask_chunks(shape, size, npartitions)
             if isinstance(input_data, da.Array):
-                self.member_data.data = input_data.rechunk(chunks=chunksize)
+                data = input_data.rechunk(chunks=chunksize)
             elif isinstance(input_data, np.ndarray):
-                self.member_data.data = da.from_array(input_data, chunks=chunksize)
+                data = da.from_array(input_data, chunks=chunksize)
+            self.member_data = xr.DataArray(data)
         elif array_type == "dask":
-            chunksize = [
-                input_data.shape[0] // self.npartitions,
-                input_data.shape[1],
-                input_data.shape[2],
-            ]
+            chunksize = _dask_chunks(shape, size, npartitions)
             if isinstance(input_data, da.Array):
                 self.member_data = input_data.rechunk(chunks=chunksize)
             elif isinstance(input_data, np.ndarray):
                 self.member_data = da.from_array(input_data, chunks=chunksize)
 
-        if self.is_compact:
-            self.member_data.transpose((0, 2, 1))
-
-        """
-        if is_compact: [size, num_components, npts]
-        else:          [size, npts, num_components]
-        """
-        self.size, self.num_components, self.npts = (
-            self.member_data.shape[0],
-            self.member_data.shape[1],
-            self.member_data.shape[2],
-        )
+        self.size = size
+        self.num_components = num_components
+        self.npts = npts
         self.capacity = self.size
 
     def __constructor_from_ensemble_obj__(
@@ -586,21 +622,15 @@ class BasicGather(ABC):
         if regularize:
             input_obj = regularize_ensemble(input_obj, regularizer)
 
-        if isinstance(input_obj, TimeSeriesEnsemble):
-            self.__constructor_from_input_data(
-                extractDataFromOldEnsemble(input_obj),
-                array_type,
-                is_compact,
-                npartitions,
-            )
-
-        elif isinstance(input_obj, SeismogramEnsemble):
-            self.__constructor_from_input_data(
-                extractDataFromOldEnsemble(input_obj),
-                array_type,
-                is_compact,
-                npartitions,
-            )
+        input_data = extractDataFromOldEnsemble(input_obj)
+        if not is_compact:
+            input_data = input_data.transpose((0, 2, 1))
+        self.__constructor_from_input_data(
+            input_data,
+            array_type,
+            is_compact,
+            npartitions,
+        )
 
         # Add the ensemble's metadata
         self._ensemble_metadata = deepcopy(dict(input_obj))
@@ -709,11 +739,14 @@ class BasicGather(ABC):
                 ),
             }
         elif input_data is not None:
+            derived_size, derived_components, derived_npts = _array_dimensions(
+                input_data.shape, is_compact
+            )
             derived_dimensions = {
-                "capacity": input_data.shape[0],
-                "size": input_data.shape[0],
-                "npts": input_data.shape[2],
-                "num_components": input_data.shape[1],
+                "capacity": derived_size,
+                "size": derived_size,
+                "npts": derived_npts,
+                "num_components": derived_components,
             }
 
         if derived_dimensions is not None:
@@ -780,7 +813,7 @@ class BasicGather(ABC):
             self._ensemble_metadata = deepcopy(dict(ensemble_metadata))
         if self.member_metadata is None:
             self.member_metadata = member_metadata
-        self.is_parallel = is_parallel
+        self.is_parallel = array_type in ("dask", "xarray")
         self.is_compact = is_compact
         self.npartitions = npartitions
         self.elog = ErrorLogger()
@@ -795,10 +828,10 @@ class BasicGather(ABC):
 
     def append(self, mspass_object):
         """
-        Appends data in mspass_object to internal array object.
-        For now, we don't handle resizing similar to std containers in C++
-        where allocs (in this case a resize) is triggered by filling.
-        Instead, we would just rely on the xarray/numpy's append.
+        Append one member along axis zero and install the returned backend array.
+
+        The stored array contains only active members.  ``capacity`` remains a
+        reservation hint and grows when the appended size exceeds it.
         """
         if not isinstance(mspass_object, (TimeSeries, Seismogram)):
             raise TypeError("only TimeSeries and Seismogram are supported")
@@ -807,28 +840,51 @@ class BasicGather(ABC):
         ):
             raise TypeError("The components number doesn't match the input object")
 
-        new_data = extractDataFromMsPassObject(mspass_object)  # get the numpy data
-        if self.is_compact:
-            new_data.transpose()
+        if mspass_object.npts != self.npts:
+            raise ValueError("The input object npts does not match the Gather")
 
-        if self.size < self.capacity:
-            self.member_data[self.size] = new_data
+        new_data = extractDataFromMsPassObject(mspass_object)
+        if isinstance(mspass_object, TimeSeries):
+            new_data = (
+                new_data.reshape(1, 1, self.npts)
+                if self.is_compact
+                else new_data.reshape(1, self.npts, 1)
+            )
         else:
-            if self.array_type == "dask":
-                if self.is_compact:
-                    da.append(self.member_data, new_data, 2)
-                else:
-                    da.append(self.member_data, new_data, 1)
-            elif self.array_type == "numpy":
-                if self.is_compact:
-                    np.append(self.member_data, new_data, 2)
-                else:
-                    np.append(self.member_data, new_data, 1)
+            if not self.is_compact:
+                new_data = new_data.transpose()
+            new_data = new_data.reshape((1,) + new_data.shape)
 
-        self.member_metadata.loc[len(self.member_metadata.index)] = (
-            mspass_object.todict()
-        )
-        self.size += 1
+        current_data = self.member_data[: self.size]
+        new_size = self.size + 1
+        new_capacity = max(self.capacity, new_size)
+        if self.array_type == "numpy":
+            self.member_data = np.concatenate((current_data, new_data), axis=0)
+        else:
+            if self.array_type == "xarray":
+                current_data = current_data.data
+            appended = da.concatenate(
+                (current_data, da.from_array(new_data, chunks=new_data.shape)),
+                axis=0,
+            )
+            appended = appended.rechunk(
+                _dask_chunks(appended.shape, new_capacity, self.npartitions)
+            )
+            self.member_data = (
+                xr.DataArray(appended) if self.array_type == "xarray" else appended
+            )
+
+        metadata = dict(mspass_object)
+        metadata.setdefault("starttime", mspass_object.t0)
+        metadata.setdefault("delta", mspass_object.dt)
+        metadata.setdefault("npts", mspass_object.npts)
+        metadata["is_live"] = mspass_object.live
+        if self.member_metadata.empty and len(self.member_metadata.columns) == 0:
+            self.member_metadata = pd.DataFrame([metadata])
+        else:
+            self.member_metadata.loc[len(self.member_metadata.index)] = metadata
+        self.size = new_size
+        self.capacity = new_capacity
 
     def starttime(self) -> list:
         """
@@ -1201,11 +1257,15 @@ class Gather(BasicGather):
                 raise TypeError("The input object should be a TimeSeriesEnsemble")
 
         elif input_data is not None:
-            input_num_comp = input_data.shape[1]
+            _, input_num_comp, _ = _array_dimensions(input_data.shape, is_compact)
             if input_num_comp != 1:
                 raise TypeError(
                     "The input data shape is not valid, should be scalar data"
                 )
+        elif num_components in (None, 0):
+            num_components = 1
+        elif num_components != 1:
+            raise ValueError("Gather requires num_components=1")
 
         super().__init__(
             capacity=capacity,
@@ -1265,28 +1325,34 @@ class Gather(BasicGather):
         else:
             return col.flatten()
 
-    def subset(self, start, end) -> "Gather":
+    def subset(self, start, end=None) -> "Gather":
         """
-        Return a subset of the Gather with signals from start to end
-        (like start:end in F90 or matlab).
+        Return members selected by an index iterable or a ``start:end`` range.
+
+        Iterable selection preserves order and duplicate indices.  An empty
+        iterable returns an empty Gather with the same trailing axes/backend.
 
         :param start:   the start index of the subset
         :param end: specifies the index where the subset ends, excluding the
           value at this index just like array slicing.
         """
-        new_input_data = self.member_data[start:end]
-        new_member_metadata = self.member_metadata[start:end]
-        new_npartitions = end - start
-        if new_npartitions > self.npartitions:
-            npartitions = self.npartitions
+        indices = list(range(start, end)) if end is not None else list(start)
+        new_input_data = self.member_data[np.asarray(indices, dtype=int)]
+        new_member_metadata = self.member_metadata.iloc[indices].reset_index(drop=True)
 
         new_gather = Gather(
             input_data=new_input_data,
             array_type=self.array_type,
             is_compact=self.is_compact,
-            npartitions=new_npartitions,
+            npartitions=self.npartitions,
             member_metadata=new_member_metadata,
+            ensemble_metadata=self.ensemble_metadata(),
+            dt=self.dt(),
         )
+        if self._column_values is not None:
+            new_gather._column_values = [
+                deepcopy(self._column_values[index]) for index in indices
+            ]
         return new_gather
 
     def __getitem__(self, pos):
@@ -1382,11 +1448,15 @@ class SeismogramGather(BasicGather):
                 raise TypeError("The input object should be a TimeSeriesEnsemble")
 
         elif input_data is not None:
-            input_num_comp = input_data.shape[1]
+            _, input_num_comp, _ = _array_dimensions(input_data.shape, is_compact)
             if input_num_comp != 3:
                 raise TypeError(
-                    "The input data shape is not valid, should be scalar data"
+                    "The input data shape is not valid, should be three-component data"
                 )
+        elif num_components in (None, 0):
+            num_components = 3
+        elif num_components != 3:
+            raise ValueError("SeismogramGather requires num_components=3")
 
         super().__init__(
             capacity=capacity,
@@ -1441,35 +1511,38 @@ class SeismogramGather(BasicGather):
                 "The given index: {} is out of range.".format(j), "Invalid"
             )
         col = self.member_data[j]
-        if self.is_compact:
-            col.transpose()
         if self.is_parallel:
-            return col.compute()
-        else:
-            return col
+            col = col.compute()
+        return col if self.is_compact else col.transpose()
 
-    def subset(self, start, end) -> "SeismogramGather":
+    def subset(self, start, end=None) -> "SeismogramGather":
         """
-        Return a subset of the Gather with signals from start to end
-        (like start:end in F90 or matlab).
+        Return members selected by an index iterable or a ``start:end`` range.
+
+        Iterable selection preserves order and duplicate indices.  An empty
+        iterable returns an empty Gather with the same trailing axes/backend.
 
         :param start:   the start index of the subset
         :param end: specifies the index where the subset ends, excluding the
           value at this index just like array slicing.
         """
-        new_input_data = self.member_data[start:end]
-        new_member_metadata = self.member_metadata[start:end]
-        new_npartitions = end - start
-        if new_npartitions > self.npartitions:
-            npartitions = self.npartitions
+        indices = list(range(start, end)) if end is not None else list(start)
+        new_input_data = self.member_data[np.asarray(indices, dtype=int)]
+        new_member_metadata = self.member_metadata.iloc[indices].reset_index(drop=True)
 
         new_gather = SeismogramGather(
             input_data=new_input_data,
             array_type=self.array_type,
             is_compact=self.is_compact,
-            npartitions=new_npartitions,
+            npartitions=self.npartitions,
             member_metadata=new_member_metadata,
+            ensemble_metadata=self.ensemble_metadata(),
+            dt=self.dt(),
         )
+        if self._column_values is not None:
+            new_gather._column_values = [
+                deepcopy(self._column_values[index]) for index in indices
+            ]
         return new_gather
 
     def __getitem__(self, pos):

--- a/python/tests/seismic/test_gather.py
+++ b/python/tests/seismic/test_gather.py
@@ -189,21 +189,21 @@ class TestGather:
             capacity=5,
             size=5,
             npts=6,
-            num_components=3,
+            num_components=1,
             npartitions=3,
             member_metadata=self.md,
         )
-        assert default_gather.member_data.shape == (5, 3, 6)
+        assert default_gather.member_data.shape == (5, 1, 6)
         compact_gather = Gather(
             capacity=5,
             size=5,
             npts=6,
-            num_components=3,
+            num_components=1,
             npartitions=3,
             member_metadata=self.md,
             is_compact=False,
         )
-        assert compact_gather.member_data.shape == (5, 6, 3)
+        assert compact_gather.member_data.shape == (5, 6, 1)
 
         es_md = Metadata(self.md_dict)
         es = TimeSeriesEnsemble(es_md, 3)
@@ -226,7 +226,7 @@ class TestGather:
     def test_subset(self):
         ts_subset = self.gather.subset(0, 2)
         assert ts_subset.size == 2
-        assert ts_subset.npartitions == 2
+        assert ts_subset.npartitions == self.gather.npartitions
 
     def test_getitem(self):
         assert self.gather[0, 0] == 1
@@ -303,7 +303,7 @@ class TestSeismogramGather:
     def test_subset(self):
         ts_subset = self.gather.subset(0, 2)
         assert ts_subset.size == 2
-        assert ts_subset.npartitions == 2
+        assert ts_subset.npartitions == self.gather.npartitions
 
     def test_getitem(self):
         assert self.gather[0, 0, 0] == 2.0

--- a/python/tests/seismic/test_gather_backend_layout_contract.py
+++ b/python/tests/seismic/test_gather_backend_layout_contract.py
@@ -69,6 +69,10 @@ def _stored_values(gather):
     return np.asarray(data)
 
 
+def _active_values(gather):
+    return _stored_values(gather)[: gather.size]
+
+
 def _expected_stored(canonical, is_compact):
     return canonical if is_compact else canonical.transpose((0, 2, 1))
 
@@ -89,11 +93,11 @@ def _assert_dask_chunks(gather):
         else gather.member_data
     )
     expected_member_chunk = max(1, int(np.ceil(gather.capacity / gather.npartitions)))
-    quotient, remainder = divmod(gather.size, expected_member_chunk)
+    quotient, remainder = divmod(gather.capacity, expected_member_chunk)
     expected_axis_zero = (expected_member_chunk,) * quotient
     if remainder:
         expected_axis_zero += (remainder,)
-    if not gather.size:
+    if not gather.capacity:
         expected_axis_zero = (0,)
     assert data.chunks[0] == expected_axis_zero
     assert data.chunks[1] == (data.shape[1],)
@@ -251,13 +255,14 @@ def test_append_installs_axis_zero_result_and_updates_size_capacity(
     second = _datum(gather_class, 4, 20.0)
 
     result.append(first)
-    first_snapshot = _stored_values(result).copy()
+    assert result.member_data.shape[0] == capacity
+    first_snapshot = _active_values(result).copy()
     result.append(second)
 
     assert result.size == 2
     assert result.capacity == max(capacity, 2)
-    assert result.member_data.shape[0] == 2
-    assert np.array_equal(_stored_values(result)[0:1], first_snapshot)
+    assert result.member_data.shape[0] == result.capacity
+    assert np.array_equal(_active_values(result)[0:1], first_snapshot)
     expected = []
     for datum in (first, second):
         values = np.asarray(datum.data)
@@ -266,11 +271,33 @@ def test_append_installs_axis_zero_result_and_updates_size_capacity(
         elif not is_compact:
             values = values.transpose()
         expected.append(values)
-    assert np.array_equal(_stored_values(result), np.stack(expected))
+    assert np.array_equal(_active_values(result), np.stack(expected))
     assert result.member_metadata["row"].tolist() == [10, 20]
     _assert_backend(result, array_type)
     if array_type in ("dask", "xarray"):
         _assert_dask_chunks(result)
+
+
+def test_append_preserves_new_metadata_columns_and_copies_values():
+    result = Gather(
+        input_data=np.zeros((1, 1, 4)),
+        member_metadata=_member_metadata(1, 4),
+        ensemble_metadata={"dt": 0.25},
+        array_type="numpy",
+        npartitions=1,
+    )
+    datum = _datum(Gather, 4, 10.0)
+    datum["new_field"] = {"tags": ["new"]}
+
+    result.append(datum)
+    datum["new_field"]["tags"].append("caller mutation")
+
+    assert "new_field" in result.member_metadata.columns
+    assert pd.isna(result.member_metadata.loc[0, "new_field"])
+    assert result.member_metadata.loc[1, "new_field"] == {"tags": ["new"]}
+    assert result.size == 2
+    assert result.capacity == 2
+    assert result.member_data.shape[0] == 2
 
 
 @pytest.mark.parametrize("gather_class", [Gather, SeismogramGather])
@@ -309,22 +336,33 @@ def test_subset_preserves_order_duplicates_empty_shape_and_backend(
 def test_pickle_round_trip_preserves_backend_layout_and_partition_state(
     gather_class, array_type, is_compact
 ):
-    source, canonical = _new_gather(
-        gather_class, array_type, is_compact, size=4, npartitions=3
+    components = 1 if gather_class is Gather else 3
+    source = gather_class(
+        capacity=7,
+        size=0,
+        npts=5,
+        num_components=components,
+        npartitions=3,
+        member_metadata=pd.DataFrame(),
+        ensemble_metadata={"name": "contract", "dt": 0.25},
+        dt=0.25,
+        array_type=array_type,
+        is_compact=is_compact,
     )
-    source.capacity = 7
+    for offset in range(4):
+        source.append(_datum(gather_class, 5, float(offset)))
     source.set_column_values(["a", "b", "c", "d"])
     source.elog.set_job_id(17)
     source.elog.log_error("contract", "round trip", ErrorSeverity.Complaint)
+    source_values = _active_values(source).copy()
 
     restored = pickle.loads(pickle.dumps(source))
 
     _assert_backend(restored, array_type)
     assert restored.is_compact is is_compact
     assert restored.member_data.shape == source.member_data.shape
-    assert np.array_equal(
-        _stored_values(restored), _expected_stored(canonical, is_compact)
-    )
+    assert restored.member_data.shape[0] == 7
+    assert np.array_equal(_active_values(restored), source_values)
     assert restored.size == 4
     assert restored.capacity == 7
     assert restored.npartitions == 3

--- a/python/tests/seismic/test_gather_backend_layout_contract.py
+++ b/python/tests/seismic/test_gather_backend_layout_contract.py
@@ -1,0 +1,354 @@
+import os
+import pickle
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import mspasspy.ccore.seismic as seismic_binding
+import mspasspy.seismic.gather as gather_module
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+from mspasspy.ccore.utility import ErrorSeverity
+from mspasspy.seismic.gather import Gather, SeismogramGather
+
+
+def _canonical_values(size, components, npts):
+    return np.arange(size * components * npts, dtype=float).reshape(
+        size, components, npts
+    )
+
+
+def _member_metadata(size, npts):
+    return pd.DataFrame(
+        {
+            "row": list(range(size)),
+            "starttime": np.arange(size, dtype=float),
+            "delta": [0.25] * size,
+            "npts": [npts] * size,
+            "is_live": [True] * size,
+        }
+    )
+
+
+def _new_gather(
+    gather_class,
+    array_type,
+    is_compact,
+    size=3,
+    npts=5,
+    npartitions=2,
+):
+    components = 1 if gather_class is Gather else 3
+    canonical = _canonical_values(size, components, npts)
+    input_data = canonical if is_compact else canonical.transpose((0, 2, 1))
+    result = gather_class(
+        input_data=input_data,
+        member_metadata=_member_metadata(size, npts),
+        ensemble_metadata={"name": "contract", "nested": {"value": 7}},
+        array_type=array_type,
+        is_compact=is_compact,
+        npartitions=npartitions,
+    )
+    return result, canonical
+
+
+def _stored_values(gather):
+    data = gather.member_data
+    if isinstance(data, xr.DataArray):
+        data = data.data
+    if isinstance(data, da.Array):
+        data = data.compute()
+    return np.asarray(data)
+
+
+def _expected_stored(canonical, is_compact):
+    return canonical if is_compact else canonical.transpose((0, 2, 1))
+
+
+def _assert_backend(gather, array_type):
+    expected = {
+        "numpy": np.ndarray,
+        "dask": da.Array,
+        "xarray": xr.DataArray,
+    }[array_type]
+    assert isinstance(gather.member_data, expected)
+
+
+def _assert_dask_chunks(gather):
+    data = (
+        gather.member_data.data
+        if isinstance(gather.member_data, xr.DataArray)
+        else gather.member_data
+    )
+    expected_member_chunk = max(1, int(np.ceil(gather.capacity / gather.npartitions)))
+    quotient, remainder = divmod(gather.size, expected_member_chunk)
+    expected_axis_zero = (expected_member_chunk,) * quotient
+    if remainder:
+        expected_axis_zero += (remainder,)
+    if not gather.size:
+        expected_axis_zero = (0,)
+    assert data.chunks[0] == expected_axis_zero
+    assert data.chunks[1] == (data.shape[1],)
+    assert data.chunks[2] == (data.shape[2],)
+    if gather.size:
+        assert all(chunk > 0 for dimension in data.chunks for chunk in dimension)
+
+
+def _datum(gather_class, npts, offset):
+    if gather_class is Gather:
+        datum = TimeSeries(npts)
+        for sample in range(npts):
+            datum.data[sample] = offset + sample
+    else:
+        datum = Seismogram(npts)
+        for component in range(3):
+            for sample in range(npts):
+                datum.data[component, sample] = offset + 10 * component + sample
+    datum.t0 = offset
+    datum.dt = 0.25
+    datum["row"] = int(offset)
+    datum.set_live()
+    return datum
+
+
+def test_contract_suite_uses_selected_source_and_real_binding():
+    selected_source = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if selected_source:
+        expected = Path(selected_source) / "mspasspy/seismic/gather.py"
+        assert Path(gather_module.__file__).resolve() == expected.resolve()
+    assert Path(seismic_binding.__file__).suffix == ".so"
+
+
+@pytest.mark.parametrize("gather_class", [Gather, SeismogramGather])
+@pytest.mark.parametrize("array_type", ["numpy", "dask"])
+@pytest.mark.parametrize("is_compact", [True, False])
+@pytest.mark.parametrize("size,npartitions", [(1, 3), (3, 3), (5, 3)])
+def test_layout_and_partition_contract(
+    gather_class, array_type, is_compact, size, npartitions
+):
+    result, canonical = _new_gather(
+        gather_class,
+        array_type,
+        is_compact,
+        size=size,
+        npartitions=npartitions,
+    )
+    components = 1 if gather_class is Gather else 3
+    expected_shape = (size, components, 5) if is_compact else (size, 5, components)
+
+    _assert_backend(result, array_type)
+    assert result.member_data.shape == expected_shape
+    assert result.size == size
+    assert result.capacity == size
+    assert result.num_components == components
+    assert result.npts == 5
+    assert result.is_compact is is_compact
+    assert np.array_equal(
+        _stored_values(result), _expected_stored(canonical, is_compact)
+    )
+    if array_type == "dask":
+        _assert_dask_chunks(result)
+
+
+@pytest.mark.parametrize("gather_class", [Gather, SeismogramGather])
+@pytest.mark.parametrize("array_type", ["numpy", "dask"])
+@pytest.mark.parametrize("is_compact", [True, False])
+def test_public_data_and_member_views_are_layout_independent(
+    gather_class, array_type, is_compact
+):
+    result, canonical = _new_gather(
+        gather_class, array_type, is_compact, size=2, npartitions=3
+    )
+
+    expected = canonical[1]
+    if gather_class is Gather:
+        expected = expected.reshape(-1)
+    assert np.array_equal(np.asarray(result.data(1)), expected)
+    assert np.array_equal(np.asarray(result.member(1).data), expected)
+
+
+@pytest.mark.parametrize("gather_class", [Gather, SeismogramGather])
+@pytest.mark.parametrize("array_type", ["numpy", "dask"])
+@pytest.mark.parametrize("is_compact", [True, False])
+def test_old_ensemble_conversion_uses_the_requested_layout(
+    gather_class, array_type, is_compact
+):
+    ensemble = TimeSeriesEnsemble() if gather_class is Gather else SeismogramEnsemble()
+    data = []
+    for offset in (10.0, 20.0):
+        datum = _datum(gather_class, 4, offset)
+        ensemble.member.append(datum)
+        values = np.asarray(datum.data)
+        data.append(values.reshape(1, 4) if gather_class is Gather else values)
+    canonical = np.stack(data)
+
+    result = gather_class(
+        input_obj=ensemble,
+        resample=False,
+        array_type=array_type,
+        is_compact=is_compact,
+        npartitions=3,
+    )
+
+    assert np.array_equal(
+        _stored_values(result), _expected_stored(canonical, is_compact)
+    )
+    assert result.member_data.shape == _expected_stored(canonical, is_compact).shape
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 1.5, None])
+def test_dask_rejects_invalid_partition_counts_before_array_creation(value):
+    with pytest.raises(ValueError, match="npartitions must be a positive integer"):
+        Gather(
+            input_data=np.zeros((2, 1, 4)),
+            member_metadata=_member_metadata(2, 4),
+            array_type="dask",
+            npartitions=value,
+        )
+
+
+def test_dask_accepts_positive_numpy_integer_partition_count():
+    result = Gather(
+        input_data=np.zeros((2, 1, 4)),
+        member_metadata=_member_metadata(2, 4),
+        array_type="dask",
+        npartitions=np.int64(2),
+    )
+
+    assert result.npartitions == 2
+    _assert_dask_chunks(result)
+
+
+@pytest.mark.parametrize("gather_class", [Gather, SeismogramGather])
+@pytest.mark.parametrize("array_type", ["numpy", "dask", "xarray"])
+@pytest.mark.parametrize("is_compact", [True, False])
+@pytest.mark.parametrize("capacity", [1, 3, 5])
+def test_append_installs_axis_zero_result_and_updates_size_capacity(
+    gather_class, array_type, is_compact, capacity
+):
+    components = 1 if gather_class is Gather else 3
+    result = gather_class(
+        capacity=capacity,
+        size=0,
+        npts=4,
+        num_components=components,
+        npartitions=3,
+        member_metadata=pd.DataFrame(),
+        ensemble_metadata={"dt": 0.25},
+        dt=0.25,
+        array_type=array_type,
+        is_compact=is_compact,
+    )
+    first = _datum(gather_class, 4, 10.0)
+    second = _datum(gather_class, 4, 20.0)
+
+    result.append(first)
+    first_snapshot = _stored_values(result).copy()
+    result.append(second)
+
+    assert result.size == 2
+    assert result.capacity == max(capacity, 2)
+    assert result.member_data.shape[0] == 2
+    assert np.array_equal(_stored_values(result)[0:1], first_snapshot)
+    expected = []
+    for datum in (first, second):
+        values = np.asarray(datum.data)
+        if gather_class is Gather:
+            values = values.reshape(1, 4) if is_compact else values.reshape(4, 1)
+        elif not is_compact:
+            values = values.transpose()
+        expected.append(values)
+    assert np.array_equal(_stored_values(result), np.stack(expected))
+    assert result.member_metadata["row"].tolist() == [10, 20]
+    _assert_backend(result, array_type)
+    if array_type in ("dask", "xarray"):
+        _assert_dask_chunks(result)
+
+
+@pytest.mark.parametrize("gather_class", [Gather, SeismogramGather])
+@pytest.mark.parametrize("array_type", ["numpy", "dask", "xarray"])
+@pytest.mark.parametrize("is_compact", [True, False])
+def test_subset_preserves_order_duplicates_empty_shape_and_backend(
+    gather_class, array_type, is_compact
+):
+    source, canonical = _new_gather(
+        gather_class, array_type, is_compact, size=4, npartitions=3
+    )
+    source.set_column_values(["a", "b", "c", "d"])
+
+    selected = source.subset([2, 0, 2])
+    expected = _expected_stored(canonical, is_compact)[[2, 0, 2]]
+    _assert_backend(selected, array_type)
+    assert np.array_equal(_stored_values(selected), expected)
+    assert selected.member_metadata["row"].tolist() == [2, 0, 2]
+    assert selected.column_values() == ["c", "a", "c"]
+    assert selected.size == 3
+    assert selected.capacity == 3
+    assert selected.npartitions == source.npartitions
+
+    empty = source.subset([])
+    _assert_backend(empty, array_type)
+    assert empty.member_data.shape == (0,) + source.member_data.shape[1:]
+    assert empty.size == 0
+    assert empty.capacity == 0
+    assert len(empty.member_metadata) == 0
+    assert empty.column_values() == []
+
+
+@pytest.mark.parametrize("gather_class", [Gather, SeismogramGather])
+@pytest.mark.parametrize("array_type", ["numpy", "dask", "xarray"])
+@pytest.mark.parametrize("is_compact", [True, False])
+def test_pickle_round_trip_preserves_backend_layout_and_partition_state(
+    gather_class, array_type, is_compact
+):
+    source, canonical = _new_gather(
+        gather_class, array_type, is_compact, size=4, npartitions=3
+    )
+    source.capacity = 7
+    source.set_column_values(["a", "b", "c", "d"])
+    source.elog.set_job_id(17)
+    source.elog.log_error("contract", "round trip", ErrorSeverity.Complaint)
+
+    restored = pickle.loads(pickle.dumps(source))
+
+    _assert_backend(restored, array_type)
+    assert restored.is_compact is is_compact
+    assert restored.member_data.shape == source.member_data.shape
+    assert np.array_equal(
+        _stored_values(restored), _expected_stored(canonical, is_compact)
+    )
+    assert restored.size == 4
+    assert restored.capacity == 7
+    assert restored.npartitions == 3
+    assert restored.is_parallel is (array_type in ("dask", "xarray"))
+    assert restored.num_components == source.num_components
+    assert restored.npts == source.npts
+    assert restored.column_values() == ["a", "b", "c", "d"]
+    assert restored.ensemble_metadata() == source.ensemble_metadata()
+    pd.testing.assert_frame_equal(restored.member_metadata, source.member_metadata)
+    assert restored.elog.get_job_id() == 17
+    restored_log = restored.elog.get_error_log()
+    assert len(restored_log) == 1
+    assert restored_log[0].algorithm == "contract"
+    assert restored_log[0].message == "round trip"
+    assert restored_log[0].badness == ErrorSeverity.Complaint
+    if array_type in ("dask", "xarray"):
+        restored_data = (
+            restored.member_data.data
+            if isinstance(restored.member_data, xr.DataArray)
+            else restored.member_data
+        )
+        source_data = (
+            source.member_data.data
+            if isinstance(source.member_data, xr.DataArray)
+            else source.member_data
+        )
+        assert restored_data.chunks == source_data.chunks


### PR DESCRIPTION
Fixes #876.

## Summary
- define one consistent three-dimensional storage contract for compact and non-compact scalar/vector gathers
- preserve NumPy, Dask, and xarray backend identity and validate Dask partition counts
- make `capacity` the physical axis-zero allocation; append fills reserved rows before growing
- preserve new metadata columns and deep-copy appended metadata values
- preserve subset order, duplicates, empty selections, backend configuration, labels, and metadata
- preserve ErrorLogger state across pickle round trips

## Behavior
- compact storage is `(member, component, sample)`
- non-compact storage is `(member, sample, component)`
- scalar gathers remain three-dimensional with a component axis of length one
- `size` counts active members; `capacity` matches the allocated member axis
- append rejects incompatible sample/component dimensions before mutation

## Verification
- 196 integrated BasicGather regression tests passed
- Black, Python byte-compilation, and `git diff --check` passed

Ready for review. The physical-capacity behavior follows the maintainer-approved design.
