### PR TITLE
Add versioned BSON persistence with legacy pickle compatibility

### DIFF
--- a/cxx/include/mspass/utility/ErrorLogger.h
+++ b/cxx/include/mspass/utility/ErrorLogger.h
@@ -69,8 +69,8 @@ public:
   ErrorLogger(int job) { job_id = job; };
   /*! Restore a logger from field-level records.
 
-  This constructor is intended for trusted language bindings that rebuild an
-  ErrorLogger from a versioned, non-executable persistence representation.
+  This constructor is used by language bindings that rebuild an ErrorLogger
+  from a field-level persistence representation.
   */
   ErrorLogger(int job, const std::list<LogData> &messages)
       : job_id(job), allmessages(messages) {};

--- a/cxx/include/mspass/utility/ErrorLogger.h
+++ b/cxx/include/mspass/utility/ErrorLogger.h
@@ -67,6 +67,13 @@ public:
   \param job processing job identifier to store in future log records.
   */
   ErrorLogger(int job) { job_id = job; };
+  /*! Restore a logger from field-level records.
+
+  This constructor is intended for trusted language bindings that rebuild an
+  ErrorLogger from a versioned, non-executable persistence representation.
+  */
+  ErrorLogger(int job, const std::list<LogData> &messages)
+      : job_id(job), allmessages(messages) {};
   /*! Standard copy constructor.
   \param parent logger whose job id and messages are copied.
   */

--- a/cxx/include/mspass/utility/ProcessingHistory.h
+++ b/cxx/include/mspass/utility/ProcessingHistory.h
@@ -252,6 +252,10 @@ public:
   \param jid - set as jobid
   */
   ProcessingHistory(const std::string jobnm, const std::string jid);
+  /*! Restore all state from a field-level persistence representation. */
+  ProcessingHistory(const std::string jobnm, const std::string jid,
+                    const std::multimap<std::string, NodeData> &nodesin,
+                    const NodeData &current, const ErrorLogger &elogin);
   /*! Standard copy constructor. */
   ProcessingHistory(const ProcessingHistory &parent);
   /*! Return true if the processing chain is empty.

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -936,8 +936,9 @@ PYBIND11_MODULE(seismic, m) {
       "Set the frequency defined for first component of vector holding spectrum")
     .def("set_dt",&BasicSpectrum::set_dt,"Set the parent data sample interval")
     .def("set_npts",&BasicSpectrum::set_npts,"Set the number of points of the parent spectrum")
+    .def("timeseries_npts",&BasicSpectrum::timeseries_npts,
+      "Return the number of samples in the parent time series")
   ;
-
 
   py::class_<PowerSpectrum,BasicSpectrum,Metadata>(m,"PowerSpectrum",
                   "Container for power spectrum estimates")

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -802,6 +802,9 @@ PYBIND11_MODULE(utility, m) {
     .def(py::init<>())
     .def(py::init<const ErrorLogger&>())
     .def(py::init<int>(), py::arg("job_id"), "Construct with a job id")
+    .def(py::init<int,const std::list<LogData>&>(),
+      py::arg("job_id"), py::arg("messages"),
+      "Restore a logger from field-level records")
     .def("set_job_id",&ErrorLogger::set_job_id,
       py::arg("job_id"),
       "Set the job id attached to future log entries")
@@ -912,6 +915,21 @@ PYBIND11_MODULE(utility, m) {
     .def(py::init<>())
     .def(py::init<const std::string,const std::string>())
     .def(py::init<const ProcessingHistory&>())
+    .def(py::init([](const std::string &job_name, const std::string &job_id,
+                     const py::list &edges, const NodeData &current,
+                     const ErrorLogger &elog) {
+      std::multimap<std::string, NodeData> nodes;
+      for (const auto &edge : edges) {
+        const auto item = edge.cast<py::tuple>();
+        if (item.size() != 2)
+          throw py::value_error("history edge must contain key and node");
+        nodes.emplace(item[0].cast<std::string>(), item[1].cast<NodeData>());
+      }
+      return ProcessingHistory(job_name, job_id, nodes, current, elog);
+    }),
+      py::arg("job_name"), py::arg("job_id"), py::arg("edges"),
+      py::arg("current"), py::arg("elog"),
+      "Restore a processing history from field-level records")
     .def("is_empty",&ProcessingHistory::is_empty,
       "Return true if the processing chain is empty")
     .def("is_raw",&ProcessingHistory::is_raw,

--- a/cxx/src/lib/utility/ProcessingHistory.cc
+++ b/cxx/src/lib/utility/ProcessingHistory.cc
@@ -99,6 +99,17 @@ ProcessingHistory::ProcessingHistory(const std::string jobnm,
   algorithm = "UNDEFINED";
   algid = "UNDEFINED";
 }
+ProcessingHistory::ProcessingHistory(
+    const std::string jobnm, const std::string jid,
+    const std::multimap<std::string, NodeData> &nodesin,
+    const NodeData &current, const ErrorLogger &elogin)
+    : BasicProcessingHistory(jobnm, jid), elog(elogin), nodes(nodesin),
+      algorithm(current.algorithm), algid(current.algid) {
+  current_status = current.status;
+  current_id = current.uuid;
+  current_stage = current.stage;
+  mytype = current.type;
+}
 ProcessingHistory::ProcessingHistory(const ProcessingHistory &parent)
     : BasicProcessingHistory(parent), elog(parent.elog), nodes(parent.nodes),
       algorithm(parent.algorithm), algid(parent.algid) {

--- a/cxx/test/history/test_history.cc
+++ b/cxx/test/history/test_history.cc
@@ -96,6 +96,7 @@ int print_history(const ProcessingHistory& ph, const string title)
 }
 int main(int argc, char **argv)
 {
+  int failures = 0;
   try{
     cout << "Trying constructor for base class BasicProcessingHistory"<<endl;
     BasicProcessingHistory bh;
@@ -273,15 +274,38 @@ int main(int argc, char **argv)
     cout << "Testing clean_accumulate_uuids"<<endl;
     phred_1.clean_accumulate_uuids();
     print_history(phred_1,"After clean_accumulate_uuids");
+
+    cout << "Testing field-level restoration constructor" << endl;
+    ErrorLogger restored_elog(42);
+    restored_elog.log_error("restore", "diagnostic", ErrorSeverity::Complaint);
+    const multimap<string, NodeData> restored_nodes = phred_1.get_nodes();
+    const NodeData restored_current = phred_1.current_nodedata();
+    ProcessingHistory restored("restored-job", "restored-id", restored_nodes,
+                               restored_current, restored_elog);
+    if (restored.jobname() != "restored-job")
+      ++failures;
+    if (restored.jobid() != "restored-id")
+      ++failures;
+    if (restored.get_nodes().size() != restored_nodes.size())
+      ++failures;
+    if (restored.current_nodedata() != restored_current)
+      ++failures;
+    if (restored.elog.get_job_id() != 42)
+      ++failures;
+    if (restored.elog.size() != 1)
+      ++failures;
   }
   catch(MsPASSError& merr)
   {
     cerr << "MsPASSError caught:"<<endl;
     merr.log_error();
+    ++failures;
   }
   catch(std::exception& serr)
   {
     cerr << "Something threw this generic std::exception:"<<endl;
     cerr << serr.what();
+    ++failures;
   }
+  return failures;
 }

--- a/python/mspasspy/algorithms/calib.py
+++ b/python/mspasspy/algorithms/calib.py
@@ -30,8 +30,10 @@ class ApplyCalibEngine:
     into a set of MongoDB documents with one entry for each
     SEED time period for each channel of data.   Inside that document is an
     attribute with the tag "serialized_channel_data" that contains
-    the detailed response data in a versioned StationXML document.  We only
-    extract the "sensitivity" value from the restored ObsPy Response object.
+    the detailed response data in a versioned StationXML document.  Records
+    written by older MsPASS releases may instead contain a pickled ObsPy
+    Channel; both representations are read automatically.  We only extract
+    the "sensitivity" value from the restored ObsPy Response object.
     A major complication is unit restrictions and invalid
     Response objects.  These are handled by the constructor as described
     below.   The current implementation can only handle Response objects

--- a/python/mspasspy/algorithms/calib.py
+++ b/python/mspasspy/algorithms/calib.py
@@ -1,9 +1,9 @@
-import pickle
 import numpy as np
 from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
 from mspasspy.ccore.utility import MsPASSError, ErrorSeverity
 from mspasspy.util.decorators import mspass_method_wrapper
 from mspasspy.util.db_utils import fetch_dbhandle
+from mspasspy.db.serialization import decode_response
 from obspy import UTCDateTime
 
 
@@ -28,12 +28,11 @@ class ApplyCalibEngine:
     Obspy converts that archain data to what they call an Inventory
     object.  In MsPASS we disaggregate the complicated Inventory object
     into a set of MongoDB documents with one entry for each
-    seed time period fr each channel of data.   Inside that document is a
-    an attibute with the tag "serialized_channel_data" that contains
-    the detailed response data serialized with pickle.   The
-    constructor for this object runs pickle.loads on that data to yield
-    an obspy Response object.  We only extract the "sensitivity" value from
-    Response.   A major complication is unit restrictions and invalid
+    SEED time period for each channel of data.   Inside that document is an
+    attribute with the tag "serialized_channel_data" that contains
+    the detailed response data in a versioned StationXML document.  We only
+    extract the "sensitivity" value from the restored ObsPy Response object.
+    A major complication is unit restrictions and invalid
     Response objects.  These are handled by the constructor as described
     below.   The current implementation can only handle Response objects
     with "input units" of meters per second and "output units" of counts.
@@ -109,13 +108,12 @@ class ApplyCalibEngine:
         try:
             for doc in cursor:
                 if response_data_key in doc:
-                    chandata = pickle.loads(doc[response_data_key])
-                    resp = chandata.response
+                    resp = decode_response(doc[response_data_key])
                     sens = resp.instrument_sensitivity
                     if sens is None and verbose:
                         stastr = self._parse_stadata(doc)
                         print(stastr, " invalid instrument response")
-                        print("pickle.loads returned this:  ", str(resp))
+                        print("response decoder returned this:  ", str(resp))
                     elif sens:
                         if verbose:
                             message = self._parse_stadata(doc) + ":  "
@@ -152,7 +150,7 @@ class ApplyCalibEngine:
                     stastr = self._parse_stadata(doc)
                     print(
                         stastr,
-                        " does not contain pickled response data - key=",
+                        " does not contain response data - key=",
                         response_data_key,
                     )
         finally:

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -60,6 +60,17 @@ from mspasspy.ccore.utility import (
 )
 from mspasspy.db.collection import Collection
 from mspasspy.db.schema import DatabaseSchema, MetadataSchema
+from mspasspy.db.serialization import (
+    decode_inventory,
+    decode_processing_history,
+    decode_response,
+    encode_inventory,
+    encode_processing_history,
+    encode_response,
+    inventory_subset,
+    merge_inventories,
+    trusted_legacy_pickle,
+)
 from mspasspy.util.converter import Textfile2Dataframe
 
 _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS = 300.0
@@ -4340,7 +4351,9 @@ class Database(pymongo.database.Database):
             res = self[collection].find_one({"_id": history_object_id})
             if res:
                 if "processing_history" in res:
-                    mspass_object.load_history(pickle.loads(res["processing_history"]))
+                    mspass_object.load_history(
+                        decode_processing_history(res["processing_history"])
+                    )
                     mspass_object.new_map(
                         alg_name, alg_id, atomic_type, ProcessingStatus.ORIGIN
                     )
@@ -5375,8 +5388,8 @@ class Database(pymongo.database.Database):
 
         The channel collection can contain full response data
         that can be obtained by extracting the data with the key
-        "serialized_channel_data" and running pickle loads on the returned
-        string.
+        ``serialized_channel_data`` and decoding either its current versioned
+        StationXML document or a legacy pickle payload.
 
         Channels are grouped by location code.  Each site document spans the
         union of its channels' validity intervals.  When all channels in a
@@ -5452,8 +5465,6 @@ class Database(pymongo.database.Database):
                 locdata = self._extract_locdata(chans)
                 # Assume loc code of 0 is same as rest
                 # loc=_extract_loc_code(chanlist[0])
-                # TODO Delete when sure we don't need to keep the full thing
-                # picklestr = pickle.dumps(x)
                 for loc, loc_channels in locdata.items():
                     # If multiple loc codes are present on the second pass
                     # rec will contain the ObjectId of the document inserted
@@ -5502,6 +5513,9 @@ class Database(pymongo.database.Database):
                         rec["edepth"] = next(iter(location_depths))
                     rec["starttime"] = loc_stime.timestamp
                     rec["endtime"] = loc_etime.timestamp
+                    rec["serialized_inventory"] = encode_inventory(
+                        inventory_subset(inv, x, station, loc_channels)
+                    )
                     if self._site_is_not_in_db(rec):
                         result = dbcol.insert_one(rec)
                         # Note this sets site_id to an ObjectId for the insertion
@@ -5547,6 +5561,7 @@ class Database(pymongo.database.Database):
                     for chan in loc_channels:
                         chanrec = copy.deepcopy(rec)
                         chanrec.pop("_id", None)
+                        chanrec.pop("serialized_inventory", None)
                         chanrec["chan"] = chan.code
                         # the Dip attribute in a stationxml file
                         # is like strike-dip and relative to horizontal
@@ -5575,8 +5590,9 @@ class Database(pymongo.database.Database):
                         chanrec["endtime"] = et.timestamp
                         n_chan_processed += 1
                         if self._channel_is_not_in_db(chanrec):
-                            picklestr = pickle.dumps(chan)
-                            chanrec["serialized_channel_data"] = picklestr
+                            chanrec["serialized_channel_data"] = encode_response(
+                                chan, chanrec
+                            )
                             result = dbchannel.insert_one(chanrec)
                             idobj = result.inserted_id
                             dbchannel.update_one(
@@ -5671,22 +5687,18 @@ class Database(pymongo.database.Database):
             query["starttime"] = {"$lt": time}
             query["endtime"] = {"$gt": time}
         matchsize = dbsite.count_documents(query)
-        result = Inventory()
         if matchsize == 0:
             return None
         else:
+            inventory_records = []
             with _managed_collection_cursor(
                 dbsite, query, no_cursor_timeout
             ) as stations:
                 for s in stations:
-                    serialized = s["serialized_inventory"]
-                    netw = pickle.loads(serialized)
-                    # It might be more efficient to build a list of
-                    # Network objects but here we add them one
-                    # station at a time.  Note the extend method
-                    # if poorly documented in obspy
-                    result.extend([netw])
-        return result
+                    inventory_records.append(
+                        decode_inventory(s["serialized_inventory"])
+                    )
+        return merge_inventories(inventory_records)
 
     def get_seed_site(self, net, sta, loc="NONE", time=-1.0, verbose=False):
         """
@@ -5985,9 +5997,7 @@ class Database(pymongo.database.Database):
             )
             print("There should be just one - returning the first one found")
         doc = self.channel.find_one(query)
-        s = doc["serialized_channel_data"]
-        chan = pickle.loads(s)
-        return chan.response
+        return decode_response(doc["serialized_channel_data"])
 
     def save_catalog(self, cat, verbose=False):
         """
@@ -8401,8 +8411,7 @@ def history2doc(
     This function can be thought of as a formatter for the ProcessingHistory
     container in a MsPASS data object.  It returns a python dictionary
     that, if retrieved, can be used to reconstruct the ProcessingHistory
-    container.  We do that a fairly easy way here by using pickle.dumps
-    of the container that is saved with the key "processing_history".
+    container.  The history is stored as a versioned BSON-native document.
 
     :param proc_history:   history container to be reformatted
     :type proc_history:  Must be an instance of a
@@ -8449,11 +8458,10 @@ def history2doc(
     if alg_name is None:
         alg_name = current_nodedata.algorithm
 
-    history_binary = pickle.dumps(proc_history)
     doc = {
         "save_uuid": current_uuid,
         "save_stage": current_stage,
-        "processing_history": history_binary,
+        "processing_history": encode_processing_history(proc_history),
         "alg_id": alg_id,
         "alg_name": alg_name,
     }

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -69,7 +69,6 @@ from mspasspy.db.serialization import (
     encode_response,
     inventory_subset,
     merge_inventories,
-    trusted_legacy_pickle,
 )
 from mspasspy.util.converter import Textfile2Dataframe
 

--- a/python/mspasspy/db/serialization.py
+++ b/python/mspasspy/db/serialization.py
@@ -1,0 +1,522 @@
+"""Versioned, non-executable database representations for complex objects."""
+
+import copy
+import io
+import pickle
+from datetime import datetime
+
+import numpy as np
+from bson import ObjectId
+from obspy import Inventory, read_inventory
+from obspy.core.inventory import Channel, Network, Station
+
+from mspasspy.ccore.seismic import DoubleVector, PowerSpectrum
+from mspasspy.ccore.utility import (
+    AtomicType,
+    ErrorLogger,
+    ErrorSeverity,
+    LogData,
+    Metadata,
+    MsPASSError,
+    NodeData,
+    ProcessingHistory,
+    ProcessingStatus,
+    dmatrix,
+)
+
+TYPE_KEY = "_mspass_serialization_type"
+VERSION_KEY = "_mspass_serialization_version"
+VERSION = 1
+
+
+def _invalid(message):
+    return MsPASSError(message, ErrorSeverity.Invalid)
+
+
+def _header(type_name):
+    return {TYPE_KEY: type_name, VERSION_KEY: VERSION}
+
+
+def _require_document(value, type_name):
+    if not isinstance(value, dict):
+        raise _invalid(
+            f"Expected versioned {type_name} document; legacy pickle payloads "
+            "must be migrated explicitly"
+        )
+    if value.get(TYPE_KEY) != type_name or value.get(VERSION_KEY) != VERSION:
+        raise _invalid(f"Unsupported {type_name} representation")
+
+
+def _severity_name(value):
+    return value.name
+
+
+def _severity_from_name(value):
+    try:
+        return getattr(ErrorSeverity, value)
+    except (AttributeError, TypeError) as exc:
+        raise _invalid(f"Invalid ErrorSeverity value={value!r}") from exc
+
+
+def _enum_from_name(enum_type, value, label):
+    try:
+        return getattr(enum_type, value)
+    except (AttributeError, TypeError) as exc:
+        raise _invalid(f"Invalid {label} value={value!r}") from exc
+
+
+def encode_error_logger(logger):
+    return {
+        "job_id": logger.get_job_id(),
+        "messages": [
+            {
+                "job_id": item.job_id,
+                "process_id": item.p_id,
+                "algorithm": item.algorithm,
+                "message": item.message,
+                "severity": _severity_name(item.badness),
+            }
+            for item in logger.get_error_log()
+        ],
+    }
+
+
+def decode_error_logger(document):
+    if not isinstance(document, dict):
+        raise _invalid("ErrorLogger representation is not a document")
+    try:
+        messages = [
+            LogData(
+                {
+                    "job_id": item["job_id"],
+                    "p_id": item["process_id"],
+                    "algorithm": item["algorithm"],
+                    "message": item["message"],
+                    "badness": _severity_from_name(item["severity"]),
+                }
+            )
+            for item in document["messages"]
+        ]
+        return ErrorLogger(document["job_id"], messages)
+    except MsPASSError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise _invalid("Malformed ErrorLogger representation") from exc
+
+
+def _encode_node(node):
+    return {
+        "status": node.status.name,
+        "uuid": node.uuid,
+        "type": node.type.name,
+        "stage": node.stage,
+        "algorithm": node.algorithm,
+        "algorithm_id": node.algid,
+    }
+
+
+def _decode_node(document):
+    if not isinstance(document, dict):
+        raise _invalid("ProcessingHistory node is not a document")
+    try:
+        node = NodeData()
+        node.status = _enum_from_name(
+            ProcessingStatus, document["status"], "ProcessingStatus"
+        )
+        node.uuid = document["uuid"]
+        node.type = _enum_from_name(AtomicType, document["type"], "AtomicType")
+        node.stage = document["stage"]
+        node.algorithm = document["algorithm"]
+        node.algid = document["algorithm_id"]
+        return node
+    except MsPASSError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise _invalid("Malformed ProcessingHistory node") from exc
+
+
+def encode_processing_history(history):
+    if not isinstance(history, ProcessingHistory):
+        raise TypeError("history must be a ProcessingHistory")
+    edges = []
+    for child, parents in history.get_nodes().items():
+        for parent in parents:
+            edges.append({"child": child, "parent": _encode_node(parent)})
+    document = _header("ProcessingHistory")
+    document.update(
+        {
+            "job_name": history.jobname(),
+            "job_id": history.jobid(),
+            "current": _encode_node(history.current_nodedata()),
+            "edges": edges,
+            "error_log": encode_error_logger(history.elog),
+        }
+    )
+    return document
+
+
+def decode_processing_history(document):
+    _require_document(document, "ProcessingHistory")
+    try:
+        edges = [
+            (edge["child"], _decode_node(edge["parent"])) for edge in document["edges"]
+        ]
+        return ProcessingHistory(
+            document["job_name"],
+            document["job_id"],
+            edges,
+            _decode_node(document["current"]),
+            decode_error_logger(document["error_log"]),
+        )
+    except MsPASSError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise _invalid("Malformed ProcessingHistory representation") from exc
+
+
+def inventory_subset(inventory, network, station, channels):
+    """Return a one-station Inventory while preserving Inventory metadata."""
+    station_copy = copy.deepcopy(station)
+    station_copy.channels = [copy.deepcopy(channel) for channel in channels]
+    network_copy = copy.deepcopy(network)
+    network_copy.stations = [station_copy]
+    return Inventory(
+        networks=[network_copy],
+        source=inventory.source,
+        sender=inventory.sender,
+        module=inventory.module,
+        module_uri=inventory.module_uri,
+        created=inventory.created,
+    )
+
+
+def encode_inventory(inventory):
+    if isinstance(inventory, Network):
+        inventory = Inventory(networks=[copy.deepcopy(inventory)], source="MsPASS")
+    if not isinstance(inventory, Inventory):
+        raise TypeError("inventory must be an ObsPy Inventory or Network")
+    stream = io.BytesIO()
+    inventory.write(stream, format="STATIONXML", validate=True)
+    document = _header("Inventory")
+    document["stationxml"] = stream.getvalue().decode("utf-8")
+    return document
+
+
+def decode_inventory(document):
+    return _decode_stationxml(document, "Inventory")
+
+
+def encode_response(channel, document):
+    """Encode one channel response with enough StationXML context to restore it."""
+    if not isinstance(channel, Channel):
+        raise TypeError("channel must be an ObsPy Channel")
+    stream = io.BytesIO()
+    channel_inventory(channel, document).write(
+        stream, format="STATIONXML", validate=True
+    )
+    result = _header("Response")
+    result["stationxml"] = stream.getvalue().decode("utf-8")
+    return result
+
+
+def _decode_stationxml(document, type_name):
+    _require_document(document, type_name)
+    try:
+        payload = document["stationxml"]
+        if not isinstance(payload, str):
+            raise TypeError("stationxml is not a string")
+        return read_inventory(io.BytesIO(payload.encode("utf-8")), format="STATIONXML")
+    except MsPASSError:
+        raise
+    except Exception as exc:
+        raise _invalid(f"Malformed {type_name} representation") from exc
+
+
+def merge_inventories(inventories):
+    """Merge one-station codec records back into a complete Inventory."""
+    inventories = list(inventories)
+    if not inventories:
+        return Inventory()
+    first = inventories[0]
+    result = Inventory(
+        networks=[],
+        source=first.source,
+        sender=first.sender,
+        module=first.module,
+        module_uri=first.module_uri,
+        created=first.created,
+    )
+    networks = {}
+    stations = {}
+    for inventory in inventories:
+        for network in inventory.networks:
+            network_key = (
+                network.code,
+                str(network.start_date),
+                str(network.end_date),
+            )
+            target_network = networks.get(network_key)
+            if target_network is None:
+                target_network = copy.deepcopy(network)
+                target_network.stations = []
+                networks[network_key] = target_network
+                result.networks.append(target_network)
+            for station in network.stations:
+                key = (
+                    network_key,
+                    station.code,
+                    str(station.start_date),
+                    str(station.end_date),
+                )
+                target_station = stations.get(key)
+                if target_station is None:
+                    target_station = copy.deepcopy(station)
+                    target_station.channels = []
+                    stations[key] = target_station
+                    target_network.stations.append(target_station)
+                existing = {
+                    (
+                        channel.code,
+                        channel.location_code,
+                        str(channel.start_date),
+                        str(channel.end_date),
+                    )
+                    for channel in target_station.channels
+                }
+                for channel in station.channels:
+                    key = (
+                        channel.code,
+                        channel.location_code,
+                        str(channel.start_date),
+                        str(channel.end_date),
+                    )
+                    if key not in existing:
+                        target_station.channels.append(copy.deepcopy(channel))
+                        existing.add(key)
+    return result
+
+
+def channel_inventory(channel, document):
+    if not isinstance(channel, Channel):
+        raise TypeError("channel must be an ObsPy Channel")
+    station = Station(
+        code=document.get("sta", "UNKNOWN"),
+        latitude=channel.latitude,
+        longitude=channel.longitude,
+        elevation=channel.elevation,
+        channels=[copy.deepcopy(channel)],
+    )
+    network = Network(code=document.get("net", "XX"), stations=[station])
+    return Inventory(networks=[network], source="MsPASS")
+
+
+def decode_channel(document):
+    inventory = _decode_stationxml(document, "Response")
+    try:
+        return inventory.networks[0].stations[0].channels[0]
+    except (IndexError, AttributeError) as exc:
+        raise _invalid("Inventory representation contains no channel") from exc
+
+
+def decode_response(document):
+    return decode_channel(document).response
+
+
+def _encode_metadata_value(value):
+    if value is None or isinstance(
+        value, (bool, int, float, str, bytes, ObjectId, datetime)
+    ):
+        return value
+    if isinstance(value, np.generic):
+        return _encode_metadata_value(value.item())
+    if isinstance(value, DoubleVector):
+        return {
+            TYPE_KEY: "DoubleVector",
+            VERSION_KEY: VERSION,
+            "values": list(value),
+        }
+    if isinstance(value, dmatrix):
+        return {
+            TYPE_KEY: "dmatrix",
+            VERSION_KEY: VERSION,
+            "values": np.asarray(value).tolist(),
+        }
+    if isinstance(value, np.ndarray):
+        return {
+            TYPE_KEY: "ndarray",
+            VERSION_KEY: VERSION,
+            "dtype": str(value.dtype),
+            "shape": list(value.shape),
+            "values": value.reshape(-1).tolist(),
+        }
+    if isinstance(value, tuple):
+        return {
+            TYPE_KEY: "tuple",
+            VERSION_KEY: VERSION,
+            "values": [_encode_metadata_value(item) for item in value],
+        }
+    if isinstance(value, list):
+        return [_encode_metadata_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            TYPE_KEY: "dict",
+            VERSION_KEY: VERSION,
+            "items": [
+                {
+                    "key": _encode_metadata_value(key),
+                    "value": _encode_metadata_value(item),
+                }
+                for key, item in value.items()
+            ],
+        }
+    raise _invalid(f"Unsupported Metadata value type={type(value)}")
+
+
+def _decode_metadata_value(value):
+    if isinstance(value, list):
+        return [_decode_metadata_value(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    value_type = value.get(TYPE_KEY)
+    if value_type is None:
+        return {key: _decode_metadata_value(item) for key, item in value.items()}
+    if value.get(VERSION_KEY) != VERSION:
+        raise _invalid("Unsupported Metadata value representation")
+    if value_type == "tuple":
+        return tuple(_decode_metadata_value(item) for item in value["values"])
+    if value_type == "dict":
+        return {
+            _decode_metadata_value(item["key"]): _decode_metadata_value(item["value"])
+            for item in value["items"]
+        }
+    if value_type == "DoubleVector":
+        return DoubleVector(value["values"])
+    if value_type == "ndarray":
+        result = np.asarray(value["values"], dtype=value["dtype"])
+        return result.reshape(value["shape"])
+    if value_type == "dmatrix":
+        return dmatrix(np.asarray(value["values"], dtype=float))
+    raise _invalid(f"Unsupported Metadata value type={value_type}")
+
+
+def encode_power_spectrum(spectrum):
+    if not isinstance(spectrum, PowerSpectrum):
+        raise TypeError("spectrum must be a PowerSpectrum")
+    document = _header("PowerSpectrum")
+    document.update(
+        {
+            "metadata": _encode_metadata_value(dict(spectrum)),
+            "spectrum": list(spectrum.spectrum),
+            "df": spectrum.df(),
+            "f0": spectrum.f0(),
+            "spectrum_type": spectrum.spectrum_type,
+            "parent_dt": spectrum.dt(),
+            "parent_npts": spectrum.timeseries_npts(),
+            "live": spectrum.live(),
+            "error_log": encode_error_logger(spectrum.elog),
+        }
+    )
+    return document
+
+
+def decode_power_spectrum(document):
+    _require_document(document, "PowerSpectrum")
+    try:
+        result = PowerSpectrum(
+            Metadata(_decode_metadata_value(document["metadata"])),
+            DoubleVector(document["spectrum"]),
+            document["df"],
+            document["spectrum_type"],
+            document["f0"],
+            document["parent_dt"],
+            document["parent_npts"],
+        )
+        if not document["live"]:
+            result.kill()
+        result.elog = decode_error_logger(document["error_log"])
+        return result
+    except MsPASSError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise _invalid("Malformed PowerSpectrum representation") from exc
+
+
+def _legacy_payload(document):
+    fields = (
+        "processing_history",
+        "serialized_inventory",
+        "serialized_channel_data",
+        "serialized_data",
+    )
+    present = [field for field in fields if field in document]
+    if len(present) != 1:
+        raise _invalid("Legacy document must contain exactly one supported payload")
+    return present[0], document[present[0]]
+
+
+def _has_new_representation(document):
+    expected_types = {
+        "processing_history": "ProcessingHistory",
+        "serialized_inventory": "Inventory",
+        "serialized_channel_data": "Response",
+        "serialized_data": "PowerSpectrum",
+    }
+    return any(
+        isinstance(document.get(field), dict)
+        and document[field].get(TYPE_KEY) == type_name
+        and document[field].get(VERSION_KEY) == VERSION
+        for field, type_name in expected_types.items()
+    )
+
+
+def _encode_legacy_object(field, value, document):
+    if field == "processing_history" and isinstance(value, ProcessingHistory):
+        return encode_processing_history(value)
+    if field == "serialized_inventory" and isinstance(value, (Inventory, Network)):
+        return encode_inventory(value)
+    if field == "serialized_channel_data" and isinstance(value, Channel):
+        return encode_response(value, document)
+    if field == "serialized_data" and isinstance(value, PowerSpectrum):
+        return encode_power_spectrum(value)
+    raise _invalid(f"Legacy payload field={field} contains an unexpected object type")
+
+
+def trusted_legacy_pickle(database, collection, query=None):
+    """Migrate caller-declared trusted pickle records in ascending ``_id`` order.
+
+    Calling this function explicitly is the trust declaration.  It executes
+    pickle deserialization and must never be used on untrusted records.
+    """
+    target = database[collection]
+    migrated = 0
+    for original in target.find(query or {}).sort("_id", 1):
+        try:
+            if _has_new_representation(original):
+                continue
+            field, payload = _legacy_payload(original)
+            expected_type = {
+                "processing_history": "ProcessingHistory",
+                "serialized_inventory": "Inventory",
+                "serialized_channel_data": "Response",
+                "serialized_data": "PowerSpectrum",
+            }[field]
+            if isinstance(payload, dict):
+                _require_document(payload, expected_type)
+            if not isinstance(payload, (bytes, bytearray)):
+                raise _invalid(
+                    f"Legacy payload field={field} must contain pickle bytes"
+                )
+            value = pickle.loads(payload)
+            replacement = copy.deepcopy(original)
+            replacement[field] = _encode_legacy_object(field, value, original)
+            result = target.replace_one({"_id": original["_id"]}, replacement)
+            if result.matched_count != 1:
+                raise RuntimeError("legacy record disappeared before replacement")
+            migrated += 1
+        except MsPASSError:
+            raise
+        except Exception as exc:
+            raise _invalid(
+                f"trusted_legacy_pickle failed at record _id={original.get('_id')}"
+            ) from exc
+    return migrated

--- a/python/mspasspy/db/serialization.py
+++ b/python/mspasspy/db/serialization.py
@@ -208,7 +208,7 @@ def encode_inventory(inventory):
     if not isinstance(inventory, Inventory):
         raise TypeError("inventory must be an ObsPy Inventory or Network")
     stream = io.BytesIO()
-    inventory.write(stream, format="STATIONXML", validate=True)
+    inventory.write(stream, format="STATIONXML")
     document = _header("Inventory")
     document["stationxml"] = stream.getvalue().decode("utf-8")
     return document
@@ -228,9 +228,7 @@ def encode_response(channel, document):
     if not isinstance(channel, Channel):
         raise TypeError("channel must be an ObsPy Channel")
     stream = io.BytesIO()
-    channel_inventory(channel, document).write(
-        stream, format="STATIONXML", validate=True
-    )
+    channel_inventory(channel, document).write(stream, format="STATIONXML")
     result = _header("Response")
     result["stationxml"] = stream.getvalue().decode("utf-8")
     return result

--- a/python/mspasspy/db/serialization.py
+++ b/python/mspasspy/db/serialization.py
@@ -1,4 +1,4 @@
-"""Versioned, non-executable database representations for complex objects."""
+"""Versioned database representations with legacy pickle compatibility."""
 
 import copy
 import io
@@ -39,12 +39,22 @@ def _header(type_name):
 
 def _require_document(value, type_name):
     if not isinstance(value, dict):
-        raise _invalid(
-            f"Expected versioned {type_name} document; legacy pickle payloads "
-            "must be migrated explicitly"
-        )
+        raise _invalid(f"Expected a versioned {type_name} document")
     if value.get(TYPE_KEY) != type_name or value.get(VERSION_KEY) != VERSION:
         raise _invalid(f"Unsupported {type_name} representation")
+
+
+def _decode_legacy_pickle(payload, expected_type, type_name):
+    """Decode a payload written by MsPASS releases that used pickle."""
+    try:
+        value = pickle.loads(bytes(payload))
+    except Exception as exc:
+        raise _invalid(f"Malformed legacy {type_name} pickle payload") from exc
+    if not isinstance(value, expected_type):
+        raise _invalid(
+            f"Legacy {type_name} pickle contains unexpected type={type(value)}"
+        )
+    return value
 
 
 def _severity_name(value):
@@ -156,6 +166,8 @@ def encode_processing_history(history):
 
 
 def decode_processing_history(document):
+    if isinstance(document, (bytes, bytearray)):
+        return _decode_legacy_pickle(document, ProcessingHistory, "ProcessingHistory")
     _require_document(document, "ProcessingHistory")
     try:
         edges = [
@@ -203,6 +215,11 @@ def encode_inventory(inventory):
 
 
 def decode_inventory(document):
+    if isinstance(document, (bytes, bytearray)):
+        inventory = _decode_legacy_pickle(document, (Inventory, Network), "Inventory")
+        if isinstance(inventory, Network):
+            return Inventory(networks=[inventory], source="MsPASS")
+        return inventory
     return _decode_stationxml(document, "Inventory")
 
 
@@ -311,6 +328,8 @@ def channel_inventory(channel, document):
 
 
 def decode_channel(document):
+    if isinstance(document, (bytes, bytearray)):
+        return _decode_legacy_pickle(document, Channel, "Response")
     inventory = _decode_stationxml(document, "Response")
     try:
         return inventory.networks[0].stations[0].channels[0]
@@ -420,6 +439,8 @@ def encode_power_spectrum(spectrum):
 
 
 def decode_power_spectrum(document):
+    if isinstance(document, (bytes, bytearray)):
+        return _decode_legacy_pickle(document, PowerSpectrum, "PowerSpectrum")
     _require_document(document, "PowerSpectrum")
     try:
         result = PowerSpectrum(
@@ -439,84 +460,3 @@ def decode_power_spectrum(document):
         raise
     except (KeyError, TypeError, ValueError) as exc:
         raise _invalid("Malformed PowerSpectrum representation") from exc
-
-
-def _legacy_payload(document):
-    fields = (
-        "processing_history",
-        "serialized_inventory",
-        "serialized_channel_data",
-        "serialized_data",
-    )
-    present = [field for field in fields if field in document]
-    if len(present) != 1:
-        raise _invalid("Legacy document must contain exactly one supported payload")
-    return present[0], document[present[0]]
-
-
-def _has_new_representation(document):
-    expected_types = {
-        "processing_history": "ProcessingHistory",
-        "serialized_inventory": "Inventory",
-        "serialized_channel_data": "Response",
-        "serialized_data": "PowerSpectrum",
-    }
-    return any(
-        isinstance(document.get(field), dict)
-        and document[field].get(TYPE_KEY) == type_name
-        and document[field].get(VERSION_KEY) == VERSION
-        for field, type_name in expected_types.items()
-    )
-
-
-def _encode_legacy_object(field, value, document):
-    if field == "processing_history" and isinstance(value, ProcessingHistory):
-        return encode_processing_history(value)
-    if field == "serialized_inventory" and isinstance(value, (Inventory, Network)):
-        return encode_inventory(value)
-    if field == "serialized_channel_data" and isinstance(value, Channel):
-        return encode_response(value, document)
-    if field == "serialized_data" and isinstance(value, PowerSpectrum):
-        return encode_power_spectrum(value)
-    raise _invalid(f"Legacy payload field={field} contains an unexpected object type")
-
-
-def trusted_legacy_pickle(database, collection, query=None):
-    """Migrate caller-declared trusted pickle records in ascending ``_id`` order.
-
-    Calling this function explicitly is the trust declaration.  It executes
-    pickle deserialization and must never be used on untrusted records.
-    """
-    target = database[collection]
-    migrated = 0
-    for original in target.find(query or {}).sort("_id", 1):
-        try:
-            if _has_new_representation(original):
-                continue
-            field, payload = _legacy_payload(original)
-            expected_type = {
-                "processing_history": "ProcessingHistory",
-                "serialized_inventory": "Inventory",
-                "serialized_channel_data": "Response",
-                "serialized_data": "PowerSpectrum",
-            }[field]
-            if isinstance(payload, dict):
-                _require_document(payload, expected_type)
-            if not isinstance(payload, (bytes, bytearray)):
-                raise _invalid(
-                    f"Legacy payload field={field} must contain pickle bytes"
-                )
-            value = pickle.loads(payload)
-            replacement = copy.deepcopy(original)
-            replacement[field] = _encode_legacy_object(field, value, original)
-            result = target.replace_one({"_id": original["_id"]}, replacement)
-            if result.matched_count != 1:
-                raise RuntimeError("legacy record disappeared before replacement")
-            migrated += 1
-        except MsPASSError:
-            raise
-        except Exception as exc:
-            raise _invalid(
-                f"trusted_legacy_pickle failed at record _id={original.get('_id')}"
-            ) from exc
-    return migrated

--- a/python/mspasspy/db/spectrumdb.py
+++ b/python/mspasspy/db/spectrumdb.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from abc import ABC, abstractmethod
+import pickle
+
 from mspasspy.ccore.seismic import PowerSpectrum
 from mspasspy.ccore.utility import MsPASSError, ErrorSeverity
 from mspasspy.db.schema import DatabaseSchema, MetadataSchema
@@ -244,8 +246,9 @@ class SpectrumDatabase(BasicObjectDatabase):
           (default) only the data fetched with these keys will be saved to
           the document created for this object.   If the key is not actually
           found in the Metadata area of datum it will be silently ignored.
-        :param format: output format of the object.  The only accepted value
-          is the non-executable default, "bson".
+        :param format: output format of the object.  The default is "bson".
+          Set this to "pickle" only when interoperability with an older
+          MsPASS release is required.
         """
         if not self.data_valid(datum):
             message = "SpectrumDatabase.save_data:  illegal data type for arg0. Found type={typ} - only support PowerSpectrum".format(
@@ -254,9 +257,9 @@ class SpectrumDatabase(BasicObjectDatabase):
             raise MsPASSError(message, ErrorSeverity.Fatal)
         if datum.dead():
             return datum
-        if format != "bson":
+        if format not in ("bson", "pickle"):
             raise MsPASSError(
-                "SpectrumDatabase.save_data: format must be bson",
+                "SpectrumDatabase.save_data: format must be bson or pickle",
                 ErrorSeverity.Invalid,
             )
         if metadata2save:
@@ -273,7 +276,10 @@ class SpectrumDatabase(BasicObjectDatabase):
             if exclude:
                 for key in exclude:
                     doc.pop(key)
-        doc["serialized_data"] = encode_power_spectrum(datum)
+        if format == "bson":
+            doc["serialized_data"] = encode_power_spectrum(datum)
+        else:
+            doc["serialized_data"] = pickle.dumps(datum)
         return self.collection.insert_one(doc).inserted_id
 
     def read_data(
@@ -285,8 +291,9 @@ class SpectrumDatabase(BasicObjectDatabase):
         """
         Reads one PowerSpectrum using an object id either directly or
         indirectly via an input MongoDB document.  The implementation restores
-        a versioned BSON-native representation.  It may be useful to verify the
-        content of the restored datum has attributes that are the same as the database.
+        either the current versioned BSON representation or a legacy pickle
+        representation.  It may be useful to verify the content of the restored
+        datum has attributes that are the same as the database.
         The can be necessary if the database was edited after a datum of
         interest was saved.  The "required" and "override" optional arguments
         are used for that purpose.

--- a/python/mspasspy/db/spectrumdb.py
+++ b/python/mspasspy/db/spectrumdb.py
@@ -5,8 +5,8 @@ from mspasspy.ccore.seismic import PowerSpectrum
 from mspasspy.ccore.utility import MsPASSError, ErrorSeverity
 from mspasspy.db.schema import DatabaseSchema, MetadataSchema
 from mspasspy.db.client import DBClient
+from mspasspy.db.serialization import decode_power_spectrum, encode_power_spectrum
 from bson import ObjectId
-import pickle
 
 
 class BasicObjectDatabase(ABC):
@@ -229,11 +229,11 @@ class SpectrumDatabase(BasicObjectDatabase):
         )
         self.collection = self.db[collection]
 
-    def save_data(self, datum, exclude=None, metadata2save=None, format="pickle"):
+    def save_data(self, datum, exclude=None, metadata2save=None, format="bson"):
         """
         Saves a single PowerSpectrum object defined through arg0.   Default
-        dumps all metadata elements to PowerSpectrum collection document
-        and saves pickled version of datum with the key "serialized_data".
+        dumps all metadata elements to the PowerSpectrum collection document
+        and saves a versioned BSON-native object under "serialized_data".
 
         :param datum:  PowerSpectrum to save.  The method will throw a
           MsPASSError if this is not a PowerSpectrum object.   If the datum
@@ -244,10 +244,8 @@ class SpectrumDatabase(BasicObjectDatabase):
           (default) only the data fetched with these keys will be saved to
           the document created for this object.   If the key is not actually
           found in the Metadata area of datum it will be silently ignored.
-        :param format:  output format of the object.  Currently the only
-          accepted value is the default of "pickle".  The default format
-          pickles the input datum and saves the result with the key
-          "serialized_data".
+        :param format: output format of the object.  The only accepted value
+          is the non-executable default, "bson".
         """
         if not self.data_valid(datum):
             message = "SpectrumDatabase.save_data:  illegal data type for arg0. Found type={typ} - only support PowerSpectrum".format(
@@ -256,10 +254,10 @@ class SpectrumDatabase(BasicObjectDatabase):
             raise MsPASSError(message, ErrorSeverity.Fatal)
         if datum.dead():
             return datum
-        if format != "pickle":
+        if format != "bson":
             raise MsPASSError(
-                "SpectrumDatabase.save_data:  format can currently only be pickle",
-                ErrorSeverity.Fatal,
+                "SpectrumDatabase.save_data: format must be bson",
+                ErrorSeverity.Invalid,
             )
         if metadata2save:
             doc = dict()
@@ -275,7 +273,7 @@ class SpectrumDatabase(BasicObjectDatabase):
             if exclude:
                 for key in exclude:
                     doc.pop(key)
-        doc["serialized_data"] = pickle.dumps(datum)
+        doc["serialized_data"] = encode_power_spectrum(datum)
         return self.collection.insert_one(doc).inserted_id
 
     def read_data(
@@ -286,10 +284,9 @@ class SpectrumDatabase(BasicObjectDatabase):
     ):
         """
         Reads one PowerSpectrum using an object id either directly or
-        indirectly via an input MongoDB document.   Because this implementation
-        uses pickle to restore the PowerSpectrum object from a serialized
-        form it may be useful to verify the content of the restored datum
-        created by pickle has attributes that are the same as the database.
+        indirectly via an input MongoDB document.  The implementation restores
+        a versioned BSON-native representation.  It may be useful to verify the
+        content of the restored datum has attributes that are the same as the database.
         The can be necessary if the database was edited after a datum of
         interest was saved.  The "required" and "override" optional arguments
         are used for that purpose.
@@ -322,7 +319,7 @@ class SpectrumDatabase(BasicObjectDatabase):
         if doc:
             datakey = "serialized_data"
             if datakey in doc:
-                datum = pickle.loads(doc[datakey])
+                datum = decode_power_spectrum(doc[datakey])
                 if required:
                     for key in required:
                         datum[key] = doc[key]
@@ -331,7 +328,9 @@ class SpectrumDatabase(BasicObjectDatabase):
                         if key in doc:
                             datum[key] = doc[key]
             else:
-                message = "SpectrumDatabase.read_data:  missing required key=serialized_data - expected to contain datum serialized with pickle"
+                message = (
+                    "SpectrumDatabase.read_data: missing required key=serialized_data"
+                )
                 raise MsPASSError(message, ErrorSeverity.Fatal)
             return datum
         else:
@@ -354,8 +353,7 @@ class SpectrumDatabase(BasicObjectDatabase):
         MongoDB query can be passed to scan a limited subset.  You can also
         pass a list of required keys that must be present in each document
         processed.  The method always tests for the existence of the special
-        key "serialized_data" that is used to store a pickled copy of the
-        datum.
+        key "serialized_data" that stores the versioned representation.
 
         :param query:  optional pymongo query (python dict) to apply the
           Power Spectrum collection.  Default scans the entire collection.

--- a/python/tests/db/test_bson_serialization_contract.py
+++ b/python/tests/db/test_bson_serialization_contract.py
@@ -1,4 +1,3 @@
-import copy
 import os
 import pickle
 import uuid
@@ -8,7 +7,6 @@ import numpy as np
 import obspy
 import pytest
 from bson import BSON, ObjectId
-from pymongo.errors import PyMongoError
 
 from mspasspy.algorithms.calib import ApplyCalibEngine
 from mspasspy.ccore.seismic import (
@@ -25,7 +23,7 @@ from mspasspy.ccore.utility import (
     ProcessingHistory,
 )
 from mspasspy.db.client import DBClient
-from mspasspy.db.database import Database, history2doc, trusted_legacy_pickle
+from mspasspy.db.database import Database, history2doc
 from mspasspy.db.serialization import (
     TYPE_KEY,
     VERSION,
@@ -39,20 +37,6 @@ from mspasspy.db.serialization import (
     encode_processing_history,
 )
 from mspasspy.db.spectrumdb import SpectrumDatabase
-
-
-def _write_marker_and_return(path, value):
-    Path(path).write_text("executed", encoding="utf-8")
-    return value
-
-
-class ExecutingPickle:
-    def __init__(self, marker, value):
-        self.marker = str(marker)
-        self.value = value
-
-    def __reduce__(self):
-        return _write_marker_and_return, (self.marker, self.value)
 
 
 def _assert_no_binary_payload(value):
@@ -318,281 +302,104 @@ def test_power_spectrum_preserves_supported_structured_metadata():
     assert restored["nested"] == spectrum["nested"]
 
 
-@pytest.mark.parametrize(
-    "collection,field,reader",
-    [
-        (
-            "history_object",
-            "processing_history",
-            lambda database, identifier: _load_legacy_history(database, identifier),
-        ),
-        (
-            "site",
-            "serialized_inventory",
-            lambda database, identifier: database.read_inventory(net="MAL"),
-        ),
-        (
-            "channel",
-            "serialized_channel_data",
-            lambda database, identifier: database.get_response(
-                "MAL", "BAD", "BHZ", "", 10.0
-            ),
-        ),
-        (
-            "PowerSpectrum",
-            "serialized_data",
-            lambda database, identifier: _read_legacy_spectrum(database, identifier),
-        ),
-    ],
-)
-def test_normal_reads_reject_legacy_pickle_without_execution(
-    mongo_database, tmp_path, collection, field, reader
-):
-    marker = tmp_path / f"{collection}.marker"
-    payload = pickle.dumps(ExecutingPickle(marker, "unexpected"))
-    document = {"_id": ObjectId(), field: payload}
-    if collection == "site":
-        document.update({"net": "MAL", "sta": "BAD"})
-    elif collection == "channel":
-        document.update(
-            {
-                "net": "MAL",
-                "sta": "BAD",
-                "chan": "BHZ",
-                "loc": "",
-                "starttime": 0.0,
-                "endtime": 20.0,
-            }
-        )
-    mongo_database[collection].insert_one(copy.deepcopy(document))
+def test_legacy_pickle_codecs_round_trip():
+    history = _make_history()
+    assert _history_signature(
+        decode_processing_history(pickle.dumps(history))
+    ) == _history_signature(history)
 
-    with pytest.raises(MsPASSError) as error:
-        reader(mongo_database, document["_id"])
-    assert error.value.severity == ErrorSeverity.Invalid
-    assert not marker.exists()
-
-
-def _read_legacy_spectrum(database, identifier):
-    handle = SpectrumDatabase.__new__(SpectrumDatabase)
-    handle.collection = database["PowerSpectrum"]
-    return handle.read_data(identifier)
-
-
-def _load_legacy_history(database, identifier):
-    target = TimeSeries(1)
-    target["_id"] = ObjectId()
-    target.set_live()
-    return database._load_history(target, identifier)
-
-
-def test_apply_calib_rejects_legacy_response_without_execution(
-    mongo_database, tmp_path
-):
-    marker = tmp_path / "calib.marker"
-    mongo_database.channel.insert_one(
-        {"serialized_channel_data": pickle.dumps(ExecutingPickle(marker, "unexpected"))}
-    )
-    with pytest.raises(MsPASSError) as error:
-        ApplyCalibEngine(mongo_database)
-    assert error.value.severity == ErrorSeverity.Invalid
-    assert not marker.exists()
-
-
-@pytest.mark.parametrize(
-    "collection,field,value",
-    [
-        pytest.param(
-            "history_object",
-            "processing_history",
-            _make_history(),
-            id="history",
-        ),
-        pytest.param(
-            "PowerSpectrum",
-            "serialized_data",
-            _make_spectrum(),
-            id="spectrum",
-        ),
-    ],
-)
-def test_explicit_trusted_migration_executes_and_is_idempotent(
-    mongo_database, tmp_path, collection, field, value
-):
-    marker = tmp_path / f"{collection}.marker"
-    identifier = (
-        mongo_database[collection]
-        .insert_one({field: pickle.dumps(ExecutingPickle(marker, value))})
-        .inserted_id
-    )
-    assert trusted_legacy_pickle(mongo_database, collection) == 1
-    assert marker.read_text(encoding="utf-8") == "executed"
-    stored = mongo_database[collection].find_one({"_id": identifier})
-    assert stored[field][VERSION_KEY] == VERSION
-    if field == "processing_history":
-        assert _history_signature(
-            decode_processing_history(stored[field])
-        ) == _history_signature(value)
-    else:
-        assert _spectrum_signature(
-            decode_power_spectrum(stored[field])
-        ) == _spectrum_signature(value)
-    assert trusted_legacy_pickle(mongo_database, collection) == 0
-
-
-def test_migration_skips_new_record_with_payload_named_metadata(
-    mongo_database, tmp_path
-):
-    marker = tmp_path / "already-new.marker"
-    mongo_database.PowerSpectrum.insert_one(
-        {
-            "processing_history": pickle.dumps(
-                ExecutingPickle(marker, "metadata, not the persisted spectrum")
-            ),
-            "serialized_data": encode_power_spectrum(_make_spectrum()),
-        }
-    )
-
-    assert trusted_legacy_pickle(mongo_database, "PowerSpectrum") == 0
-    assert not marker.exists()
-
-
-def test_inventory_and_response_trusted_migration(mongo_database):
     inventory = obspy.read_inventory("python/tests/data/TA.035A.xml")
     network = inventory.networks[0]
     channel = network.stations[0].channels[0]
-    site_id = mongo_database.site.insert_one(
-        {"serialized_inventory": pickle.dumps(network)}
-    ).inserted_id
-    channel_id = mongo_database.channel.insert_one(
+    assert decode_inventory(pickle.dumps(network)).networks == [network]
+    assert decode_inventory(pickle.dumps(inventory)) == inventory
+    assert decode_response(pickle.dumps(channel)) == channel.response
+
+    spectrum = _make_spectrum()
+    assert _spectrum_signature(
+        decode_power_spectrum(pickle.dumps(spectrum))
+    ) == _spectrum_signature(spectrum)
+
+
+def test_public_readers_accept_legacy_pickle(mongo_database):
+    history = _make_history()
+    history_document = history2doc(history)
+    history_document["processing_history"] = pickle.dumps(history)
+    history_id = mongo_database.history_object.insert_one(history_document).inserted_id
+    target = TimeSeries(1)
+    target["_id"] = ObjectId()
+    target.set_live()
+    mongo_database._load_history(target, history_id, alg_name="read", alg_id="read-id")
+    assert target.current_nodedata().algorithm == "read"
+
+    inventory = obspy.read_inventory("python/tests/data/TA.035A.xml")
+    network = inventory.networks[0]
+    station = network.stations[0]
+    channel = station.channels[0]
+    mongo_database.site.insert_one(
         {
             "net": network.code,
-            "sta": network.stations[0].code,
+            "sta": station.code,
+            "loc": channel.location_code,
+            "serialized_inventory": pickle.dumps(network),
+        }
+    )
+    restored = mongo_database.read_inventory(net=network.code, sta=station.code)
+    assert restored.networks == [network]
+
+    starttime = channel.start_date.timestamp
+    endtime = channel.end_date.timestamp
+    mongo_database.channel.insert_one(
+        {
+            "net": network.code,
+            "sta": station.code,
+            "chan": channel.code,
+            "loc": channel.location_code,
+            "starttime": starttime,
+            "endtime": endtime,
             "serialized_channel_data": pickle.dumps(channel),
         }
-    ).inserted_id
-    assert trusted_legacy_pickle(mongo_database, "site") == 1
-    assert trusted_legacy_pickle(mongo_database, "channel") == 1
-    inventory_payload = mongo_database.site.find_one({"_id": site_id})[
-        "serialized_inventory"
-    ]
-    response_payload = mongo_database.channel.find_one({"_id": channel_id})[
-        "serialized_channel_data"
-    ]
-    assert inventory_payload[TYPE_KEY] == "Inventory"
-    assert response_payload[TYPE_KEY] == "Response"
-    assert decode_inventory(inventory_payload).networks == [network]
-    assert decode_response(response_payload) == channel.response
-
-
-def test_migration_query_order_failure_prefix_and_retry(mongo_database):
-    collection = mongo_database["migration_order"]
-    identifiers = [
-        ObjectId.from_datetime(obspy.UTCDateTime(x).datetime) for x in (1, 2, 3)
-    ]
-    values = [_make_spectrum(), "wrong type", _make_spectrum()]
-    originals = []
-    for identifier, value in zip(identifiers, values):
-        document = {
-            "_id": identifier,
-            "selected": True,
-            "serialized_data": pickle.dumps(value),
-        }
-        originals.append(copy.deepcopy(document))
-        collection.insert_one(document)
-    collection.insert_one(
-        {"selected": False, "serialized_data": pickle.dumps(_make_spectrum())}
     )
-
-    with pytest.raises(MsPASSError) as error:
-        trusted_legacy_pickle(mongo_database, "migration_order", {"selected": True})
-    assert error.value.severity == ErrorSeverity.Invalid
-    assert isinstance(
-        collection.find_one({"_id": identifiers[0]})["serialized_data"], dict
-    )
-    assert collection.find_one({"_id": identifiers[1]}) == originals[1]
-    assert collection.find_one({"_id": identifiers[2]}) == originals[2]
-
-    collection.update_one(
-        {"_id": identifiers[1]},
-        {"$set": {"serialized_data": pickle.dumps(_make_spectrum())}},
-    )
+    query_time = (starttime + endtime) / 2.0
     assert (
-        trusted_legacy_pickle(mongo_database, "migration_order", {"selected": True})
-        == 2
+        mongo_database.get_response(
+            network.code,
+            station.code,
+            channel.code,
+            channel.location_code,
+            query_time,
+        )
+        == channel.response
+    )
+    assert len(ApplyCalibEngine(mongo_database).calib) == 1
+
+    spectrum = _make_spectrum()
+    handle = SpectrumDatabase.__new__(SpectrumDatabase)
+    handle.type_list = [PowerSpectrum]
+    handle.collection = mongo_database["PowerSpectrum"]
+    spectrum_id = handle.collection.insert_one(
+        {"serialized_data": pickle.dumps(spectrum)}
+    ).inserted_id
+    assert _spectrum_signature(handle.read_data(spectrum_id)) == _spectrum_signature(
+        spectrum
+    )
+
+
+def test_mixed_power_spectrum_formats_are_read_per_document(mongo_database):
+    handle = SpectrumDatabase.__new__(SpectrumDatabase)
+    handle.type_list = [PowerSpectrum]
+    handle.collection = mongo_database["PowerSpectrum"]
+    spectrum = _make_spectrum()
+    bson_id = handle.save_data(spectrum)
+    pickle_id = handle.save_data(spectrum, format="pickle")
+
+    assert isinstance(
+        handle.collection.find_one({"_id": bson_id})["serialized_data"], dict
     )
     assert isinstance(
-        collection.find_one({"selected": False})["serialized_data"], bytes
+        handle.collection.find_one({"_id": pickle_id})["serialized_data"], bytes
     )
-
-
-@pytest.mark.parametrize(
-    "payload",
-    [b"not a pickle", "not bytes"],
-    ids=["unpickle-error", "non-bytes"],
-)
-def test_migration_deserialization_failure_leaves_record_unchanged(
-    mongo_database, payload
-):
-    collection_name = "migration_deserialization_failure"
-    collection = mongo_database[collection_name]
-    original = {"_id": ObjectId(), "serialized_data": payload}
-    collection.insert_one(copy.deepcopy(original))
-
-    with pytest.raises(MsPASSError) as error:
-        trusted_legacy_pickle(mongo_database, collection_name)
-    assert error.value.severity == ErrorSeverity.Invalid
-    assert collection.find_one({"_id": original["_id"]}) == original
-
-
-class FailingCollection:
-    def __init__(self, collection, fail_id):
-        self.collection = collection
-        self.fail_id = fail_id
-
-    def find(self, query):
-        return self.collection.find(query)
-
-    def replace_one(self, query, replacement):
-        if query["_id"] == self.fail_id:
-            raise PyMongoError("injected write failure")
-        return self.collection.replace_one(query, replacement)
-
-
-class FailingDatabase:
-    def __init__(self, database, collection_name, fail_id):
-        self.database = database
-        self.collection_name = collection_name
-        self.fail_id = fail_id
-
-    def __getitem__(self, collection_name):
-        assert collection_name == self.collection_name
-        return FailingCollection(self.database[collection_name], self.fail_id)
-
-
-def test_migration_write_failure_keeps_failing_record_and_successful_prefix(
-    mongo_database,
-):
-    collection_name = "migration_write_failure"
-    collection = mongo_database[collection_name]
-    identifiers = [
-        ObjectId.from_datetime(obspy.UTCDateTime(x).datetime) for x in (4, 5, 6)
-    ]
-    originals = {}
-    for identifier in identifiers:
-        original = {
-            "_id": identifier,
-            "serialized_data": pickle.dumps(_make_spectrum()),
-        }
-        originals[identifier] = copy.deepcopy(original)
-        collection.insert_one(original)
-
-    failing_database = FailingDatabase(mongo_database, collection_name, identifiers[1])
-    with pytest.raises(MsPASSError) as error:
-        trusted_legacy_pickle(failing_database, collection_name)
-    assert error.value.severity == ErrorSeverity.Invalid
-    assert isinstance(
-        collection.find_one({"_id": identifiers[0]})["serialized_data"], dict
-    )
-    assert collection.find_one({"_id": identifiers[1]}) == originals[identifiers[1]]
-    assert collection.find_one({"_id": identifiers[2]}) == originals[identifiers[2]]
-    assert trusted_legacy_pickle(mongo_database, collection_name) == 2
+    for identifier in (bson_id, pickle_id):
+        assert _spectrum_signature(handle.read_data(identifier)) == _spectrum_signature(
+            spectrum
+        )

--- a/python/tests/db/test_bson_serialization_contract.py
+++ b/python/tests/db/test_bson_serialization_contract.py
@@ -1,0 +1,598 @@
+import copy
+import os
+import pickle
+import uuid
+from pathlib import Path
+
+import numpy as np
+import obspy
+import pytest
+from bson import BSON, ObjectId
+from pymongo.errors import PyMongoError
+
+from mspasspy.algorithms.calib import ApplyCalibEngine
+from mspasspy.ccore.seismic import (
+    DoubleVector,
+    PowerSpectrum,
+    TimeReferenceType,
+    TimeSeries,
+)
+from mspasspy.ccore.utility import (
+    AtomicType,
+    ErrorSeverity,
+    Metadata,
+    MsPASSError,
+    ProcessingHistory,
+)
+from mspasspy.db.client import DBClient
+from mspasspy.db.database import Database, history2doc, trusted_legacy_pickle
+from mspasspy.db.serialization import (
+    TYPE_KEY,
+    VERSION,
+    VERSION_KEY,
+    decode_inventory,
+    decode_power_spectrum,
+    decode_processing_history,
+    decode_response,
+    encode_inventory,
+    encode_power_spectrum,
+    encode_processing_history,
+)
+from mspasspy.db.spectrumdb import SpectrumDatabase
+
+
+def _write_marker_and_return(path, value):
+    Path(path).write_text("executed", encoding="utf-8")
+    return value
+
+
+class ExecutingPickle:
+    def __init__(self, marker, value):
+        self.marker = str(marker)
+        self.value = value
+
+    def __reduce__(self):
+        return _write_marker_and_return, (self.marker, self.value)
+
+
+def _assert_no_binary_payload(value):
+    if isinstance(value, dict):
+        for item in value.values():
+            _assert_no_binary_payload(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _assert_no_binary_payload(item)
+    else:
+        assert not isinstance(value, (bytes, bytearray))
+
+
+def _history_signature(history):
+    current = history.current_nodedata()
+    current_signature = (
+        current.status.name,
+        current.uuid,
+        current.type.name,
+        current.stage,
+        current.algorithm,
+        current.algid,
+    )
+    edges = []
+    for child, parents in history.get_nodes().items():
+        for parent in parents:
+            edges.append(
+                (
+                    child,
+                    parent.status.name,
+                    parent.uuid,
+                    parent.type.name,
+                    parent.stage,
+                    parent.algorithm,
+                    parent.algid,
+                )
+            )
+    logs = [
+        (x.job_id, x.p_id, x.algorithm, x.message, x.badness.name)
+        for x in history.elog.get_error_log()
+    ]
+    return (
+        history.jobname(),
+        history.jobid(),
+        current_signature,
+        sorted(edges),
+        history.elog.get_job_id(),
+        logs,
+    )
+
+
+def _make_history():
+    left = TimeSeries(4)
+    left.set_as_origin("reader", "left", "left-uuid", AtomicType.TIMESERIES, True)
+    left.new_map("filter", "left-filter", AtomicType.TIMESERIES)
+    right = TimeSeries(4)
+    right.set_as_origin("reader", "right", "right-uuid", AtomicType.TIMESERIES, True)
+    history = ProcessingHistory("job-name", "job-id")
+    history.new_ensemble_process(
+        "stack", "stack-id", AtomicType.TIMESERIES, [left, right]
+    )
+    history.elog.set_job_id(23)
+    history.elog.log_error("stack", "diagnostic", ErrorSeverity.Complaint)
+    return history
+
+
+def _make_spectrum():
+    spectrum = PowerSpectrum(
+        Metadata({"station": "AAA", "quality": 7, "weights": (1.0, 2.0)}),
+        DoubleVector([1.0, 4.0, 9.0]),
+        0.25,
+        "contract-spectrum",
+        0.0,
+        0.1,
+        20,
+    )
+    spectrum.elog.set_job_id(31)
+    spectrum.elog.log_error("spectrum", "diagnostic", ErrorSeverity.Debug)
+    return spectrum
+
+
+def _spectrum_signature(spectrum):
+    logs = [
+        (x.job_id, x.p_id, x.algorithm, x.message, x.badness.name)
+        for x in spectrum.elog.get_error_log()
+    ]
+    return (
+        dict(spectrum),
+        list(spectrum.spectrum),
+        spectrum.df(),
+        spectrum.f0(),
+        spectrum.spectrum_type,
+        spectrum.dt(),
+        spectrum.timeseries_npts(),
+        spectrum.live(),
+        spectrum.elog.get_job_id(),
+        logs,
+    )
+
+
+@pytest.fixture
+def mongo_database():
+    client = DBClient("mongodb://127.0.0.1:27017", serverSelectionTimeoutMS=3000)
+    client.admin.command("ping")
+    name = f"mspass_issue_841_{uuid.uuid4().hex}"
+    database = Database(client, name)
+    try:
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+def test_contract_suite_loads_selected_source():
+    selected_source = os.environ.get("MSPASS_TEST_SOURCE_ROOT")
+    if selected_source:
+        assert (
+            Path(encode_processing_history.__code__.co_filename).resolve()
+            == (Path(selected_source) / "mspasspy/db/serialization.py").resolve()
+        )
+
+
+def test_history_field_document_round_trip_and_database_read(mongo_database):
+    history = _make_history()
+    document = encode_processing_history(history)
+    BSON.encode({"payload": document})
+    assert document[TYPE_KEY] == "ProcessingHistory"
+    assert document[VERSION_KEY] == VERSION
+    _assert_no_binary_payload(document)
+    assert _history_signature(
+        decode_processing_history(document)
+    ) == _history_signature(history)
+
+    saved = history2doc(history)
+    identifier = mongo_database.history_object.insert_one(saved).inserted_id
+    target = TimeSeries(2)
+    target.set_live()
+    target["_id"] = ObjectId()
+    mongo_database._load_history(target, identifier, alg_name="read", alg_id="read-id")
+    assert target.current_nodedata().algorithm == "read"
+    assert target.number_of_stages() == history.number_of_stages() + 1
+
+
+def test_public_save_and_read_history_round_trip(mongo_database):
+    source = TimeSeries(4)
+    source.set_live()
+    source.dt = 0.05
+    source.t0 = 1_700_000_000.0
+    source.tref = TimeReferenceType.UTC
+    source["npts"] = source.npts
+    source["sampling_rate"] = 20.0
+    source["starttime"] = source.t0
+    source["delta"] = source.dt
+    source["calib"] = 1.0
+    source.data = DoubleVector([1.0, 2.0, 3.0, 4.0])
+    source.set_as_origin(
+        "reader", "reader-id", "source-uuid", AtomicType.TIMESERIES, True
+    )
+    source.new_map("filter", "filter-id", AtomicType.TIMESERIES)
+
+    saved = mongo_database.save_data(
+        source,
+        storage_mode="gridfs",
+        save_history=True,
+        alg_id="save-id",
+        return_data=True,
+    )
+    history_document = mongo_database.history_object.find_one(
+        {"_id": saved["history_object_id"]}
+    )
+    assert history_document["processing_history"][TYPE_KEY] == "ProcessingHistory"
+    BSON.encode(history_document)
+
+    restored = mongo_database.read_data(
+        saved["_id"], load_history=True, alg_id="read-id"
+    )
+    assert restored.live
+    assert restored.current_nodedata().algorithm == "read_data"
+    assert restored.current_nodedata().algid == "read-id"
+    assert restored.number_of_stages() == 3
+
+
+def test_inventory_response_public_round_trip(mongo_database):
+    source = obspy.read_inventory("python/tests/data/TA.035A.xml")
+    counts = mongo_database.save_inventory(source, networks_to_exclude=None)
+    assert counts[0] > 0
+    assert counts[1] == 3
+
+    for document in mongo_database.site.find({}):
+        payload = document["serialized_inventory"]
+        assert payload[TYPE_KEY] == "Inventory"
+        _assert_no_binary_payload(payload)
+        BSON.encode({"payload": payload})
+    for document in mongo_database.channel.find({}):
+        payload = document["serialized_channel_data"]
+        assert payload[TYPE_KEY] == "Response"
+        _assert_no_binary_payload(payload)
+        BSON.encode({"payload": payload})
+
+    restored = mongo_database.read_inventory(net="TA", sta="035A")
+    assert restored == source
+    time = 1263254500.0
+    for channel in ("BHE", "BHN", "BHZ"):
+        assert mongo_database.get_response("TA", "035A", channel, "", time) == (
+            source.get_response(f"TA.035A..{channel}", time)
+        )
+
+    engine = ApplyCalibEngine(mongo_database)
+    assert len(engine.calib) == 3
+
+
+def test_inventory_codec_preserves_complete_obspy_graph():
+    source = obspy.read_inventory("python/tests/data/calib_teststa.xml")
+    payload = encode_inventory(source)
+    BSON.encode({"payload": payload})
+    _assert_no_binary_payload(payload)
+    assert decode_inventory(payload) == source
+
+
+def test_power_spectrum_field_document_and_public_round_trip(mongo_database):
+    spectrum = _make_spectrum()
+    payload = BSON.encode({"payload": encode_power_spectrum(spectrum)}).decode()[
+        "payload"
+    ]
+    assert payload[TYPE_KEY] == "PowerSpectrum"
+    _assert_no_binary_payload(payload)
+    assert _spectrum_signature(decode_power_spectrum(payload)) == _spectrum_signature(
+        spectrum
+    )
+
+    handle = SpectrumDatabase.__new__(SpectrumDatabase)
+    handle.type_list = [PowerSpectrum]
+    handle.collection = mongo_database["PowerSpectrum"]
+    identifier = handle.save_data(spectrum)
+    stored = handle.collection.find_one({"_id": identifier})
+    assert stored["serialized_data"][TYPE_KEY] == "PowerSpectrum"
+    assert _spectrum_signature(handle.read_data(identifier)) == _spectrum_signature(
+        spectrum
+    )
+
+    spectrum.kill()
+    dead = decode_power_spectrum(encode_power_spectrum(spectrum))
+    assert dead.dead()
+    assert _spectrum_signature(dead) == _spectrum_signature(spectrum)
+
+
+def test_power_spectrum_preserves_supported_structured_metadata():
+    spectrum = _make_spectrum()
+    spectrum["double_vector"] = DoubleVector([2.0, 3.0])
+    spectrum["nested"] = {
+        7: "integer key",
+        TYPE_KEY: "literal metadata value",
+        ("tuple", 1): {VERSION_KEY: "also literal"},
+    }
+
+    payload = BSON.encode({"payload": encode_power_spectrum(spectrum)}).decode()[
+        "payload"
+    ]
+    restored = decode_power_spectrum(payload)
+
+    assert isinstance(restored["double_vector"], DoubleVector)
+    assert list(restored["double_vector"]) == [2.0, 3.0]
+    assert restored["nested"] == spectrum["nested"]
+
+
+@pytest.mark.parametrize(
+    "collection,field,reader",
+    [
+        (
+            "history_object",
+            "processing_history",
+            lambda database, identifier: _load_legacy_history(database, identifier),
+        ),
+        (
+            "site",
+            "serialized_inventory",
+            lambda database, identifier: database.read_inventory(net="MAL"),
+        ),
+        (
+            "channel",
+            "serialized_channel_data",
+            lambda database, identifier: database.get_response(
+                "MAL", "BAD", "BHZ", "", 10.0
+            ),
+        ),
+        (
+            "PowerSpectrum",
+            "serialized_data",
+            lambda database, identifier: _read_legacy_spectrum(database, identifier),
+        ),
+    ],
+)
+def test_normal_reads_reject_legacy_pickle_without_execution(
+    mongo_database, tmp_path, collection, field, reader
+):
+    marker = tmp_path / f"{collection}.marker"
+    payload = pickle.dumps(ExecutingPickle(marker, "unexpected"))
+    document = {"_id": ObjectId(), field: payload}
+    if collection == "site":
+        document.update({"net": "MAL", "sta": "BAD"})
+    elif collection == "channel":
+        document.update(
+            {
+                "net": "MAL",
+                "sta": "BAD",
+                "chan": "BHZ",
+                "loc": "",
+                "starttime": 0.0,
+                "endtime": 20.0,
+            }
+        )
+    mongo_database[collection].insert_one(copy.deepcopy(document))
+
+    with pytest.raises(MsPASSError) as error:
+        reader(mongo_database, document["_id"])
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert not marker.exists()
+
+
+def _read_legacy_spectrum(database, identifier):
+    handle = SpectrumDatabase.__new__(SpectrumDatabase)
+    handle.collection = database["PowerSpectrum"]
+    return handle.read_data(identifier)
+
+
+def _load_legacy_history(database, identifier):
+    target = TimeSeries(1)
+    target["_id"] = ObjectId()
+    target.set_live()
+    return database._load_history(target, identifier)
+
+
+def test_apply_calib_rejects_legacy_response_without_execution(
+    mongo_database, tmp_path
+):
+    marker = tmp_path / "calib.marker"
+    mongo_database.channel.insert_one(
+        {"serialized_channel_data": pickle.dumps(ExecutingPickle(marker, "unexpected"))}
+    )
+    with pytest.raises(MsPASSError) as error:
+        ApplyCalibEngine(mongo_database)
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "collection,field,value",
+    [
+        pytest.param(
+            "history_object",
+            "processing_history",
+            _make_history(),
+            id="history",
+        ),
+        pytest.param(
+            "PowerSpectrum",
+            "serialized_data",
+            _make_spectrum(),
+            id="spectrum",
+        ),
+    ],
+)
+def test_explicit_trusted_migration_executes_and_is_idempotent(
+    mongo_database, tmp_path, collection, field, value
+):
+    marker = tmp_path / f"{collection}.marker"
+    identifier = (
+        mongo_database[collection]
+        .insert_one({field: pickle.dumps(ExecutingPickle(marker, value))})
+        .inserted_id
+    )
+    assert trusted_legacy_pickle(mongo_database, collection) == 1
+    assert marker.read_text(encoding="utf-8") == "executed"
+    stored = mongo_database[collection].find_one({"_id": identifier})
+    assert stored[field][VERSION_KEY] == VERSION
+    if field == "processing_history":
+        assert _history_signature(
+            decode_processing_history(stored[field])
+        ) == _history_signature(value)
+    else:
+        assert _spectrum_signature(
+            decode_power_spectrum(stored[field])
+        ) == _spectrum_signature(value)
+    assert trusted_legacy_pickle(mongo_database, collection) == 0
+
+
+def test_migration_skips_new_record_with_payload_named_metadata(
+    mongo_database, tmp_path
+):
+    marker = tmp_path / "already-new.marker"
+    mongo_database.PowerSpectrum.insert_one(
+        {
+            "processing_history": pickle.dumps(
+                ExecutingPickle(marker, "metadata, not the persisted spectrum")
+            ),
+            "serialized_data": encode_power_spectrum(_make_spectrum()),
+        }
+    )
+
+    assert trusted_legacy_pickle(mongo_database, "PowerSpectrum") == 0
+    assert not marker.exists()
+
+
+def test_inventory_and_response_trusted_migration(mongo_database):
+    inventory = obspy.read_inventory("python/tests/data/TA.035A.xml")
+    network = inventory.networks[0]
+    channel = network.stations[0].channels[0]
+    site_id = mongo_database.site.insert_one(
+        {"serialized_inventory": pickle.dumps(network)}
+    ).inserted_id
+    channel_id = mongo_database.channel.insert_one(
+        {
+            "net": network.code,
+            "sta": network.stations[0].code,
+            "serialized_channel_data": pickle.dumps(channel),
+        }
+    ).inserted_id
+    assert trusted_legacy_pickle(mongo_database, "site") == 1
+    assert trusted_legacy_pickle(mongo_database, "channel") == 1
+    inventory_payload = mongo_database.site.find_one({"_id": site_id})[
+        "serialized_inventory"
+    ]
+    response_payload = mongo_database.channel.find_one({"_id": channel_id})[
+        "serialized_channel_data"
+    ]
+    assert inventory_payload[TYPE_KEY] == "Inventory"
+    assert response_payload[TYPE_KEY] == "Response"
+    assert decode_inventory(inventory_payload).networks == [network]
+    assert decode_response(response_payload) == channel.response
+
+
+def test_migration_query_order_failure_prefix_and_retry(mongo_database):
+    collection = mongo_database["migration_order"]
+    identifiers = [
+        ObjectId.from_datetime(obspy.UTCDateTime(x).datetime) for x in (1, 2, 3)
+    ]
+    values = [_make_spectrum(), "wrong type", _make_spectrum()]
+    originals = []
+    for identifier, value in zip(identifiers, values):
+        document = {
+            "_id": identifier,
+            "selected": True,
+            "serialized_data": pickle.dumps(value),
+        }
+        originals.append(copy.deepcopy(document))
+        collection.insert_one(document)
+    collection.insert_one(
+        {"selected": False, "serialized_data": pickle.dumps(_make_spectrum())}
+    )
+
+    with pytest.raises(MsPASSError) as error:
+        trusted_legacy_pickle(mongo_database, "migration_order", {"selected": True})
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert isinstance(
+        collection.find_one({"_id": identifiers[0]})["serialized_data"], dict
+    )
+    assert collection.find_one({"_id": identifiers[1]}) == originals[1]
+    assert collection.find_one({"_id": identifiers[2]}) == originals[2]
+
+    collection.update_one(
+        {"_id": identifiers[1]},
+        {"$set": {"serialized_data": pickle.dumps(_make_spectrum())}},
+    )
+    assert (
+        trusted_legacy_pickle(mongo_database, "migration_order", {"selected": True})
+        == 2
+    )
+    assert isinstance(
+        collection.find_one({"selected": False})["serialized_data"], bytes
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [b"not a pickle", "not bytes"],
+    ids=["unpickle-error", "non-bytes"],
+)
+def test_migration_deserialization_failure_leaves_record_unchanged(
+    mongo_database, payload
+):
+    collection_name = "migration_deserialization_failure"
+    collection = mongo_database[collection_name]
+    original = {"_id": ObjectId(), "serialized_data": payload}
+    collection.insert_one(copy.deepcopy(original))
+
+    with pytest.raises(MsPASSError) as error:
+        trusted_legacy_pickle(mongo_database, collection_name)
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert collection.find_one({"_id": original["_id"]}) == original
+
+
+class FailingCollection:
+    def __init__(self, collection, fail_id):
+        self.collection = collection
+        self.fail_id = fail_id
+
+    def find(self, query):
+        return self.collection.find(query)
+
+    def replace_one(self, query, replacement):
+        if query["_id"] == self.fail_id:
+            raise PyMongoError("injected write failure")
+        return self.collection.replace_one(query, replacement)
+
+
+class FailingDatabase:
+    def __init__(self, database, collection_name, fail_id):
+        self.database = database
+        self.collection_name = collection_name
+        self.fail_id = fail_id
+
+    def __getitem__(self, collection_name):
+        assert collection_name == self.collection_name
+        return FailingCollection(self.database[collection_name], self.fail_id)
+
+
+def test_migration_write_failure_keeps_failing_record_and_successful_prefix(
+    mongo_database,
+):
+    collection_name = "migration_write_failure"
+    collection = mongo_database[collection_name]
+    identifiers = [
+        ObjectId.from_datetime(obspy.UTCDateTime(x).datetime) for x in (4, 5, 6)
+    ]
+    originals = {}
+    for identifier in identifiers:
+        original = {
+            "_id": identifier,
+            "serialized_data": pickle.dumps(_make_spectrum()),
+        }
+        originals[identifier] = copy.deepcopy(original)
+        collection.insert_one(original)
+
+    failing_database = FailingDatabase(mongo_database, collection_name, identifiers[1])
+    with pytest.raises(MsPASSError) as error:
+        trusted_legacy_pickle(failing_database, collection_name)
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert isinstance(
+        collection.find_one({"_id": identifiers[0]})["serialized_data"], dict
+    )
+    assert collection.find_one({"_id": identifiers[1]}) == originals[identifiers[1]]
+    assert collection.find_one({"_id": identifiers[2]}) == originals[identifiers[2]]
+    assert trusted_legacy_pickle(mongo_database, collection_name) == 2

--- a/python/tests/db/test_bson_serialization_contract.py
+++ b/python/tests/db/test_bson_serialization_contract.py
@@ -302,12 +302,14 @@ def test_power_spectrum_preserves_supported_structured_metadata():
     assert restored["nested"] == spectrum["nested"]
 
 
-def test_legacy_pickle_codecs_round_trip():
+def test_legacy_history_pickle_codec_round_trip():
     history = _make_history()
     assert _history_signature(
         decode_processing_history(pickle.dumps(history))
     ) == _history_signature(history)
 
+
+def test_legacy_inventory_and_response_pickle_codecs_round_trip():
     inventory = obspy.read_inventory("python/tests/data/TA.035A.xml")
     network = inventory.networks[0]
     channel = network.stations[0].channels[0]
@@ -315,6 +317,8 @@ def test_legacy_pickle_codecs_round_trip():
     assert decode_inventory(pickle.dumps(inventory)) == inventory
     assert decode_response(pickle.dumps(channel)) == channel.response
 
+
+def test_legacy_power_spectrum_pickle_codec_round_trip():
     spectrum = _make_spectrum()
     assert _spectrum_signature(
         decode_power_spectrum(pickle.dumps(spectrum))

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -54,6 +54,7 @@ from mspasspy.db.database import (
     _managed_collection_cursor,
     geoJSON_doc,
 )
+from mspasspy.db.serialization import encode_inventory
 from mspasspy.db.client import DBClient
 from mspasspy.db.collection import Collection
 
@@ -225,7 +226,7 @@ class TestDatabase:
             {
                 "net": "CURSOR_TEST",
                 "sta": "CURSOR_TEST",
-                "serialized_inventory": pickle.dumps(source_inventory.networks[0]),
+                "serialized_inventory": encode_inventory(source_inventory),
             }
         ).inserted_id
         try:

--- a/python/tests/db/test_inventory_location_contract.py
+++ b/python/tests/db/test_inventory_location_contract.py
@@ -1,7 +1,6 @@
 import copy
 import os
 import uuid
-from unittest.mock import patch
 
 import pytest
 from obspy import UTCDateTime
@@ -12,6 +11,7 @@ from pymongo.errors import ServerSelectionTimeoutError
 from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
+from mspasspy.db.serialization import decode_channel, decode_inventory
 
 
 @pytest.fixture
@@ -111,16 +111,7 @@ def test_save_inventory_groups_channels_only_under_their_own_location(database):
         for channel in source_channels
     ]
 
-    def codec_boundary(channel):
-        return f"{channel.location_code}:{channel.code}:{id(channel.response)}".encode()
-
-    expected_payloads = {
-        (channel.location_code, channel.code): codec_boundary(channel)
-        for channel in source_channels
-    }
-
-    with patch("mspasspy.db.database.pickle.dumps", side_effect=codec_boundary):
-        counts = database.save_inventory(inventory, networks_to_exclude=None)
+    counts = database.save_inventory(inventory, networks_to_exclude=None)
 
     assert counts == (2, 3, 2, 3)
     assert [
@@ -153,6 +144,14 @@ def test_save_inventory_groups_channels_only_under_their_own_location(database):
         assert document["edepth"] == depth
         assert document["starttime"] == UTCDateTime(start).timestamp
         assert document["endtime"] == UTCDateTime(end).timestamp
+        restored = decode_inventory(document["serialized_inventory"])
+        restored_channels = restored.networks[0].stations[0].channels
+        assert {channel.location_code for channel in restored_channels} == {location}
+        assert {channel.code for channel in restored_channels} == {
+            channel.code
+            for channel in source_channels
+            if channel.location_code == location
+        }
 
     channels = list(database.channel.find({"net": "XX", "sta": "TEST"}))
     assert len(channels) == 3
@@ -161,13 +160,16 @@ def test_save_inventory_groups_channels_only_under_their_own_location(database):
         ("00", "BHN"),
         ("10", "HHZ"),
     }
-    assert len({document["serialized_channel_data"] for document in channels}) == 3
+    source_by_key = {
+        (channel.location_code, channel.code): channel for channel in source_channels
+    }
     for document in channels:
         expected = expected_locations[document["loc"]]
-        assert (
-            document["serialized_channel_data"]
-            == expected_payloads[(document["loc"], document["chan"])]
-        )
+        restored = decode_channel(document["serialized_channel_data"])
+        source = source_by_key[(document["loc"], document["chan"])]
+        assert restored.code == source.code
+        assert restored.location_code == source.location_code
+        assert restored.response == source.response
         assert document["lat"] == expected[0]
         assert document["lon"] == expected[1]
         assert document["starttime"] == UTCDateTime(expected[4]).timestamp
@@ -192,11 +194,7 @@ def test_conflicting_channel_geometry_uses_station_site_and_exact_channels(
         networks=[Network(code="XX", stations=[station])], source="test"
     )
 
-    with patch(
-        "mspasspy.db.database.pickle.dumps",
-        side_effect=lambda channel: channel.code.encode(),
-    ):
-        counts = database.save_inventory(inventory, networks_to_exclude=None)
+    counts = database.save_inventory(inventory, networks_to_exclude=None)
 
     assert counts == (1, 2, 1, 2)
     output = capsys.readouterr().out
@@ -230,7 +228,14 @@ def test_conflicting_channel_geometry_uses_station_site_and_exact_channels(
         ]
         assert document["starttime"] == channel.start_date.timestamp
         assert document["endtime"] == channel.end_date.timestamp
-        assert document["serialized_channel_data"] == channel.code.encode()
+        restored = decode_channel(document["serialized_channel_data"])
+        assert restored.code == channel.code
+        assert restored.location_code == channel.location_code
+        assert restored.latitude == channel.latitude
+        assert restored.longitude == channel.longitude
+        assert restored.elevation == channel.elevation
+        assert restored.depth == channel.depth
+        assert restored.response == channel.response
 
 
 @pytest.mark.parametrize("location", ["00", ""])

--- a/python/tests/db/test_spectrumdb_contract.py
+++ b/python/tests/db/test_spectrumdb_contract.py
@@ -13,6 +13,7 @@ import mspasspy.ccore.seismic as seismic_binding
 from mspasspy.ccore.seismic import DoubleVector, PowerSpectrum
 from mspasspy.ccore.utility import ErrorSeverity, Metadata, MsPASSError
 from mspasspy.db.spectrumdb import SpectrumDatabase
+from mspasspy.db.serialization import TYPE_KEY, VERSION, VERSION_KEY
 
 
 class MemoryCollection:
@@ -153,7 +154,8 @@ def test_live_save_read_and_delete_roundtrip(monkeypatch):
     assert isinstance(oid, ObjectId)
     stored = handle.collection.find_one({"_id": oid})
     assert stored["station"] == "AAA"
-    assert isinstance(stored["serialized_data"], bytes)
+    assert stored["serialized_data"][TYPE_KEY] == "PowerSpectrum"
+    assert stored["serialized_data"][VERSION_KEY] == VERSION
     BSON.encode(stored)
     restored = handle.read_data(oid)
     assert isinstance(restored, PowerSpectrum)
@@ -202,6 +204,16 @@ def test_dead_save_returns_identity_and_performs_no_write(monkeypatch):
     assert result is dead
     assert handle.collection.insert_calls == 0
     assert handle.collection.documents == []
+
+
+def test_save_rejects_executable_pickle_format(monkeypatch):
+    handle, _, _ = _build_database(monkeypatch)
+
+    with pytest.raises(MsPASSError) as excinfo:
+        handle.save_data(_live_spectrum(), format="pickle")
+
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+    assert handle.collection.insert_calls == 0
 
 
 @pytest.mark.parametrize("value", (None, 1, "spectrum", {}, object()))

--- a/python/tests/db/test_spectrumdb_contract.py
+++ b/python/tests/db/test_spectrumdb_contract.py
@@ -206,11 +206,20 @@ def test_dead_save_returns_identity_and_performs_no_write(monkeypatch):
     assert handle.collection.documents == []
 
 
-def test_save_rejects_executable_pickle_format(monkeypatch):
+def test_save_supports_explicit_legacy_pickle_format(monkeypatch):
+    handle, _, _ = _build_database(monkeypatch)
+
+    identifier = handle.save_data(_live_spectrum(), format="pickle")
+
+    assert isinstance(identifier, ObjectId)
+    assert isinstance(handle.collection.documents[0]["serialized_data"], bytes)
+
+
+def test_save_rejects_unknown_format(monkeypatch):
     handle, _, _ = _build_database(monkeypatch)
 
     with pytest.raises(MsPASSError) as excinfo:
-        handle.save_data(_live_spectrum(), format="pickle")
+        handle.save_data(_live_spectrum(), format="json")
 
     assert excinfo.value.severity == ErrorSeverity.Invalid
     assert handle.collection.insert_calls == 0

--- a/python/tests/io/test_distributed_write_state_contract.py
+++ b/python/tests/io/test_distributed_write_state_contract.py
@@ -15,6 +15,7 @@ from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
 from mspasspy.ccore.utility import AtomicType, ErrorLogger, ErrorSeverity
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
+from mspasspy.db.serialization import decode_processing_history
 import mspasspy.io.distributed as distributed_module
 from mspasspy.util.Undertaker import Undertaker
 
@@ -213,7 +214,10 @@ def test_public_distributed_history_preserves_waveform_and_is_bson_writable(
     assert history["save_stage"] == 0
     assert history["alg_name"] == "contract_origin"
     assert history["alg_id"] == "0"
-    assert isinstance(history["processing_history"], bytes)
+    restored_history = decode_processing_history(history["processing_history"])
+    assert restored_history.current_nodedata().uuid == marker
+    assert restored_history.current_nodedata().algorithm == "contract_origin"
+    assert restored_history.current_nodedata().algid == "0"
     assert "history_data" not in history
 
 


### PR DESCRIPTION
## Summary

- Write ProcessingHistory, Inventory/Response, and PowerSpectrum payloads as versioned BSON-native documents by default.
- Auto-detect and read legacy pickle bytes in every normal reader, including mixed collections where BSON and pickle records coexist.
- Keep `SpectrumDatabase.save_data(format="pickle")` as an explicit compatibility option; its default is now `"bson"`.
- Preserve PR #962's location grouping: each site payload contains only its location's channels, while channel documents retain their exact metadata.

## Compatibility

New MsPASS releases read both old pickle records and new BSON records. Existing databases therefore require no migration and writes are not duplicated. Older MsPASS releases are not expected to read newly written BSON records.

## Validation

- Local legacy history, Inventory, and Response decoding tests pass.
- Local explicit pickle-write, invalid-format, and location-grouping tests pass.
- Python compilation, Black formatting, and diff checks pass.
- Full PowerSpectrum and MongoDB integration coverage runs in GitHub CI, which rebuilds the updated C++ bindings.

Closes #841
