### PR TITLE
Fix miniSEED time-tear indexing

### DIFF
--- a/cxx/include/mspass/io/mseed_index.h
+++ b/cxx/include/mspass/io/mseed_index.h
@@ -92,16 +92,18 @@ of interest only if something breaks.
   in consecutive packets that aren't an actual time tear in this sense.
   e.g. event data concenated so all channels are back to back would require
   using this parameter true.
+  Sample-rate changes beyond a 1e-12 relative tolerance always start a new
+  segment, independent of this parameter.
 \param Verbose is a boolean largely controlling how time tears are or are not
-  logged.  That is, at present if this parameter is true any time the logic
-  detects a time tear it is logged in the returned error log as an informational
-  log message.   If false only reading errors for things like garbled miniseed
-  packets are logged.
+  logged.  When true, each detected time tear writes one diagnostic line to
+  standard error.  When false, time tears produce no diagnostic output.
 \return std::pair whose first element contains a vector of objects
   called mseed_index that contain the basic information defining an index for
   inputfile.  See class description of mseed_index for more details. "second"
-  contains an ErrorLogger objects.  Caller should test that the contents are
-  empty and if not save the error log or print it.
+  contains an ErrorLogger object.  Caller should test that the contents are
+  empty and if not save the error log or print it.  A valid empty file returns
+  an empty vector.  A libmseed parse error throws MsPASSError with Invalid
+  severity instead of returning a partial index.
 */
 std::pair<std::vector<mseed_index>, mspass::utility::ErrorLogger>
 mseed_file_indexer(const std::string inputfile, const bool segment_timetears,

--- a/cxx/src/lib/io/mseed_file_indexer.cc
+++ b/cxx/src/lib/io/mseed_file_indexer.cc
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <errno.h>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <math.h>
@@ -13,6 +15,7 @@
 #include "libmseed.h"
 #include "mspass/io/mseed_index.h"
 #include "mspass/utility/ErrorLogger.h"
+#include "mspass/utility/MsPASSError.h"
 
 using namespace std;
 namespace mspass::io {
@@ -110,12 +113,12 @@ typedef std::pair<std::vector<mseed_index>, mspass::utility::ErrorLogger>
     MSDINDEX_returntype;
 thread_local std::string buffer;
 /*! Internal function translates miniseed reader function return codes
-  to readable messages posted in mseed_file_indexer to ErrorLogger.
+  to readable messages used by mseed_file_indexer exceptions.
   */
 std::string MS_code_to_message(int retcode) {
   string message(
       "Read error detected by libmseed reader function ms3_readmsr_r\n");
-  message += "File index will be empty or truncated\n";
+  message += "No file index was returned\n";
   switch (retcode) {
   case MS_GENERROR:
     message += "MS_GENERROR(-1) return - generic unspecified error";
@@ -159,17 +162,16 @@ std::string MS_code_to_message(int retcode) {
  * 1.  miniseed files are often produced by concatenation of data form multiple
  *     channel.  Any change in station id returned by the function triggers a
  *     new index entry.
- * 2.  Packet errors will force a new segment.
- * 3.  Time tears defined by either a jump or accumulated time mismatch of
- *     more than 1/2 sample will trigger a new segments.
- * 4.  Changes in sample interval trigger a new segments.   That is
- *     actually implicit in point 1 with the "sid" because of the
- *     seed channel code naming convention.
+ * 2.  Packet errors abort indexing so a damaged file cannot produce a partial
+ *     index.
+ * 3.  A time mismatch between consecutive packets of more than 1/2 the
+ *     previous sample interval triggers a new segment.
+ * 4.  A sample-rate change beyond the relative tolerance triggers a new
+ *     segment even when the source identifier and time are continuous.
  * \return std::pair   first is a vector of index data.  second is
- *   an ErrorLogger object.  Caller should test for empty vector
- *   that is a signal for a open failure or a file that probably isn't
- *   miniseed.   The content of elog should always be tested as any
- *   errors there should be inspected/handled.
+ *   an ErrorLogger object.  The content of elog should always be tested as
+ *   any errors there should be inspected/handled.  A valid empty file
+ *   produces an empty vector; a parse failure throws MsPASSError.
  * */
 MSDINDEX_returntype mseed_file_indexer(const string inputfile,
                                        const bool segment_timetears,
@@ -183,46 +185,45 @@ MSDINDEX_returntype mseed_file_indexer(const string inputfile,
   struct.  The weird cleanup call at the end of the read loop
   calls the equivalent of a destructor.*/
   MS3FileParam *msfp = NULL;
-  uint32_t flags = MSF_SKIPNOTDATA;
+  uint32_t flags = MSF_VALIDATECRC;
   // int8_t ppackets = 0;
   int8_t verbose = 0;
   int retcode;
   // char last_sid[128],current_sid[128];
   MSEED_sid last_sid, current_sid;
-  /* This is used to define a time tear (gap).  When the computed endtime of
-  the previous packet read mismatches the starttime of the current packet we
-  create  a segment by defining a new index entry terminated at the time
-  tear */
-  const double time_tear_tolerance(0.5);
-
   vector<mseed_index> indexdata;
 
   mspass::utility::ErrorLogger elog;
 
+  /* libmseed reports an empty file as MS_NOTSEED.  Empty input is a valid
+     index with no segments, while an unreadable or nonempty damaged file is
+     left to the reader so it can report the appropriate parse error. */
+  {
+    std::ifstream empty_test(inputfile, std::ios::binary | std::ios::ate);
+    if (empty_test.is_open() && empty_test.tellg() == 0)
+      return MSDINDEX_returntype(indexdata, elog);
+  }
+
   /* Loop over the input file record by record */
   int64_t fpos = 0;
-  uint64_t start_foff, nbytes;
-  mseed_index ind;
+  uint64_t start_foff(0), nbytes(0);
   /* These values have a different time standard structure than
    * epoch times.  These can only be compared with epoch times by
    * calling the function MS_NSTIME2EPOCH
    */
   nstime_t stime;
-  int64_t npts(0), current_npts, record_length(4096);
+  int64_t npts(0), last_packet_npts(0), record_length(0);
   uint64_t number_packets_read(0), number_valid_packets(0);
-  double last_packet_samprate, last_packet_endtime, expected_starttime, last_dt;
-  /* These are used to handle long time series where the accumulated time
-   * from the start of a segment (many packets) gets inconsistent with
-   * the next packet's starttime.*/
-  double segment_starttime, computed_segment_starttime;
+  double last_packet_samprate(0.0), expected_starttime(0.0), last_dt(0.0);
+  double segment_starttime(0.0), segment_samprate(0.0);
   /* mseed stores time in an int (I think) this holds float
    * conversions for current and last packet read.*/
-  double current_epoch_stime, last_epoch_stime;
+  double current_epoch_stime(0.0), last_epoch_stime(0.0);
+  nstime_t last_packet_stime(0);
   /* loop break boolean */
-  bool data_available;
-  /* It is not clear what verbose means in this function so we currently always
-  turn it off.   Note Verbose and verbose are different - a bit dangerous but
-  that is what is for now.
+  bool data_available(true);
+  /* Keep libmseed's verbosity off.  The public Verbose argument controls the
+  single-line time-tear diagnostics emitted below.
   Also changed dec 2021:  changed to thread safe version.  Requires adding
   msfp struct initialized as NULL.
 
@@ -236,169 +237,140 @@ MSDINDEX_returntype mseed_file_indexer(const string inputfile,
   /* Although we don't use it this log initialization seems necessary as
      libmseed functions will dogmatically use the facility */
   ms_rloginit(NULL, NULL, NULL, NULL, 10);
-  do {
-    bool timetear_detected(false), sid_change_detected(false);
-    retcode = ms3_readmsr_r(&msfp, &msr, inputfile.c_str(), &fpos, NULL, flags,
-                            verbose);
-    switch (retcode) {
-    case MS_NOERROR:
-      try {
-        current_sid = MSEED_sid(msr->sid);
-      } catch (...) {
-        stringstream ss;
-        ss << "source id string=" << current_sid << " in packet number "
-           << number_packets_read << " of file " << inputfile
-           << " could not be decoded but reader did not flag an error" << endl
-           << "Segment break at this point is likely" << endl;
-        elog.log_error(function_name, ss.str(), ErrorSeverity::Complaint);
-        continue;
-      }
-      /* Land here for normal reads with no error return*/
-      if (number_valid_packets == 0) {
-        /* Initializations needed for first packet in the file */
-        last_sid = current_sid;
-        stime = msr->starttime;
-        current_epoch_stime = MS_NSTIME2EPOCH(static_cast<double>(stime));
-        last_epoch_stime = current_epoch_stime;
-        last_packet_samprate = msr->samprate;
-        last_dt = 1.0 / last_packet_samprate;
-        npts = msr->samplecnt;
-        last_packet_endtime =
-            current_epoch_stime + static_cast<double>(npts - 1) * last_dt;
-        segment_starttime = last_epoch_stime;
-        start_foff = 0;
-        /* Set this for the first packet and assume it is constant for the
-           whole file.  I don't think seed technically requires this but
-           in practice it is alway the case. */
-        record_length = msr->reclen;
-      } else {
-        stime = msr->starttime;
-        current_epoch_stime = MS_NSTIME2EPOCH(static_cast<double>(stime));
-        expected_starttime = last_packet_endtime + last_dt;
-        computed_segment_starttime =
-            segment_starttime + last_dt * static_cast<double>(npts);
-        if (current_sid != last_sid)
-          sid_change_detected = true;
-        if (segment_timetears) {
-          if ((fabs(current_epoch_stime - expected_starttime) >
-               time_tear_tolerance) ||
-              (fabs(current_epoch_stime - computed_segment_starttime) >
-               time_tear_tolerance))
-            timetear_detected = true;
-          else
-            /* This explicit setting isn't essential but makes the logic
-             * clearer.*/
-            timetear_detected = false;
-        }
+  auto append_segment = [&]() {
+    mseed_index ind;
+    ind.net = last_sid.net;
+    ind.sta = last_sid.sta;
+    ind.chan = last_sid.chan;
+    ind.loc = last_sid.loc;
+    ind.foff = start_foff;
+    ind.nbytes = nbytes;
+    ind.starttime = segment_starttime;
+    ind.last_packet_time = last_epoch_stime;
+    ind.samprate = segment_samprate;
+    ind.npts = npts;
+    ind.endtime =
+        ind.starttime + (static_cast<double>(npts - 1)) / ind.samprate;
+    indexdata.push_back(ind);
+  };
+  auto cleanup_reader = [&]() {
+    ms3_readmsr_r(&msfp, &msr, NULL, NULL, NULL, 0, 0);
+    buffer.clear();
+    ms_rlog_emit(NULL, 0, verbose);
+  };
 
-        if (sid_change_detected || timetear_detected) {
-          nbytes = fpos - start_foff;
-          ind.net = last_sid.net;
-          ind.sta = last_sid.sta;
-          ind.chan = last_sid.chan;
-          ind.loc = last_sid.loc;
-          ind.foff = start_foff;
-          ind.nbytes = nbytes;
-          ind.starttime = segment_starttime;
-          ind.last_packet_time = last_epoch_stime;
-          ind.samprate = last_packet_samprate;
-          ind.npts = npts;
-          ind.endtime =
-              ind.starttime + (static_cast<double>(npts - 1)) / ind.samprate;
-          indexdata.push_back(ind);
-          /* Initate a new segment.  Note the only difference if there was a
-           * decoding error is the index entry will be dropped. */
+  try {
+    do {
+      bool timetear_detected(false), sid_change_detected(false),
+          samprate_change_detected(false);
+      retcode = ms3_readmsr_r(&msfp, &msr, inputfile.c_str(), &fpos, NULL,
+                              flags, verbose);
+      switch (retcode) {
+      case MS_NOERROR:
+        try {
+          current_sid = MSEED_sid(msr->sid);
+        } catch (...) {
+          stringstream ss;
+          ss << "source id string=" << msr->sid << " in packet number "
+             << number_packets_read + 1 << " of file " << inputfile
+             << " could not be decoded but reader did not flag an error";
+          throw mspass::utility::MsPASSError(ss.str(), ErrorSeverity::Invalid);
+        }
+        /* Land here for normal reads with no error return. */
+        stime = msr->starttime;
+        current_epoch_stime = MS_NSTIME2EPOCH(static_cast<double>(stime));
+        record_length = msr->reclen;
+        if (number_valid_packets == 0) {
+          /* Initializations needed for first packet in the file. */
           last_sid = current_sid;
           last_epoch_stime = current_epoch_stime;
+          last_packet_stime = stime;
           last_packet_samprate = msr->samprate;
+          segment_samprate = msr->samprate;
           last_dt = 1.0 / last_packet_samprate;
+          last_packet_npts = msr->samplecnt;
           npts = msr->samplecnt;
-          last_packet_endtime =
-              current_epoch_stime + static_cast<double>(npts - 1) * last_dt;
-          segment_starttime = current_epoch_stime;
-          start_foff = fpos;
+          segment_starttime = last_epoch_stime;
+          start_foff = static_cast<uint64_t>(fpos);
         } else {
-          /* Packets without a break land here */
+          if (current_sid != last_sid)
+            sid_change_detected = true;
+
+          const long double current_samprate = msr->samprate;
+          const long double previous_samprate = last_packet_samprate;
+          const long double samprate_tolerance =
+              1.0e-12L * std::max(std::fabs(current_samprate),
+                                  std::fabs(previous_samprate));
+          samprate_change_detected =
+              std::fabs(current_samprate - previous_samprate) >
+              samprate_tolerance;
+
+          expected_starttime = last_epoch_stime +
+                               static_cast<double>(last_packet_npts) * last_dt;
+          if (segment_timetears && !sid_change_detected &&
+              !samprate_change_detected) {
+            const long double timing_error =
+                std::fabs(static_cast<long double>(stime - last_packet_stime) *
+                              previous_samprate -
+                          static_cast<long double>(last_packet_npts) *
+                              static_cast<long double>(NSTMODULUS));
+            timetear_detected =
+                timing_error > 0.5L * static_cast<long double>(NSTMODULUS);
+          }
+
+          if (timetear_detected && Verbose) {
+            stringstream diagnostic;
+            diagnostic << function_name << ": time tear at packet "
+                       << number_packets_read + 1 << " SID " << msr->sid
+                       << " previous expected time " << setprecision(17)
+                       << expected_starttime << " actual start "
+                       << current_epoch_stime;
+            cerr << diagnostic.str() << '\n';
+          }
+
+          if (sid_change_detected || samprate_change_detected ||
+              timetear_detected) {
+            nbytes = static_cast<uint64_t>(fpos) - start_foff;
+            append_segment();
+            npts = msr->samplecnt;
+            segment_starttime = current_epoch_stime;
+            segment_samprate = msr->samprate;
+            start_foff = static_cast<uint64_t>(fpos);
+          } else {
+            /* Packets without a break land here. */
+            npts += msr->samplecnt;
+          }
+
           last_sid = current_sid;
-          stime = msr->starttime;
-          last_epoch_stime = MS_NSTIME2EPOCH(static_cast<double>(stime));
+          last_epoch_stime = current_epoch_stime;
+          last_packet_stime = stime;
           last_packet_samprate = msr->samprate;
           last_dt = 1.0 / last_packet_samprate;
-          current_npts = msr->samplecnt;
-          npts += current_npts;
-          last_packet_endtime = current_epoch_stime +
-                                static_cast<double>(current_npts - 1) * last_dt;
+          last_packet_npts = msr->samplecnt;
         }
-      }
-      ++number_valid_packets;
-      data_available = true;
-      break;
-    case MS_ENDOFFILE:
-      if (number_valid_packets > 0) {
-        /* VERY IMPORTANT:   reader handles data per packet.   fpos is updated
-           by the reader but on EOF it is NOT updated. As a result we have to
-           add the record length or we drop the last packet from
-           the index. A too classic problem of use of a pointer to a pointer
-           in plain C.  Furthermore had to save the record length earlier
-           as msr is a NULL pointer when EOF is returned */
-        nbytes = fpos - start_foff + record_length;
-        ind.net = last_sid.net;
-        ind.sta = last_sid.sta;
-        ind.chan = last_sid.chan;
-        ind.loc = last_sid.loc;
-        ind.foff = start_foff;
-        ind.nbytes = nbytes;
-        ind.starttime = segment_starttime;
-        ind.last_packet_time = last_epoch_stime;
-        ind.samprate = last_packet_samprate;
-        ind.npts = npts;
-        ind.endtime =
-            ind.starttime + (static_cast<double>(npts - 1)) / ind.samprate;
-        indexdata.push_back(ind);
+        ++number_valid_packets;
+        data_available = true;
+        break;
+      case MS_ENDOFFILE:
+        if (number_valid_packets > 0) {
+          /* fpos is the offset of the last record when EOF is returned. */
+          nbytes = static_cast<uint64_t>(fpos) - start_foff + record_length;
+          append_segment();
+        }
         data_available = false;
-      } else {
-        elog.log_error(function_name,
-                       string("Hit end of file before reading any valid "
-                              "packets\nEmpty index"),
-                       ErrorSeverity::Invalid);
-      }
-      break;
-    default:
-      /* All other error conditions end here.  Function MS_code_to_message
-         translates to a rational error message return */
-      string message = MS_code_to_message(retcode);
-      elog.log_error(function_name, message, ErrorSeverity::Complaint);
-      data_available = false;
-      /* If we land here we need to add a final index entry to salvage what
-         we can from this file.   This is almost identical to the eof section
-         except here we intentionally drop the last packet assuming it
-         is the problem. */
-      if (number_valid_packets > 0) {
-        // NOTE not the same as EOF section
-        nbytes = fpos - start_foff;
-        ind.net = last_sid.net;
-        ind.sta = last_sid.sta;
-        ind.chan = last_sid.chan;
-        ind.loc = last_sid.loc;
-        ind.foff = start_foff;
-        ind.nbytes = nbytes;
-        ind.starttime = segment_starttime;
-        ind.last_packet_time = last_epoch_stime;
-        ind.samprate = last_packet_samprate;
-        ind.npts = npts;
-        ind.endtime =
-            ind.starttime + (static_cast<double>(npts - 1)) / ind.samprate;
-        indexdata.push_back(ind);
-        data_available = false;
-      }
-    };
-    ++number_packets_read;
-  } while (data_available);
-  /* Make sure everything is cleaned up.  Documentation says this is needed
-  to invoke the plain C equivalent of a destructor.*/
-  ms3_readmsr_r(&msfp, &msr, NULL, NULL, NULL, 0, 0);
-  buffer.clear();
-  ms_rlog_emit(NULL, 0, verbose);
+        break;
+      default:
+        /* A damaged input cannot produce a trustworthy partial index. */
+        throw mspass::utility::MsPASSError(MS_code_to_message(retcode),
+                                           ErrorSeverity::Invalid);
+      };
+      ++number_packets_read;
+    } while (data_available);
+  } catch (...) {
+    cleanup_reader();
+    throw;
+  }
+  cleanup_reader();
   return MSDINDEX_returntype(indexdata, elog);
 }
 } // End namespace mspass::io

--- a/cxx/test/mseed/CMakeLists.txt
+++ b/cxx/test/mseed/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(test_mseed test_mseed.cc)
 configure_file(test.msd test.msd COPYONLY)
 include_directories(
   ${Boost_INCLUDE_DIRS}
+  ${MSEED_INCLUDE_DIR}
   ${pybind11_INCLUDE_DIR}
   ${Python_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/include/)

--- a/cxx/test/mseed/test_mseed.cc
+++ b/cxx/test/mseed/test_mseed.cc
@@ -1,58 +1,442 @@
-#include <assert.h>
-#include "mspass/io/mseed_index.h"
-#include "mspass/seismic/TimeSeries.h"
-#include "mspass/utility/ErrorLogger.h"
-using namespace std;
-using namespace mspass::io;
-using namespace mspass::seismic;
-int main(int argc, char **argv)
-{
-	string fname;
-	fname=string(argv[1]);
-	std::pair<std::vector<mseed_index>,mspass::utility::ErrorLogger> msfiret;
-	std::vector<mseed_index> ind;
-	mspass::utility::ErrorLogger elog;
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unistd.h>
+#include <vector>
 
-	msfiret=mseed_file_indexer(fname.c_str(),true,true);
-	ind=msfiret.first;
-	elog=msfiret.second;
-	cout << "size of index="<<ind.size()<<endl;
-  cout << "Content:"<<endl;
-  for(auto x=ind.begin();x!=ind.end();++x)
-    cout << x->net
-      << " " << x->sta
-      << " " << x->chan
-      << " " << x->foff
-      << " " << x->nbytes
-      << " " << x->npts
-      << " " << x->samprate
-      << std::setprecision(20)
-      << " " << x->starttime
-      << " " << x->endtime<<endl;
-	cout << "Size of error log="<<elog.size()<<endl;
-  /* these tests are keyed to one and only one test file.  
-     They will need to be changed if the file is changed
-     to add tests for problem data - may be needed in 
-     the future */
-  assert(ind.size()==5);
-  assert(ind[0].sta=="E2000");
-  assert(ind[0].chan=="VHE");
-  assert(ind[0].foff==0);
-  assert(ind[0].nbytes==4096);
-  assert(ind[0].npts==70);
-  assert(fabs(ind[0].samprate-0.1)<0.0001);
-  assert(ind[1].sta=="E2000");
-  assert(ind[1].foff==4096);
-  assert(ind[1].npts==2434403);
-  assert(ind[2].sta=="A2000");
-  assert(ind[2].chan=="UHE");
-  assert(ind[2].foff==1921024);
-  assert(ind[2].nbytes==4096);
-  assert(ind[2].npts==15);
-  assert(fabs(ind[2].samprate-0.01)<0.0001);
-  assert(ind[3].sta=="A2000");
-  assert(ind[3].foff==1925120);
-  assert(ind[3].npts==47205);
+#include "libmseed.h"
+#include "mspass/io/mseed_index.h"
+#include "mspass/utility/MsPASSError.h"
+
+using mspass::io::mseed_file_indexer;
+using mspass::io::mseed_index;
+using mspass::utility::ErrorSeverity;
+using mspass::utility::MsPASSError;
+using std::string;
+using std::vector;
+
+namespace {
+void CheckCondition(const bool condition, const char *expression,
+                    const char *file, const int line) {
+  if (!condition) {
+    std::ostringstream message;
+    message << file << ":" << line << ": test check failed: " << expression;
+    throw std::runtime_error(message.str());
+  }
+}
+#define CHECK(...)                                                             \
+  CheckCondition(static_cast<bool>((__VA_ARGS__)), #__VA_ARGS__, __FILE__,     \
+                 __LINE__)
+
+void CheckClose(const double actual, const double expected,
+                const double tolerance, const char *expression,
+                const char *file, const int line) {
+  if (std::fabs(actual - expected) > tolerance) {
+    std::ostringstream message;
+    message << file << ":" << line << ": test check failed: " << expression
+            << " (actual=" << std::setprecision(17) << actual
+            << ", expected=" << expected << ")";
+    throw std::runtime_error(message.str());
+  }
+}
+#define CHECK_CLOSE(actual, expected, tolerance)                               \
+  CheckClose((actual), (expected), (tolerance), #actual " ~= " #expected,      \
+             __FILE__, __LINE__)
+
+class TempFiles {
+public:
+  string make_path(const string &label) {
+    const string path = "/tmp/mspass_mseed_index_" +
+                        std::to_string(static_cast<long>(getpid())) + "_" +
+                        std::to_string(paths.size()) + "_" + label;
+    paths.push_back(path);
+    return path;
+  }
+  ~TempFiles() {
+    for (const auto &path : paths)
+      std::remove(path.c_str());
+  }
+
+private:
+  vector<string> paths;
+};
+
+void CollectRecord(char *record, int record_length, void *handler_data) {
+  auto *records = static_cast<vector<vector<char>> *>(handler_data);
+  records->emplace_back(record, record + record_length);
 }
 
+vector<char> PackRecord(const string &sid, const nstime_t starttime,
+                        const double samprate, const int64_t sample_count) {
+  MS3Record *msr = msr3_init(nullptr);
+  CHECK(msr != nullptr);
+  CHECK(sid.size() < sizeof(msr->sid));
+  std::strcpy(msr->sid, sid.c_str());
+  msr->formatversion = 3;
+  msr->reclen = 256;
+  msr->pubversion = 1;
+  msr->starttime = starttime;
+  msr->samprate = samprate;
+  msr->encoding = DE_INT32;
+  vector<int32_t> samples(static_cast<size_t>(sample_count));
+  for (int64_t i = 0; i < sample_count; ++i)
+    samples[static_cast<size_t>(i)] = static_cast<int32_t>(i + 1);
+  msr->samplecnt = sample_count;
+  msr->numsamples = sample_count;
+  msr->datasamples = samples.data();
+  msr->datasize = samples.size() * sizeof(int32_t);
+  msr->sampletype = 'i';
 
+  vector<vector<char>> records;
+  int64_t packed_samples(0);
+  const int packed_records = msr3_pack(msr, CollectRecord, &records,
+                                       &packed_samples, MSF_FLUSHDATA, 0);
+  msr->datasamples = nullptr;
+  msr->datasize = 0;
+  msr3_free(&msr);
+  CHECK(packed_records == 1);
+  CHECK(packed_samples == sample_count);
+  CHECK(records.size() == 1);
+  return records.front();
+}
+
+string WriteRecords(TempFiles &temp_files, const string &label,
+                    const vector<vector<char>> &records) {
+  const string path = temp_files.make_path(label);
+  std::ofstream output(path, std::ios::binary);
+  CHECK(output.is_open());
+  for (const auto &record : records)
+    output.write(record.data(), static_cast<std::streamsize>(record.size()));
+  output.close();
+  CHECK(output.good());
+  return path;
+}
+
+void CheckEndtimeFormula(const mseed_index &index) {
+  const double expected =
+      index.starttime + static_cast<double>(index.npts - 1) / index.samprate;
+  CHECK(index.endtime == expected);
+}
+
+size_t CountLines(const string &text) {
+  return static_cast<size_t>(std::count(text.begin(), text.end(), '\n'));
+}
+
+size_t CountOccurrences(const string &text, const string &needle) {
+  size_t count(0), position(0);
+  while ((position = text.find(needle, position)) != string::npos) {
+    ++count;
+    position += needle.size();
+  }
+  return count;
+}
+
+bool RateChanges(const double first, const double second) {
+  const long double lhs = std::fabs(static_cast<long double>(second) - first);
+  const long double rhs =
+      1.0e-12L * std::max(std::fabs(static_cast<long double>(first)),
+                          std::fabs(static_cast<long double>(second)));
+  return lhs > rhs;
+}
+
+void TestTimeTearBoundaries(TempFiles &temp_files) {
+  const vector<int> sample_rates{1, 20, 50, 100, 500};
+  const string sid("XFDSN:XX_TEST_00_B_H_Z");
+  const int64_t packet_npts(4);
+  size_t test_number(0);
+  for (const int rate : sample_rates) {
+    const nstime_t base =
+        1600000000000000000LL +
+        static_cast<nstime_t>(test_number++) * 1000000000000LL;
+    const nstime_t packet_duration =
+        packet_npts * static_cast<nstime_t>(NSTMODULUS) / rate;
+    const nstime_t half_sample = static_cast<nstime_t>(NSTMODULUS) / (2 * rate);
+    const nstime_t second_start = base + packet_duration + half_sample;
+    const nstime_t third_start =
+        second_start + packet_duration + half_sample + 1;
+    vector<vector<char>> records{
+        PackRecord(sid, base, rate, packet_npts),
+        PackRecord(sid, second_start, rate, packet_npts),
+        PackRecord(sid, third_start, rate, packet_npts)};
+    const string path = WriteRecords(
+        temp_files, "time_boundary_" + std::to_string(rate), records);
+
+    std::ostringstream diagnostics;
+    std::streambuf *saved_cerr = std::cerr.rdbuf(diagnostics.rdbuf());
+    std::pair<vector<mseed_index>, mspass::utility::ErrorLogger> result;
+    try {
+      result = mseed_file_indexer(path, true, true);
+    } catch (...) {
+      std::cerr.rdbuf(saved_cerr);
+      throw;
+    }
+    std::cerr.rdbuf(saved_cerr);
+
+    CHECK(result.second.size() == 0);
+    CHECK(result.first.size() == 2);
+    const auto &first = result.first[0];
+    const auto &second = result.first[1];
+    CHECK(first.net == "XX");
+    CHECK(first.sta == "TEST");
+    CHECK(first.loc == "00");
+    CHECK(first.chan == "BHZ");
+    CHECK(first.foff == 0);
+    CHECK(first.nbytes == records[0].size() + records[1].size());
+    CHECK(first.npts == static_cast<size_t>(2 * packet_npts));
+    CHECK(first.samprate == rate);
+    CHECK_CLOSE(first.starttime, MS_NSTIME2EPOCH(static_cast<double>(base)),
+                0.0);
+    CHECK_CLOSE(first.last_packet_time,
+                MS_NSTIME2EPOCH(static_cast<double>(second_start)), 0.0);
+    CheckEndtimeFormula(first);
+
+    CHECK(second.foff == first.nbytes);
+    CHECK(second.nbytes == records[2].size());
+    CHECK(second.npts == static_cast<size_t>(packet_npts));
+    CHECK(second.samprate == rate);
+    CHECK_CLOSE(second.starttime,
+                MS_NSTIME2EPOCH(static_cast<double>(third_start)), 0.0);
+    CHECK(second.last_packet_time == second.starttime);
+    CheckEndtimeFormula(second);
+
+    const string output = diagnostics.str();
+    CHECK(CountLines(output) == 1);
+    CHECK(output.find("time tear at packet 3") != string::npos);
+    CHECK(output.find(sid) != string::npos);
+    CHECK(output.find("previous expected time") != string::npos);
+    CHECK(output.find("actual start") != string::npos);
+
+    std::ostringstream quiet_diagnostics;
+    saved_cerr = std::cerr.rdbuf(quiet_diagnostics.rdbuf());
+    try {
+      result = mseed_file_indexer(path, true, false);
+    } catch (...) {
+      std::cerr.rdbuf(saved_cerr);
+      throw;
+    }
+    std::cerr.rdbuf(saved_cerr);
+    CHECK(result.first.size() == 2);
+    CHECK(quiet_diagnostics.str().empty());
+
+    const auto unsplit = mseed_file_indexer(path, false, true);
+    CHECK(unsplit.first.size() == 1);
+    CHECK(unsplit.first[0].npts == static_cast<size_t>(3 * packet_npts));
+  }
+}
+
+void TestSampleRateBoundaries(TempFiles &temp_files) {
+  const string sid("XFDSN:XX_RATE_00_B_H_Z");
+  const double base_rate(100.0);
+  double boundary_rate(base_rate);
+  double beyond_rate(base_rate);
+  for (int i = 0; i < 100000; ++i) {
+    const double candidate =
+        std::nextafter(boundary_rate, std::numeric_limits<double>::infinity());
+    if (RateChanges(base_rate, candidate)) {
+      beyond_rate = candidate;
+      break;
+    }
+    boundary_rate = candidate;
+  }
+  CHECK(boundary_rate > base_rate);
+  CHECK(!RateChanges(base_rate, boundary_rate));
+  CHECK(RateChanges(base_rate, beyond_rate));
+
+  const nstime_t base(1610000000000000000LL);
+  const int64_t packet_npts(4);
+  const nstime_t second_start =
+      base + packet_npts * static_cast<nstime_t>(NSTMODULUS) / 100;
+  vector<vector<char>> at_boundary{
+      PackRecord(sid, base, base_rate, packet_npts),
+      PackRecord(sid, second_start, boundary_rate, packet_npts)};
+  const string boundary_path =
+      WriteRecords(temp_files, "rate_boundary", at_boundary);
+  const auto boundary_result = mseed_file_indexer(boundary_path, false, false);
+  CHECK(boundary_result.first.size() == 1);
+  CHECK(boundary_result.first[0].npts == static_cast<size_t>(2 * packet_npts));
+  CHECK(boundary_result.first[0].samprate == base_rate);
+  CHECK(boundary_result.first[0].nbytes ==
+        at_boundary[0].size() + at_boundary[1].size());
+  CheckEndtimeFormula(boundary_result.first[0]);
+
+  vector<vector<char>> beyond_boundary{
+      PackRecord(sid, base, base_rate, packet_npts),
+      PackRecord(sid, second_start, beyond_rate, packet_npts)};
+  const string beyond_path =
+      WriteRecords(temp_files, "rate_beyond", beyond_boundary);
+  const auto beyond_result = mseed_file_indexer(beyond_path, false, false);
+  CHECK(beyond_result.first.size() == 2);
+  CHECK(beyond_result.first[0].foff == 0);
+  CHECK(beyond_result.first[0].nbytes == beyond_boundary[0].size());
+  CHECK(beyond_result.first[0].samprate == base_rate);
+  CHECK(beyond_result.first[1].foff == beyond_boundary[0].size());
+  CHECK(beyond_result.first[1].nbytes == beyond_boundary[1].size());
+  CHECK(beyond_result.first[1].samprate == beyond_rate);
+  CHECK(beyond_result.first[0].npts == static_cast<size_t>(packet_npts));
+  CHECK(beyond_result.first[1].npts == static_cast<size_t>(packet_npts));
+  CheckEndtimeFormula(beyond_result.first[0]);
+  CheckEndtimeFormula(beyond_result.first[1]);
+}
+
+void TestOneDiagnosticPerTimeTear(TempFiles &temp_files) {
+  const string sid("XFDSN:XX_VERBOSE_00_B_H_Z");
+  const double rate(20.0);
+  const int64_t packet_npts(4);
+  const nstime_t base(1615000000000000000LL);
+  const nstime_t packet_duration = 200000000LL;
+  const nstime_t beyond_half_sample = 25000001LL;
+  const nstime_t second_start = base + packet_duration + beyond_half_sample;
+  const nstime_t third_start =
+      second_start + packet_duration + beyond_half_sample;
+  const vector<vector<char>> records{
+      PackRecord(sid, base, rate, packet_npts),
+      PackRecord(sid, second_start, rate, packet_npts),
+      PackRecord(sid, third_start, rate, packet_npts)};
+  const string path = WriteRecords(temp_files, "verbose_tears", records);
+
+  std::ostringstream diagnostics;
+  std::streambuf *saved_cerr = std::cerr.rdbuf(diagnostics.rdbuf());
+  std::pair<vector<mseed_index>, mspass::utility::ErrorLogger> result;
+  try {
+    result = mseed_file_indexer(path, true, true);
+  } catch (...) {
+    std::cerr.rdbuf(saved_cerr);
+    throw;
+  }
+  std::cerr.rdbuf(saved_cerr);
+  CHECK(result.first.size() == 3);
+  CHECK(CountLines(diagnostics.str()) == 2);
+  CHECK(CountOccurrences(diagnostics.str(), "time tear at packet") == 2);
+  CHECK(diagnostics.str().find("time tear at packet 2") != string::npos);
+  CHECK(diagnostics.str().find("time tear at packet 3") != string::npos);
+}
+
+void TestSidAndRecordBounds(TempFiles &temp_files) {
+  const nstime_t base(1620000000000000000LL);
+  vector<vector<char>> records{
+      PackRecord("XFDSN:AA_FIRST_01_L_H_Z", base, 20.0, 3),
+      PackRecord("XFDSN:BB_SECOND_02_H_H_N", base + 150000000LL, 20.0, 7)};
+  CHECK(records[0].size() != records[1].size());
+  const string path = WriteRecords(temp_files, "sid_change", records);
+  const auto result = mseed_file_indexer(path, true, false);
+  CHECK(result.first.size() == 2);
+  CHECK(result.first[0].net == "AA");
+  CHECK(result.first[0].sta == "FIRST");
+  CHECK(result.first[0].loc == "01");
+  CHECK(result.first[0].chan == "LHZ");
+  CHECK(result.first[0].foff == 0);
+  CHECK(result.first[0].nbytes == records[0].size());
+  CHECK(result.first[0].npts == 3);
+  CHECK(result.first[1].net == "BB");
+  CHECK(result.first[1].sta == "SECOND");
+  CHECK(result.first[1].loc == "02");
+  CHECK(result.first[1].chan == "HHN");
+  CHECK(result.first[1].foff == records[0].size());
+  CHECK(result.first[1].nbytes == records[1].size());
+  CHECK(result.first[1].npts == 7);
+  CheckEndtimeFormula(result.first[0]);
+  CheckEndtimeFormula(result.first[1]);
+}
+
+void ExpectInvalidParse(const string &path) {
+  bool threw(false);
+  try {
+    static_cast<void>(mseed_file_indexer(path, true, false));
+  } catch (const MsPASSError &error) {
+    threw = true;
+    CHECK(error.severity() == ErrorSeverity::Invalid);
+    CHECK(string(error.what()).find("ms3_readmsr_r") != string::npos);
+  }
+  CHECK(threw);
+}
+
+void TestEmptyAndCorruption(TempFiles &temp_files) {
+  const string empty_path = WriteRecords(temp_files, "empty", {});
+  const auto empty_result = mseed_file_indexer(empty_path, true, false);
+  CHECK(empty_result.first.empty());
+  CHECK(empty_result.second.size() == 0);
+
+  const vector<char> valid =
+      PackRecord("XFDSN:XX_DAMAGE_00_B_H_Z", 1630000000000000000LL, 100.0, 8);
+  vector<char> damaged(valid);
+  damaged.back() ^= 0x01;
+  const string before_path =
+      WriteRecords(temp_files, "damage_before", {damaged, valid});
+  const string after_path =
+      WriteRecords(temp_files, "damage_after", {valid, damaged});
+  ExpectInvalidParse(before_path);
+  ExpectInvalidParse(after_path);
+
+  vector<char> junk(64, static_cast<char>(0x7f));
+  const string junk_before =
+      WriteRecords(temp_files, "junk_before", {junk, valid});
+  const string junk_after =
+      WriteRecords(temp_files, "junk_after", {valid, junk});
+  ExpectInvalidParse(junk_before);
+  ExpectInvalidParse(junk_after);
+}
+
+void TestExistingFixture(const string &path) {
+  const auto result = mseed_file_indexer(path, true, false);
+  CHECK(result.second.size() == 0);
+  CHECK(result.first.size() == 5);
+  CHECK(result.first[0].sta == "E2000");
+  CHECK(result.first[0].chan == "VHE");
+  CHECK(result.first[0].foff == 0);
+  CHECK(result.first[0].nbytes == 4096);
+  CHECK(result.first[0].npts == 70);
+  CHECK_CLOSE(result.first[0].samprate, 0.1, 0.0001);
+  CHECK(result.first[1].sta == "E2000");
+  CHECK(result.first[1].foff == 4096);
+  CHECK(result.first[1].npts == 2434403);
+  CHECK(result.first[2].sta == "A2000");
+  CHECK(result.first[2].chan == "UHE");
+  CHECK(result.first[2].foff == 1921024);
+  CHECK(result.first[2].nbytes == 4096);
+  CHECK(result.first[2].npts == 15);
+  CHECK_CLOSE(result.first[2].samprate, 0.01, 0.0001);
+  CHECK(result.first[3].sta == "A2000");
+  CHECK(result.first[3].foff == 1925120);
+  CHECK(result.first[3].npts == 47205);
+  for (size_t i = 0; i < result.first.size(); ++i) {
+    CHECK(result.first[i].nbytes > 0);
+    CHECK(result.first[i].npts > 0);
+    CHECK(result.first[i].samprate > 0.0);
+    CheckEndtimeFormula(result.first[i]);
+    if (i > 0)
+      CHECK(result.first[i].foff ==
+            result.first[i - 1].foff + result.first[i - 1].nbytes);
+  }
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  try {
+    CHECK(argc == 2);
+    TempFiles temp_files;
+    TestTimeTearBoundaries(temp_files);
+    TestSampleRateBoundaries(temp_files);
+    TestOneDiagnosticPerTimeTear(temp_files);
+    TestSidAndRecordBounds(temp_files);
+    TestEmptyAndCorruption(temp_files);
+    TestExistingFixture(argv[1]);
+    std::cout << "MiniSEED index contract tests passed" << std::endl;
+    return EXIT_SUCCESS;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << std::endl;
+  } catch (...) {
+    std::cerr << "Unknown exception in MiniSEED index contract test"
+              << std::endl;
+  }
+  return EXIT_FAILURE;
+}

--- a/python/tests/io/test_mseed_file_indexer.py
+++ b/python/tests/io/test_mseed_file_indexer.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import pytest
+
+from mspasspy.ccore.io import _mseed_file_indexer
+from mspasspy.ccore.utility import ErrorSeverity, MsPASSError
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+MSEED_FIXTURE = REPOSITORY_ROOT / "cxx" / "test" / "mseed" / "test.msd"
+
+
+def test_mseed_file_indexer_binding_valid_and_empty(tmp_path):
+    index, elog = _mseed_file_indexer(str(MSEED_FIXTURE), True, False)
+    assert len(index) > 0
+    assert elog.size() == 0
+    assert index[0].sta == "E2000"
+    assert index[0].chan == "VHE"
+    assert index[0].foff == 0
+    for segment in index:
+        assert segment.nbytes > 0
+        assert segment.npts > 0
+        assert segment.endtime == pytest.approx(
+            segment.starttime + (segment.npts - 1) / segment.samprate,
+            rel=0.0,
+            abs=0.0,
+        )
+
+    empty = tmp_path / "empty.mseed"
+    empty.write_bytes(b"")
+    empty_index, empty_elog = _mseed_file_indexer(str(empty), True, False)
+    assert len(empty_index) == 0
+    assert empty_elog.size() == 0
+
+
+def test_mseed_file_indexer_binding_matches_native_segments_and_verbose(capfd):
+    index, elog = _mseed_file_indexer(str(MSEED_FIXTURE), True, True)
+    captured = capfd.readouterr()
+
+    assert elog.size() == 0
+    assert [
+        (
+            segment.net,
+            segment.sta,
+            segment.loc,
+            segment.chan,
+            segment.foff,
+            segment.nbytes,
+            segment.npts,
+            segment.samprate,
+        )
+        for segment in index
+    ] == [
+        ("X6", "E2000", "", "VHE", 0, 4096, 70, 0.1),
+        ("X6", "E2000", "", "VHE", 4096, 1916928, 2434403, 0.1),
+        ("X6", "A2000", "", "UHE", 1921024, 4096, 15, 0.01),
+        ("X6", "A2000", "", "UHE", 1925120, 57344, 47205, 0.01),
+        ("X6", "A2000", "", "UHE", 1982464, 229376, 200030, 0.01),
+    ]
+    diagnostic_lines = captured.err.splitlines()
+    assert captured.out == ""
+    assert len(diagnostic_lines) == 3
+    assert all("time tear at packet" in line for line in diagnostic_lines)
+    assert all("previous expected time" in line for line in diagnostic_lines)
+    assert all("actual start" in line for line in diagnostic_lines)
+
+    quiet_index, quiet_elog = _mseed_file_indexer(str(MSEED_FIXTURE), True, False)
+    quiet_output = capfd.readouterr()
+    assert len(quiet_index) == len(index)
+    assert quiet_elog.size() == 0
+    assert quiet_output.out == ""
+    assert quiet_output.err == ""
+
+
+@pytest.mark.parametrize("damage_position", ["before", "after"])
+def test_mseed_file_indexer_binding_rejects_corruption_without_partial_result(
+    tmp_path, damage_position
+):
+    complete_record = MSEED_FIXTURE.read_bytes()[:4096]
+    corruption = b"\x7f" * 64
+    if damage_position == "before":
+        payload = corruption + complete_record
+    else:
+        payload = complete_record + corruption
+    damaged = tmp_path / f"damaged_{damage_position}.mseed"
+    damaged.write_bytes(payload)
+
+    with pytest.raises(MsPASSError) as excinfo:
+        _mseed_file_indexer(str(damaged), True, False)
+    assert excinfo.value.severity == ErrorSeverity.Invalid
+    assert "ms3_readmsr_r" in str(excinfo.value)


### PR DESCRIPTION
## What changed

- split miniSEED index segments when consecutive packets differ by more than half of the previous sample interval
- split segments on sample-rate changes using the documented relative tolerance
- preserve exact segment offsets, byte counts, sample counts, rates, and inclusive end times
- emit one diagnostic per time tear only when `Verbose` is enabled
- return an empty index for a valid empty file and reject damaged/non-SEED input without a partial result

## Root cause and impact

The indexer compared packet timing with inconsistent units and did not enforce the sample-rate or parse-failure contracts.  High-rate tears could be missed, segment metadata could become inconsistent, and damaged files could return a misleading partial index.

## Validation

- Release CTest: 12/12 passed
- native `-O3 -DNDEBUG` contract tests passed
- rebuilt Python 3.13 binding tests: 4 passed
- adjacent ccore regression tests: 31 passed, 2 unrelated data-location tests deselected
- Valgrind: 0 leaks and 0 errors
- exact audited baseline reproduces the half-sample/Verbose failure
- clang-format, Black, Python 3.12/3.13 `py_compile`, and `git diff --check` passed

Fixes #261
