### PR TITLE
Delay history reset until waveform commit

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1669,6 +1669,26 @@ class Database(pymongo.database.Database):
                 # only atomic data can land here
                 mspass_object["storage_mode"] = storage_mode
 
+            atomic_data = (
+                [mspass_object]
+                if isinstance(mspass_object, (TimeSeries, Seismogram))
+                else mspass_object.member
+            )
+            for datum in atomic_data:
+                if datum.live:
+                    self._sync_metadata_before_update(datum)
+                    _, metadata_is_valid, _ = md2doc(
+                        datum,
+                        save_schema,
+                        exclude_keys=exclude_keys,
+                        mode=mode,
+                        normalizing_collections=normalizing_collections,
+                    )
+                    if not metadata_is_valid:
+                        datum.kill()
+
+            # Complete schema validation before creating sample data.
+
             # Extend this method to add new storge modes
             # Note this implementation alters metadata in mspass_object
             # and all members of ensembles
@@ -3293,8 +3313,15 @@ class Database(pymongo.database.Database):
             self.database_schema.default_name("history_object") + "_id"
         )
         history_object_id = None
+        history_save_uuid = None
         if save_history and not mspass_object.is_empty():
-            history_object_id = self._save_history(mspass_object, alg_name, alg_id)
+            history_save_uuid = ProcessingHistory(mspass_object).id()
+            history_object_id = self._save_history(
+                mspass_object,
+                alg_name,
+                alg_id,
+                reset_history=not mspass_object.live,
+            )
             update_record[history_obj_id_name] = history_object_id
 
         # Now handle update of sample data.  The gridfs method used here
@@ -3322,6 +3349,10 @@ class Database(pymongo.database.Database):
             # Supplying the replacement id lets rollback remove a blob even
             # when GridFS writes it and then raises an exception.
             staged_gridfs_id = ObjectId() if old_gridfs_id is not None else None
+            new_gridfs_id = None
+            elog_id = None
+            old_elog_id = None
+            created_elog_id = None
             try:
                 mspass_object = self._save_sample_data_to_gridfs(
                     mspass_object,
@@ -3339,20 +3370,33 @@ class Database(pymongo.database.Database):
                     # A weird construct
                     wf_collection_name = save_schema.collection("_id")
                 wf_collection = self[wf_collection_name]
+                if history_object_id is not None:
+                    wf_id_name = wf_collection_name + "_id"
+                    history_result = self[
+                        self.database_schema.default_name("history_object")
+                    ].update_one(
+                        {"_id": history_object_id},
+                        {"$set": {wf_id_name: mspass_object["_id"]}},
+                    )
+                    if history_result.matched_count != 1:
+                        raise MsPASSError(
+                            "Database.update_data could not link the saved history "
+                            "to the waveform",
+                            ErrorSeverity.Invalid,
+                        )
 
-                elog_id = None
                 if mspass_object.elog.size() > 0:
                     elog_id_name = self.database_schema.default_name("elog") + "_id"
                     # FIXME I think here we should check if elog_id field exists in the mspass_object
                     # and we should update the elog entry if mspass_object already had one
                     if elog_id_name in mspass_object:
                         old_elog_id = mspass_object[elog_id_name]
-                    else:
-                        old_elog_id = None
                     # elog ids will be updated in the wf col when saving metadata
                     elog_id = self._save_elog(
                         mspass_object, elog_id=old_elog_id, data_tag=data_tag
                     )
+                    if old_elog_id is None:
+                        created_elog_id = elog_id
                     update_record[elog_id_name] = elog_id
 
                     # update elog collection
@@ -3375,15 +3419,27 @@ class Database(pymongo.database.Database):
                         ErrorSeverity.Invalid,
                     )
             except Exception as original_error:
-                if old_gridfs_id is not None:
-                    try:
+                try:
+                    gridfs_id_to_remove = staged_gridfs_id or new_gridfs_id
+                    if gridfs_id_to_remove is not None:
                         gfsh = gridfs.GridFS(self)
-                        if gfsh.exists(staged_gridfs_id):
-                            gfsh.delete(staged_gridfs_id)
-                    except Exception as cleanup_error:
-                        raise original_error from cleanup_error
-                    finally:
+                        if gfsh.exists(gridfs_id_to_remove):
+                            gfsh.delete(gridfs_id_to_remove)
+                    if history_object_id is not None:
+                        history_collection = self.database_schema.default_name(
+                            "history_object"
+                        )
+                        self[history_collection].delete_one({"_id": history_object_id})
+                    if created_elog_id is not None:
+                        elog_collection = self.database_schema.default_name("elog")
+                        self[elog_collection].delete_one({"_id": created_elog_id})
+                except Exception as cleanup_error:
+                    raise original_error from cleanup_error
+                finally:
+                    if old_gridfs_id is not None:
                         mspass_object["gridfs_id"] = old_gridfs_id
+                    elif "gridfs_id" in mspass_object:
+                        mspass_object.erase("gridfs_id")
                 raise
             # we may probably set the elog_id field in the mspass_object
             if elog_id:
@@ -3391,6 +3447,10 @@ class Database(pymongo.database.Database):
             # we may probably set the history_object_id field in the mspass_object
             if history_object_id:
                 mspass_object[history_obj_id_name] = history_object_id
+            if history_save_uuid is not None:
+                self._reset_processing_history(
+                    mspass_object, alg_name, alg_id, history_save_uuid
+                )
             if old_gridfs_id is not None:
                 try:
                     gfsh = gridfs.GridFS(self)
@@ -4157,7 +4217,24 @@ class Database(pymongo.database.Database):
             mspass_object["cardinal"] = mspass_object.cardinal()
             mspass_object["orthogonal"] = mspass_object.orthogonal()
 
-    def _save_history(self, mspass_object, alg_name=None, alg_id=None, collection=None):
+    @staticmethod
+    def _reset_processing_history(mspass_object, alg_name, alg_id, save_uuid):
+        atomic_type = (
+            AtomicType.TIMESERIES
+            if isinstance(mspass_object, TimeSeries)
+            else AtomicType.SEISMOGRAM
+        )
+        mspass_object.clear_history()
+        mspass_object.set_as_origin(alg_name, alg_id, str(save_uuid), atomic_type)
+
+    def _save_history(
+        self,
+        mspass_object,
+        alg_name=None,
+        alg_id=None,
+        collection=None,
+        reset_history=True,
+    ):
         """
         Save the processing history of a mspasspy object.
 
@@ -4167,6 +4244,10 @@ class Database(pymongo.database.Database):
         :type prev_history_object_id: :class:`bson.ObjectId.ObjectId`
         :param collection: the collection that you want to store the history object. If not specified, use the defined
           collection in the schema.
+        :param reset_history: reset the caller history after persistence.  Set
+          False only when the caller will reset it after committing its waveform
+          reference.
+        :type reset_history: bool
         :return: current history_object_id.
         """
         if isinstance(mspass_object, TimeSeries):
@@ -4195,11 +4276,10 @@ class Database(pymongo.database.Database):
         current_uuid = insert_dict["save_uuid"]
         history_id = history_col.insert_one(insert_dict).inserted_id
 
-        # clear the history chain of the mspass object
-        mspass_object.clear_history()
-        # set_as_origin with uuid set to the newly generated id
-        # Note we have to convert to a string to match C++ function type
-        mspass_object.set_as_origin(alg_name, alg_id, str(current_uuid), atomic_type)
+        if reset_history:
+            self._reset_processing_history(
+                mspass_object, alg_name, alg_id, current_uuid
+            )
 
         return history_id
 
@@ -6994,69 +7074,92 @@ class Database(pymongo.database.Database):
         else:
             # gridfs default
             insertion_dict["storage_mode"] = "gridfs"
-        # We depend on Undertaker to save history for dead data
+        history_object_id = None
+        history_save_uuid = None
+        history_collection_name = self.database_schema.default_name("history_object")
         if save_history and mspass_object.live:
-            history_obj_id_name = (
-                self.database_schema.default_name("history_object") + "_id"
-            )
-            history_object_id = None
-            # is_empty is a method of ProcessingHistory - mame is generic so possibly confusing
+            history_obj_id_name = history_collection_name + "_id"
             if mspass_object.is_empty():
-                # Use this trick in update_metadata too. None is needed to
-                # avoid a TypeError exception if the name is not defined.
-                # could do this with a conditional as an alternative
                 insertion_dict.pop(history_obj_id_name, None)
             else:
-                # optional history save - only done if history container is not empty
-                # first we need to push the definition of this algorithm
-                # to the chain.  Note it is always defined by the special
-                # save defined with the C++ enum class mapped to python
-                # vi ProcessingStatus
                 if isinstance(mspass_object, TimeSeries):
                     atomic_type = AtomicType.TIMESERIES
                 elif isinstance(mspass_object, Seismogram):
                     atomic_type = AtomicType.SEISMOGRAM
                 else:
                     raise TypeError("only TimeSeries and Seismogram are supported")
-                mspass_object.new_map(
+                history_source = ProcessingHistory(mspass_object)
+                history_source.new_map(
                     alg_name, alg_id, atomic_type, ProcessingStatus.SAVED
                 )
-                history_object_id = self._save_history(mspass_object, alg_name, alg_id)
+                history_save_uuid = history_source.id()
+                history_document = history2doc(
+                    history_source, alg_id=alg_id, alg_name=alg_name
+                )
+                history_object_id = (
+                    self[history_collection_name]
+                    .insert_one(history_document)
+                    .inserted_id
+                )
                 insertion_dict[history_obj_id_name] = history_object_id
-                mspass_object[history_obj_id_name] = history_object_id
-        # save elogs if the size of elog is greater than 0
+
         elog_id = None
+        elog_collection_name = self.database_schema.default_name("elog")
         if mspass_object.elog.size() > 0:
-            elog_id_name = self.database_schema.default_name("elog") + "_id"
-            # elog ids will be updated in the wf col when saving metadata
-            elog_id = self._save_elog(mspass_object, elog_id=None, data_tag=data_tag)
+            elog_id_name = elog_collection_name + "_id"
+            try:
+                elog_id = self._save_elog(
+                    mspass_object, elog_id=None, data_tag=data_tag
+                )
+            except Exception:
+                if history_object_id is not None:
+                    self[history_collection_name].delete_one({"_id": history_object_id})
+                if storage_mode == "gridfs" and "gridfs_id" in mspass_object:
+                    gfsh = gridfs.GridFS(self)
+                    gridfs_id = mspass_object["gridfs_id"]
+                    if gfsh.exists(gridfs_id):
+                        gfsh.delete(gridfs_id)
+                raise
             insertion_dict[elog_id_name] = elog_id
-            mspass_object[elog_id_name] = elog_id
 
-        # finally ready to insert the wf doc - keep the id as we'll need
-        # it for tagging any elog entries.
-        # Note we don't save if something above killed mspass_object.
-        # currently that only happens with errors in md2doc, but if there
-        # are changes use the kill mechanism
         if mspass_object.live:
-            wfid = wf_collection.insert_one(insertion_dict).inserted_id
-
-            # Put wfid into the object's meta as the new definition of
-            # the parent of this waveform
-            mspass_object["_id"] = wfid
-            if save_history and mspass_object.live:
-                # When history is enable we need to do an update to put the
-                # wf collection id as a cross-reference.    Any value stored
-                # above with saave_history may be incorrect.  We use a
-                # stock test with the is_empty method for know if history data is present
-                if not mspass_object.is_empty():
-                    history_object_col = self[
-                        self.database_schema.default_name("history_object")
-                    ]
+            wfid = None
+            try:
+                wfid = wf_collection.insert_one(insertion_dict).inserted_id
+                if history_object_id is not None:
                     wf_id_name = wf_collection.name + "_id"
-                    filter_ = {"_id": history_object_id}
-                    update_dict = {wf_id_name: wfid}
-                    history_object_col.update_one(filter_, {"$set": update_dict})
+                    history_result = self[history_collection_name].update_one(
+                        {"_id": history_object_id},
+                        {"$set": {wf_id_name: wfid}},
+                    )
+                    if history_result.matched_count != 1:
+                        raise MsPASSError(
+                            "Database.save_data could not link the saved history "
+                            "to the waveform",
+                            ErrorSeverity.Invalid,
+                        )
+            except Exception:
+                if wfid is not None:
+                    wf_collection.delete_one({"_id": wfid})
+                if history_object_id is not None:
+                    self[history_collection_name].delete_one({"_id": history_object_id})
+                if elog_id is not None:
+                    self[elog_collection_name].delete_one({"_id": elog_id})
+                if storage_mode == "gridfs" and "gridfs_id" in mspass_object:
+                    gfsh = gridfs.GridFS(self)
+                    gridfs_id = mspass_object["gridfs_id"]
+                    if gfsh.exists(gridfs_id):
+                        gfsh.delete(gridfs_id)
+                raise
+
+            mspass_object["_id"] = wfid
+            if history_object_id is not None:
+                mspass_object[history_obj_id_name] = history_object_id
+                self._reset_processing_history(
+                    mspass_object, alg_name, alg_id, history_save_uuid
+                )
+            if elog_id is not None:
+                mspass_object[elog_id_name] = elog_id
         else:
             mspass_object = self.stedronsky.bury(
                 mspass_object, save_history=save_history

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -7119,6 +7119,7 @@ class Database(pymongo.database.Database):
                     gridfs_id = mspass_object["gridfs_id"]
                     if gfsh.exists(gridfs_id):
                         gfsh.delete(gridfs_id)
+                    mspass_object.erase("gridfs_id")
                 raise
             insertion_dict[elog_id_name] = elog_id
 
@@ -7150,6 +7151,7 @@ class Database(pymongo.database.Database):
                     gridfs_id = mspass_object["gridfs_id"]
                     if gfsh.exists(gridfs_id):
                         gfsh.delete(gridfs_id)
+                    mspass_object.erase("gridfs_id")
                 raise
 
             mspass_object["_id"] = wfid

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import uuid
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -15,7 +16,14 @@ from mspasspy.ccore.seismic import (
     TimeSeries,
     TimeSeriesEnsemble,
 )
-from mspasspy.ccore.utility import AtomicType, ErrorSeverity, MsPASSError, dmatrix
+from mspasspy.ccore.utility import (
+    AtomicType,
+    ErrorSeverity,
+    MsPASSError,
+    ProcessingHistory,
+    dmatrix,
+)
+import mspasspy.db.database as database_module
 from mspasspy.db.client import DBClient
 from mspasspy.db.collection import Collection
 from mspasspy.db.database import Database
@@ -328,3 +336,131 @@ def test_write_distributed_data_rejects_overwrite_before_execution(storage_mode)
         write_distributed_data(
             None, database, storage_mode=storage_mode, overwrite=True
         )
+
+
+def _history_snapshot(datum):
+    history = ProcessingHistory(datum)
+    return pickle.dumps(
+        (
+            history.get_nodes(),
+            history.current_nodedata(),
+            history.id(),
+            history.stage(),
+            history.is_origin(),
+        )
+    )
+
+
+def test_save_schema_preflight_precedes_sample_write(database, monkeypatch):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    failure = RuntimeError("injected schema preflight failure")
+    sample_writes = []
+
+    def fail_preflight(*args, **kwargs):
+        raise failure
+
+    def record_sample_write(*args, **kwargs):
+        sample_writes.append(True)
+
+    monkeypatch.setattr(database_module, "md2doc", fail_preflight)
+    monkeypatch.setattr(Database, "_save_sample_data", record_sample_write)
+
+    with pytest.raises(RuntimeError) as error:
+        database.save_data(datum, storage_mode="gridfs", return_data=True)
+
+    assert error.value is failure
+    assert sample_writes == []
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_update_failure_preserves_history_and_removes_new_children(
+    database, monkeypatch, factory, collection
+):
+    datum = save_original(database, factory)
+    old_gridfs_id = datum["gridfs_id"]
+    history_before = _history_snapshot(datum)
+    replacement = factory([5.0, 6.0, 7.0, 8.0])
+    datum.data = replacement.data
+    failure = RuntimeError("injected waveform reference failure")
+    original_update_one = Collection.update_one
+
+    def fail_waveform_reference(self, query, update, *args, **kwargs):
+        if self.name == collection and "gridfs_id" in update.get("$set", {}):
+            raise failure
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "update_one", fail_waveform_reference)
+
+    with pytest.raises(RuntimeError) as error:
+        database.update_data(datum, mode="promiscuous", save_history=True)
+
+    assert error.value is failure
+    assert _history_snapshot(datum) == history_before
+    assert database["history_object"].count_documents({}) == 0
+    document = database[collection].find_one({"_id": datum["_id"]})
+    assert document["gridfs_id"] == old_gridfs_id
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    assert database["fs.files"].count_documents({}) == 1
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+@pytest.mark.parametrize("entrypoint", ["save", "update"])
+def test_history_resets_only_after_durable_waveform_references(
+    database, monkeypatch, factory, collection, entrypoint
+):
+    if entrypoint == "save":
+        datum = factory([1.0, 2.0, 3.0, 4.0])
+    else:
+        datum = save_original(database, factory)
+        datum.data = factory([5.0, 6.0, 7.0, 8.0]).data
+    observations = []
+    original_reset = Database._reset_processing_history
+
+    def observe_reset(datum, alg_name, alg_id, save_uuid):
+        waveform = database[collection].find_one({"_id": datum["_id"]})
+        history_id = waveform["history_object_id"]
+        history = database["history_object"].find_one({"_id": history_id})
+        assert history[collection + "_id"] == datum["_id"]
+        assert gridfs.GridFS(database).exists(waveform["gridfs_id"])
+        observations.append(waveform)
+        original_reset(datum, alg_name, alg_id, save_uuid)
+
+    monkeypatch.setattr(
+        Database, "_reset_processing_history", staticmethod(observe_reset)
+    )
+
+    if entrypoint == "save":
+        result = database.save_data(
+            datum,
+            mode="promiscuous",
+            storage_mode="gridfs",
+            save_history=True,
+            return_data=True,
+        )
+    else:
+        result = database.update_data(datum, mode="promiscuous", save_history=True)
+
+    assert result is datum
+    assert len(observations) == 1
+    assert datum.is_origin()
+
+
+def test_save_history_can_defer_reset_without_database_io(monkeypatch):
+    database = object.__new__(Database)
+    database.database_schema = SimpleNamespace(default_name=lambda name: name)
+    inserted_documents = []
+
+    def insert_one(document):
+        inserted_documents.append(document)
+        return SimpleNamespace(inserted_id="history-id")
+
+    collection = SimpleNamespace(insert_one=insert_one)
+    monkeypatch.setattr(Database, "__getitem__", lambda self, name: collection)
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    history_before = _history_snapshot(datum)
+
+    history_id = database._save_history(datum, reset_history=False)
+
+    assert history_id == "history-id"
+    assert len(inserted_documents) == 1
+    assert _history_snapshot(datum) == history_before

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -445,6 +445,71 @@ def test_history_resets_only_after_durable_waveform_references(
     assert datum.is_origin()
 
 
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_save_history_link_miss_removes_created_resources(
+    database, monkeypatch, factory, collection
+):
+    datum = factory([1.0, 2.0, 3.0, 4.0])
+    history_before = _history_snapshot(datum)
+    original_update_one = Collection.update_one
+
+    def miss_history_link(self, query, update, *args, **kwargs):
+        if self.name == "history_object" and collection + "_id" in update.get(
+            "$set", {}
+        ):
+            return SimpleNamespace(matched_count=0)
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "update_one", miss_history_link)
+
+    with pytest.raises(MsPASSError, match="could not link the saved history"):
+        database.save_data(
+            datum,
+            mode="promiscuous",
+            storage_mode="gridfs",
+            save_history=True,
+            return_data=True,
+        )
+
+    assert _history_snapshot(datum) == history_before
+    assert "gridfs_id" not in datum
+    assert database[collection].count_documents({}) == 0
+    assert database["history_object"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_save_elog_failure_removes_known_created_resources(
+    database, monkeypatch, factory, collection
+):
+    datum = factory([1.0, 2.0, 3.0, 4.0])
+    datum.elog.log_error("test", "injected elog", ErrorSeverity.Complaint)
+    history_before = _history_snapshot(datum)
+    failure = RuntimeError("injected elog save failure")
+
+    def fail_elog_save(*args, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(Database, "_save_elog", fail_elog_save)
+
+    with pytest.raises(RuntimeError) as error:
+        database.save_data(
+            datum,
+            mode="promiscuous",
+            storage_mode="gridfs",
+            save_history=True,
+            return_data=True,
+        )
+
+    assert error.value is failure
+    assert _history_snapshot(datum) == history_before
+    assert "gridfs_id" not in datum
+    assert database[collection].count_documents({}) == 0
+    assert database["history_object"].count_documents({}) == 0
+    assert database["elog"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+
+
 def test_save_history_can_defer_reset_without_database_io(monkeypatch):
     database = object.__new__(Database)
     database.database_schema = SimpleNamespace(default_name=lambda name: name)


### PR DESCRIPTION
Fixes #815.

Supersedes #1001, which GitHub automatically closed when its stacked base branch was merged and deleted.

## Scope

- Complete schema metadata preflight before creating sample data.
- Persist the SAVED history node from a history-only copy.
- Keep the caller history unchanged until the waveform document and both history references are durable.
- On failure, remove only invocation-created resources whose identifiers are known: waveform, history, elog, and GridFS documents.
- Surface cleanup failures instead of hiding them.

## Intentionally out of scope

- Distributed overwrite, which master now rejects explicitly.
- Cross-resource transactions or ensemble-wide all-or-nothing commits.
- Truncating shared data files. A failed final database write can leave unreferenced appended bytes; removing them safely requires a separate file-layout design.

## Verification

- Rebased onto master after #955.
- Black, Python compilation, and whitespace checks passed.
- All 32 focused contract tests were collected.
- 3 connection-free contract tests passed locally.
- 29 MongoDB-backed cases were skipped locally because no MongoDB service is available; required CI must pass before merge.