### PR TITLE
Apply missed Black formatting from PR 999

### DIFF
--- a/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
+++ b/python/tests/algorithms/test_mcxcor_empty_diagnostics_contract.py
@@ -253,9 +253,7 @@ def test_align_and_stack_regularization_drop_is_logged_once(monkeypatch, capsys)
     ensemble.set_live()
     beam = _live_timeseries([1.0, 2.0, 3.0])
 
-    def forced_regularization_drop(
-        input_ensemble, dt, Nsamp, abort_on_error=False
-    ):
+    def forced_regularization_drop(input_ensemble, dt, Nsamp, abort_on_error=False):
         assert input_ensemble is ensemble
         assert dt == beam.dt
         assert Nsamp == beam.npts


### PR DESCRIPTION
## Summary
- restore the Black-only change generated by #999 after its base PR #985 was merged and the formatter PR was auto-closed
- keep the repair behavior-neutral and limited to one test function signature

## Audit of related formatter PRs
- #966, #970, and #998: their formatter output is already present in `master`
- #974: targets the still-open feature PR #973 and will be applied there instead of `master`
- #999: this PR carries its exact file result (matching blob hash)

## Verification
- formatted file blob exactly matches #999 (`0c22bcb31f49cd74b92d15f70e4fba520fb1434e`)
- `python3 -m py_compile` passed
- `git diff --check` passed

Supersedes the formatting content of #999.