### PR TITLE
Isolate cursor refresh clock tests

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -4,7 +4,7 @@ import copy
 import pathlib
 import pickle
 import tempfile
-import time
+from time import monotonic
 import urllib.error
 import urllib.request
 from array import array
@@ -92,13 +92,13 @@ def _managed_collection_cursor(collection, query, no_cursor_timeout=False):
     client = collection.database.client
     with client.start_session() as session:
         with collection.find(query, no_cursor_timeout=True, session=session) as cursor:
-            last_refresh = time.monotonic()
+            last_refresh = monotonic()
 
             def refreshing_documents():
                 nonlocal last_refresh
                 for document in cursor:
                     yield document
-                    now = time.monotonic()
+                    now = monotonic()
                     if now - last_refresh >= _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS:
                         client.admin.command({"refreshSessions": [session.session_id]})
                         last_refresh = now

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -18,6 +18,7 @@ import botocore.session
 from unittest.mock import patch, Mock
 import json
 import base64
+import time
 from unittest import mock
 
 sys.path.append("python/tests")
@@ -97,7 +98,9 @@ def test_managed_collection_cursor_refreshes_explicit_session():
     collection.database.client = client
     collection.find.return_value = cursor
 
-    with patch("mspasspy.db.database.time.monotonic", side_effect=[0.0, 301.0, 302.0]):
+    real_monotonic = time.monotonic
+    with patch("mspasspy.db.database.monotonic", side_effect=[0.0, 301.0, 302.0]):
+        assert time.monotonic is real_monotonic
         with _managed_collection_cursor(
             collection, {}, no_cursor_timeout=True
         ) as documents:


### PR DESCRIPTION
## Summary

- import `monotonic` directly in the database module
- patch only that module-local reference in the cursor refresh test
- assert that the standard-library clock is not replaced

This fixes the order-dependent Python 3.10 master failure without changing cursor refresh behavior or weakening the test.

Focused validation: 2 passed; diff check passed; Black reports both files unchanged.

Closes #1005
