### PR TITLE
Upgrade containers to MongoDB 8.0.29

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,7 +32,49 @@ env:
   SPARK_SHA512: 5d5d2e6e111182ee1210d4a46a17ae27107c7ccc70433da0ded3d8197e027f949b00445bb5678ed0c1d5c59f12993d9b9ed12e43686d5aad89a9ec570e93a083
 
 jobs:
+  mongodb-migration:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install migration-test dependencies
+        run: python -m pip install pytest pyyaml
+
+      - name: Run MongoDB migration contract
+        run: python -m pytest python/tests/test_mongodb_upgrade_contract.py -q
+
+      - name: Run staged MongoDB migration
+        shell: bash
+        run: |
+          set -euo pipefail
+          for forced_stage in 6.0 7.0 ''; do
+            migration_root="${RUNNER_TEMP}/mongodb-migration-${forced_stage:-complete}"
+            set +e
+            MSPASS_MONGO_UPGRADE_ROOT="$migration_root" \
+              MSPASS_MONGO_UPGRADE_FAIL_AFTER="$forced_stage" \
+              scripts/mongodb_upgrade_6_to_8.sh
+            status=$?
+            set -e
+            if [[ -n "$forced_stage" ]]; then
+              test "$status" -eq 70
+              test "$(cat "$migration_root/last_completed_stage")" = "$forced_stage"
+            else
+              test "$status" -eq 0
+              test "$(cat "$migration_root/last_completed_stage")" = 8.0
+            fi
+          done
+
   download-spark:
+    needs: mongodb-migration
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -161,11 +203,20 @@ jobs:
           target: runtime
           platforms: linux/amd64
           push: false
-          tags: ${{ steps.meta.outputs.tags }}
+          load: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            mspass/mspass:mongodb-contract
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
             spark-build-assets=.docker-build-assets
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:buildcache-runtime-amd64
+
+      - name: Test standalone and sharded MongoDB 8.0.29
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          MSPASS_MONGODB_TEST_IMAGE: mspass/mspass:mongodb-contract
+        run: scripts/test_mongodb_8029_containers.sh
 
       - name: Build and push Docker image (amd64)
         uses: docker/build-push-action@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
+		curl \
 		dirmngr \
 		gnupg \
 		jq \
@@ -106,18 +107,6 @@ RUN set -ex; \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-RUN set -ex; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	set -- '39BD841E4BE5FB195A65400E6A26B1AE64C3C388'; \
-	for key; do \
-		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-	done; \
-	mkdir -p /etc/apt/keyrings; \
-	gpg --batch --export "$@" > /etc/apt/keyrings/mongodb.gpg; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" \
-	&& docker-clean
-
 # Allow build-time overrides (eg. to build image with MongoDB Enterprise version)
 # Options for MONGO_PACKAGE: mongodb-org OR mongodb-enterprise
 # Options for MONGO_REPO: repo.mongodb.org OR repo.mongodb.com
@@ -126,12 +115,15 @@ ARG MONGO_PACKAGE=mongodb-org
 ARG MONGO_REPO=repo.mongodb.org
 ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
-ENV MONGO_MAJOR=6.0
-RUN echo "deb [ signed-by=/etc/apt/keyrings/mongodb.gpg ] http://$MONGO_REPO/apt/ubuntu jammy/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
-
-# https://docs.mongodb.org/master/release-notes/6.0/
-ENV MONGO_VERSION=6.0.5
-# 03/08/2023, https://github.com/mongodb/mongo/tree/c9a99c120371d4d4c52cbb15dac34a36ce8d3b1d
+# MongoDB skipped the unpublished 8.0.27 package; 8.0.29 is the exact
+# supported patch available for Ubuntu 22.04 on both amd64 and arm64.
+ENV MONGO_MAJOR=8.0
+ENV MONGO_VERSION=8.0.29
+RUN set -eux; \
+	curl -fsSL "https://pgp.mongodb.com/server-${MONGO_MAJOR}.asc" \
+		| gpg --dearmor -o "/etc/apt/keyrings/mongodb-server-${MONGO_MAJOR}.gpg"; \
+	echo "deb [ arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/mongodb-server-${MONGO_MAJOR}.gpg ] https://$MONGO_REPO/apt/ubuntu jammy/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" \
+		> "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \
 # installing "mongodb-enterprise" pulls in "tzdata" which prompts for input
@@ -326,8 +318,8 @@ ARG NB_USER=jovyan
 ARG NB_UID=1000
 ARG NB_GID=1000
 ARG NB_HOME=/home/jovyan
-ARG MONGO_MAJOR=6.0
-ARG MONGO_VERSION=6.0.5
+ARG MONGO_MAJOR=8.0
+ARG MONGO_VERSION=8.0.29
 ENV NB_USER=${NB_USER} \
     NB_UID=${NB_UID} \
     NB_GID=${NB_GID} \

--- a/docs/source/getting_started/mongodb_6_to_8_migration.rst
+++ b/docs/source/getting_started/mongodb_6_to_8_migration.rst
@@ -1,0 +1,48 @@
+.. _mongodb_6_to_8_migration:
+
+MongoDB 6.0 to 8.0 migration
+================================
+
+MsPASS container images install MongoDB ``8.0.29`` exactly.  MongoDB does not
+support skipping a major release when upgrading persisted data.  A 6.0 data
+directory must therefore pass through 7.0 before an 8.0 binary opens it.
+
+Back up production data and rehearse the migration on disposable data first.
+The repository supplies a standalone rehearsal harness that performs and
+verifies this sequence:
+
+#. MongoDB 6.0.26 with FCV 6.0, followed by a read/write check and clean stop.
+#. Start MongoDB 7.0.29 at FCV 6.0, set FCV 7.0, cleanly restart the same
+   7.0.29 binary, and repeat the check.
+#. Start MongoDB 8.0.29 at FCV 7.0, set FCV 8.0, cleanly restart the same
+   8.0.29 binary, and repeat the check.
+
+Run it with a new, explicitly disposable directory:
+
+.. code-block:: bash
+
+   export MSPASS_MONGO_UPGRADE_ROOT="$(mktemp -d)/mspass-mongo-upgrade"
+   scripts/mongodb_upgrade_6_to_8.sh
+
+The harness refuses an existing directory and broad paths such as ``/`` or a
+home directory.  It writes ``last_completed_stage`` after each verified stage.
+If any command fails, ``set -e`` stops the harness before the next binary or
+FCV is started and leaves the data directory available for inspection.
+**Do not point this rehearsal harness at production data.**
+
+CI also exercises the stop boundary explicitly.  The following command exits
+after the 6.0 verification and must leave ``last_completed_stage`` equal to
+``6.0``:
+
+.. code-block:: bash
+
+   MSPASS_MONGO_UPGRADE_FAIL_AFTER=6.0 \
+     MSPASS_MONGO_UPGRADE_ROOT="$(mktemp -d)/mspass-mongo-upgrade" \
+     scripts/mongodb_upgrade_6_to_8.sh
+
+For a production migration, take and validate a restorable backup, stop all
+MsPASS writers, and follow the same major-version/FCV sequence using the
+deployment's supported backup, rolling-upgrade, monitoring, and rollback
+procedures.  Never start the next major binary until the current binary has
+restarted at its target FCV, its read/write validation has succeeded, and the
+current stage has stopped cleanly.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,6 +61,7 @@ Choose your path
    Multi-container Docker Compose deployment <getting_started/deploy_mspass_with_docker_compose>
    Conda installation <getting_started/deploy_mspass_with_conda>
    Advanced setup considerations <getting_started/advanced_setup_considerations>
+   MongoDB 6.0 to 8.0 migration <getting_started/mongodb_6_to_8_migration>
 
 .. toctree::
    :maxdepth: 1

--- a/python/tests/test_mongodb_upgrade_contract.py
+++ b/python/tests/test_mongodb_upgrade_contract.py
@@ -1,0 +1,279 @@
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(
+    os.environ.get("MSPASS_TEST_SOURCE_ROOT", Path(__file__).resolve().parents[2])
+).resolve()
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+MIGRATION_SCRIPT = REPO_ROOT / "scripts" / "mongodb_upgrade_6_to_8.sh"
+MIGRATION_DOC = (
+    REPO_ROOT / "docs" / "source" / "getting_started" / "mongodb_6_to_8_migration.rst"
+)
+RUNTIME_TEST_SCRIPT = REPO_ROOT / "scripts" / "test_mongodb_8029_containers.sh"
+RUNTIME_VERIFIER = REPO_ROOT / "scripts" / "verify_mongodb_runtime.py"
+
+
+def test_all_ubuntu_2204_image_paths_pin_mongodb_8029():
+    dockerfile = DOCKERFILE.read_text()
+    package_suffixes = ("", "-server", "-shell", "-mongos", "-tools")
+
+    assert dockerfile.count("MONGO_MAJOR=8.0") == 2
+    assert dockerfile.count("MONGO_VERSION=8.0.29") == 2
+    assert "MONGO_MAJOR=6.0" not in dockerfile
+    assert "MONGO_VERSION=6.0.5" not in dockerfile
+    for suffix in package_suffixes:
+        assert dockerfile.count(f"${{MONGO_PACKAGE}}{suffix}=$MONGO_VERSION") == 1
+        assert dockerfile.count(f"mongodb-org{suffix}=${{MONGO_VERSION}}") == 1
+    assert dockerfile.count("server-${MONGO_MAJOR}.asc") == 2
+    assert dockerfile.count("arch=$(dpkg --print-architecture)") == 2
+    assert "jammy/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR" in dockerfile
+    assert "jammy/mongodb-org/${MONGO_MAJOR}" in dockerfile
+
+
+def test_migration_harness_has_one_fixed_order_and_stop_boundary():
+    source = MIGRATION_SCRIPT.read_text()
+    starts = re.findall(
+        r'^start_stage "\$MONGO_([678])_IMAGE" ([678]\.0)$', source, re.M
+    )
+    assert starts == [
+        ("6", "6.0"),
+        ("7", "7.0"),
+        ("7", "7.0"),
+        ("8", "8.0"),
+        ("8", "8.0"),
+    ]
+    assert source.index("set_fcv 6.0") < source.index('start_stage "$MONGO_7_IMAGE"')
+    assert source.index("set_fcv 7.0") < source.index('start_stage "$MONGO_8_IMAGE"')
+    assert source.index(
+        "assert_fcv 6.0", source.index('start_stage "$MONGO_7_IMAGE"')
+    ) < source.index("set_fcv 7.0")
+    assert source.index(
+        "assert_fcv 7.0", source.index('start_stage "$MONGO_8_IMAGE"')
+    ) < source.index("set_fcv 8.0")
+    assert source.index("fail_if_requested 6.0") < source.index(
+        'start_stage "$MONGO_7_IMAGE"'
+    )
+    assert source.index("fail_if_requested 7.0") < source.index(
+        'start_stage "$MONGO_8_IMAGE"'
+    )
+    assert "stop_stage\nfail_if_requested 6.0" in source
+    assert "stop_stage\nfail_if_requested 7.0" in source
+    assert 'if docker inspect "$container_name"' in source
+    assert "stop_stage || true" in source
+    assert "mongo:8.0.29" in source
+    assert "confirm:true" in source
+    assert 'if [[ "$target" == "6.0" ]]' in source
+    assert re.findall(r"^assert_binary_version (\S+)$", source, re.M) == [
+        "6.0.26",
+        "7.0.29",
+        "7.0.29",
+        "8.0.29",
+        "8.0.29",
+    ]
+    assert source.count('start_stage "$MONGO_7_IMAGE" 7.0') == 2
+    assert source.count('start_stage "$MONGO_8_IMAGE" 8.0') == 2
+    assert "trap cleanup EXIT" in source
+    assert "trap 'exit 130' INT" in source
+    assert "trap 'exit 143' TERM" in source
+
+
+def test_migration_harness_stops_at_forced_boundaries_and_restarts(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_log = tmp_path / "docker.log"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf \'%s\\n\' "$*" >> "$DOCKER_LOG"\n'
+        'if [[ "$1" == inspect ]]; then exit 1; fi\n'
+    )
+    fake_docker.chmod(0o755)
+    base_env = os.environ | {
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "DOCKER_LOG": str(docker_log),
+    }
+
+    def run_case(name, fail_after, expected_status, expected_images, marker):
+        docker_log.unlink(missing_ok=True)
+        root = tmp_path / name
+        completed = subprocess.run(
+            [str(MIGRATION_SCRIPT)],
+            env=base_env
+            | {
+                "MSPASS_MONGO_UPGRADE_ROOT": str(root),
+                "MSPASS_MONGO_UPGRADE_FAIL_AFTER": fail_after,
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == expected_status
+        run_lines = [
+            line
+            for line in docker_log.read_text().splitlines()
+            if line.startswith("run ")
+        ]
+        images = [
+            next(part for part in line.split() if part.startswith("mongo:"))
+            for line in run_lines
+        ]
+        assert images == expected_images
+        stage_events = [
+            (
+                "run"
+                if line.startswith("run ")
+                else "stop" if "shutdownServer()" in line else None
+            )
+            for line in docker_log.read_text().splitlines()
+        ]
+        assert [event for event in stage_events if event] == [
+            event for _ in expected_images for event in ("run", "stop")
+        ]
+        assert (root / "last_completed_stage").read_text().strip() == marker
+
+    run_case("fail6", "6.0", 70, ["mongo:6.0.26-jammy"], "6.0")
+    run_case(
+        "fail7",
+        "7.0",
+        70,
+        ["mongo:6.0.26-jammy", "mongo:7.0.29-jammy", "mongo:7.0.29-jammy"],
+        "7.0",
+    )
+    run_case(
+        "complete",
+        "",
+        0,
+        [
+            "mongo:6.0.26-jammy",
+            "mongo:7.0.29-jammy",
+            "mongo:7.0.29-jammy",
+            "mongo:8.0.29",
+            "mongo:8.0.29",
+        ],
+        "8.0",
+    )
+
+
+def test_migration_harness_validates_before_using_docker(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_log = tmp_path / "docker.log"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$DOCKER_LOG"\n'
+    )
+    fake_docker.chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "DOCKER_LOG": str(docker_log),
+    }
+
+    missing = subprocess.run(
+        [str(MIGRATION_SCRIPT)], env=env, capture_output=True, text=True
+    )
+    assert missing.returncode == 2
+    assert "must name a disposable directory" in missing.stderr
+    assert not docker_log.exists()
+
+    existing_root = tmp_path / "existing"
+    existing_root.mkdir()
+    existing = subprocess.run(
+        [str(MIGRATION_SCRIPT)],
+        env=env | {"MSPASS_MONGO_UPGRADE_ROOT": str(existing_root)},
+        capture_output=True,
+        text=True,
+    )
+    assert existing.returncode == 2
+    assert "already exists" in existing.stderr
+    assert not docker_log.exists()
+
+
+def test_migration_documentation_names_every_required_gate():
+    documentation = MIGRATION_DOC.read_text()
+    for token in (
+        "MongoDB 6.0.26 with FCV 6.0",
+        "Start MongoDB 7.0.29 at FCV 6.0",
+        "Start MongoDB 8.0.29 at FCV 7.0",
+        "cleanly restart the same",
+        "current stage has stopped cleanly",
+        "last_completed_stage",
+        "Do not point this rehearsal harness at production data",
+    ):
+        assert token in documentation
+
+
+def test_runtime_container_contract_covers_standalone_sharded_and_mspass_paths():
+    source = RUNTIME_TEST_SCRIPT.read_text()
+    assert "MSPASS_MONGODB_TEST_IMAGE is required" in source
+    assert "MSPASS_ROLE=db" in source
+    assert "docker-compose_sharding.yaml" in source
+    assert "up --detach --wait mspass-dbmanager" in source
+    assert source.count("verify_mongodb_runtime.py") >= 4
+    assert "mspass/mspass:latest" not in source
+    assert "compose.override.yaml" in source
+    assert 'docker image rm "$test_image"' in source
+    assert 'docker volume rm "$standalone_volume"' in source
+    assert source.count("mongodb_contract_") >= 6
+
+    verifier = RUNTIME_VERIFIER.read_text()
+    for token in (
+        'server_version != "8.0.29"',
+        "uuid.uuid4().hex",
+        'create_index("value", unique=True)',
+        'delete_one({"_id": "record"})',
+        "gridfs.GridFS(database)",
+        "database.save_data(",
+        "database.read_data(",
+        "HistoryLogger(database",
+    ):
+        assert token in verifier
+
+
+def test_sharded_compose_fixture_remains_parseable():
+    fixture = REPO_ROOT / "data" / "yaml" / "docker-compose_sharding.yaml"
+    parsed = yaml.safe_load(fixture.read_text())
+    assert {"mspass-dbmanager", "mspass-shard-0", "mspass-shard-1"} <= set(
+        parsed["services"]
+    )
+
+
+def test_docker_workflow_runs_migration_and_built_image_integrations():
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "docker-publish.yml"
+    workflow = yaml.safe_load(workflow_path.read_text())
+
+    migration_steps = workflow["jobs"]["mongodb-migration"]["steps"]
+    migration_commands = [step.get("run", "") for step in migration_steps]
+    assert any(
+        "pytest python/tests/test_mongodb_upgrade_contract.py" in command
+        for command in migration_commands
+    )
+    assert any(
+        "scripts/mongodb_upgrade_6_to_8.sh" in command
+        and "MSPASS_MONGO_UPGRADE_FAIL_AFTER" in command
+        and 'test "$status" -eq 70' in command
+        and 'test "$status" -eq 0' in command
+        for command in migration_commands
+    )
+    assert workflow["jobs"]["download-spark"]["needs"] == "mongodb-migration"
+
+    runtime_steps = workflow["jobs"]["build-latest"]["steps"]
+    build_step = next(
+        step
+        for step in runtime_steps
+        if step["name"] == "Build Docker image (amd64 only)"
+    )
+    assert build_step["with"]["load"] is True
+    assert "mspass/mspass:mongodb-contract" in build_step["with"]["tags"]
+    integration_step = next(
+        step
+        for step in runtime_steps
+        if step["name"] == "Test standalone and sharded MongoDB 8.0.29"
+    )
+    assert integration_step["run"] == "scripts/test_mongodb_8029_containers.sh"
+    assert (
+        integration_step["env"]["MSPASS_MONGODB_TEST_IMAGE"]
+        == "mspass/mspass:mongodb-contract"
+    )

--- a/scripts/mongodb_upgrade_6_to_8.sh
+++ b/scripts/mongodb_upgrade_6_to_8.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+MONGO_6_IMAGE=${MONGO_6_IMAGE:-mongo:6.0.26-jammy}
+MONGO_7_IMAGE=${MONGO_7_IMAGE:-mongo:7.0.29-jammy}
+MONGO_8_IMAGE=${MONGO_8_IMAGE:-mongo:8.0.29}
+MSPASS_MONGO_UPGRADE_PORT=${MSPASS_MONGO_UPGRADE_PORT:-27029}
+MSPASS_MONGO_UPGRADE_ROOT=${MSPASS_MONGO_UPGRADE_ROOT:-}
+MSPASS_MONGO_UPGRADE_FAIL_AFTER=${MSPASS_MONGO_UPGRADE_FAIL_AFTER:-}
+
+if [[ -z "$MSPASS_MONGO_UPGRADE_ROOT" ]]; then
+    echo "MSPASS_MONGO_UPGRADE_ROOT must name a disposable directory" >&2
+    exit 2
+fi
+
+case "$MSPASS_MONGO_UPGRADE_FAIL_AFTER" in
+    ""|6.0|7.0) ;;
+    *)
+        echo "MSPASS_MONGO_UPGRADE_FAIL_AFTER must be empty, 6.0, or 7.0" >&2
+        exit 2
+        ;;
+esac
+
+case "$MSPASS_MONGO_UPGRADE_ROOT" in
+    /|/home|/root|"$HOME")
+        echo "refusing unsafe MSPASS_MONGO_UPGRADE_ROOT=$MSPASS_MONGO_UPGRADE_ROOT" >&2
+        exit 2
+        ;;
+esac
+
+if [[ -e "$MSPASS_MONGO_UPGRADE_ROOT" ]]; then
+    echo "MSPASS_MONGO_UPGRADE_ROOT already exists; use a fresh disposable path" >&2
+    exit 2
+fi
+
+command -v docker >/dev/null
+mkdir -p "$MSPASS_MONGO_UPGRADE_ROOT/db"
+
+container_name="mspass-mongodb-upgrade-$$"
+current_stage=""
+
+cleanup() {
+    if docker inspect "$container_name" >/dev/null 2>&1; then
+        stop_stage || true
+    fi
+    docker rm -f "$container_name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+wait_for_mongo() {
+    local attempts=60
+    while ((attempts > 0)); do
+        if docker exec "$container_name" mongosh --quiet --eval \
+            'quit(db.adminCommand({ping: 1}).ok === 1 ? 0 : 1)' >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+        ((attempts--))
+    done
+    echo "MongoDB ${current_stage} did not become ready" >&2
+    return 1
+}
+
+start_stage() {
+    local image=$1
+    current_stage=$2
+    docker run --detach --rm \
+        --name "$container_name" \
+        --publish "127.0.0.1:${MSPASS_MONGO_UPGRADE_PORT}:27017" \
+        --volume "$MSPASS_MONGO_UPGRADE_ROOT/db:/data/db" \
+        "$image" --bind_ip_all >/dev/null
+    wait_for_mongo
+}
+
+stop_stage() {
+    docker exec "$container_name" mongosh --quiet --eval \
+        'db.getSiblingDB("admin").shutdownServer()' >/dev/null 2>&1 || true
+    for _ in {1..30}; do
+        if ! docker inspect "$container_name" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "MongoDB ${current_stage} did not stop cleanly" >&2
+    return 1
+}
+
+assert_binary_version() {
+    local expected=$1
+    docker exec "$container_name" mongosh --quiet --eval \
+        "const v=db.version(); if (v !== '${expected}') throw new Error('expected MongoDB ${expected}, got '+v)"
+}
+
+assert_fcv() {
+    local expected=$1
+    docker exec "$container_name" mongosh --quiet --eval \
+        "const v=db.adminCommand({getParameter:1,featureCompatibilityVersion:1}).featureCompatibilityVersion.version; if (v !== '${expected}') throw new Error('expected FCV ${expected}, got '+v)"
+}
+
+set_fcv() {
+    local target=$1
+    if [[ "$target" == "6.0" ]]; then
+        docker exec "$container_name" mongosh --quiet --eval \
+            "const r=db.adminCommand({setFeatureCompatibilityVersion:'${target}'}); if (r.ok !== 1) throw new Error(JSON.stringify(r))"
+    else
+        docker exec "$container_name" mongosh --quiet --eval \
+            "const r=db.adminCommand({setFeatureCompatibilityVersion:'${target}',confirm:true}); if (r.ok !== 1) throw new Error(JSON.stringify(r))"
+    fi
+}
+
+verify_read_write() {
+    local stage=$1
+    docker exec "$container_name" mongosh --quiet --eval \
+        "const c=db.getSiblingDB('mspass_upgrade_fixture').state; c.updateOne({_id:'${stage}'},{\$set:{stage:'${stage}',verified:true}},{upsert:true}); if (c.countDocuments({verified:true}) !== $(case "$stage" in 6.0) echo 1;; 7.0) echo 2;; 8.0) echo 3;; esac)) throw new Error('read/write verification failed at ${stage}')"
+}
+
+fail_if_requested() {
+    local stage=$1
+    if [[ "$MSPASS_MONGO_UPGRADE_FAIL_AFTER" == "$stage" ]]; then
+        printf '%s\n' "$stage" > "$MSPASS_MONGO_UPGRADE_ROOT/last_completed_stage"
+        echo "forced failure after MongoDB ${stage}; no later binary or FCV was started" >&2
+        exit 70
+    fi
+}
+
+start_stage "$MONGO_6_IMAGE" 6.0
+assert_binary_version 6.0.26
+set_fcv 6.0
+assert_fcv 6.0
+verify_read_write 6.0
+printf '%s\n' 6.0 > "$MSPASS_MONGO_UPGRADE_ROOT/last_completed_stage"
+stop_stage
+fail_if_requested 6.0
+
+start_stage "$MONGO_7_IMAGE" 7.0
+assert_binary_version 7.0.29
+assert_fcv 6.0
+set_fcv 7.0
+stop_stage
+start_stage "$MONGO_7_IMAGE" 7.0
+assert_binary_version 7.0.29
+assert_fcv 7.0
+verify_read_write 7.0
+printf '%s\n' 7.0 > "$MSPASS_MONGO_UPGRADE_ROOT/last_completed_stage"
+stop_stage
+fail_if_requested 7.0
+
+start_stage "$MONGO_8_IMAGE" 8.0
+assert_binary_version 8.0.29
+assert_fcv 7.0
+set_fcv 8.0
+stop_stage
+start_stage "$MONGO_8_IMAGE" 8.0
+assert_binary_version 8.0.29
+assert_fcv 8.0
+verify_read_write 8.0
+printf '%s\n' 8.0 > "$MSPASS_MONGO_UPGRADE_ROOT/last_completed_stage"
+stop_stage
+
+echo "MongoDB migration fixture completed: 6.0/FCV6 -> 7.0/FCV7 -> 8.0.29/FCV8"

--- a/scripts/test_mongodb_8029_containers.sh
+++ b/scripts/test_mongodb_8029_containers.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+MSPASS_MONGODB_TEST_IMAGE=${MSPASS_MONGODB_TEST_IMAGE:-}
+if [[ -z "$MSPASS_MONGODB_TEST_IMAGE" ]]; then
+    echo "MSPASS_MONGODB_TEST_IMAGE is required" >&2
+    exit 2
+fi
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+standalone_name="mspass-mongodb-8029-standalone-$$"
+standalone_volume="${standalone_name}-home"
+compose_project="mspass-mongodb-8029-sharded-$$"
+fixture_root=$(mktemp -d)
+compose_override="$fixture_root/compose.override.yaml"
+test_image="mspass/mspass:mongodb-8029-contract-$$"
+
+cleanup() {
+    docker rm -f "$standalone_name" >/dev/null 2>&1 || true
+    docker volume rm "$standalone_volume" >/dev/null 2>&1 || true
+    if [[ -f "$compose_override" ]]; then
+        docker compose \
+            --project-name "$compose_project" \
+            --file "$repository_root/data/yaml/docker-compose_sharding.yaml" \
+            --file "$compose_override" \
+            down --volumes --remove-orphans >/dev/null 2>&1 || true
+    fi
+    docker image rm "$test_image" >/dev/null 2>&1 || true
+    rm -rf "$fixture_root" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+wait_for_ping() {
+    local container=$1
+    local attempts=120
+    while ((attempts > 0)); do
+        if docker exec "$container" mongosh --quiet --eval \
+            'quit(db.adminCommand({ping:1}).ok === 1 ? 0 : 1)' >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+        ((attempts--))
+    done
+    echo "MongoDB did not become ready in $container" >&2
+    return 1
+}
+
+docker volume create "$standalone_volume" >/dev/null
+docker run --detach --rm \
+    --name "$standalone_name" \
+    --volume "$standalone_volume:/home" \
+    --env MSPASS_ROLE=db \
+    --env MSPASS_SLEEP_TIME=1 \
+    "$MSPASS_MONGODB_TEST_IMAGE" >/dev/null
+wait_for_ping "$standalone_name"
+docker cp "$repository_root/scripts/verify_mongodb_runtime.py" \
+    "$standalone_name:/tmp/verify_mongodb_runtime.py"
+docker exec "$standalone_name" \
+    python /tmp/verify_mongodb_runtime.py mongodb://127.0.0.1:27017
+docker rm -f "$standalone_name" >/dev/null
+
+# Give the image under test a process-unique tag and override only the three
+# database services used by this contract.
+docker tag "$MSPASS_MONGODB_TEST_IMAGE" "$test_image"
+cat > "$compose_override" <<EOF
+services:
+  mspass-dbmanager:
+    image: $test_image
+    volumes:
+      - mongodb_contract_dbmanager:/home
+    environment:
+      MSPASS_SLEEP_TIME: "1"
+  mspass-shard-0:
+    image: $test_image
+    volumes:
+      - mongodb_contract_shard0:/home
+    environment:
+      MSPASS_SLEEP_TIME: "1"
+  mspass-shard-1:
+    image: $test_image
+    volumes:
+      - mongodb_contract_shard1:/home
+    environment:
+      MSPASS_SLEEP_TIME: "1"
+volumes:
+  mongodb_contract_dbmanager:
+  mongodb_contract_shard0:
+  mongodb_contract_shard1:
+EOF
+(
+    cd "$fixture_root"
+    docker compose \
+        --project-name "$compose_project" \
+        --file "$repository_root/data/yaml/docker-compose_sharding.yaml" \
+        --file "$compose_override" \
+        up --detach --wait mspass-dbmanager
+)
+dbmanager_id=$(docker compose \
+    --project-name "$compose_project" \
+    --file "$repository_root/data/yaml/docker-compose_sharding.yaml" \
+    --file "$compose_override" \
+    ps --quiet mspass-dbmanager)
+if [[ -z "$dbmanager_id" ]]; then
+    echo "sharded MongoDB dbmanager did not start" >&2
+    exit 1
+fi
+docker cp "$repository_root/scripts/verify_mongodb_runtime.py" \
+    "$dbmanager_id:/tmp/verify_mongodb_runtime.py"
+docker exec "$dbmanager_id" \
+    python /tmp/verify_mongodb_runtime.py mongodb://127.0.0.1:27017

--- a/scripts/verify_mongodb_runtime.py
+++ b/scripts/verify_mongodb_runtime.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import sys
+import uuid
+
+import gridfs
+
+from mspasspy.ccore.seismic import TimeSeries
+from mspasspy.db.client import DBClient
+from mspasspy.db.database import Database
+from mspasspy.history import HistoryLogger
+
+
+def main(uri):
+    client = DBClient(uri, serverSelectionTimeoutMS=10000)
+    server_version = client.server_info()["version"]
+    if server_version != "8.0.29":
+        raise RuntimeError(f"expected MongoDB 8.0.29, got {server_version}")
+
+    database = Database(client, f"mspass_mongodb_8029_contract_{uuid.uuid4().hex}")
+    try:
+        database["crud"].insert_one({"_id": "record", "value": 1})
+        database["crud"].update_one({"_id": "record"}, {"$set": {"value": 2}})
+        if database["crud"].find_one({"_id": "record"})["value"] != 2:
+            raise RuntimeError("MongoDB CRUD verification failed")
+        index_name = database["crud"].create_index("value", unique=True)
+        if index_name not in database["crud"].index_information():
+            raise RuntimeError("MongoDB index verification failed")
+        delete_result = database["crud"].delete_one({"_id": "record"})
+        if (
+            delete_result.deleted_count != 1
+            or database["crud"].find_one({"_id": "record"}) is not None
+        ):
+            raise RuntimeError("MongoDB delete verification failed")
+
+        fs = gridfs.GridFS(database)
+        file_id = fs.put(b"mspass-gridfs-contract")
+        if fs.get(file_id).read() != b"mspass-gridfs-contract":
+            raise RuntimeError("GridFS verification failed")
+
+        waveform = TimeSeries(3)
+        waveform.dt = 0.1
+        waveform.t0 = 0.0
+        waveform.set_live()
+        for sample, value in enumerate((1.0, 2.0, 3.0)):
+            waveform.data[sample] = value
+        saved = database.save_data(
+            waveform,
+            storage_mode="gridfs",
+            mode="promiscuous",
+            return_data=True,
+        )
+        restored = database.read_data(saved["_id"], collection="wf_TimeSeries")
+        if list(restored.data) != [1.0, 2.0, 3.0]:
+            raise RuntimeError("MsPASS waveform round trip failed")
+
+        history = HistoryLogger(database, job=19029)
+        history.register("mongodb_8029_contract", "dict", {"value": 2})
+        history.save()
+        if database.history.find_one({"jobid": history.jobid}) is None:
+            raise RuntimeError("MsPASS history verification failed")
+    finally:
+        client.drop_database(database.name)
+        client.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: verify_mongodb_runtime.py MONGODB_URI")
+    main(sys.argv[1])


### PR DESCRIPTION
## Valid implementation work
- pins available MongoDB 8.0.29 packages for both Ubuntu 22.04 image paths
- provides a disposable 6.0→7.0→8.0 rehearsal with clean restarts and exact FCV checks
- adds image-level standalone and sharded verification gates

## Renewed release review — draft blocker
This PR remains draft.  Moving the shipped database runtime across two major versions is a product/release and persisted-data decision even when the rehearsal is technically sound.  The repository still needs an owner-approved production backup, rollback, outage, compatibility, and support policy; CI against disposable volumes cannot authorize upgrading user data.

The exact package/manifests and migration tests remain useful evidence, but this must not auto-close the Issue or be described as merge-ready until the release owner approves the production migration plan.

Related to #793