### PR TITLE
Restore GeoLab services for interpreter-wrapped JupyterHub

### DIFF
--- a/python/tests/test_geolab_bootstrap.py
+++ b/python/tests/test_geolab_bootstrap.py
@@ -303,6 +303,12 @@ def test_live_geolab_workflow_is_path_filtered_and_enables_container_test():
     (
         ("jupyter", ("lab", "--no-browser"), "bootstrap"),
         ("jupyterhub-singleuser", ("--port=8888",), "bootstrap"),
+        (
+            "python3.12",
+            ("/srv/conda/envs/notebook/bin/jupyterhub-singleuser",),
+            "bootstrap",
+        ),
+        ("python3.12", ("-m", "distributed.cli.dask_scheduler"), "direct"),
         ("dask-scheduler", ("--port", "8786"), "direct"),
         ("dask-worker", ("tcp://scheduler:8786",), "direct"),
         ("dask", ("scheduler", "--port", "8786"), "direct"),
@@ -684,9 +690,9 @@ def test_live_geolab_container_startup_readiness_and_cleanup(tmp_path):
             """
         ).lstrip()
     )
-    fake_jupyter = tmp_path / "jupyter"
+    fake_python = tmp_path / "python3.12"
     _write_executable(
-        fake_jupyter,
+        fake_python,
         """
         #!/bin/sh
         set -eu
@@ -697,6 +703,10 @@ def test_live_geolab_container_startup_readiness_and_cleanup(tmp_path):
             "$NB_HOME|$HOME|$MSPASS_WORK_DIR|$MSPASS_WORKDIR" \
             > /test-state/frontend-ready
         """,
+    )
+    fake_singleuser = tmp_path / "jupyterhub-singleuser"
+    fake_singleuser.write_text(
+        "# GeoLab passes this script to the Python interpreter.\n"
     )
 
     image = os.environ.get("MSPASS_GEOLAB_TEST_IMAGE", "mspass/mspass:geolab")
@@ -716,7 +726,9 @@ def test_live_geolab_container_startup_readiness_and_cleanup(tmp_path):
         "--volume",
         f"{mounted_entrypoint_script}:/usr/sbin/start-mspass-geolab-entrypoint.sh:ro",
         "--volume",
-        f"{fake_jupyter}:/test-bin/jupyter:ro",
+        f"{fake_python}:/test-bin/python3.12:ro",
+        "--volume",
+        f"{fake_singleuser}:/test-bin/jupyterhub-singleuser:ro",
         "--volume",
         f"{frontend_check}:/test-bin/verify-geolab-frontend.py:ro",
         "--volume",
@@ -748,9 +760,8 @@ def test_live_geolab_container_startup_readiness_and_cleanup(tmp_path):
         "--env",
         "MSPASS_STARTUP_POLL_SECONDS=1",
         image,
-        "jupyter",
-        "lab",
-        "--no-browser",
+        "/test-bin/python3.12",
+        "/test-bin/jupyterhub-singleuser",
     ]
     try:
         result = subprocess.run(command, text=True, capture_output=True, timeout=180)

--- a/scripts/start-mspass-geolab-entrypoint.sh
+++ b/scripts/start-mspass-geolab-entrypoint.sh
@@ -12,6 +12,13 @@ case "$command_name" in
             exec /usr/sbin/start-mspass-geolab.sh "$@"
         fi
         ;;
+    python|python[0-9]*)
+        wrapped_command_name=${2:-}
+        wrapped_command_name=${wrapped_command_name##*/}
+        if [ "$wrapped_command_name" = "jupyterhub-singleuser" ]; then
+            exec /usr/sbin/start-mspass-geolab.sh "$@"
+        fi
+        ;;
 esac
 
 exec "$@"


### PR DESCRIPTION
Closes #1008.

## Root cause

EarthScope GeoLab launches JupyterHub as:

```text
python3.12 /srv/conda/envs/notebook/bin/jupyterhub-singleuser ...
```

#941 narrowed the GeoLab entrypoint routing to a directly invoked `jupyterhub-singleuser`. The interpreter-wrapped command was therefore passed through without running `start-mspass-geolab.sh`, leaving MongoDB and local Dask stopped.

## Fix

- Route `python* <path>/jupyterhub-singleuser` through the existing GeoLab bootstrap.
- Preserve direct pass-through for Dask Gateway scheduler/worker commands and unrelated Python commands.
- Make the live container test use GeoLab's actual interpreter-wrapped argv while still verifying MongoDB ping and Dask scheduler readiness.

## Verification

- The new routing case fails against the current `master` entrypoint and passes with this change.
- `38 passed, 1 skipped` locally for both GeoLab bootstrap test modules; the skipped test is the Docker-backed live test because Docker is unavailable in this WSL environment.
- GitHub's `GeoLab bootstrap` workflow passed for the final commit. It exercised the interpreter-wrapped argv in the existing GeoLab image and verified MongoDB ping, Dask scheduler readiness, frontend startup, and cleanup.
- `sh -n` passes for both GeoLab shell scripts.
- GitHub Black 25.1.0, local `git diff --check`, dependency alignment, and static gates pass.
