### PR TITLE
Choose SEED hypocenters by a deterministic arrival-time misfit

### DIFF
--- a/python/mspasspy/preprocessing/seed/ensembles.py
+++ b/python/mspasspy/preprocessing/seed/ensembles.py
@@ -513,110 +513,140 @@ def load_hypocenter_data_by_time(
     kill_null=True,
 ):
     """
-    Loads hypocenter data (space time coordinates) into an ensemble using
-    an arrival time matching algorithm.  This is a generalization of earlier
-    prototypes with the objective of a single interface to a common concept -
-    that is, matching arrival documents to ensemble data using timing
-    based on travel times.
+    Load the best matching source into the live members of ``ens``.
 
-    We frequently guide processing by the time of one or more seismic phases.
-    Those times can be either measured times done by a human or an automated
-    system or theoretical times from an earth model.   This function should
-    work with either approach provided some earlier function created an
-    arrival document that can be used for matching.  The matching algorithm uses
-    three keys:  an exact match for net, an exact match for sta, and a time
-    range travel time association.
+    ``origin_time`` compares member start times with source origin times.
+    ``phase_time`` first requires an exact event, network, station, and phase
+    match in the arrival collection.  In either mode a residual whose absolute
+    value exceeds ``dt`` is not a match.  The source with the lowest RMS of its
+    finite residuals is selected; equal RMS values are ordered by the string
+    form of ``event_id_key``.
 
-    The algorithm is not a general associator.  It assumes we have access to
-    an arrival collection that has been previously associated.  For those
-    familiar with CSS3.0 the type example is the join of event->origin->assoc->arrival
-    grouped by evid or orid.  We use a staged match to the ensemble to
-    reduce compute time.  That is, we first run a db find on arrival to select
-    only arrival documents within the time span of the ensemble with the
-    defined arrival name key.  From each matching arrival we compute a theoretical
-    origin time using obspy's taup calculator and a specified model and
-    hypocenter coordinates in the arrival document that we assume was loaded
-    previously from a css3.0 database (i.e. the event->origin->assoc->arrival
-    view).   We then select and load source coordinates for the closest
-    origin time match in the source collection.   This is much simpler than
-    the general phase association (determine source coordinates from a random
-    bad of arrival times) but still has one complication - if multiple
-    events have arrivals within the time span of the ensemble the simple match
-    described above is ambiguous.   We resolve that with a switch defined by
-    the argument t0_definition.   Currently there are two options defining
-    the only two options I know of for time selection of downloaded segments.
-    (1) if set to 'origin_time' we assume member t0 values are near the origin
-    time of the event.  (2) if set to 'phase_time' we assume the member t0
-    values are relative to the phase used as a reference.  In both cases an
-    optional t0_offset can be specified to offset each start time by a constant.
-    The sign of the shift is to compare the data start time to the computed
-    time MINUS the specified offset.  (e.g. if the reference is a P phase time
-    and we expect the data to have been windowed with a start time 100 s before
-    the theoretical P time, the offset would be 100.0)   Note if arrival windowing
-    is selected the source information in arrival will not be referenced but
-    that data is required if using origin time matching.  In any case when
-    multiple sources are found to match the ensemble the one with the smallest
-    rms misfit for the windowing is chosen.  A warning message is always
-    posted in that situation.
-
-    By default any ensemble members without a match in arrival will be
-    killed. Note we use the kill method which only marks the data dead but
-    does not clear the contents. Hence, on exit most ensembles will have
-    at least some members marked dead.  The function returns the number of
-    members set.  The caller should test and complain if there are no matches.
+    The source coordinates, origin time, and MongoDB ``_id`` are written as
+    ``source_lat``, ``source_lon``, ``source_depth``, ``source_time``, and
+    ``source_id``.  Members without a match to the selected source are killed
+    only when ``kill_null`` is true.  ``mdtime_key`` and ``model`` remain in the
+    signature for compatibility with the prototype API.
     """
-    base_error_message = "load_hypocenter_data_by_time:  "
-    if db == None:
-        raise MsPASSError(
-            base_error_message + "Missing required argument db=MongoDB Database handle",
-            ErrorSeverity.Fatal,
-        )
-    elif ens == None:
-        raise MsPASSError(
-            base_error_message + "Missing required argument ens=mspass Ensemble data",
-            ErrorSeverity.Fatal,
-        )
-    # First we need to query the arrival table to find all arrivals within
-    # the time range of this ensemble
+    base_error_message = "load_hypocenter_data_by_time: "
     try:
-        dbarrival = db.arrival
-        stime = ens["startttime"]
-        etime = ens["endtime"]
-        query = {{dbtime_key: {"$gte": stime, "$lte": etime}}}
-        narr = dbarrival.count_documents(query)
-        if narr == 0:
-            print(base_error_message, "No arrivals found in data time range:")
-            print(UTCDateTime(stime), " to ", UTCDateTime(etime))
-            if kill_null:
-                for d in ens.member:
-                    d.kill()
+        if db is None:
+            raise ValueError("db is required")
+        if ens is None:
+            raise ValueError("ens is required")
+        if t0_definition not in ("origin_time", "phase_time"):
+            raise ValueError(
+                "t0_definition must be either 'origin_time' or 'phase_time'"
+            )
+
+        tolerance = float(dt)
+        offset = float(t0_offset)
+        if not np.isfinite(tolerance) or tolerance < 0.0:
+            raise ValueError("dt must be a finite, nonnegative number")
+        if not np.isfinite(offset):
+            raise ValueError("t0_offset must be finite")
+
+        members = list(ens.member)
+        live_indices = [index for index, datum in enumerate(members) if datum.live]
+        if not live_indices:
             return 0
+
+        sources = list(db.source.find({}))
+        if t0_definition == "phase_time" and sources:
+            arrivals = list(db.arrival.find({"phase": phase}))
         else:
-            # This else block isn't essential, but makes the logic clearer
-            # first scan the data for unique events.  For now use an evid
-            # test.  This could be generalized to coordinates
-            arrivals = dbarrival.find(query)
-            evids = dict()
-            for doc in arrivals:
-                evnow = doc[event_id_key]
-                lat = doc["source.lat"]
-                lon = doc["source.lon"]
-                depth = doc["source.depth"]
-                otime = doc["source.time"]
-                evids[evnow] = [lat, lon, depth, otime]
-            if len(evids) > 1:
-                # land if picks from multiple events are inside the data window
-                # INCOMPLETE - will probably drop this function
-                for k in evids.keys():
-                    print(k)
-            # Above block always sets lat,lon,depth, and otime to the
-            # selected hypocenter data.  IMPORTANT is for the unambiguous
-            # case where len(evids) is one we depend on the python property
-            # that lat,lon,depth, and otime are set because they have not
-            # gone out of scope
-    except MsPASSError as err:
-        print(err)
-        raise err
+            arrivals = []
+
+        candidates = []
+        for source in sources:
+            source_id = source["_id"]
+            event_id = source[event_id_key]
+
+            matches = {}
+            if t0_definition == "origin_time":
+                source_time = float(source["time"])
+                for index in live_indices:
+                    residual = members[index].t0 - (source_time - offset)
+                    if np.isfinite(residual) and abs(residual) <= tolerance:
+                        matches[index] = residual
+            else:
+                for index in live_indices:
+                    datum = members[index]
+                    if "net" not in datum or "sta" not in datum:
+                        continue
+                    residuals = []
+                    for arrival in arrivals:
+                        if (
+                            event_id_key not in arrival
+                            or "net" not in arrival
+                            or "sta" not in arrival
+                            or "phase" not in arrival
+                            or arrival[event_id_key] != event_id
+                            or arrival["net"] != datum["net"]
+                            or arrival["sta"] != datum["sta"]
+                            or arrival["phase"] != phase
+                        ):
+                            continue
+                        arrival_time = float(arrival[dbtime_key])
+                        residual = datum.t0 - (arrival_time - offset)
+                        if np.isfinite(residual) and abs(residual) <= tolerance:
+                            residuals.append(residual)
+                    if residuals:
+                        matches[index] = min(
+                            residuals, key=lambda value: (abs(value), value)
+                        )
+
+            if matches:
+                residual_values = list(matches.values())
+                scale = max(abs(value) for value in residual_values)
+                if scale == 0.0:
+                    rms = 0.0
+                else:
+                    rms = scale * np.sqrt(
+                        sum((value / scale) ** 2 for value in residual_values)
+                        / len(residual_values)
+                    )
+                candidates.append((rms, str(event_id), str(source_id), source, matches))
+
+        if not candidates:
+            if kill_null:
+                for index in live_indices:
+                    members[index].kill()
+            return 0
+
+        _, _, _, selected_source, selected_matches = min(
+            candidates, key=lambda candidate: candidate[:3]
+        )
+        source_values = {}
+        for source_key, metadata_key in (
+            ("lat", "source_lat"),
+            ("lon", "source_lon"),
+            ("depth", "source_depth"),
+            ("time", "source_time"),
+        ):
+            value = selected_source[source_key]
+            if not np.isfinite(float(value)):
+                raise ValueError(
+                    f"selected source has nonfinite required field '{source_key}'"
+                )
+            source_values[metadata_key] = value
+        source_values["source_id"] = selected_source["_id"]
+
+        _assignment_preflight = Metadata()
+        for key, value in source_values.items():
+            _assignment_preflight[key] = value
+
+        for index in live_indices:
+            datum = members[index]
+            if index in selected_matches:
+                for key, value in source_values.items():
+                    datum[key] = value
+            elif kill_null:
+                datum.kill()
+        return len(selected_matches)
+    except Exception as err:
+        message = str(err).strip() or err.__class__.__name__
+        raise MsPASSError(base_error_message + message, ErrorSeverity.Invalid) from err
 
 
 def load_site_data(db, ens):

--- a/python/tests/preprocessing/test_seed_hypocenter.py
+++ b/python/tests/preprocessing/test_seed_hypocenter.py
@@ -1,0 +1,411 @@
+import copy
+
+import pytest
+
+from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+from mspasspy.preprocessing.seed.ensembles import (
+    load_channel_data,
+    load_hypocenter_data_by_time,
+    load_site_data,
+)
+
+
+def _matches(document, query):
+    for key, condition in query.items():
+        if key not in document:
+            return False
+        value = document[key]
+        if not isinstance(condition, dict):
+            if value != condition:
+                return False
+            continue
+        for operator, expected in condition.items():
+            if operator == "$eq" and value != expected:
+                return False
+            if operator == "$gte" and value < expected:
+                return False
+            if operator == "$lte" and value > expected:
+                return False
+            if operator == "$gt" and value <= expected:
+                return False
+            if operator == "$lt" and value >= expected:
+                return False
+    return True
+
+
+class FakeCollection:
+    def __init__(self, documents=()):
+        self.documents = copy.deepcopy(list(documents))
+        self.queries = []
+
+    def find(self, query=None):
+        query = {} if query is None else copy.deepcopy(query)
+        self.queries.append(query)
+        return iter(
+            copy.deepcopy(
+                [document for document in self.documents if _matches(document, query)]
+            )
+        )
+
+    def count_documents(self, query):
+        return sum(_matches(document, query) for document in self.documents)
+
+    def find_one(self, query):
+        return next(self.find(query), None)
+
+
+class FakeDatabase:
+    def __init__(self, sources=(), arrivals=(), sites=(), channels=()):
+        self.source = FakeCollection(sources)
+        self.arrival = FakeCollection(arrivals)
+        self.site = FakeCollection(sites)
+        self.channel = FakeCollection(channels)
+
+
+def _source(event_id, origin_time, **overrides):
+    document = {
+        "_id": f"source-{event_id}",
+        "evid": event_id,
+        "lat": 10.0 + float(origin_time),
+        "lon": 20.0 + float(origin_time),
+        "depth": 5.0,
+        "time": origin_time,
+    }
+    document.update(overrides)
+    return document
+
+
+def _arrival(event_id, net, sta, arrival_time, phase="P"):
+    return {
+        "evid": event_id,
+        "net": net,
+        "sta": sta,
+        "phase": phase,
+        "time": arrival_time,
+    }
+
+
+def _ensemble(member_specs):
+    ensemble = TimeSeriesEnsemble(len(member_specs))
+    for spec in member_specs:
+        datum = TimeSeries(1)
+        datum.t0 = spec[2]
+        datum["net"] = spec[0]
+        datum["sta"] = spec[1]
+        datum["marker"] = f"{spec[0]}.{spec[1]}"
+        datum.set_live()
+        if len(spec) == 4 and not spec[3]:
+            datum.kill()
+        ensemble.member.append(datum)
+    ensemble["ensemble_marker"] = "unchanged"
+    ensemble.set_live()
+    return ensemble
+
+
+def _assert_source_metadata(datum, source):
+    assert datum["source_id"] == source["_id"]
+    assert datum["source_lat"] == source["lat"]
+    assert datum["source_lon"] == source["lon"]
+    assert datum["source_depth"] == source["depth"]
+    assert datum["source_time"] == source["time"]
+
+
+@pytest.mark.parametrize("kill_null", [False, True])
+def test_no_candidate_event_has_defined_kill_behavior(kill_null, capsys):
+    ensemble = _ensemble([("IU", "AAA", 100.0), ("IU", "BBB", 101.0)])
+    database = FakeDatabase()
+
+    count = load_hypocenter_data_by_time(database, ensemble, kill_null=kill_null)
+
+    assert count == 0
+    assert [datum.dead() for datum in ensemble.member] == [kill_null, kill_null]
+    assert all("source_id" not in datum for datum in ensemble.member)
+    assert ensemble["ensemble_marker"] == "unchanged"
+    assert capsys.readouterr().out == ""
+
+
+def test_origin_time_mode_selects_lowest_rms_before_mutation(capsys):
+    source_a = _source("a", 100.0)
+    source_b = _source("b", 102.0)
+    database = FakeDatabase(sources=[source_b, source_a])
+    ensemble = _ensemble(
+        [
+            ("IU", "AAA", 95.0),
+            ("IU", "BBB", 96.0),
+            ("IU", "CCC", 130.0),
+            ("IU", "DDD", 95.0, False),
+        ]
+    )
+
+    count = load_hypocenter_data_by_time(
+        database,
+        ensemble,
+        t0_definition="origin_time",
+        t0_offset=5.0,
+        dt=4.0,
+        kill_null=False,
+    )
+
+    assert count == 2
+    _assert_source_metadata(ensemble.member[0], source_a)
+    _assert_source_metadata(ensemble.member[1], source_a)
+    assert ensemble.member[2].live
+    assert "source_id" not in ensemble.member[2]
+    assert ensemble.member[3].dead()
+    assert "source_id" not in ensemble.member[3]
+    assert capsys.readouterr().out == ""
+
+
+def test_origin_time_tie_uses_lexical_event_id_and_dt_is_inclusive():
+    lexical_later = _source("z", 100.0)
+    lexical_first = _source("a", 102.0)
+    database = FakeDatabase(sources=[lexical_later, lexical_first])
+    ensemble = _ensemble([("IU", "AAA", 101.0)])
+
+    count = load_hypocenter_data_by_time(database, ensemble, dt=2.0, kill_null=True)
+
+    assert count == 1
+    _assert_source_metadata(ensemble.member[0], lexical_first)
+
+    boundary_ensemble = _ensemble([("IU", "BBB", 104.0), ("IU", "CCC", 104.1)])
+    boundary_database = FakeDatabase(sources=[lexical_first])
+    count = load_hypocenter_data_by_time(
+        boundary_database, boundary_ensemble, dt=2.0, kill_null=True
+    )
+    assert count == 1
+    _assert_source_metadata(boundary_ensemble.member[0], lexical_first)
+    assert boundary_ensemble.member[1].dead()
+
+
+def test_falsey_event_id_is_used_for_phase_association():
+    source = _source(0, 10.0)
+    arrival = _arrival(0, "IU", "AAA", 100.0)
+    arrival["pick_time"] = arrival.pop("time")
+    database = FakeDatabase(sources=[source], arrivals=[arrival])
+    ensemble = _ensemble([("IU", "AAA", 100.0)])
+
+    count = load_hypocenter_data_by_time(
+        database,
+        ensemble,
+        dbtime_key="pick_time",
+        t0_definition="phase_time",
+        dt=0.0,
+    )
+
+    assert count == 1
+    _assert_source_metadata(ensemble.member[0], source)
+
+
+def test_custom_event_id_key_is_exact_and_missing_key_is_not_none():
+    source_a = _source("unused-a", 10.0, _id="source-a")
+    source_a["catalog_id"] = "a"
+    source_a.pop("evid")
+    source_b = _source("unused-b", 20.0, _id="source-b")
+    source_b["catalog_id"] = "b"
+    source_b.pop("evid")
+    missing_key_source = _source(None, 30.0, _id="source-none")
+    missing_key_source["catalog_id"] = None
+    missing_key_source.pop("evid")
+    arrival_a = _arrival("unused", "IU", "AAA", 110.0)
+    arrival_a["catalog_id"] = "a"
+    arrival_b = _arrival("unused", "IU", "AAA", 100.0)
+    arrival_b["catalog_id"] = "b"
+    missing_event_key = _arrival("unused", "IU", "AAA", 100.0)
+    del missing_event_key["evid"]
+    database = FakeDatabase(
+        sources=[source_a, missing_key_source, source_b],
+        arrivals=[missing_event_key, arrival_a, arrival_b],
+    )
+    ensemble = _ensemble([("IU", "AAA", 100.0)])
+
+    count = load_hypocenter_data_by_time(
+        database,
+        ensemble,
+        event_id_key="catalog_id",
+        t0_definition="phase_time",
+        dt=10.0,
+        kill_null=False,
+    )
+
+    assert count == 1
+    _assert_source_metadata(ensemble.member[0], source_b)
+
+
+def test_all_dead_members_return_without_database_access_or_mutation():
+    ensemble = _ensemble([("IU", "AAA", 100.0, False)])
+    member = ensemble.member[0]
+    before = (dict(member), member.live)
+    database = FakeDatabase()
+
+    count = load_hypocenter_data_by_time(database, ensemble)
+
+    assert count == 0
+    assert ensemble.member[0] is member
+    assert (dict(member), member.live) == before
+    assert database.source.queries == []
+    assert database.arrival.queries == []
+
+
+@pytest.mark.parametrize("kill_null", [False, True])
+def test_phase_time_mode_requires_exact_net_sta_and_phase(kill_null, capsys):
+    source_a = _source("a", 10.0)
+    source_b = _source("b", 20.0)
+    arrivals = [
+        _arrival("a", "IU", "AAA", 100.0),
+        _arrival("a", "IU", "BBB", 106.0),
+        _arrival("a", "XX", "AAA", 100.0, phase="S"),
+        _arrival("b", "IU", "AAA", 99.0),
+        _arrival("b", "IU", "BBB", 103.0),
+    ]
+    database = FakeDatabase(sources=[source_b, source_a], arrivals=arrivals)
+    ensemble = _ensemble(
+        [
+            ("IU", "AAA", 95.0),
+            ("IU", "BBB", 100.0),
+            ("XX", "AAA", 95.0),
+            ("IU", "CCC", 100.0),
+        ]
+    )
+
+    count = load_hypocenter_data_by_time(
+        database,
+        ensemble,
+        t0_definition="phase_time",
+        t0_offset=5.0,
+        dt=5.0,
+        phase="P",
+        kill_null=kill_null,
+    )
+
+    assert count == 2
+    _assert_source_metadata(ensemble.member[0], source_a)
+    _assert_source_metadata(ensemble.member[1], source_a)
+    for datum in ensemble.member[2:]:
+        assert datum.dead() is kill_null
+        assert "source_id" not in datum
+    assert database.arrival.queries == [{"phase": "P"}]
+    assert capsys.readouterr().out == ""
+
+
+def test_nonfinite_residual_does_not_match():
+    source = _source("one", 100.0)
+    database = FakeDatabase(sources=[source])
+    ensemble = _ensemble([("IU", "AAA", float("nan")), ("IU", "BBB", 100.0)])
+
+    count = load_hypocenter_data_by_time(database, ensemble, kill_null=True)
+
+    assert count == 1
+    assert ensemble.member[0].dead()
+    _assert_source_metadata(ensemble.member[1], source)
+
+
+def test_rms_remains_finite_for_large_finite_residuals():
+    worse_but_lexical_first = _source("a", 0.0)
+    better_but_lexical_later = _source("z", 5.0e307)
+    database = FakeDatabase(sources=[worse_but_lexical_first, better_but_lexical_later])
+    ensemble = _ensemble([("IU", "AAA", 1.0e308)])
+
+    count = load_hypocenter_data_by_time(database, ensemble, dt=1.0e308)
+
+    assert count == 1
+    _assert_source_metadata(ensemble.member[0], better_but_lexical_later)
+
+
+def test_selected_source_validation_is_atomic_and_invalid(capsys):
+    malformed_source = _source("bad", 100.0)
+    del malformed_source["lat"]
+    database = FakeDatabase(sources=[malformed_source])
+    ensemble = _ensemble([("IU", "AAA", 100.0), ("IU", "BBB", 130.0)])
+    ensemble.member[0]["source_id"] = "preexisting"
+    before = [(dict(datum), datum.live) for datum in ensemble.member]
+
+    with pytest.raises(MsPASSError) as excinfo:
+        load_hypocenter_data_by_time(database, ensemble, dt=5.0, kill_null=True)
+
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+    assert str(excinfo.value).startswith("load_hypocenter_data_by_time: ")
+    assert "lat" in str(excinfo.value)
+    assert [(dict(datum), datum.live) for datum in ensemble.member] == before
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    "kwargs, diagnostic",
+    [
+        ({"t0_definition": "unknown"}, "t0_definition"),
+        ({"dt": -1.0}, "dt"),
+        ({"dt": float("nan")}, "dt"),
+        ({"t0_offset": float("inf")}, "t0_offset"),
+    ],
+)
+def test_invalid_configuration_is_invalid_and_atomic(kwargs, diagnostic, capsys):
+    database = FakeDatabase(sources=[_source("one", 100.0)])
+    ensemble = _ensemble([("IU", "AAA", 100.0)])
+    before = (dict(ensemble.member[0]), ensemble.member[0].live)
+
+    with pytest.raises(MsPASSError) as excinfo:
+        load_hypocenter_data_by_time(database, ensemble, **kwargs)
+
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+    assert str(excinfo.value).startswith("load_hypocenter_data_by_time: ")
+    assert diagnostic in str(excinfo.value)
+    assert (dict(ensemble.member[0]), ensemble.member[0].live) == before
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize("missing", ["db", "ens"])
+def test_missing_required_argument_is_invalid_and_silent(missing, capsys):
+    database = FakeDatabase()
+    ensemble = _ensemble([("IU", "AAA", 100.0)])
+    before = (dict(ensemble.member[0]), ensemble.member[0].live)
+    kwargs = {"db": database, "ens": ensemble}
+    kwargs[missing] = None
+
+    with pytest.raises(MsPASSError) as excinfo:
+        load_hypocenter_data_by_time(**kwargs)
+
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+    assert str(excinfo.value).startswith("load_hypocenter_data_by_time: ")
+    assert missing in str(excinfo.value)
+    assert (dict(ensemble.member[0]), ensemble.member[0].live) == before
+    assert capsys.readouterr().out == ""
+
+
+def test_adjacent_site_and_channel_loaders_still_use_their_collections():
+    site = {
+        "site_id": "site-id",
+        "net": "IU",
+        "sta": "AAA",
+        "starttime": 0.0,
+        "endtime": 200.0,
+        "lat": 1.0,
+        "lon": 2.0,
+        "elev": 3.0,
+    }
+    channel = {
+        "_id": "channel-id",
+        "net": "IU",
+        "sta": "AAA",
+        "loc": "00",
+        "chan": "BHZ",
+        "starttime": 0.0,
+        "endtime": 200.0,
+        "lat": 4.0,
+        "lon": 5.0,
+        "elev": 6.0,
+        "vang": 0.0,
+        "hang": 90.0,
+    }
+    database = FakeDatabase(sites=[site], channels=[channel])
+    ensemble = _ensemble([("IU", "AAA", 100.0)])
+    datum = ensemble.member[0]
+    datum["starttime"] = 100.0
+    datum["loc"] = "00"
+    datum["chan"] = "BHZ"
+
+    assert load_site_data(database, ensemble) is ensemble
+    assert datum["site_id"] == "site-id"
+    assert load_channel_data(database, ensemble) is ensemble
+    assert datum["site_id"] == "channel-id"
+    assert datum["site_lat"] == 4.0


### PR DESCRIPTION
Fixes #877

This completes the SEED hypocenter loader with deterministic phase-arrival matching, finite RMS ranking, lexical event-ID tie breaking, and all-or-nothing metadata mutation. It writes the selected source reference and source coordinates only after validating the full match result.

Independent agent review found and fixed a falsey-ID blocker: missing event/net/sta/phase keys can no longer be mistaken for an exact match when an ID is `None`. The final implementation requires explicit key presence and exact association before computing a residual.

Validation:

- Final contract and adjacent loader matrix: 19 passed with the worktree module and real ccore bindings.
- Exact audit baseline: 18 failed / 1 adjacent loader passed.
- Coverage includes custom event keys, wrong-event arrivals, missing/falsey IDs, inclusive sample tolerance, finite RMS and stable tie breaking, all-dead identity/zero-query behavior, Invalid diagnostics, and zero stdout.
- Black, Ruff on changed/new code, Python 3.12/3.13 compilation, conflict checks, and `git diff --check` passed.

This PR is ready for human review. It is intentionally non-draft and is not merged.
