### PR TITLE
Delay history reset until waveform commit

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3169,6 +3169,11 @@ class Database(pymongo.database.Database):
         # only for usage errors.   We test the elog size to check if there
         # are other warning messages and add a summary if there were any
         logsize0 = mspass_object.elog.size()
+        old_gridfs_id = (
+            mspass_object["gridfs_id"] if "gridfs_id" in mspass_object else None
+        )
+        if old_gridfs_id is not None:
+            mspass_object.erase("gridfs_id")
         try:
             self.update_metadata(
                 mspass_object,
@@ -3179,8 +3184,9 @@ class Database(pymongo.database.Database):
                 normalizing_collections=normalizing_collections,
                 alg_name=alg_name,
             )
-        except:
-            raise
+        finally:
+            if old_gridfs_id is not None:
+                mspass_object["gridfs_id"] = old_gridfs_id
         logsize = mspass_object.elog.size()
         # A bit verbose, but we post this warning to make it clear the
         # problem originated from update_data - probably not really needed
@@ -3227,69 +3233,90 @@ class Database(pymongo.database.Database):
                 )
                 mspass_object["storage_mode"] = "gridfs"
                 update_record["storage_mode"] = "gridfs"
-            # This logic overwrites the content if the magic key
-            # "gridfs_id" exists in the input. In both cases gridfs_id is set
-            # in returned
-            if "gridfs_id" in mspass_object:
+            # Supplying the replacement id lets rollback remove a blob even
+            # when GridFS writes it and then raises an exception.
+            staged_gridfs_id = ObjectId() if old_gridfs_id is not None else None
+            try:
                 mspass_object = self._save_sample_data_to_gridfs(
                     mspass_object,
-                    overwrite=True,
+                    overwrite=False,
+                    gridfs_id=staged_gridfs_id,
                 )
-            else:
-                mspass_object = self._save_sample_data_to_gridfs(
-                    mspass_object, overwrite=False
-                )
+                new_gridfs_id = mspass_object["gridfs_id"]
+                update_record["gridfs_id"] = new_gridfs_id
 
-            # There is a possible efficiency gain right here.  Not sure if
-            # gridfs_id is altered when the sample data are updated in place.
-            # if we can be sure the returned gridfs_id is the same as theresult
-            # input in that case, we would omit gridfs_id from the update
-            # record and most data would not require the final update
-            # transaction below
-            update_record["gridfs_id"] = mspass_object["gridfs_id"]
-            # should define wf_collection here because if the mspass_object is dead
-            if collection:
-                wf_collection_name = collection
-            else:
-                # This returns a string that is the collection name for this atomic data type
-                # A weird construct
-                wf_collection_name = save_schema.collection("_id")
-            wf_collection = self[wf_collection_name]
-
-            elog_id = None
-            if mspass_object.elog.size() > 0:
-                elog_id_name = self.database_schema.default_name("elog") + "_id"
-                # FIXME I think here we should check if elog_id field exists in the mspass_object
-                # and we should update the elog entry if mspass_object already had one
-                if elog_id_name in mspass_object:
-                    old_elog_id = mspass_object[elog_id_name]
+                # should define wf_collection here because if the mspass_object is dead
+                if collection:
+                    wf_collection_name = collection
                 else:
-                    old_elog_id = None
-                # elog ids will be updated in the wf col when saving metadata
-                elog_id = self._save_elog(
-                    mspass_object, elog_id=old_elog_id, data_tag=data_tag
-                )
-                update_record[elog_id_name] = elog_id
+                    # This returns a string that is the collection name for this atomic data type
+                    # A weird construct
+                    wf_collection_name = save_schema.collection("_id")
+                wf_collection = self[wf_collection_name]
 
-                # update elog collection
-                # we have to do the xref to wf collection like this too
-                elog_col = self[self.database_schema.default_name("elog")]
-                wf_id_name = wf_collection_name + "_id"
-                filter_ = {"_id": elog_id}
-                elog_col.update_one(
-                    filter_, {"$set": {wf_id_name: mspass_object["_id"]}}
-                )
-            # finally we need to update the wf document if we set anything
-            # in update_record
-            if len(update_record):
+                elog_id = None
+                if mspass_object.elog.size() > 0:
+                    elog_id_name = self.database_schema.default_name("elog") + "_id"
+                    # FIXME I think here we should check if elog_id field exists in the mspass_object
+                    # and we should update the elog entry if mspass_object already had one
+                    if elog_id_name in mspass_object:
+                        old_elog_id = mspass_object[elog_id_name]
+                    else:
+                        old_elog_id = None
+                    # elog ids will be updated in the wf col when saving metadata
+                    elog_id = self._save_elog(
+                        mspass_object, elog_id=old_elog_id, data_tag=data_tag
+                    )
+                    update_record[elog_id_name] = elog_id
+
+                    # update elog collection
+                    # we have to do the xref to wf collection like this too
+                    elog_col = self[self.database_schema.default_name("elog")]
+                    wf_id_name = wf_collection_name + "_id"
+                    filter_ = {"_id": elog_id}
+                    elog_col.update_one(
+                        filter_, {"$set": {wf_id_name: mspass_object["_id"]}}
+                    )
+
                 filter_ = {"_id": mspass_object["_id"]}
-                wf_collection.update_one(filter_, {"$set": update_record})
-                # we may probably set the elog_id field in the mspass_object
-                if elog_id:
-                    mspass_object[elog_id_name] = elog_id
-                # we may probably set the history_object_id field in the mspass_object
-                if history_object_id:
-                    mspass_object[history_obj_id_name] = history_object_id
+                if old_gridfs_id is not None:
+                    filter_["gridfs_id"] = old_gridfs_id
+                result = wf_collection.update_one(filter_, {"$set": update_record})
+                if old_gridfs_id is not None and result.matched_count != 1:
+                    raise MsPASSError(
+                        "Database.update_data could not replace the expected "
+                        "GridFS reference",
+                        ErrorSeverity.Invalid,
+                    )
+            except BaseException as original_error:
+                if old_gridfs_id is not None:
+                    try:
+                        gfsh = gridfs.GridFS(self)
+                        if gfsh.exists(staged_gridfs_id):
+                            gfsh.delete(staged_gridfs_id)
+                    except Exception as cleanup_error:
+                        raise original_error from cleanup_error
+                    finally:
+                        mspass_object["gridfs_id"] = old_gridfs_id
+                raise
+            # we may probably set the elog_id field in the mspass_object
+            if elog_id:
+                mspass_object[elog_id_name] = elog_id
+            # we may probably set the history_object_id field in the mspass_object
+            if history_object_id:
+                mspass_object[history_obj_id_name] = history_object_id
+            if old_gridfs_id is not None:
+                try:
+                    gfsh = gridfs.GridFS(self)
+                    if gfsh.exists(old_gridfs_id):
+                        gfsh.delete(old_gridfs_id)
+                except Exception as error:
+                    mspass_object.elog.log_error(
+                        alg_name,
+                        "GridFS replacement was committed, but the previous "
+                        f"sample object could not be deleted: {error}",
+                        ErrorSeverity.Complaint,
+                    )
         else:
             # Dead data land here
             elog_id_name = self.database_schema.default_name("elog") + "_id"
@@ -6750,6 +6777,7 @@ class Database(pymongo.database.Database):
         self,
         mspass_object,
         overwrite=False,
+        gridfs_id=None,
     ):
         """
         Saves the sample data array for a mspass seismic data object using
@@ -6776,6 +6804,10 @@ class Database(pymongo.database.Database):
           set of documents will be created to hold the data in the gridfs
           system.  Default is False.
 
+        :param gridfs_id: optional id to assign to the newly written GridFS
+          object.  Used by update_data so a failed staged write can be rolled
+          back even if GridFS raises after creating the object.
+
         :return: edited version of input (mspass_object).  Return changed
           only by adding metadata attributes "storage_mode" and "gridfs_id"
         """
@@ -6785,12 +6817,15 @@ class Database(pymongo.database.Database):
 
         if isinstance(mspass_object, (TimeSeries, Seismogram)):
             if overwrite and mspass_object.is_defined("gridfs_id"):
-                gridfs_id = mspass_object["gridfs_id"]
-                if gfsh.exists(gridfs_id):
-                    gfsh.delete(gridfs_id)
+                old_gridfs_id = mspass_object["gridfs_id"]
+                if gfsh.exists(old_gridfs_id):
+                    gfsh.delete(old_gridfs_id)
             # verdion 2 had a transpose here that seemed unncessary
             ub = bytes(np.array(mspass_object.data))
-            gridfs_id = gfsh.put(ub)
+            if gridfs_id is None:
+                gridfs_id = gfsh.put(ub)
+            else:
+                gridfs_id = gfsh.put(ub, _id=gridfs_id)
             mspass_object["gridfs_id"] = gridfs_id
             mspass_object["storage_mode"] = "gridfs"
         elif isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1669,6 +1669,26 @@ class Database(pymongo.database.Database):
                 # only atomic data can land here
                 mspass_object["storage_mode"] = storage_mode
 
+            atomic_data = (
+                [mspass_object]
+                if isinstance(mspass_object, (TimeSeries, Seismogram))
+                else mspass_object.member
+            )
+            for datum in atomic_data:
+                if datum.live:
+                    self._sync_metadata_before_update(datum)
+                    _, metadata_is_valid, _ = md2doc(
+                        datum,
+                        save_schema,
+                        exclude_keys=exclude_keys,
+                        mode=mode,
+                        normalizing_collections=normalizing_collections,
+                    )
+                    if not metadata_is_valid:
+                        datum.kill()
+
+            # Complete schema validation before creating sample data.
+
             # Extend this method to add new storge modes
             # Note this implementation alters metadata in mspass_object
             # and all members of ensembles
@@ -3293,8 +3313,15 @@ class Database(pymongo.database.Database):
             self.database_schema.default_name("history_object") + "_id"
         )
         history_object_id = None
+        history_save_uuid = None
         if save_history and not mspass_object.is_empty():
-            history_object_id = self._save_history(mspass_object, alg_name, alg_id)
+            history_save_uuid = ProcessingHistory(mspass_object).id()
+            history_object_id = self._save_history(
+                mspass_object,
+                alg_name,
+                alg_id,
+                reset_history=not mspass_object.live,
+            )
             update_record[history_obj_id_name] = history_object_id
 
         # Now handle update of sample data.  The gridfs method used here
@@ -3322,6 +3349,10 @@ class Database(pymongo.database.Database):
             # Supplying the replacement id lets rollback remove a blob even
             # when GridFS writes it and then raises an exception.
             staged_gridfs_id = ObjectId() if old_gridfs_id is not None else None
+            new_gridfs_id = None
+            elog_id = None
+            old_elog_id = None
+            created_elog_id = None
             try:
                 mspass_object = self._save_sample_data_to_gridfs(
                     mspass_object,
@@ -3339,20 +3370,33 @@ class Database(pymongo.database.Database):
                     # A weird construct
                     wf_collection_name = save_schema.collection("_id")
                 wf_collection = self[wf_collection_name]
+                if history_object_id is not None:
+                    wf_id_name = wf_collection_name + "_id"
+                    history_result = self[
+                        self.database_schema.default_name("history_object")
+                    ].update_one(
+                        {"_id": history_object_id},
+                        {"$set": {wf_id_name: mspass_object["_id"]}},
+                    )
+                    if history_result.matched_count != 1:
+                        raise MsPASSError(
+                            "Database.update_data could not link the saved history "
+                            "to the waveform",
+                            ErrorSeverity.Invalid,
+                        )
 
-                elog_id = None
                 if mspass_object.elog.size() > 0:
                     elog_id_name = self.database_schema.default_name("elog") + "_id"
                     # FIXME I think here we should check if elog_id field exists in the mspass_object
                     # and we should update the elog entry if mspass_object already had one
                     if elog_id_name in mspass_object:
                         old_elog_id = mspass_object[elog_id_name]
-                    else:
-                        old_elog_id = None
                     # elog ids will be updated in the wf col when saving metadata
                     elog_id = self._save_elog(
                         mspass_object, elog_id=old_elog_id, data_tag=data_tag
                     )
+                    if old_elog_id is None:
+                        created_elog_id = elog_id
                     update_record[elog_id_name] = elog_id
 
                     # update elog collection
@@ -3375,15 +3419,27 @@ class Database(pymongo.database.Database):
                         ErrorSeverity.Invalid,
                     )
             except Exception as original_error:
-                if old_gridfs_id is not None:
-                    try:
+                try:
+                    gridfs_id_to_remove = staged_gridfs_id or new_gridfs_id
+                    if gridfs_id_to_remove is not None:
                         gfsh = gridfs.GridFS(self)
-                        if gfsh.exists(staged_gridfs_id):
-                            gfsh.delete(staged_gridfs_id)
-                    except Exception as cleanup_error:
-                        raise original_error from cleanup_error
-                    finally:
+                        if gfsh.exists(gridfs_id_to_remove):
+                            gfsh.delete(gridfs_id_to_remove)
+                    if history_object_id is not None:
+                        history_collection = self.database_schema.default_name(
+                            "history_object"
+                        )
+                        self[history_collection].delete_one({"_id": history_object_id})
+                    if created_elog_id is not None:
+                        elog_collection = self.database_schema.default_name("elog")
+                        self[elog_collection].delete_one({"_id": created_elog_id})
+                except Exception as cleanup_error:
+                    raise original_error from cleanup_error
+                finally:
+                    if old_gridfs_id is not None:
                         mspass_object["gridfs_id"] = old_gridfs_id
+                    elif "gridfs_id" in mspass_object:
+                        mspass_object.erase("gridfs_id")
                 raise
             # we may probably set the elog_id field in the mspass_object
             if elog_id:
@@ -3391,6 +3447,10 @@ class Database(pymongo.database.Database):
             # we may probably set the history_object_id field in the mspass_object
             if history_object_id:
                 mspass_object[history_obj_id_name] = history_object_id
+            if history_save_uuid is not None:
+                self._reset_processing_history(
+                    mspass_object, alg_name, alg_id, history_save_uuid
+                )
             if old_gridfs_id is not None:
                 try:
                     gfsh = gridfs.GridFS(self)
@@ -4157,7 +4217,24 @@ class Database(pymongo.database.Database):
             mspass_object["cardinal"] = mspass_object.cardinal()
             mspass_object["orthogonal"] = mspass_object.orthogonal()
 
-    def _save_history(self, mspass_object, alg_name=None, alg_id=None, collection=None):
+    @staticmethod
+    def _reset_processing_history(mspass_object, alg_name, alg_id, save_uuid):
+        atomic_type = (
+            AtomicType.TIMESERIES
+            if isinstance(mspass_object, TimeSeries)
+            else AtomicType.SEISMOGRAM
+        )
+        mspass_object.clear_history()
+        mspass_object.set_as_origin(alg_name, alg_id, str(save_uuid), atomic_type)
+
+    def _save_history(
+        self,
+        mspass_object,
+        alg_name=None,
+        alg_id=None,
+        collection=None,
+        reset_history=True,
+    ):
         """
         Save the processing history of a mspasspy object.
 
@@ -4167,6 +4244,10 @@ class Database(pymongo.database.Database):
         :type prev_history_object_id: :class:`bson.ObjectId.ObjectId`
         :param collection: the collection that you want to store the history object. If not specified, use the defined
           collection in the schema.
+        :param reset_history: reset the caller history after persistence.  Set
+          False only when the caller will reset it after committing its waveform
+          reference.
+        :type reset_history: bool
         :return: current history_object_id.
         """
         if isinstance(mspass_object, TimeSeries):
@@ -4195,11 +4276,10 @@ class Database(pymongo.database.Database):
         current_uuid = insert_dict["save_uuid"]
         history_id = history_col.insert_one(insert_dict).inserted_id
 
-        # clear the history chain of the mspass object
-        mspass_object.clear_history()
-        # set_as_origin with uuid set to the newly generated id
-        # Note we have to convert to a string to match C++ function type
-        mspass_object.set_as_origin(alg_name, alg_id, str(current_uuid), atomic_type)
+        if reset_history:
+            self._reset_processing_history(
+                mspass_object, alg_name, alg_id, current_uuid
+            )
 
         return history_id
 
@@ -6994,69 +7074,92 @@ class Database(pymongo.database.Database):
         else:
             # gridfs default
             insertion_dict["storage_mode"] = "gridfs"
-        # We depend on Undertaker to save history for dead data
+        history_object_id = None
+        history_save_uuid = None
+        history_collection_name = self.database_schema.default_name("history_object")
         if save_history and mspass_object.live:
-            history_obj_id_name = (
-                self.database_schema.default_name("history_object") + "_id"
-            )
-            history_object_id = None
-            # is_empty is a method of ProcessingHistory - mame is generic so possibly confusing
+            history_obj_id_name = history_collection_name + "_id"
             if mspass_object.is_empty():
-                # Use this trick in update_metadata too. None is needed to
-                # avoid a TypeError exception if the name is not defined.
-                # could do this with a conditional as an alternative
                 insertion_dict.pop(history_obj_id_name, None)
             else:
-                # optional history save - only done if history container is not empty
-                # first we need to push the definition of this algorithm
-                # to the chain.  Note it is always defined by the special
-                # save defined with the C++ enum class mapped to python
-                # vi ProcessingStatus
                 if isinstance(mspass_object, TimeSeries):
                     atomic_type = AtomicType.TIMESERIES
                 elif isinstance(mspass_object, Seismogram):
                     atomic_type = AtomicType.SEISMOGRAM
                 else:
                     raise TypeError("only TimeSeries and Seismogram are supported")
-                mspass_object.new_map(
+                history_source = ProcessingHistory(mspass_object)
+                history_source.new_map(
                     alg_name, alg_id, atomic_type, ProcessingStatus.SAVED
                 )
-                history_object_id = self._save_history(mspass_object, alg_name, alg_id)
+                history_save_uuid = history_source.id()
+                history_document = history2doc(
+                    history_source, alg_id=alg_id, alg_name=alg_name
+                )
+                history_object_id = (
+                    self[history_collection_name]
+                    .insert_one(history_document)
+                    .inserted_id
+                )
                 insertion_dict[history_obj_id_name] = history_object_id
-                mspass_object[history_obj_id_name] = history_object_id
-        # save elogs if the size of elog is greater than 0
+
         elog_id = None
+        elog_collection_name = self.database_schema.default_name("elog")
         if mspass_object.elog.size() > 0:
-            elog_id_name = self.database_schema.default_name("elog") + "_id"
-            # elog ids will be updated in the wf col when saving metadata
-            elog_id = self._save_elog(mspass_object, elog_id=None, data_tag=data_tag)
+            elog_id_name = elog_collection_name + "_id"
+            try:
+                elog_id = self._save_elog(
+                    mspass_object, elog_id=None, data_tag=data_tag
+                )
+            except Exception:
+                if history_object_id is not None:
+                    self[history_collection_name].delete_one({"_id": history_object_id})
+                if storage_mode == "gridfs" and "gridfs_id" in mspass_object:
+                    gfsh = gridfs.GridFS(self)
+                    gridfs_id = mspass_object["gridfs_id"]
+                    if gfsh.exists(gridfs_id):
+                        gfsh.delete(gridfs_id)
+                raise
             insertion_dict[elog_id_name] = elog_id
-            mspass_object[elog_id_name] = elog_id
 
-        # finally ready to insert the wf doc - keep the id as we'll need
-        # it for tagging any elog entries.
-        # Note we don't save if something above killed mspass_object.
-        # currently that only happens with errors in md2doc, but if there
-        # are changes use the kill mechanism
         if mspass_object.live:
-            wfid = wf_collection.insert_one(insertion_dict).inserted_id
-
-            # Put wfid into the object's meta as the new definition of
-            # the parent of this waveform
-            mspass_object["_id"] = wfid
-            if save_history and mspass_object.live:
-                # When history is enable we need to do an update to put the
-                # wf collection id as a cross-reference.    Any value stored
-                # above with saave_history may be incorrect.  We use a
-                # stock test with the is_empty method for know if history data is present
-                if not mspass_object.is_empty():
-                    history_object_col = self[
-                        self.database_schema.default_name("history_object")
-                    ]
+            wfid = None
+            try:
+                wfid = wf_collection.insert_one(insertion_dict).inserted_id
+                if history_object_id is not None:
                     wf_id_name = wf_collection.name + "_id"
-                    filter_ = {"_id": history_object_id}
-                    update_dict = {wf_id_name: wfid}
-                    history_object_col.update_one(filter_, {"$set": update_dict})
+                    history_result = self[history_collection_name].update_one(
+                        {"_id": history_object_id},
+                        {"$set": {wf_id_name: wfid}},
+                    )
+                    if history_result.matched_count != 1:
+                        raise MsPASSError(
+                            "Database.save_data could not link the saved history "
+                            "to the waveform",
+                            ErrorSeverity.Invalid,
+                        )
+            except Exception:
+                if wfid is not None:
+                    wf_collection.delete_one({"_id": wfid})
+                if history_object_id is not None:
+                    self[history_collection_name].delete_one({"_id": history_object_id})
+                if elog_id is not None:
+                    self[elog_collection_name].delete_one({"_id": elog_id})
+                if storage_mode == "gridfs" and "gridfs_id" in mspass_object:
+                    gfsh = gridfs.GridFS(self)
+                    gridfs_id = mspass_object["gridfs_id"]
+                    if gfsh.exists(gridfs_id):
+                        gfsh.delete(gridfs_id)
+                raise
+
+            mspass_object["_id"] = wfid
+            if history_object_id is not None:
+                mspass_object[history_obj_id_name] = history_object_id
+                self._reset_processing_history(
+                    mspass_object, alg_name, alg_id, history_save_uuid
+                )
+            if elog_id is not None:
+                mspass_object[elog_id_name] = elog_id
         else:
             mspass_object = self.stedronsky.bury(
                 mspass_object, save_history=save_history

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3374,7 +3374,7 @@ class Database(pymongo.database.Database):
                         "GridFS reference",
                         ErrorSeverity.Invalid,
                     )
-            except BaseException as original_error:
+            except Exception as original_error:
                 if old_gridfs_id is not None:
                     try:
                         gfsh = gridfs.GridFS(self)

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1472,7 +1472,12 @@ class Database(pymongo.database.Database):
           A discussion of format caveats can be found above.
         :type format: :class:`str`
         :param overwrite:  If true gridfs data linked to the original
-          waveform will be replaced by the sample data from this save.
+          waveform will be replaced by the sample data from this save.  A
+          previously saved atomic datum must carry both its waveform ``_id``
+          and ``gridfs_id``; the existing waveform document is updated rather
+          than inserting a second document.  Ensemble members follow the same
+          rule independently.  Objects carrying neither reference are new
+          data and are saved normally.
           Default is false, and should be the normal use.  This option
           should never be used after a reduce operator as the parents
           are not tracked and the space advantage is likely minimal for
@@ -1554,7 +1559,80 @@ class Database(pymongo.database.Database):
             )
             raise MsPASSError(message, "Fatal")
 
-        if mspass_object.live:
+        overwrite_handled = False
+        if overwrite and storage_mode == "gridfs" and mspass_object.live:
+            if isinstance(mspass_object, (TimeSeries, Seismogram)):
+                has_wfid = "_id" in mspass_object
+                has_gridfs_id = "gridfs_id" in mspass_object
+                if has_wfid != has_gridfs_id:
+                    raise ValueError(
+                        "Database.save_data: overwrite=True requires both _id "
+                        "and gridfs_id when either reference is defined"
+                    )
+                if has_wfid:
+                    mspass_object = self.update_data(
+                        mspass_object,
+                        collection=collection,
+                        mode=mode,
+                        exclude_keys=exclude_keys,
+                        data_tag=data_tag,
+                        save_history=save_history,
+                        normalizing_collections=normalizing_collections,
+                        alg_name=alg_name,
+                        alg_id=alg_id,
+                    )
+                    overwrite_handled = True
+            else:
+                live_members = [d for d in mspass_object.member if d.live]
+                for d in live_members:
+                    has_wfid = "_id" in d
+                    has_gridfs_id = "gridfs_id" in d
+                    if has_wfid != has_gridfs_id:
+                        raise ValueError(
+                            "Database.save_data: overwrite=True requires both "
+                            "_id and gridfs_id for every previously saved member"
+                        )
+                if any("_id" in d for d in live_members):
+                    mspass_object, bodies = self.stedronsky.bring_out_your_dead(
+                        mspass_object
+                    )
+                    if not cremate and len(bodies.member) > 0:
+                        self.stedronsky.bury(bodies)
+                    mspass_object.sync_metadata()
+                    for d in mspass_object.member:
+                        if d.live:
+                            if "_id" in d:
+                                d["storage_mode"] = "gridfs"
+                                self.update_data(
+                                    d,
+                                    collection=collection,
+                                    mode=mode,
+                                    exclude_keys=exclude_keys,
+                                    data_tag=data_tag,
+                                    save_history=save_history,
+                                    normalizing_collections=normalizing_collections,
+                                    alg_name=alg_name,
+                                    alg_id=alg_id,
+                                )
+                            else:
+                                self.save_data(
+                                    d,
+                                    return_data=True,
+                                    mode=mode,
+                                    storage_mode="gridfs",
+                                    overwrite=False,
+                                    exclude_keys=exclude_keys,
+                                    collection=collection,
+                                    data_tag=data_tag,
+                                    cremate=cremate,
+                                    save_history=save_history,
+                                    normalizing_collections=normalizing_collections,
+                                    alg_name=alg_name,
+                                    alg_id=alg_id,
+                                )
+                    overwrite_handled = True
+
+        if mspass_object.live and not overwrite_handled:
             # We remove dead bodies from ensembles to simplify saving
             # data below.
             if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
@@ -1635,7 +1713,7 @@ class Database(pymongo.database.Database):
                         alg_name,
                         alg_id,
                     )
-        else:
+        elif not overwrite_handled:
             # may need to clean Metadata before calling this method
             # to assure there are not values that will cause MongoDB
             # to throw an exception when the tombstone subdocument
@@ -3086,6 +3164,7 @@ class Database(pymongo.database.Database):
         normalizing_collections=["channel", "site", "source"],
         alg_id="0",
         alg_name="Database.update_data",
+        save_history=True,
     ):
         """
         Updates both metadata and sample data corresponding to an input data
@@ -3108,11 +3187,13 @@ class Database(pymongo.database.Database):
                this could create a blaat problem with large data sets so
                we do not currently support that type of update.
 
-        A VERY IMPORTANT implicit feature of this method is that
-        if the magic key "gridfs_id" exists the sample data in the
-        input to this method (mspass_object.data) will overwrite any
-        the existing content of gridfs found at the matching id.   This
-        is a somewhat hidden feature so beware.
+        A VERY IMPORTANT feature of this method is that, when the magic
+        key ``gridfs_id`` exists, replacement samples are first written as
+        a new GridFS object.  The waveform document is then changed from the
+        expected old id to the new id with one conditional update.  Only
+        after that reference is durable is the old GridFS object deleted.
+        Consequently, a put or reference-update failure leaves the old
+        waveform readable instead of destroying its only sample copy.
 
         :param mspass_object: the object you want to update.
         :type mspass_object: either :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`
@@ -3149,6 +3230,11 @@ class Database(pymongo.database.Database):
           (e.g. if one added a "shot" collection to the schema the list would need
           to be changed to at least add "shot".)
         :type normalizing_collections: list of strings defining collection names.
+        :param save_history: When True (the default), save a nonempty object
+          history and update its waveform cross-reference.  False suppresses
+          that write.  This option is used by :meth:`save_data` when its
+          documented GridFS overwrite mode updates an existing waveform.
+        :type save_history: :class:`bool`
         :param alg_name: alg_name is the name the func we are gonna save while preserving the history.
           (defaults to 'Database.update_data' and should not normally need to be changed)
         :type alg_name: :class:`str`
@@ -3207,7 +3293,7 @@ class Database(pymongo.database.Database):
             self.database_schema.default_name("history_object") + "_id"
         )
         history_object_id = None
-        if not mspass_object.is_empty():
+        if save_history and not mspass_object.is_empty():
             history_object_id = self._save_history(mspass_object, alg_name, alg_id)
             update_record[history_obj_id_name] = history_object_id
 
@@ -6798,11 +6884,13 @@ class Database(pymongo.database.Database):
         :type mspass_object:  one of TimeSeries, Seismogram,
           TimeSeriesEnsemble, or Seismogram Ensemble.
 
-        :param overwrite:  When set True if there is an existing datum
-          with a matching id for the attribute "gridfs_id", the existing datum
-          will be deleted before the new data is saved.  When False a new
-          set of documents will be created to hold the data in the gridfs
-          system.  Default is False.
+        :param overwrite:  Compatibility flag used by higher-level writers.
+          This low-level method always stages a new GridFS object and never
+          deletes the object named by an existing ``gridfs_id``: it cannot
+          know whether a waveform reference has been committed.  Public
+          atomic overwrite paths perform that conditional reference update
+          and delete the old object afterward.  Direct callers must provide
+          the same ordering if they intend to remove old data.
 
         :param gridfs_id: optional id to assign to the newly written GridFS
           object.  Used by update_data so a failed staged write can be rolled
@@ -6816,10 +6904,6 @@ class Database(pymongo.database.Database):
         gfsh = gridfs.GridFS(self)
 
         if isinstance(mspass_object, (TimeSeries, Seismogram)):
-            if overwrite and mspass_object.is_defined("gridfs_id"):
-                old_gridfs_id = mspass_object["gridfs_id"]
-                if gfsh.exists(old_gridfs_id):
-                    gfsh.delete(old_gridfs_id)
             # verdion 2 had a transpose here that seemed unncessary
             ub = bytes(np.array(mspass_object.data))
             if gridfs_id is None:

--- a/python/mspasspy/io/distributed.py
+++ b/python/mspasspy/io/distributed.py
@@ -1431,16 +1431,12 @@ def write_distributed_data(
         more details on data export.  Used only for "file" storage mode.
     :type file_format: :class:`str`
 
-    :param overwrite:  If true gridfs data linked to the original
-        waveform will be replaced by the sample data from this save.
-        Default is false, and should be the normal use.  This option
-        should never be used after a reduce operator as the parents
-        are not tracked and the space advantage is likely minimal for
-        the confusion it would cause.   This is most useful for light, stable
-        preprocessing with a set of map operators to regularize a data
-        set before more extensive processing.  It can only be used when
-        storage_mode is set to gridfs.
-    :type overwrite:  boolean
+    :param overwrite: Distributed overwrite is not supported because this
+        writer bulk-inserts waveform documents and cannot atomically replace an
+        existing GridFS reference.  Passing ``True`` raises ``ValueError`` before
+        any computation or persistent write.  Use :meth:`Database.save_data` or
+        :meth:`Database.update_data` for failure-safe serial GridFS replacement.
+    :type overwrite: boolean
 
     :param collectiion:   name of wf collection where the documents
         derived from the data are to be saved.  Standard values are
@@ -1550,6 +1546,12 @@ def write_distributed_data(
             "Must be one one of the following:  promiscuous, cautious, or pedantic"
         )
         raise ValueError(message)
+    if overwrite:
+        raise ValueError(
+            "write_distributed_data does not support overwrite=True; "
+            "use Database.save_data or Database.update_data for "
+            "failure-safe GridFS replacement"
+        )
     if scheduler:
         if scheduler not in ["dask", "spark"]:
             message = "write_distributed_data:  Illegal value of scheduler={}\n".format(
@@ -1578,14 +1580,6 @@ def write_distributed_data(
         )
         message += "Currently must be either wf_TimeSeries, wf_Seismogram, or default that implies wf_TimeSeries"
         raise ValueError(message)
-
-    if overwrite:
-        if storage_mode != "gridfs":
-            message = "write_distributed_data:  overwrite mode is set True with storage_mode={}\n".format(
-                storage_mode
-            )
-            message += "overwrite is only allowed with gridfs storage_mode"
-            raise ValueError(message)
 
     stedronsky = Undertaker(db)
     if scheduler == "spark":

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -430,9 +430,14 @@ class TestDatabase:
 
         gfsh = gridfs.GridFS(self.db)
         assert gfsh.exists(gridfs_id)
-        # test overwrite mode
+        # The low-level helper can only stage replacement data.  It cannot
+        # delete the old object before a caller durably switches the waveform
+        # reference.
         self.db._save_sample_data_to_gridfs(tmp_ts, True)
-        assert not gfsh.exists(gridfs_id)
+        new_gridfs_id = tmp_ts["gridfs_id"]
+        assert new_gridfs_id != gridfs_id
+        assert gfsh.exists(gridfs_id)
+        assert gfsh.exists(new_gridfs_id)
 
     def mock_urlopen(*args):
         response = Mock()

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import uuid
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -15,7 +16,14 @@ from mspasspy.ccore.seismic import (
     TimeSeries,
     TimeSeriesEnsemble,
 )
-from mspasspy.ccore.utility import AtomicType, ErrorSeverity, MsPASSError, dmatrix
+from mspasspy.ccore.utility import (
+    AtomicType,
+    ErrorSeverity,
+    MsPASSError,
+    ProcessingHistory,
+    dmatrix,
+)
+import mspasspy.db.database as database_module
 from mspasspy.db.client import DBClient
 from mspasspy.db.collection import Collection
 from mspasspy.db.database import Database
@@ -328,3 +336,131 @@ def test_write_distributed_data_rejects_overwrite_before_execution(storage_mode)
         write_distributed_data(
             None, database, storage_mode=storage_mode, overwrite=True
         )
+
+
+def _history_snapshot(datum):
+    history = ProcessingHistory(datum)
+    return pickle.dumps(
+        (
+            history.get_nodes(),
+            history.current_nodedata(),
+            history.id(),
+            history.stage(),
+            history.is_origin(),
+        )
+    )
+
+
+def test_save_schema_preflight_precedes_sample_write(database, monkeypatch):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    failure = RuntimeError("injected schema preflight failure")
+    sample_writes = []
+
+    def fail_preflight(*args, **kwargs):
+        raise failure
+
+    def record_sample_write(*args, **kwargs):
+        sample_writes.append(True)
+
+    monkeypatch.setattr(database_module, "md2doc", fail_preflight)
+    monkeypatch.setattr(Database, "_save_sample_data", record_sample_write)
+
+    with pytest.raises(RuntimeError) as error:
+        database.save_data(datum, storage_mode="gridfs", return_data=True)
+
+    assert error.value is failure
+    assert sample_writes == []
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_update_failure_preserves_history_and_removes_new_children(
+    database, monkeypatch, factory, collection
+):
+    datum = save_original(database, factory)
+    old_gridfs_id = datum["gridfs_id"]
+    history_before = _history_snapshot(datum)
+    replacement = factory([5.0, 6.0, 7.0, 8.0])
+    datum.data = replacement.data
+    failure = RuntimeError("injected waveform reference failure")
+    original_update_one = Collection.update_one
+
+    def fail_waveform_reference(self, query, update, *args, **kwargs):
+        if self.name == collection and "gridfs_id" in update.get("$set", {}):
+            raise failure
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "update_one", fail_waveform_reference)
+
+    with pytest.raises(RuntimeError) as error:
+        database.update_data(datum, mode="promiscuous", save_history=True)
+
+    assert error.value is failure
+    assert _history_snapshot(datum) == history_before
+    assert database["history_object"].count_documents({}) == 0
+    document = database[collection].find_one({"_id": datum["_id"]})
+    assert document["gridfs_id"] == old_gridfs_id
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    assert database["fs.files"].count_documents({}) == 1
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+@pytest.mark.parametrize("entrypoint", ["save", "update"])
+def test_history_resets_only_after_durable_waveform_references(
+    database, monkeypatch, factory, collection, entrypoint
+):
+    if entrypoint == "save":
+        datum = factory([1.0, 2.0, 3.0, 4.0])
+    else:
+        datum = save_original(database, factory)
+        datum.data = factory([5.0, 6.0, 7.0, 8.0]).data
+    observations = []
+    original_reset = Database._reset_processing_history
+
+    def observe_reset(datum, alg_name, alg_id, save_uuid):
+        waveform = database[collection].find_one({"_id": datum["_id"]})
+        history_id = waveform["history_object_id"]
+        history = database["history_object"].find_one({"_id": history_id})
+        assert history[collection + "_id"] == datum["_id"]
+        assert gridfs.GridFS(database).exists(waveform["gridfs_id"])
+        observations.append(waveform)
+        original_reset(datum, alg_name, alg_id, save_uuid)
+
+    monkeypatch.setattr(
+        Database, "_reset_processing_history", staticmethod(observe_reset)
+    )
+
+    if entrypoint == "save":
+        result = database.save_data(
+            datum,
+            mode="promiscuous",
+            storage_mode="gridfs",
+            save_history=True,
+            return_data=True,
+        )
+    else:
+        result = database.update_data(datum, mode="promiscuous", save_history=True)
+
+    assert result is datum
+    assert len(observations) == 1
+    assert datum.is_origin()
+
+
+def test_save_history_can_defer_reset_without_database_io(monkeypatch):
+    database = object.__new__(Database)
+    database.database_schema = SimpleNamespace(default_name=lambda name: name)
+    inserted_documents = []
+
+    def insert_one(document):
+        inserted_documents.append(document)
+        return SimpleNamespace(inserted_id="history-id")
+
+    collection = SimpleNamespace(insert_one=insert_one)
+    monkeypatch.setattr(Database, "__getitem__", lambda self, name: collection)
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    history_before = _history_snapshot(datum)
+
+    history_id = database._save_history(datum, reset_history=False)
+
+    assert history_id == "history-id"
+    assert len(inserted_documents) == 1
+    assert _history_snapshot(datum) == history_before

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -19,6 +19,7 @@ from mspasspy.ccore.utility import AtomicType, ErrorSeverity, MsPASSError, dmatr
 from mspasspy.db.client import DBClient
 from mspasspy.db.collection import Collection
 from mspasspy.db.database import Database
+from mspasspy.io.distributed import write_distributed_data
 
 
 @pytest.fixture
@@ -317,3 +318,13 @@ def test_save_data_overwrite_updates_existing_ensemble_member_references(
         assert storage.exists(datum["gridfs_id"])
         reread = database.read_data(waveform_ids[index], collection=collection)
         np.testing.assert_allclose(samples(reread), samples(replacements[index]))
+
+
+@pytest.mark.parametrize("storage_mode", ["gridfs", "file"])
+def test_write_distributed_data_rejects_overwrite_before_execution(storage_mode):
+    database = object.__new__(Database)
+
+    with pytest.raises(ValueError, match="does not support overwrite=True"):
+        write_distributed_data(
+            None, database, storage_mode=storage_mode, overwrite=True
+        )

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -10,8 +10,10 @@ import pytest
 from mspasspy.ccore.seismic import (
     DoubleVector,
     Seismogram,
+    SeismogramEnsemble,
     TimeReferenceType,
     TimeSeries,
+    TimeSeriesEnsemble,
 )
 from mspasspy.ccore.utility import AtomicType, ErrorSeverity, MsPASSError, dmatrix
 from mspasspy.db.client import DBClient
@@ -87,20 +89,37 @@ CASES = [
 ]
 
 
+def replace_samples(database, datum, entrypoint):
+    if entrypoint == "update_data":
+        return database.update_data(datum, mode="promiscuous")
+    return database.save_data(
+        datum,
+        mode="promiscuous",
+        storage_mode="gridfs",
+        overwrite=True,
+        save_history=False,
+        return_data=True,
+    )
+
+
 @pytest.mark.parametrize("factory,collection", CASES)
+@pytest.mark.parametrize("entrypoint", ["update_data", "save_data"])
 def test_successful_overwrite_commits_new_reference_before_removing_old_blob(
-    database, factory, collection
+    database, factory, collection, entrypoint
 ):
     datum = save_original(database, factory)
     old_gridfs_id = datum["gridfs_id"]
     replacement = factory([5.0, 6.0, 7.0, 8.0])
     datum.data = replacement.data
 
-    result = database.update_data(datum, mode="promiscuous")
+    result = replace_samples(database, datum, entrypoint)
 
     document = database[collection].find_one({"_id": datum["_id"]})
     new_gridfs_id = document["gridfs_id"]
     assert result is datum
+    assert database[collection].count_documents({}) == 1
+    if entrypoint == "save_data":
+        assert database["history_object"].count_documents({}) == 0
     assert new_gridfs_id == datum["gridfs_id"]
     assert new_gridfs_id != old_gridfs_id
     storage = gridfs.GridFS(database)
@@ -112,8 +131,9 @@ def test_successful_overwrite_commits_new_reference_before_removing_old_blob(
 
 
 @pytest.mark.parametrize("factory,collection", CASES)
+@pytest.mark.parametrize("entrypoint", ["update_data", "save_data"])
 def test_new_put_failure_preserves_old_reference_and_blob(
-    database, factory, collection
+    database, factory, collection, entrypoint
 ):
     datum = save_original(database, factory)
     old_gridfs_id = datum["gridfs_id"]
@@ -129,7 +149,7 @@ def test_new_put_failure_preserves_old_reference_and_blob(
 
     with patch.object(gridfs.GridFS, "put", put_then_fail):
         with pytest.raises(RuntimeError) as error:
-            database.update_data(datum, mode="promiscuous")
+            replace_samples(database, datum, entrypoint)
 
     assert error.value is failure
     assert datum["gridfs_id"] == old_gridfs_id
@@ -143,8 +163,9 @@ def test_new_put_failure_preserves_old_reference_and_blob(
 
 
 @pytest.mark.parametrize("factory,collection", CASES)
+@pytest.mark.parametrize("entrypoint", ["update_data", "save_data"])
 def test_reference_update_failure_removes_new_blob_and_rethrows_original_error(
-    database, factory, collection
+    database, factory, collection, entrypoint
 ):
     datum = save_original(database, factory)
     old_gridfs_id = datum["gridfs_id"]
@@ -162,7 +183,7 @@ def test_reference_update_failure_removes_new_blob_and_rethrows_original_error(
 
     with patch.object(Collection, "update_one", fail_reference_update):
         with pytest.raises(RuntimeError) as error:
-            database.update_data(datum, mode="promiscuous")
+            replace_samples(database, datum, entrypoint)
 
     assert error.value is failure
     assert datum["gridfs_id"] == old_gridfs_id
@@ -176,8 +197,9 @@ def test_reference_update_failure_removes_new_blob_and_rethrows_original_error(
 
 
 @pytest.mark.parametrize("factory,collection", CASES)
+@pytest.mark.parametrize("entrypoint", ["update_data", "save_data"])
 def test_reference_compare_miss_removes_new_blob_without_overwriting_current_reference(
-    database, factory, collection
+    database, factory, collection, entrypoint
 ):
     datum = save_original(database, factory)
     waveform_id = datum["_id"]
@@ -196,7 +218,7 @@ def test_reference_compare_miss_removes_new_blob_without_overwriting_current_ref
 
     with patch.object(Collection, "update_one", miss_reference_update):
         with pytest.raises(MsPASSError) as error:
-            database.update_data(datum, mode="promiscuous")
+            replace_samples(database, datum, entrypoint)
 
     assert error.value.severity == ErrorSeverity.Invalid
     assert final_queries == [{"_id": waveform_id, "gridfs_id": old_gridfs_id}]
@@ -208,8 +230,9 @@ def test_reference_compare_miss_removes_new_blob_without_overwriting_current_ref
 
 
 @pytest.mark.parametrize("factory,collection", CASES)
+@pytest.mark.parametrize("entrypoint", ["update_data", "save_data"])
 def test_old_delete_failure_keeps_committed_new_data_and_logs_one_complaint(
-    database, factory, collection
+    database, factory, collection, entrypoint
 ):
     datum = save_original(database, factory)
     old_gridfs_id = datum["gridfs_id"]
@@ -225,7 +248,7 @@ def test_old_delete_failure_keeps_committed_new_data_and_logs_one_complaint(
         return original_delete(self, gridfs_id, *args, **kwargs)
 
     with patch.object(gridfs.GridFS, "delete", fail_old_delete):
-        result = database.update_data(datum, mode="promiscuous")
+        result = replace_samples(database, datum, entrypoint)
 
     document = database[collection].find_one({"_id": datum["_id"]})
     new_gridfs_id = document["gridfs_id"]
@@ -244,3 +267,53 @@ def test_old_delete_failure_keeps_committed_new_data_and_logs_one_complaint(
     reread = database.read_data(document, collection=collection)
     assert reread.live
     np.testing.assert_allclose(samples(reread), samples(replacement))
+
+
+@pytest.mark.parametrize(
+    "factory,ensemble_type,collection",
+    [
+        (make_timeseries, TimeSeriesEnsemble, "wf_TimeSeries"),
+        (make_seismogram, SeismogramEnsemble, "wf_Seismogram"),
+    ],
+)
+def test_save_data_overwrite_updates_existing_ensemble_member_references(
+    database, factory, ensemble_type, collection
+):
+    ensemble = ensemble_type()
+    ensemble.member.append(factory([1.0, 2.0, 3.0, 4.0]))
+    ensemble.member.append(factory([11.0, 12.0, 13.0, 14.0]))
+    ensemble.set_live()
+    ensemble = database.save_data(
+        ensemble,
+        storage_mode="gridfs",
+        save_history=False,
+        return_data=True,
+    )
+    waveform_ids = [d["_id"] for d in ensemble.member]
+    old_gridfs_ids = [d["gridfs_id"] for d in ensemble.member]
+    replacements = [
+        factory([5.0, 6.0, 7.0, 8.0]),
+        factory([15.0, 16.0, 17.0, 18.0]),
+    ]
+    for datum, replacement in zip(ensemble.member, replacements):
+        datum.data = replacement.data
+
+    result = database.save_data(
+        ensemble,
+        mode="promiscuous",
+        storage_mode="gridfs",
+        overwrite=True,
+        save_history=False,
+        return_data=True,
+    )
+
+    ensemble = result
+    assert database[collection].count_documents({}) == 2
+    storage = gridfs.GridFS(database)
+    for index, datum in enumerate(ensemble.member):
+        assert datum["_id"] == waveform_ids[index]
+        assert datum["gridfs_id"] != old_gridfs_ids[index]
+        assert not storage.exists(old_gridfs_ids[index])
+        assert storage.exists(datum["gridfs_id"])
+        reread = database.read_data(waveform_ids[index], collection=collection)
+        np.testing.assert_allclose(samples(reread), samples(replacements[index]))

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -1,0 +1,246 @@
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import gridfs
+import numpy as np
+import pytest
+
+from mspasspy.ccore.seismic import (
+    DoubleVector,
+    Seismogram,
+    TimeReferenceType,
+    TimeSeries,
+)
+from mspasspy.ccore.utility import AtomicType, ErrorSeverity, MsPASSError, dmatrix
+from mspasspy.db.client import DBClient
+from mspasspy.db.collection import Collection
+from mspasspy.db.database import Database
+
+
+@pytest.fixture
+def database():
+    uri = os.environ.get("MSPASS_TEST_MONGODB_URI", "mongodb://127.0.0.1:27017")
+    client = DBClient(uri, serverSelectionTimeoutMS=2000)
+    try:
+        client.admin.command("ping")
+    except Exception as error:
+        client.close()
+        pytest.skip(f"MongoDB is unavailable at {uri}: {error}")
+    name = "test_gridfs_overwrite_" + uuid.uuid4().hex
+    database = Database(client, name)
+    try:
+        yield database
+    finally:
+        client.drop_database(name)
+        client.close()
+
+
+def make_timeseries(values):
+    datum = TimeSeries(len(values))
+    datum.data = DoubleVector(values)
+    datum.set_as_origin("test", "0", "0", AtomicType.TIMESERIES)
+    return finish_datum(datum, len(values))
+
+
+def make_seismogram(values):
+    datum = Seismogram(len(values))
+    samples = dmatrix(3, len(values))
+    for component in range(3):
+        for sample, value in enumerate(values):
+            samples[component, sample] = value + 10.0 * component
+    datum.data = samples
+    datum.set_as_origin("test", "0", "0", AtomicType.SEISMOGRAM)
+    return finish_datum(datum, len(values))
+
+
+def finish_datum(datum, npts):
+    datum.dt = 0.1
+    datum.t0 = 10.0
+    datum.tref = TimeReferenceType.UTC
+    datum.set_live()
+    datum["npts"] = npts
+    datum["sampling_rate"] = 10.0
+    datum["delta"] = 0.1
+    datum["calib"] = 1.0
+    return datum
+
+
+def samples(datum):
+    return np.asarray(datum.data)
+
+
+def save_original(database, factory):
+    return database.save_data(
+        factory([1.0, 2.0, 3.0, 4.0]),
+        mode="promiscuous",
+        storage_mode="gridfs",
+        save_history=False,
+        return_data=True,
+    )
+
+
+CASES = [
+    (make_timeseries, "wf_TimeSeries"),
+    (make_seismogram, "wf_Seismogram"),
+]
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_successful_overwrite_commits_new_reference_before_removing_old_blob(
+    database, factory, collection
+):
+    datum = save_original(database, factory)
+    old_gridfs_id = datum["gridfs_id"]
+    replacement = factory([5.0, 6.0, 7.0, 8.0])
+    datum.data = replacement.data
+
+    result = database.update_data(datum, mode="promiscuous")
+
+    document = database[collection].find_one({"_id": datum["_id"]})
+    new_gridfs_id = document["gridfs_id"]
+    assert result is datum
+    assert new_gridfs_id == datum["gridfs_id"]
+    assert new_gridfs_id != old_gridfs_id
+    storage = gridfs.GridFS(database)
+    assert not storage.exists(old_gridfs_id)
+    assert storage.exists(new_gridfs_id)
+    reread = database.read_data(document, collection=collection)
+    assert reread.live
+    np.testing.assert_allclose(samples(reread), samples(replacement))
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_new_put_failure_preserves_old_reference_and_blob(
+    database, factory, collection
+):
+    datum = save_original(database, factory)
+    old_gridfs_id = datum["gridfs_id"]
+    old_document = database[collection].find_one({"_id": datum["_id"]})
+    old_samples = samples(datum).copy()
+    datum.data = factory([5.0, 6.0, 7.0, 8.0]).data
+    failure = RuntimeError("injected GridFS put failure")
+    original_put = gridfs.GridFS.put
+
+    def put_then_fail(self, data, *args, **kwargs):
+        original_put(self, data, *args, **kwargs)
+        raise failure
+
+    with patch.object(gridfs.GridFS, "put", put_then_fail):
+        with pytest.raises(RuntimeError) as error:
+            database.update_data(datum, mode="promiscuous")
+
+    assert error.value is failure
+    assert datum["gridfs_id"] == old_gridfs_id
+    document = database[collection].find_one({"_id": datum["_id"]})
+    assert document["gridfs_id"] == old_gridfs_id
+    assert database["fs.files"].count_documents({}) == 1
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    reread = database.read_data(old_document, collection=collection)
+    assert reread.live
+    np.testing.assert_allclose(samples(reread), old_samples)
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_reference_update_failure_removes_new_blob_and_rethrows_original_error(
+    database, factory, collection
+):
+    datum = save_original(database, factory)
+    old_gridfs_id = datum["gridfs_id"]
+    old_document = database[collection].find_one({"_id": datum["_id"]})
+    old_samples = samples(datum).copy()
+    datum.data = factory([5.0, 6.0, 7.0, 8.0]).data
+    failure = RuntimeError("injected waveform reference failure")
+    original_update_one = Collection.update_one
+
+    def fail_reference_update(self, query, update, *args, **kwargs):
+        gridfs_id = update.get("$set", {}).get("gridfs_id")
+        if gridfs_id is not None and gridfs_id != old_gridfs_id:
+            raise failure
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with patch.object(Collection, "update_one", fail_reference_update):
+        with pytest.raises(RuntimeError) as error:
+            database.update_data(datum, mode="promiscuous")
+
+    assert error.value is failure
+    assert datum["gridfs_id"] == old_gridfs_id
+    document = database[collection].find_one({"_id": datum["_id"]})
+    assert document["gridfs_id"] == old_gridfs_id
+    assert database["fs.files"].count_documents({}) == 1
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    reread = database.read_data(old_document, collection=collection)
+    assert reread.live
+    np.testing.assert_allclose(samples(reread), old_samples)
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_reference_compare_miss_removes_new_blob_without_overwriting_current_reference(
+    database, factory, collection
+):
+    datum = save_original(database, factory)
+    waveform_id = datum["_id"]
+    old_gridfs_id = datum["gridfs_id"]
+    datum.data = factory([5.0, 6.0, 7.0, 8.0]).data
+    final_queries = []
+    original_update_one = Collection.update_one
+
+    def miss_reference_update(self, query, update, *args, **kwargs):
+        gridfs_id = update.get("$set", {}).get("gridfs_id")
+        if gridfs_id is not None:
+            assert gridfs_id != old_gridfs_id
+            final_queries.append(query)
+            return SimpleNamespace(matched_count=0)
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    with patch.object(Collection, "update_one", miss_reference_update):
+        with pytest.raises(MsPASSError) as error:
+            database.update_data(datum, mode="promiscuous")
+
+    assert error.value.severity == ErrorSeverity.Invalid
+    assert final_queries == [{"_id": waveform_id, "gridfs_id": old_gridfs_id}]
+    assert datum["gridfs_id"] == old_gridfs_id
+    document = database[collection].find_one({"_id": waveform_id})
+    assert document["gridfs_id"] == old_gridfs_id
+    assert database["fs.files"].count_documents({}) == 1
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_old_delete_failure_keeps_committed_new_data_and_logs_one_complaint(
+    database, factory, collection
+):
+    datum = save_original(database, factory)
+    old_gridfs_id = datum["gridfs_id"]
+    replacement = factory([5.0, 6.0, 7.0, 8.0])
+    datum.data = replacement.data
+    old_log_size = datum.elog.size()
+    failure = RuntimeError("injected old GridFS delete failure")
+    original_delete = gridfs.GridFS.delete
+
+    def fail_old_delete(self, gridfs_id, *args, **kwargs):
+        if gridfs_id == old_gridfs_id:
+            raise failure
+        return original_delete(self, gridfs_id, *args, **kwargs)
+
+    with patch.object(gridfs.GridFS, "delete", fail_old_delete):
+        result = database.update_data(datum, mode="promiscuous")
+
+    document = database[collection].find_one({"_id": datum["_id"]})
+    new_gridfs_id = document["gridfs_id"]
+    assert result is datum
+    assert new_gridfs_id == datum["gridfs_id"]
+    assert new_gridfs_id != old_gridfs_id
+    storage = gridfs.GridFS(database)
+    assert storage.exists(old_gridfs_id)
+    assert storage.exists(new_gridfs_id)
+    assert database["fs.files"].count_documents({}) == 2
+    assert datum.elog.size() == old_log_size + 1
+    complaint = datum.elog.get_error_log()[-1]
+    assert complaint.badness == ErrorSeverity.Complaint
+    assert "previous sample object could not be deleted" in complaint.message
+    assert str(failure) in complaint.message
+    reread = database.read_data(document, collection=collection)
+    assert reread.live
+    np.testing.assert_allclose(samples(reread), samples(replacement))


### PR DESCRIPTION
Fixes #815.

Depends on #955. This PR is based on the #955 branch so reviewers see only the Issue #815 changes. Retarget it to master after #955 merges.

## Scope

- Complete schema metadata preflight before creating sample data.
- Persist the SAVED history node from a history-only copy.
- Keep the caller history unchanged until the waveform document and both history references are durable.
- On failure, remove only invocation-created resources whose identifiers are known: waveform, history, elog, and GridFS documents.
- Surface cleanup failures instead of hiding them.

## Intentionally out of scope

- Distributed overwrite, which #955 rejects explicitly.
- Cross-resource transactions or ensemble-wide all-or-nothing commits.
- Truncating shared data files. A failed final database write can leave unreferenced appended bytes; removing them safely requires a separate file-layout design.

## Verification

- Black, Python compilation, and whitespace checks passed.
- All 32 focused contract tests were collected.
- 3 connection-free contract tests passed locally.
- 29 MongoDB-backed cases were skipped because no local MongoDB service is available; CI must execute them before this draft becomes ready.