### PR TITLE
Add S3-compatible object storage mode

### DIFF
--- a/data/yaml/mspass.yaml
+++ b/data/yaml/mspass.yaml
@@ -84,8 +84,12 @@ Database:
           constraint: normal
         storage_mode:
           type: string
-          concept: The storage mode of the saved data ('file', 'url' or 'gridfs')
+          concept: The storage mode of the saved data ('file', 'url', 'gridfs', or 'object_store')
           constraint: required
+        object_store:
+          type: dict
+          concept: Provider-specific location of sample data in an object store.
+          constraint: optional
         format:
           type: string
           concept: The file format of the saved data (e.g., 'MSEED', 'SAC', ...).
@@ -516,6 +520,9 @@ Metadata:
       storage_mode:
         collection: wf_TimeSeries
         readonly: false
+      object_store:
+        collection: wf_TimeSeries
+        readonly: false
       gridfs_id:
         collection: wf_TimeSeries
         readonly: false
@@ -634,6 +641,9 @@ Metadata:
         collection: wf_Seismogram
         readonly: false
       storage_mode:
+        collection: wf_Seismogram
+        readonly: false
+      object_store:
         collection: wf_Seismogram
         readonly: false
       gridfs_id:

--- a/data/yaml/mspass_fdsn.yaml
+++ b/data/yaml/mspass_fdsn.yaml
@@ -80,11 +80,19 @@ Database:
           constraint: normal
         storage_mode:
           type: string
-          concept: The storage mode of the saved data ('file', 'url' or 'gridfs')
+          concept: The storage mode of the saved data ('file', 'url', 'gridfs', or 'object_store')
           constraint: required
+        object_store:
+          type: dict
+          concept: Provider-specific object-store location and encoding metadata
+          constraint: optional
         format:
           type: string
           concept: The file format of the saved data (e.g., 'MSEED', 'SAC', ...).
+          constraint: optional
+        nbytes:
+          type: int
+          concept: Number of bytes occupied by the serialized sample data
           constraint: optional
         dir:
           type: string
@@ -475,6 +483,18 @@ Metadata:
       calib:
         collection: wf_TimeSeries
         readonly: false
+      storage_mode:
+        collection: wf_TimeSeries
+        readonly: false
+      object_store:
+        collection: wf_TimeSeries
+        readonly: false
+      format:
+        collection: wf_TimeSeries
+        readonly: false
+      nbytes:
+        collection: wf_TimeSeries
+        readonly: false
       site_id:
         collection: wf_TimeSeries
         readonly: false
@@ -575,6 +595,18 @@ Metadata:
         collection: wf_Seismogram
         readonly: false
       calib:
+        collection: wf_Seismogram
+        readonly: false
+      storage_mode:
+        collection: wf_Seismogram
+        readonly: false
+      object_store:
+        collection: wf_Seismogram
+        readonly: false
+      format:
+        collection: wf_Seismogram
+        readonly: false
+      nbytes:
         collection: wf_Seismogram
         readonly: false
       site_id:

--- a/data/yaml/mspass_lite.yaml
+++ b/data/yaml/mspass_lite.yaml
@@ -55,11 +55,19 @@ Database:
           constraint: normal
         storage_mode:
           type: string
-          concept: The storage mode of the saved data ('file', 'url' or 'gridfs')
+          concept: The storage mode of the saved data ('file', 'url', 'gridfs', or 'object_store')
           constraint: required
+        object_store:
+          type: dict
+          concept: Provider-specific object-store location and encoding metadata
+          constraint: optional
         format:
           type: string
           concept: The file format of the saved data (e.g., 'MSEED', 'SAC', ...).
+          constraint: optional
+        nbytes:
+          type: int
+          concept: Number of bytes occupied by the serialized sample data
           constraint: optional
         dir:
           type: string
@@ -269,6 +277,18 @@ Metadata:
       calib:
         collection: wf_TimeSeries
         readonly: false
+      storage_mode:
+        collection: wf_TimeSeries
+        readonly: false
+      object_store:
+        collection: wf_TimeSeries
+        readonly: false
+      format:
+        collection: wf_TimeSeries
+        readonly: false
+      nbytes:
+        collection: wf_TimeSeries
+        readonly: false
       net:
         collection: wf_TimeSeries
         readonly: false
@@ -306,6 +326,18 @@ Metadata:
         collection: wf_Seismogram
         readonly: false
       calib:
+        collection: wf_Seismogram
+        readonly: false
+      storage_mode:
+        collection: wf_Seismogram
+        readonly: false
+      object_store:
+        collection: wf_Seismogram
+        readonly: false
+      format:
+        collection: wf_Seismogram
+        readonly: false
+      nbytes:
         collection: wf_Seismogram
         readonly: false
       tmatrix:

--- a/data/yaml/mspass_s3.yaml
+++ b/data/yaml/mspass_s3.yaml
@@ -80,11 +80,19 @@ Database:
           constraint: normal
         storage_mode:
           type: string
-          concept: The storage mode of the saved data ('file', 'url' or 'gridfs')
+          concept: The storage mode of the saved data ('file', 'url', 'gridfs', or 'object_store')
           constraint: required
+        object_store:
+          type: dict
+          concept: Provider-specific object-store location and encoding metadata
+          constraint: optional
         format:
           type: string
           concept: The file format of the saved data (e.g., 'MSEED', 'SAC', ...).
+          constraint: optional
+        nbytes:
+          type: int
+          concept: Number of bytes occupied by the serialized sample data
           constraint: optional
         dir:
           type: string
@@ -470,6 +478,18 @@ Metadata:
       calib:
         collection: wf_TimeSeries
         readonly: false
+      storage_mode:
+        collection: wf_TimeSeries
+        readonly: false
+      object_store:
+        collection: wf_TimeSeries
+        readonly: false
+      format:
+        collection: wf_TimeSeries
+        readonly: false
+      nbytes:
+        collection: wf_TimeSeries
+        readonly: false
       site_id:
         collection: wf_TimeSeries
         readonly: false
@@ -570,6 +590,18 @@ Metadata:
         collection: wf_Seismogram
         readonly: false
       calib:
+        collection: wf_Seismogram
+        readonly: false
+      storage_mode:
+        collection: wf_Seismogram
+        readonly: false
+      object_store:
+        collection: wf_Seismogram
+        readonly: false
+      format:
+        collection: wf_Seismogram
+        readonly: false
+      nbytes:
         collection: wf_Seismogram
         readonly: false
       site_id:

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -86,6 +86,31 @@ the docstring pages for detailed and most up to date usage:
     Set :code:`return_data=True` when an
     intermediate save needs the updated data object returned to the workflow.
 
+    GridFS saves, including
+    :code:`write_distributed_data(..., storage_mode="gridfs")`, use a durable
+    :code:`gridfs_staging` record containing
+    preallocated waveform, GridFS, history, and elog ids before sample bytes
+    are written.  A network or write-concern result that cannot prove whether
+    a write committed leaves that stage and the caller's recovery ids intact.
+    After stopping GridFS writers and waiting for outstanding MongoDB requests,
+    call :code:`db.reconcile_gridfs_staging()`.  Its default mode repairs
+    committed auxiliary links and reports unresolved stages without deleting
+    samples; :code:`delete_uncommitted=True` also removes unreferenced files,
+    partial chunks, auxiliary documents, and stages.  Lifecycle reads use the
+    primary and writes use majority acknowledgement even if the caller's
+    Database handle requests weaker options.  The shared-reference scan and
+    GridFS delete are not one MongoDB transaction.  If :code:`gridfs_id`
+    values are intentionally shared or edited manually, writers capable of
+    creating those references must also remain quiescent during replacement,
+    :code:`delete_data`, and reconciliation.  Reference scans cover every
+    schema-defined waveform collection plus the staged/requested collection;
+    they cannot discover a manually created reference in an unrelated custom
+    collection that is absent from the active database schema.
+    During known-failure compensation, a caller's original storage Metadata
+    is restored as soon as staged samples are confirmed deleted.  If later
+    auxiliary or staging-record cleanup fails, the durable stage remains for
+    reconciliation; the caller is not left pointing at the deleted samples.
+
     Sample data can instead be stored in an S3-compatible object store by
     supplying an authenticated boto3 client and an explicit destination:
 
@@ -114,29 +139,56 @@ the docstring pages for detailed and most up to date usage:
     little-endian byte order.  A Seismogram payload is three component-major
     rows of :code:`npts` contiguous values in C order.  Formatted writes use
     the selected ObsPy format.  Each upload is preceded by a durable MongoDB
-    staging record containing its preallocated waveform id and exact S3
-    location.  If a later MongoDB write raises an exception caught by the
-    current process, :code:`save_data` removes the object and restores the
-    caller's original storage Metadata only after MongoDB confirms that no
-    waveform document references the object.  If commit status cannot be
-    determined because an attempted waveform insert ends with a connection,
-    topology, or write-concern error, no immediate negative reference query is
-    treated as a commit barrier.  The S3 object, staging record, and new caller
-    Metadata are retained for reconciliation and the save raises an explicit
-    fatal error.  The same retention rule applies when the intended waveform
-    owner is already durable.
+    staging record containing the preallocated waveform, history, and elog
+    ids plus the exact S3 location.  This lifecycle currently supports only
+    unversioned S3 buckets; bucket version ids are not persisted or passed to
+    deletion operations.  Lifecycle state is written with MongoDB majority
+    write concern, and owner/reference decisions are read from the primary;
+    these safety settings override weaker options on the caller's Database
+    handle.
+
+    Once :code:`put_object` has been invoked, an exception cannot prove that
+    the upload did not finish at the service.  MsPASS therefore retains the
+    S3 location, staging record, preallocated waveform :code:`_id`, and new
+    caller Metadata and raises an explicit fatal error.  It does not issue an
+    immediate compensating delete.  The same rule applies to connection,
+    topology, timeout, or write-concern failures after a staged MongoDB write
+    has been attempted.  If an error is known to precede those uncertain
+    operations, :code:`save_data` removes the object and staged auxiliary
+    documents and restores the caller's original storage Metadata, including
+    its original :code:`_id`, only after MongoDB confirms that no waveform
+    document references the object.
+    Once an unreferenced S3 object is confirmed deleted, the caller's original
+    storage Metadata is restored even if later auxiliary or staging-record
+    cleanup fails.  The retained durable stage then records the remaining
+    reconciliation work without making the caller point at a deleted object.
+
+    On an uncertain result, the datum held by the caller is a recovery handle:
+    its :code:`_id` is the preallocated waveform id recorded in staging, not
+    the id of a previous waveform document.  Do not reuse that in-memory datum
+    directly after reconciliation.  If the staged owner committed, reload it
+    by that :code:`_id`; if reconciliation removes the uncommitted save,
+    discard the datum or restore it from an application-owned copy of its
+    prior state.
     An abrupt process or host termination leaves the staging record available
-    to :code:`db.reconcile_object_store_staging(s3_client)`, which reports
-    uncommitted S3 URIs without deleting them.  After stopping concurrent
-    object-store writers, pass :code:`delete_uncommitted=True` to delete those
-    objects and their staging records.  Reconciliation treats
+    for reconciliation.  Stop concurrent object-store reference writers and
+    wait for all outstanding S3 and MongoDB requests before every call to
+    :code:`db.reconcile_object_store_staging(s3_client)`: even its default
+    mode repairs committed auxiliary links and clears resolved staging
+    records.  The default reports unresolved S3 URIs without deleting their
+    samples.  Pass :code:`delete_uncommitted=True` to also delete uncommitted
+    objects, any staged history/elog documents, and their staging records.
+    Reconciliation treats
     :code:`provider`, :code:`bucket`, and :code:`object_name` as the canonical
     S3 object identity.  It first queries the exact staged waveform id and
     collection, including alternate collections not present in the database
     schema, then checks every schema-defined waveform collection for shared
-    references.  A referenced identity is cleared from staging without
-    deleting its S3 object; nonidentity fields such as :code:`encoding` or
-    :code:`etag` do not affect that decision.
+    references.  For the exact intended owner, it validates the saved
+    history/elog ids and repairs their reverse waveform links before clearing
+    staging.  If only another waveform shares the S3 identity, it preserves
+    the object while removing the failed owner's staged auxiliary documents.
+    Nonidentity fields such as :code:`encoding` or :code:`etag` do not affect
+    that decision.
     Object-store ensemble members use this upload-and-commit sequence one at a
     time, bounding the uncommitted window to one member.
     :code:`update_data` does not replace samples for object-store data; save a
@@ -440,6 +492,52 @@ updates Metadata, the error log, history, and sample data for an atomic
 records should be managed through these APIs rather than edited directly with
 PyMongo.
 
+For waveform documents backed by GridFS or an object store,
+:code:`update_metadata` reads the owner from the MongoDB primary and
+deliberately excludes lifecycle-owned sample and history/elog pointers from
+its update payload.  A real change to :code:`storage_mode`, :code:`gridfs_id`,
+an object-store canonical identity, or an auxiliary-document id is rejected.
+Adding nonidentity object-store Metadata such as :code:`etag` is allowed only
+while a compare-and-swap still matches the same provider, bucket, and object
+name.  Existing file- and URL-backed Metadata repair behavior is unchanged.
+Use :code:`save_data`, :code:`update_data`, or :code:`delete_data` for storage
+transitions so staging and compensation remain consistent.  Direct PyMongo
+edits bypass this protection and must be treated as an offline repair: stop
+all related writers and reconcile durable stages before resuming normal CRUD
+operations.  For backward compatibility, :code:`update_metadata` can still
+upsert when its primary read finds no waveform.  Once that read finds an
+existing waveform, however, the operation is fixed as non-upserting so a
+concurrent deletion cannot recreate a metadata-only document.
+
+:code:`update_data` requires an existing waveform :code:`_id`.  It reads the
+persisted sample location from the MongoDB primary before performing any
+write, writes replacement GridFS samples with majority write concern, and
+commits the new pointer with a primary/majority compare-and-swap against the
+complete old location.  Only a confirmed commit permits deletion of the old
+GridFS object.  If the GridFS write or pointer commit has an uncertain network
+or write-concern result, both the old and staged objects plus the durable stage
+are retained.  Wait for outstanding MongoDB writes to finish, run
+:code:`reconcile_gridfs_staging`, and reload the waveform by :code:`_id` from
+the primary; the in-memory datum is only a recovery handle during that
+interval.  A file or URL source is converted to an explicit
+:code:`storage_mode="gridfs"` based on the persisted source location, not on
+mutable caller Metadata.
+If a prior save committed its waveform but could not remove its staging
+record, a later :code:`update_data` or :code:`delete_data` first repairs its
+auxiliary links, finishes any safe old-GridFS cleanup, and removes that exact
+committed stage.  A conflicting or unreadable stage stops the new operation
+and must be reconciled before the waveform location can change again.
+The selected Metadata schema must be able to persist writable
+:code:`storage_mode` and :code:`gridfs_id` fields, and those fields cannot be
+listed in :code:`exclude_keys`.  The same preflight applies to direct updates,
+serial overwrite, and distributed GridFS saves before any sample write.  A
+live zero-length datum is never allowed to replace an existing GridFS object;
+the old waveform and samples remain unchanged.
+For new saves, metadata-validation failures and live zero-length data follow
+the normal :code:`cremate` contract: :code:`cremate=True` discards them
+without creating cemetery documents, including atomic and ensemble members
+saved through :code:`write_distributed_data`.
+
 As noted elsewhere Metadata loaded with data objects in MsPASS can come
 from one of two places:  (1) attributes loaded directly with the atomic data from
 the unique document in a wf collection with which that data is associated,
@@ -508,7 +606,7 @@ method of the Database class:
   def delete_data(self, object_id, object_type,
                   remove_unreferenced_files=False,
                   clear_history=True, clear_elog=True,
-                  collection=None):
+                  collection=None, object_store_client=None):
 
 As with the read methods, :code:`object_id` is the ObjectId of the waveform
 document that references the data to be deleted.  :code:`object_type` must be
@@ -525,6 +623,16 @@ true will result in a loss of information that might be needed to address
 problems during processing.  Both default to true to perform a complete
 delete and avoid orphaned records.  Set either false only when intentionally
 retaining those records and prepared to manage the broken waveform reference.
+Before deleting any requested auxiliary record, :code:`delete_data` places a
+durable internal claim on the waveform document.  Supported metadata and
+sample writers cannot commit while that claim exists.  The waveform and claim
+are retained if a later sample deletion fails, and a subsequent
+:code:`delete_data` call resumes the idempotent cleanup.  The claim is removed
+only with the final waveform deletion and is never copied into a newly saved
+waveform.  Claim, auxiliary cleanup, reference checks, and final parent
+deletion use primary reads and majority writes for every storage mode,
+including file and URL data, even when the caller's Database handle requests
+weaker options.
 
 The main complexity in this method is behind the boolean argument with the name
 :code:`remove_unreferenced_files`.  First, recognize this argument is completely

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -113,14 +113,19 @@ the docstring pages for detailed and most up to date usage:
     TimeSeries payload is :code:`npts` contiguous IEEE 754 float64 values in
     little-endian byte order.  A Seismogram payload is three component-major
     rows of :code:`npts` contiguous values in C order.  Formatted writes use
-    the selected ObsPy format.  If a later MongoDB write raises an exception
-    caught by the current process, :code:`save_data` removes uploaded objects
-    that have not acquired waveform documents, restores the caller's original
-    storage Metadata, and reports full S3 locations if compensation also
-    fails.  Abrupt process or host termination cannot run this in-process
-    compensation and requires durable reconciliation outside this operation;
-    that recovery work is tracked in `GitHub issue #1013
-    <https://github.com/mspass-team/mspass/issues/1013>`_.
+    the selected ObsPy format.  Each upload is preceded by a durable MongoDB
+    staging record containing its preallocated waveform id and exact S3
+    location.  If a later MongoDB write raises an exception caught by the
+    current process, :code:`save_data` removes the uncommitted object and
+    staging record, then restores the caller's original storage Metadata.
+    An abrupt process or host termination leaves the staging record available
+    to :code:`db.reconcile_object_store_staging(s3_client)`, which reports
+    uncommitted S3 URIs without deleting them.  After stopping concurrent
+    object-store writers, pass :code:`delete_uncommitted=True` to delete those
+    objects and their staging records.  A record that exactly matches a
+    committed waveform document is cleared without deleting its S3 object.
+    Object-store ensemble members use this upload-and-commit sequence one at a
+    time, bounding the uncommitted window to one member.
     :code:`update_data` does not replace samples for object-store data; save a
     new datum with :code:`save_data` instead.  :code:`delete_data` requires
     the caller-owned :code:`object_store_client` for object-store data and

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -122,8 +122,12 @@ the docstring pages for detailed and most up to date usage:
     to :code:`db.reconcile_object_store_staging(s3_client)`, which reports
     uncommitted S3 URIs without deleting them.  After stopping concurrent
     object-store writers, pass :code:`delete_uncommitted=True` to delete those
-    objects and their staging records.  A record that exactly matches a
-    committed waveform document is cleared without deleting its S3 object.
+    objects and their staging records.  Reconciliation treats
+    :code:`provider`, :code:`bucket`, and :code:`object_name` as the canonical
+    S3 object identity and checks every schema-defined waveform collection.
+    A referenced identity is cleared from staging without deleting its S3
+    object; nonidentity fields such as :code:`encoding` or :code:`etag` do not
+    affect that decision.
     Object-store ensemble members use this upload-and-commit sequence one at a
     time, bounding the uncommitted window to one member.
     :code:`update_data` does not replace samples for object-store data; save a

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -97,8 +97,9 @@ the docstring pages for detailed and most up to date usage:
     committed auxiliary links and reports unresolved stages without deleting
     samples; :code:`delete_uncommitted=True` also removes unreferenced files,
     partial chunks, auxiliary documents, and stages.  Lifecycle reads use the
-    primary and writes use majority acknowledgement even if the caller's
-    Database handle requests weaker options.  The shared-reference scan and
+    primary with majority read concern and writes use majority acknowledgement
+    even if the caller's Database handle requests weaker options.  The
+    shared-reference scan and
     GridFS delete are not one MongoDB transaction.  If :code:`gridfs_id`
     values are intentionally shared or edited manually, writers capable of
     creating those references must also remain quiescent during replacement,
@@ -143,9 +144,10 @@ the docstring pages for detailed and most up to date usage:
     ids plus the exact S3 location.  This lifecycle currently supports only
     unversioned S3 buckets; bucket version ids are not persisted or passed to
     deletion operations.  Lifecycle state is written with MongoDB majority
-    write concern, and owner/reference decisions are read from the primary;
-    these safety settings override weaker options on the caller's Database
-    handle.
+    write concern, and owner/reference decisions are read from the primary
+    with majority read concern.  Thus irreversible cleanup decisions use only
+    majority-committed state; these safety settings override weaker options on
+    the caller's Database handle.
 
     Once :code:`put_object` has been invoked, an exception cannot prove that
     the upload did not finish at the service.  MsPASS therefore retains the
@@ -165,11 +167,12 @@ the docstring pages for detailed and most up to date usage:
 
     On an uncertain result, the datum held by the caller is a recovery handle:
     its :code:`_id` is the preallocated waveform id recorded in staging, not
-    the id of a previous waveform document.  Do not reuse that in-memory datum
-    directly after reconciliation.  If the staged owner committed, reload it
-    by that :code:`_id`; if reconciliation removes the uncommitted save,
-    discard the datum or restore it from an application-owned copy of its
-    prior state.
+    the id of a previous waveform document.  History, elog, and deletion-claim
+    pointers inherited from a previous owner are removed because they do not
+    belong to the staged owner.  Do not reuse that in-memory datum directly
+    after reconciliation.  If the staged owner committed, reload it by that
+    :code:`_id`; if reconciliation removes the uncommitted save, discard the
+    datum or restore it from an application-owned copy of its prior state.
     An abrupt process or host termination leaves the staging record available
     for reconciliation.  Stop concurrent object-store reference writers and
     wait for all outstanding S3 and MongoDB requests before every call to
@@ -611,9 +614,11 @@ method of the Database class:
 As with the read methods, :code:`object_id` is the ObjectId of the waveform
 document that references the data to be deleted.  :code:`object_type` must be
 either :code:`"TimeSeries"` or :code:`"Seismogram"` and selects the
-corresponding default waveform collection.  Set :code:`collection` to a
-schema-defined waveform collection of that type to delete from an explicit
-collection instead.
+corresponding default waveform collection.  Set :code:`collection` to an
+explicit waveform collection instead.  Schema-defined collections are checked
+against :code:`object_type`; a literal alternate collection accepted by
+:code:`save_data` can also be deleted even when absent from the active database
+schema, with :code:`object_type` supplying its atomic waveform type.
 Similarly, the idea of the :code:`clear_history` and :code:`clear_elog`
 may be apparent from the name.  When true all documents linked to the
 waveform data being deleted in the history and elog collections (respectively)
@@ -630,9 +635,9 @@ are retained if a later sample deletion fails, and a subsequent
 :code:`delete_data` call resumes the idempotent cleanup.  The claim is removed
 only with the final waveform deletion and is never copied into a newly saved
 waveform.  Claim, auxiliary cleanup, reference checks, and final parent
-deletion use primary reads and majority writes for every storage mode,
-including file and URL data, even when the caller's Database handle requests
-weaker options.
+deletion use primary reads with majority read concern and majority writes for
+every storage mode, including file and URL data, even when the caller's
+Database handle requests weaker options.
 
 The main complexity in this method is behind the boolean argument with the name
 :code:`remove_unreferenced_files`.  First, recognize this argument is completely

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -119,9 +119,12 @@ the docstring pages for detailed and most up to date usage:
     current process, :code:`save_data` removes the object and restores the
     caller's original storage Metadata only after MongoDB confirms that no
     waveform document references the object.  If commit status cannot be
-    determined, or the intended waveform owner is already durable, the S3
-    object, staging record, and new caller Metadata are retained for
-    reconciliation and the save raises an explicit fatal error.
+    determined because an attempted waveform insert ends with a connection,
+    topology, or write-concern error, no immediate negative reference query is
+    treated as a commit barrier.  The S3 object, staging record, and new caller
+    Metadata are retained for reconciliation and the save raises an explicit
+    fatal error.  The same retention rule applies when the intended waveform
+    owner is already durable.
     An abrupt process or host termination leaves the staging record available
     to :code:`db.reconcile_object_store_staging(s3_client)`, which reports
     uncommitted S3 URIs without deleting them.  After stopping concurrent
@@ -142,7 +145,12 @@ the docstring pages for detailed and most up to date usage:
     retains the waveform document if the external object cannot be deleted.
     If another waveform document references the same canonical S3 identity,
     only the requested waveform and auxiliary documents are removed; the
-    shared S3 object is retained.
+    shared S3 object is retained.  The MongoDB shared-reference query and S3
+    deletion cannot be one atomic operation.  If identities are intentionally
+    shared or can be edited manually, all writers capable of creating or
+    changing object-store references must remain quiescent for the duration of
+    :code:`delete_data`.  Concurrent creation of a new shared reference is not
+    protected by this API.
 
     When :code:`save_data` is passed an ensemble, it writes each live member
     as an atomic datum.  Ensemble Metadata are copied to each member before

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -109,13 +109,22 @@ the docstring pages for detailed and most up to date usage:
     waveform requires passing a compatible client to
     :code:`db.read_data(..., object_store_client=s3_client)`.  Authentication
     and client lifetime are intentionally managed by the caller.  Native
-    binary samples use the versioned :code:`float64-le-v1` encoding (IEEE 754
-    64-bit floats in little-endian byte order); formatted writes use the
-    selected ObsPy format.  If a later MongoDB write fails, :code:`save_data`
-    removes any uploaded objects that have not acquired waveform documents
-    and reports their full S3 locations if that compensation also fails.
+    binary samples use the versioned :code:`float64-le-v1` encoding.  A
+    TimeSeries payload is :code:`npts` contiguous IEEE 754 float64 values in
+    little-endian byte order.  A Seismogram payload is three component-major
+    rows of :code:`npts` contiguous values in C order.  Formatted writes use
+    the selected ObsPy format.  If a later MongoDB write raises an exception
+    caught by the current process, :code:`save_data` removes uploaded objects
+    that have not acquired waveform documents, restores the caller's original
+    storage Metadata, and reports full S3 locations if compensation also
+    fails.  Abrupt process or host termination cannot run this in-process
+    compensation and requires durable reconciliation outside this operation;
+    that recovery work is tracked in `GitHub issue #1013
+    <https://github.com/mspass-team/mspass/issues/1013>`_.
     :code:`update_data` does not replace samples for object-store data; save a
-    new datum with :code:`save_data` instead.
+    new datum with :code:`save_data` instead.  :code:`delete_data` requires
+    the caller-owned :code:`object_store_client` for object-store data and
+    retains the waveform document if the external object cannot be deleted.
 
     When :code:`save_data` is passed an ensemble, it writes each live member
     as an atomic datum.  Ensemble Metadata are copied to each member before

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -86,6 +86,30 @@ the docstring pages for detailed and most up to date usage:
     Set :code:`return_data=True` when an
     intermediate save needs the updated data object returned to the workflow.
 
+    Sample data can instead be stored in an S3-compatible object store by
+    supplying an authenticated boto3 client and an explicit destination:
+
+    .. code-block:: python
+
+        import boto3
+
+        s3_client = boto3.client("s3")
+        db.save_data(
+            d,
+            storage_mode="object_store",
+            object_store={
+                "provider": "s3",
+                "bucket": "earthscope-scratch",
+                "key_prefix": "auth0|user-id/waveforms",
+            },
+            object_store_client=s3_client,
+        )
+
+    Each atomic datum is stored as an independent object.  Reading the saved
+    waveform requires passing a compatible client to
+    :code:`db.read_data(..., object_store_client=s3_client)`.  Authentication
+    and client lifetime are intentionally managed by the caller.
+
     When :code:`save_data` is passed an ensemble, it writes each live member
     as an atomic datum.  Ensemble Metadata are copied to each member before
     the member is saved.  A common pattern for miniseed data is to bundle

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -116,24 +116,33 @@ the docstring pages for detailed and most up to date usage:
     the selected ObsPy format.  Each upload is preceded by a durable MongoDB
     staging record containing its preallocated waveform id and exact S3
     location.  If a later MongoDB write raises an exception caught by the
-    current process, :code:`save_data` removes the uncommitted object and
-    staging record, then restores the caller's original storage Metadata.
+    current process, :code:`save_data` removes the object and restores the
+    caller's original storage Metadata only after MongoDB confirms that no
+    waveform document references the object.  If commit status cannot be
+    determined, or the intended waveform owner is already durable, the S3
+    object, staging record, and new caller Metadata are retained for
+    reconciliation and the save raises an explicit fatal error.
     An abrupt process or host termination leaves the staging record available
     to :code:`db.reconcile_object_store_staging(s3_client)`, which reports
     uncommitted S3 URIs without deleting them.  After stopping concurrent
     object-store writers, pass :code:`delete_uncommitted=True` to delete those
     objects and their staging records.  Reconciliation treats
     :code:`provider`, :code:`bucket`, and :code:`object_name` as the canonical
-    S3 object identity and checks every schema-defined waveform collection.
-    A referenced identity is cleared from staging without deleting its S3
-    object; nonidentity fields such as :code:`encoding` or :code:`etag` do not
-    affect that decision.
+    S3 object identity.  It first queries the exact staged waveform id and
+    collection, including alternate collections not present in the database
+    schema, then checks every schema-defined waveform collection for shared
+    references.  A referenced identity is cleared from staging without
+    deleting its S3 object; nonidentity fields such as :code:`encoding` or
+    :code:`etag` do not affect that decision.
     Object-store ensemble members use this upload-and-commit sequence one at a
     time, bounding the uncommitted window to one member.
     :code:`update_data` does not replace samples for object-store data; save a
     new datum with :code:`save_data` instead.  :code:`delete_data` requires
     the caller-owned :code:`object_store_client` for object-store data and
     retains the waveform document if the external object cannot be deleted.
+    If another waveform document references the same canonical S3 identity,
+    only the requested waveform and auxiliary documents are removed; the
+    shared S3 object is retained.
 
     When :code:`save_data` is passed an ensemble, it writes each live member
     as an atomic datum.  Ensemble Metadata are copied to each member before

--- a/docs/source/user_manual/CRUD_operations.rst
+++ b/docs/source/user_manual/CRUD_operations.rst
@@ -108,7 +108,14 @@ the docstring pages for detailed and most up to date usage:
     Each atomic datum is stored as an independent object.  Reading the saved
     waveform requires passing a compatible client to
     :code:`db.read_data(..., object_store_client=s3_client)`.  Authentication
-    and client lifetime are intentionally managed by the caller.
+    and client lifetime are intentionally managed by the caller.  Native
+    binary samples use the versioned :code:`float64-le-v1` encoding (IEEE 754
+    64-bit floats in little-endian byte order); formatted writes use the
+    selected ObsPy format.  If a later MongoDB write fails, :code:`save_data`
+    removes any uploaded objects that have not acquired waveform documents
+    and reports their full S3 locations if that compensation also fails.
+    :code:`update_data` does not replace samples for object-store data; save a
+    new datum with :code:`save_data` instead.
 
     When :code:`save_data` is passed an ensemble, it writes each live member
     as an atomic datum.  Ensemble Metadata are copied to each member before

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1907,7 +1907,15 @@ class Database(pymongo.database.Database):
                         waveform_collection=wf_collection_name,
                     )
                     location = copy.deepcopy(datum["object_store"])
-                    staged_data = [(datum, location, snapshot, waveform_id)]
+                    staged_data = [
+                        (
+                            datum,
+                            location,
+                            snapshot,
+                            waveform_id,
+                            wf_collection_name,
+                        )
+                    ]
                     try:
                         saved_datum = self._atomic_save_all_documents(
                             datum,
@@ -1924,13 +1932,26 @@ class Database(pymongo.database.Database):
                             waveform_id=waveform_id,
                         )
                     except Exception as original_error:
-                        cleanup_failures = self._cleanup_staged_object_store_data(
+                        (
+                            cleanup_failures,
+                            durable_references,
+                        ) = self._cleanup_staged_object_store_data(
                             object_store_client, staged_data
                         )
+                        if durable_references:
+                            raise MsPASSError(
+                                "Database.save_data failed after the waveform "
+                                "reference became durable; the object-store "
+                                "samples and staging record were retained for "
+                                "reconciliation: {}".format(
+                                    ", ".join(durable_references)
+                                ),
+                                "Fatal",
+                            ) from original_error
                         if cleanup_failures:
                             raise MsPASSError(
                                 "Database.save_data failed and object-store "
-                                "compensation could not remove: {}".format(
+                                "compensation could not safely remove: {}".format(
                                     ", ".join(cleanup_failures)
                                 ),
                                 "Fatal",
@@ -1946,13 +1967,25 @@ class Database(pymongo.database.Database):
                                 ErrorSeverity.Complaint,
                             )
                     else:
-                        cleanup_failures = self._cleanup_staged_object_store_data(
+                        (
+                            cleanup_failures,
+                            durable_references,
+                        ) = self._cleanup_staged_object_store_data(
                             object_store_client, staged_data
                         )
+                        if durable_references:
+                            raise MsPASSError(
+                                "Waveform samples are durably referenced; the "
+                                "object-store samples and staging record were "
+                                "retained for reconciliation: {}".format(
+                                    ", ".join(durable_references)
+                                ),
+                                "Fatal",
+                            )
                         if cleanup_failures:
                             raise MsPASSError(
                                 "Waveform document was not committed and object-store "
-                                "compensation could not remove: {}".format(
+                                "compensation could not safely remove: {}".format(
                                     ", ".join(cleanup_failures)
                                 ),
                                 "Fatal",
@@ -4273,7 +4306,8 @@ class Database(pymongo.database.Database):
         waveform data.  If the data are stored in gridfs the deletion of
         the waveform data will be immediate.  If the data are stored in
         object store the independent object is deleted through the caller-owned
-        client.  If the data are stored in disk files the file will be deleted
+        client when no other waveform document references the same canonical
+        identity.  If the data are stored in disk files the file will be deleted
         when there are no more references
         in any schema-defined waveform collection for the exact combination
         of dir and dfile associated with an atomic deletion.  Requested
@@ -4405,17 +4439,31 @@ class Database(pymongo.database.Database):
 
         elif storage_mode == "object_store":
             try:
-                object_store_client.delete_object(
-                    Bucket=bucket,
-                    Key=object_name,
+                object_store_is_shared = self._object_store_is_referenced(
+                    object_store_location,
+                    exclude_collection=wf_collection_name,
+                    exclude_id=oid,
                 )
             except Exception as error:
                 raise MsPASSError(
-                    "Could not delete object-store samples at "
-                    "s3://{}/{}; the waveform document was retained for "
-                    "retry".format(bucket, object_name),
+                    "Could not determine whether object-store samples at "
+                    "s3://{}/{} are shared; the waveform document was "
+                    "retained for retry".format(bucket, object_name),
                     ErrorSeverity.Fatal,
                 ) from error
+            if not object_store_is_shared:
+                try:
+                    object_store_client.delete_object(
+                        Bucket=bucket,
+                        Key=object_name,
+                    )
+                except Exception as error:
+                    raise MsPASSError(
+                        "Could not delete object-store samples at "
+                        "s3://{}/{}; the waveform document was retained for "
+                        "retry".format(bucket, object_name),
+                        ErrorSeverity.Fatal,
+                    ) from error
 
         elif (
             storage_mode == "file"
@@ -5796,13 +5844,50 @@ class Database(pymongo.database.Database):
             if definition.data_type() in (TimeSeries, Seismogram)
         }
 
-    def _object_store_is_referenced(self, location):
-        """Return True if any waveform document names this S3 object."""
-        query = self._object_store_identity_filter(location)
-        return any(
-            self[collection_name].find_one(query, {"_id": 1}) is not None
-            for collection_name in self._waveform_collection_names()
-        )
+    def _object_store_is_referenced(
+        self,
+        location,
+        expected_collection=None,
+        expected_id=None,
+        exclude_collection=None,
+        exclude_id=None,
+    ):
+        """Return True if a waveform document names this S3 object.
+
+        ``expected_collection`` and ``expected_id`` identify a staging
+        record's intended owner and provide an indexed fast path, including
+        for alternate collections not present in ``DatabaseSchema``.
+        ``exclude_collection`` and ``exclude_id`` omit the waveform document
+        currently being deleted while retaining shared-reference checks.
+        """
+        if (expected_collection is None) != (expected_id is None):
+            raise ValueError(
+                "expected_collection and expected_id must be supplied together"
+            )
+        if (exclude_collection is None) != (exclude_id is None):
+            raise ValueError(
+                "exclude_collection and exclude_id must be supplied together"
+            )
+
+        identity_query = self._object_store_identity_filter(location)
+        if expected_collection is not None:
+            owner_query = {"_id": expected_id}
+            owner_query.update(identity_query)
+            if self[expected_collection].find_one(owner_query, {"_id": 1}) is not None:
+                return True
+
+        collection_names = self._waveform_collection_names()
+        if expected_collection is not None:
+            collection_names.add(expected_collection)
+        if exclude_collection is not None:
+            collection_names.add(exclude_collection)
+        for collection_name in collection_names:
+            query = dict(identity_query)
+            if collection_name == exclude_collection:
+                query["_id"] = {"$ne": exclude_id}
+            if self[collection_name].find_one(query, {"_id": 1}) is not None:
+                return True
+        return False
 
     @staticmethod
     def _validate_object_store_schema(save_schema, mode, exclude_keys=None):
@@ -5853,17 +5938,33 @@ class Database(pymongo.database.Database):
                 mspass_object.erase(key)
 
     def _cleanup_staged_object_store_data(self, object_store_client, staged_data):
-        """Delete uploaded objects that have no committed waveform document."""
+        """Delete uploads only after MongoDB proves they are unreferenced."""
         failures = []
+        durable_references = []
         for staged_item in staged_data:
             datum, location, metadata_snapshot = staged_item[:3]
             stage_id = staged_item[3] if len(staged_item) > 3 else None
+            waveform_collection = staged_item[4] if len(staged_item) > 4 else None
             bucket = location["bucket"]
             object_name = location["object_name"]
+            uri = "s3://{}/{}".format(bucket, object_name)
+            if stage_id is not None and waveform_collection is not None:
+                try:
+                    referenced = self._object_store_is_referenced(
+                        location,
+                        expected_collection=waveform_collection,
+                        expected_id=stage_id,
+                    )
+                except Exception:
+                    failures.append("reference status for {}".format(uri))
+                    continue
+                if referenced:
+                    durable_references.append(uri)
+                    continue
             try:
                 object_store_client.delete_object(Bucket=bucket, Key=object_name)
             except Exception:
-                failures.append("s3://{}/{}".format(bucket, object_name))
+                failures.append(uri)
                 continue
             Database._restore_object_store_metadata(datum, metadata_snapshot)
             if stage_id is not None:
@@ -5873,7 +5974,7 @@ class Database(pymongo.database.Database):
                     self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(stage_filter)
                 except Exception:
                     failures.append("staging record {}".format(stage_id))
-        return failures
+        return failures, durable_references
 
     def _complete_object_store_stage(self, stage_id, location):
         """Remove a staging record after its waveform reference is durable."""
@@ -5892,11 +5993,13 @@ class Database(pymongo.database.Database):
 
         A staging record is written before each S3 upload and removed only
         after the corresponding waveform document has been committed.  A
-        record whose canonical S3 identity (provider, bucket, and object
-        name) is referenced by any schema-defined waveform collection is
-        committed; reconciliation removes only the stale staging record and
-        never its sample object.  Other records are reported as uncommitted by
-        default.
+        record whose intended owner has the same canonical S3 identity
+        (provider, bucket, and object name) is committed, including owners in
+        alternate collections not present in ``DatabaseSchema``.  If that
+        exact owner is absent, every schema-defined waveform collection is
+        checked for a shared reference.  Reconciliation removes only the
+        stale staging record for committed objects and never their samples.
+        Other records are reported as uncommitted by default.
 
         Set ``delete_uncommitted=True`` only while object-store writers are
         quiescent.  MongoDB and S3 cannot provide a cross-system transaction,
@@ -5933,7 +6036,18 @@ class Database(pymongo.database.Database):
                 )
                 continue
             uri = "s3://{}/{}".format(location["bucket"], location["object_name"])
-            if self._object_store_is_referenced(location):
+            try:
+                referenced = self._object_store_is_referenced(
+                    location,
+                    expected_collection=waveform_collection,
+                    expected_id=waveform_id,
+                )
+            except Exception as error:
+                report["failures"].append(
+                    "{}: could not determine waveform references: {}".format(uri, error)
+                )
+                continue
+            if referenced:
                 try:
                     stage_filter = {"_id": stage_id}
                     stage_filter.update(self._object_store_identity_filter(location))
@@ -7840,13 +7954,27 @@ class Database(pymongo.database.Database):
                             )
                         )
             except Exception as original_error:
-                cleanup_failures = self._cleanup_staged_object_store_data(
+                (
+                    cleanup_failures,
+                    durable_references,
+                ) = self._cleanup_staged_object_store_data(
                     object_store_client, staged_data
                 )
+                if durable_references:
+                    raise MsPASSError(
+                        "Object-store ensemble upload failed after a waveform "
+                        "reference became durable; samples and staging were "
+                        "retained for reconciliation: {}".format(
+                            ", ".join(durable_references)
+                        ),
+                        "Fatal",
+                    ) from original_error
                 if cleanup_failures:
                     raise MsPASSError(
                         "Object-store ensemble upload failed and compensation "
-                        "could not remove: {}".format(", ".join(cleanup_failures)),
+                        "could not safely remove: {}".format(
+                            ", ".join(cleanup_failures)
+                        ),
                         "Fatal",
                     ) from original_error
                 raise
@@ -7913,14 +8041,33 @@ class Database(pymongo.database.Database):
                 Body=payload,
             )
         except Exception as err:
-            cleanup_failures = self._cleanup_staged_object_store_data(
+            (
+                cleanup_failures,
+                durable_references,
+            ) = self._cleanup_staged_object_store_data(
                 object_store_client,
-                [(mspass_object, location, metadata_snapshot, stage_id)],
+                [
+                    (
+                        mspass_object,
+                        location,
+                        metadata_snapshot,
+                        stage_id,
+                        waveform_collection,
+                    )
+                ],
             )
+            if durable_references:
+                raise MsPASSError(
+                    "Error while writing {}; a waveform reference is durable, "
+                    "so samples and staging were retained for reconciliation".format(
+                        durable_references[0]
+                    ),
+                    "Fatal",
+                ) from err
             if cleanup_failures:
                 raise MsPASSError(
                     "Error while writing s3://{}/{}; compensation could not "
-                    "remove: {}".format(
+                    "safely remove: {}".format(
                         bucket, object_name, ", ".join(cleanup_failures)
                     ),
                     "Fatal",

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -200,6 +200,22 @@ def _managed_response_stream(stream):
         stream.close()
 
 
+class _ObjectStoreWaveformCommitUncertain(Exception):
+    """Signal that an attempted waveform insert may still become durable."""
+
+
+def _waveform_insert_result_is_uncertain(error):
+    """Return True when PyMongo cannot prove an attempted insert was rejected."""
+    if not isinstance(error, pymongo.errors.PyMongoError):
+        return False
+    if error.has_error_label("NoWritesPerformed"):
+        return False
+    return isinstance(
+        error,
+        (pymongo.errors.ConnectionFailure, pymongo.errors.WriteConcernError),
+    ) or error.has_error_label("RetryableWriteError")
+
+
 @contextmanager
 def _managed_collection_cursor(collection, query, no_cursor_timeout=False):
     """Yield a cursor that is closed reliably after a collection scan.
@@ -1648,7 +1664,10 @@ class Database(pymongo.database.Database):
         :type object_store: :class:`dict`
         :param object_store_client: boto3-compatible S3 client used to write
           object-store sample data.  Authentication and client lifetime remain
-          the caller's responsibility.
+          the caller's responsibility.  If an attempted waveform insert ends
+          with an uncertain MongoDB result, the uploaded samples, durable
+          staging record, and new caller metadata are retained for later
+          reconciliation instead of being compensated in process.
 
         :param exclude_keys: Metadata can often become contaminated with
           attributes that are no longer needed or a mismatch with the data.
@@ -1931,6 +1950,17 @@ class Database(pymongo.database.Database):
                             alg_id,
                             waveform_id=waveform_id,
                         )
+                    except _ObjectStoreWaveformCommitUncertain as original_error:
+                        raise MsPASSError(
+                            "Database.save_data could not determine whether the "
+                            "waveform insert committed; the object-store samples, "
+                            "staging record, and new caller metadata were retained "
+                            "for reconciliation: "
+                            "s3://{}/{}".format(
+                                location["bucket"], location["object_name"]
+                            ),
+                            "Fatal",
+                        ) from original_error
                     except Exception as original_error:
                         (
                             cleanup_failures,
@@ -4307,7 +4337,11 @@ class Database(pymongo.database.Database):
         the waveform data will be immediate.  If the data are stored in
         object store the independent object is deleted through the caller-owned
         client when no other waveform document references the same canonical
-        identity.  If the data are stored in disk files the file will be deleted
+        identity.  That MongoDB reference check and the external deletion are
+        not atomic.  Callers that intentionally share or manually edit object-
+        store identities must keep all reference writers quiescent until this
+        method returns.  Concurrent creation of a new shared reference is not
+        protected.  If the data are stored in disk files the file will be deleted
         when there are no more references
         in any schema-defined waveform collection for the exact combination
         of dir and dfile associated with an atomic deletion.  Requested
@@ -8275,7 +8309,14 @@ class Database(pymongo.database.Database):
             try:
                 if wfid is not None:
                     insertion_dict["_id"] = wfid
-                wfid = wf_collection.insert_one(insertion_dict).inserted_id
+                try:
+                    wfid = wf_collection.insert_one(insertion_dict).inserted_id
+                except Exception as error:
+                    if storage_mode == "object_store" and (
+                        _waveform_insert_result_is_uncertain(error)
+                    ):
+                        raise _ObjectStoreWaveformCommitUncertain() from error
+                    raise
                 waveform_inserted = True
                 if history_object_id is not None:
                     wf_id_name = wf_collection.name + "_id"
@@ -8289,6 +8330,8 @@ class Database(pymongo.database.Database):
                             "to the waveform",
                             ErrorSeverity.Invalid,
                         )
+            except _ObjectStoreWaveformCommitUncertain:
+                raise
             except Exception:
                 if waveform_inserted:
                     wf_collection.delete_one({"_id": wfid})

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -74,6 +74,7 @@ from mspasspy.util.converter import Textfile2Dataframe
 
 _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS = 300.0
 _GRIDFS_IO_CHUNK_BYTES = 1024 * 1024
+_OBJECT_STORE_BINARY_ENCODING = "float64-le-v1"
 
 
 class _NativeSampleReader(io.RawIOBase):
@@ -1804,6 +1805,10 @@ class Database(pymongo.database.Database):
                 # this only an else.  If more data types are added this will
                 # break
                 save_schema = schema.Seismogram
+            if storage_mode == "object_store":
+                self._validate_object_store_schema(
+                    save_schema, mode, exclude_keys=exclude_keys
+                )
 
             if collection:
                 wf_collection_name = collection
@@ -1855,28 +1860,19 @@ class Database(pymongo.database.Database):
                 object_store=object_store,
                 object_store_client=object_store_client,
             )
-            # ensembles need to loop over members to do the atomic operations
-            # remaining.  Hence, this conditional
-            if isinstance(mspass_object, (TimeSeries, Seismogram)):
-                mspass_object = self._atomic_save_all_documents(
-                    mspass_object,
-                    save_schema,
-                    exclude_keys,
-                    mode,
-                    wf_collection,
-                    save_history,
-                    data_tag,
-                    storage_mode,
-                    normalizing_collections,
-                    alg_name,
-                    alg_id,
-                )
-
-            else:
-                # note else not elif because above guarantees only ensembles land here
-                for d in mspass_object.member:
-                    d = self._atomic_save_all_documents(
-                        d,
+            staged_object_store_data = []
+            if storage_mode == "object_store":
+                staged_object_store_data = [
+                    (datum, copy.deepcopy(datum["object_store"]))
+                    for datum in atomic_data
+                    if datum.live and "object_store" in datum
+                ]
+            try:
+                # ensembles need to loop over members to do the atomic operations
+                # remaining.  Hence, this conditional
+                if isinstance(mspass_object, (TimeSeries, Seismogram)):
+                    mspass_object = self._atomic_save_all_documents(
+                        mspass_object,
                         save_schema,
                         exclude_keys,
                         mode,
@@ -1888,6 +1884,53 @@ class Database(pymongo.database.Database):
                         alg_name,
                         alg_id,
                     )
+                    if mspass_object.live:
+                        staged_object_store_data.clear()
+
+                else:
+                    # note else not elif because above guarantees only ensembles land here
+                    for datum in mspass_object.member:
+                        saved_datum = self._atomic_save_all_documents(
+                            datum,
+                            save_schema,
+                            exclude_keys,
+                            mode,
+                            wf_collection,
+                            save_history,
+                            data_tag,
+                            storage_mode,
+                            normalizing_collections,
+                            alg_name,
+                            alg_id,
+                        )
+                        if saved_datum.live:
+                            staged_object_store_data = [
+                                staged
+                                for staged in staged_object_store_data
+                                if staged[0] is not datum
+                            ]
+            except Exception as original_error:
+                cleanup_failures = self._cleanup_staged_object_store_data(
+                    object_store_client, staged_object_store_data
+                )
+                if cleanup_failures:
+                    raise MsPASSError(
+                        "Database.save_data failed and object-store compensation "
+                        "could not remove: {}".format(", ".join(cleanup_failures)),
+                        "Fatal",
+                    ) from original_error
+                raise
+            cleanup_failures = self._cleanup_staged_object_store_data(
+                object_store_client, staged_object_store_data
+            )
+            if cleanup_failures:
+                raise MsPASSError(
+                    "Waveform documents were not committed and object-store "
+                    "compensation could not remove: {}".format(
+                        ", ".join(cleanup_failures)
+                    ),
+                    "Fatal",
+                )
         elif not overwrite_handled:
             # may need to clean Metadata before calling this method
             # to assure there are not values that will cause MongoDB
@@ -3484,6 +3527,14 @@ class Database(pymongo.database.Database):
             save_schema = schema.TimeSeries
         else:
             save_schema = schema.Seismogram
+        if (
+            "storage_mode" in mspass_object
+            and mspass_object["storage_mode"] == "object_store"
+        ):
+            raise ValueError(
+                "Database.update_data does not support sample updates for "
+                "object_store data; save a new datum with Database.save_data instead"
+            )
         # First update metadata.  update_metadata will throw an exception
         # only for usage errors.   We test the elog size to check if there
         # are other warning messages and add a summary if there were any
@@ -3540,16 +3591,15 @@ class Database(pymongo.database.Database):
         # Now handle update of sample data.  The gridfs method used here
         # handles that correctly based on the gridfs id.
         if mspass_object.live:
+            original_has_storage_mode = "storage_mode" in mspass_object
             original_storage_mode = (
-                mspass_object["storage_mode"]
-                if "storage_mode" in mspass_object
-                else None
+                mspass_object["storage_mode"] if original_has_storage_mode else None
             )
             original_has_gridfs_id = "gridfs_id" in mspass_object
             original_gridfs_id = (
                 mspass_object["gridfs_id"] if original_has_gridfs_id else None
             )
-            file_to_gridfs_transition = original_storage_mode == "file"
+            transition_to_gridfs = original_storage_mode != "gridfs"
             if "storage_mode" in mspass_object:
                 storage_mode = mspass_object["storage_mode"]
                 if not storage_mode == "gridfs":
@@ -3561,8 +3611,7 @@ class Database(pymongo.database.Database):
                         ErrorSeverity.Complaint,
                     )
                     mspass_object["storage_mode"] = "gridfs"
-                    if file_to_gridfs_transition:
-                        update_record["storage_mode"] = "gridfs"
+                    update_record["storage_mode"] = "gridfs"
             else:
                 mspass_object.elog.log_error(
                     alg_name,
@@ -3573,9 +3622,10 @@ class Database(pymongo.database.Database):
                 update_record["storage_mode"] = "gridfs"
             # Supplying the replacement id lets rollback remove a blob even
             # when GridFS writes it and then raises an exception.
-            # A file-backed datum never treats a stale gridfs_id as its active
-            # sample reference; storage_mode remains authoritative.
-            active_old_gridfs_id = None if file_to_gridfs_transition else old_gridfs_id
+            # A datum transitioning from another mode never treats a stale
+            # gridfs_id as its active sample reference; storage_mode remains
+            # authoritative.
+            active_old_gridfs_id = None if transition_to_gridfs else old_gridfs_id
             staged_gridfs_id = ObjectId() if active_old_gridfs_id is not None else None
             new_gridfs_id = None
             elog_id = None
@@ -3638,9 +3688,14 @@ class Database(pymongo.database.Database):
                 filter_ = {"_id": mspass_object["_id"]}
                 if active_old_gridfs_id is not None:
                     filter_["gridfs_id"] = active_old_gridfs_id
-                result = wf_collection.update_one(filter_, {"$set": update_record})
+                update_operation = {"$set": update_record}
+                inactive_pointer_keys = Database._inactive_storage_pointer_keys(
+                    "gridfs"
+                )
+                update_operation["$unset"] = {key: "" for key in inactive_pointer_keys}
+                result = wf_collection.update_one(filter_, update_operation)
                 if (
-                    active_old_gridfs_id is not None or file_to_gridfs_transition
+                    active_old_gridfs_id is not None or transition_to_gridfs
                 ) and result.matched_count != 1:
                     raise MsPASSError(
                         "Database.update_data could not commit the new GridFS "
@@ -3669,9 +3724,13 @@ class Database(pymongo.database.Database):
                         mspass_object["gridfs_id"] = original_gridfs_id
                     elif "gridfs_id" in mspass_object:
                         mspass_object.erase("gridfs_id")
-                    if file_to_gridfs_transition:
-                        mspass_object["storage_mode"] = original_storage_mode
+                    if transition_to_gridfs:
+                        if original_has_storage_mode:
+                            mspass_object["storage_mode"] = original_storage_mode
+                        elif "storage_mode" in mspass_object:
+                            mspass_object.erase("storage_mode")
                 raise
+            Database._normalize_storage_pointers(mspass_object, "gridfs")
             # we may probably set the elog_id field in the mspass_object
             if elog_id:
                 mspass_object[elog_id_name] = elog_id
@@ -5515,6 +5574,70 @@ class Database(pymongo.database.Database):
         Database._load_data_from_formatted_bytes(mspass_object, payload, format)
 
     @staticmethod
+    def _inactive_storage_pointer_keys(storage_mode):
+        """Return sample-location keys that are invalid for ``storage_mode``."""
+        pointer_keys = {
+            "file": {"dir", "dfile", "foff"},
+            "gridfs": {"gridfs_id"},
+            "object_store": {"object_store"},
+            "url": {"url"},
+        }
+        if storage_mode not in pointer_keys:
+            raise ValueError("unknown storage mode={}".format(storage_mode))
+        active_keys = pointer_keys[storage_mode]
+        return set().union(*pointer_keys.values()) - active_keys
+
+    @staticmethod
+    def _normalize_storage_pointers(mspass_object, storage_mode):
+        """Remove sample pointers belonging to inactive storage modes."""
+        for key in Database._inactive_storage_pointer_keys(storage_mode):
+            if key in mspass_object:
+                mspass_object.erase(key)
+
+    @staticmethod
+    def _validate_object_store_schema(save_schema, mode, exclude_keys=None):
+        """Reject schemas that would discard object-store location metadata."""
+        required_attributes = {
+            "storage_mode": str,
+            "object_store": dict,
+            "format": str,
+            "nbytes": int,
+        }
+        problems = []
+        for key, required_type in required_attributes.items():
+            if exclude_keys and key in exclude_keys:
+                problems.append("{} is excluded".format(key))
+            elif mode == "promiscuous":
+                continue
+            elif key not in save_schema.keys():
+                problems.append("{} is undefined".format(key))
+            elif save_schema.type(key) is not required_type:
+                problems.append("{} has the wrong type".format(key))
+            elif save_schema.readonly(key):
+                problems.append("{} is readonly".format(key))
+        if problems:
+            raise ValueError(
+                "storage_mode=object_store is incompatible with the selected "
+                "metadata schema: {}".format(", ".join(problems))
+            )
+
+    @staticmethod
+    def _cleanup_staged_object_store_data(object_store_client, staged_data):
+        """Delete uploaded objects that have no committed waveform document."""
+        failures = []
+        for datum, location in staged_data:
+            bucket = location["bucket"]
+            object_name = location["object_name"]
+            try:
+                object_store_client.delete_object(Bucket=bucket, Key=object_name)
+            except Exception:
+                failures.append("s3://{}/{}".format(bucket, object_name))
+                continue
+            if "object_store" in datum and datum["object_store"] == location:
+                datum.erase("object_store")
+        return failures
+
+    @staticmethod
     def _read_data_from_object_store(
         mspass_object, object_store, object_store_client, format=None
     ):
@@ -5533,6 +5656,12 @@ class Database(pymongo.database.Database):
             raise ValueError(
                 "object_store_client is required to read object_store data"
             )
+        if format is None or format == "binary":
+            encoding = object_store.get("encoding")
+            if encoding != _OBJECT_STORE_BINARY_ENCODING:
+                raise ValueError(
+                    "unsupported object-store binary encoding={!r}".format(encoding)
+                )
 
         try:
             response = object_store_client.get_object(Bucket=bucket, Key=object_name)
@@ -5571,15 +5700,13 @@ class Database(pymongo.database.Database):
                 ),
                 "Invalid",
             )
+        np_arr = np.frombuffer(payload, dtype="<f8")
         if isinstance(mspass_object, TimeSeries):
-            float_array = array("d")
-            float_array.frombytes(payload)
-            mspass_object.data = DoubleVector(float_array)
+            mspass_object.data = DoubleVector(np.asarray(np_arr, dtype=np.float64))
         else:
-            np_arr = np.frombuffer(payload, dtype=np.float64).reshape(
-                3, mspass_object.npts
+            mspass_object.data = dmatrix(
+                np.asarray(np_arr.reshape(3, mspass_object.npts), dtype=np.float64)
             )
-            mspass_object.data = dmatrix(np_arr)
         if mspass_object.npts > 0:
             mspass_object.set_live()
         else:
@@ -7016,6 +7143,14 @@ class Database(pymongo.database.Database):
                     + storage_mode
                 )
                 raise ValueError(message)
+            atomic_data = (
+                [mspass_object]
+                if isinstance(mspass_object, (TimeSeries, Seismogram))
+                else mspass_object.member
+            )
+            for datum in atomic_data:
+                if datum.live:
+                    Database._normalize_storage_pointers(datum, storage_mode)
             return mspass_object
         else:
             message = "_save_sample_data:  arg0 must be a MsPASS data object\n"
@@ -7343,14 +7478,30 @@ class Database(pymongo.database.Database):
             )
 
         if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
-            for datum in mspass_object.member:
-                if datum.live:
-                    self._save_sample_data_to_object_store(
-                        datum,
-                        object_store,
-                        object_store_client,
-                        format,
-                    )
+            staged_data = []
+            try:
+                for datum in mspass_object.member:
+                    if datum.live:
+                        self._save_sample_data_to_object_store(
+                            datum,
+                            object_store,
+                            object_store_client,
+                            format,
+                        )
+                        staged_data.append(
+                            (datum, copy.deepcopy(datum["object_store"]))
+                        )
+            except Exception as original_error:
+                cleanup_failures = self._cleanup_staged_object_store_data(
+                    object_store_client, staged_data
+                )
+                if cleanup_failures:
+                    raise MsPASSError(
+                        "Object-store ensemble upload failed and compensation "
+                        "could not remove: {}".format(", ".join(cleanup_failures)),
+                        "Fatal",
+                    ) from original_error
+                raise
             return mspass_object
 
         if not isinstance(mspass_object, (TimeSeries, Seismogram)):
@@ -7359,7 +7510,7 @@ class Database(pymongo.database.Database):
         if format is None:
             format = "binary"
         if format == "binary":
-            payload = bytes(np.array(mspass_object.data))
+            payload = np.asarray(mspass_object.data, dtype="<f8").tobytes(order="C")
             suffix = ".bin"
         else:
             buffer = io.BytesIO()
@@ -7373,6 +7524,13 @@ class Database(pymongo.database.Database):
         object_name = uuid.uuid4().hex + suffix
         if key_prefix:
             object_name = key_prefix.rstrip("/") + "/" + object_name
+        location = {
+            "provider": "s3",
+            "bucket": bucket,
+            "object_name": object_name,
+        }
+        if format == "binary":
+            location["encoding"] = _OBJECT_STORE_BINARY_ENCODING
         try:
             object_store_client.put_object(
                 Bucket=bucket,
@@ -7384,19 +7542,27 @@ class Database(pymongo.database.Database):
             botocore.exceptions.ClientError,
             OSError,
         ) as err:
+            cleanup_failures = self._cleanup_staged_object_store_data(
+                object_store_client, [(mspass_object, location)]
+            )
+            if cleanup_failures:
+                raise MsPASSError(
+                    "Error while writing s3://{}/{}; compensation could not "
+                    "remove: {}".format(
+                        bucket, object_name, ", ".join(cleanup_failures)
+                    ),
+                    "Fatal",
+                ) from err
             raise MsPASSError(
                 "Error while writing s3://{}/{}".format(bucket, object_name),
                 "Fatal",
             ) from err
 
         mspass_object["storage_mode"] = "object_store"
-        mspass_object["object_store"] = {
-            "provider": "s3",
-            "bucket": bucket,
-            "object_name": object_name,
-        }
+        mspass_object["object_store"] = location
         mspass_object["format"] = format
         mspass_object["nbytes"] = len(payload)
+        Database._normalize_storage_pointers(mspass_object, "object_store")
         return mspass_object
 
     def _save_sample_data_to_gridfs(

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -4,6 +4,7 @@ import copy
 import pathlib
 import pickle
 import tempfile
+from datetime import datetime, timezone
 from time import monotonic
 import urllib.error
 import urllib.request
@@ -75,6 +76,7 @@ from mspasspy.util.converter import Textfile2Dataframe
 _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS = 300.0
 _GRIDFS_IO_CHUNK_BYTES = 1024 * 1024
 _OBJECT_STORE_BINARY_ENCODING = "float64-le-v1"
+_OBJECT_STORE_STAGING_COLLECTION = "object_store_staging"
 _OBJECT_STORE_STORAGE_KEYS = (
     "storage_mode",
     "object_store",
@@ -1840,14 +1842,19 @@ class Database(pymongo.database.Database):
                     for datum in atomic_data
                 ]
 
-            # We need to make sure storage_mode is set in all live data
             if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
                 mspass_object.sync_metadata()
-                for d in mspass_object.member:
-                    if d.live:
-                        d["storage_mode"] = storage_mode
-            else:
-                # only atomic data can land here
+                if storage_mode == "object_store":
+                    for index, datum in enumerate(atomic_data):
+                        if datum.live:
+                            self._restore_object_store_metadata(
+                                datum, object_store_metadata_snapshots[index]
+                            )
+                else:
+                    for datum in atomic_data:
+                        if datum.live:
+                            datum["storage_mode"] = storage_mode
+            elif storage_mode != "object_store":
                 mspass_object["storage_mode"] = storage_mode
 
             for datum in atomic_data:
@@ -1863,36 +1870,101 @@ class Database(pymongo.database.Database):
                     if not metadata_is_valid:
                         datum.kill()
 
-            # Complete schema validation before creating sample data.
-
-            # Extend this method to add new storge modes
-            # Note this implementation alters metadata in mspass_object
-            # and all members of ensembles
-            mspass_object = self._save_sample_data(
-                mspass_object,
-                storage_mode=storage_mode,
-                dir=dir,
-                dfile=dfile,
-                format=format,
-                overwrite=overwrite,
-                object_store=object_store,
-                object_store_client=object_store_client,
-                object_store_metadata_snapshots=object_store_metadata_snapshots,
-            )
-            staged_object_store_data = []
             if storage_mode == "object_store":
-                staged_object_store_data = [
-                    (
+                # Each live member is serialized, durably staged, uploaded,
+                # and committed before the next member starts.  This both
+                # gives interrupted writes a persistent reconciliation record
+                # and bounds an ensemble's uncommitted upload window to one
+                # object.
+                for index, datum in enumerate(atomic_data):
+                    if datum.dead():
+                        buried_datum = self._atomic_save_all_documents(
+                            datum,
+                            save_schema,
+                            exclude_keys,
+                            mode,
+                            wf_collection,
+                            save_history,
+                            data_tag,
+                            storage_mode,
+                            normalizing_collections,
+                            alg_name,
+                            alg_id,
+                        )
+                        if isinstance(mspass_object, (TimeSeries, Seismogram)):
+                            mspass_object = buried_datum
+                        continue
+                    waveform_id = ObjectId()
+                    snapshot = object_store_metadata_snapshots[index]
+                    self._save_sample_data_to_object_store(
                         datum,
-                        copy.deepcopy(datum["object_store"]),
-                        object_store_metadata_snapshots[index],
+                        object_store,
+                        object_store_client,
+                        format=format,
+                        metadata_snapshots=[snapshot],
+                        waveform_id=waveform_id,
+                        waveform_collection=wf_collection_name,
                     )
-                    for index, datum in enumerate(atomic_data)
-                    if datum.live and "object_store" in datum
-                ]
-            try:
-                # ensembles need to loop over members to do the atomic operations
-                # remaining.  Hence, this conditional
+                    location = copy.deepcopy(datum["object_store"])
+                    staged_data = [(datum, location, snapshot, waveform_id)]
+                    try:
+                        saved_datum = self._atomic_save_all_documents(
+                            datum,
+                            save_schema,
+                            exclude_keys,
+                            mode,
+                            wf_collection,
+                            save_history,
+                            data_tag,
+                            storage_mode,
+                            normalizing_collections,
+                            alg_name,
+                            alg_id,
+                            waveform_id=waveform_id,
+                        )
+                    except Exception as original_error:
+                        cleanup_failures = self._cleanup_staged_object_store_data(
+                            object_store_client, staged_data
+                        )
+                        if cleanup_failures:
+                            raise MsPASSError(
+                                "Database.save_data failed and object-store "
+                                "compensation could not remove: {}".format(
+                                    ", ".join(cleanup_failures)
+                                ),
+                                "Fatal",
+                            ) from original_error
+                        raise
+                    if saved_datum.live:
+                        if not self._complete_object_store_stage(waveform_id, location):
+                            saved_datum.elog.log_error(
+                                "Database.save_data",
+                                "Waveform data were committed, but the durable "
+                                "object-store staging record could not be removed; "
+                                "reconciliation will preserve the committed object",
+                                ErrorSeverity.Complaint,
+                            )
+                    else:
+                        cleanup_failures = self._cleanup_staged_object_store_data(
+                            object_store_client, staged_data
+                        )
+                        if cleanup_failures:
+                            raise MsPASSError(
+                                "Waveform document was not committed and object-store "
+                                "compensation could not remove: {}".format(
+                                    ", ".join(cleanup_failures)
+                                ),
+                                "Fatal",
+                            )
+            else:
+                mspass_object = self._save_sample_data(
+                    mspass_object,
+                    storage_mode=storage_mode,
+                    dir=dir,
+                    dfile=dfile,
+                    format=format,
+                    overwrite=overwrite,
+                )
                 if isinstance(mspass_object, (TimeSeries, Seismogram)):
                     mspass_object = self._atomic_save_all_documents(
                         mspass_object,
@@ -1907,13 +1979,9 @@ class Database(pymongo.database.Database):
                         alg_name,
                         alg_id,
                     )
-                    if mspass_object.live:
-                        staged_object_store_data.clear()
-
                 else:
-                    # note else not elif because above guarantees only ensembles land here
                     for datum in mspass_object.member:
-                        saved_datum = self._atomic_save_all_documents(
+                        self._atomic_save_all_documents(
                             datum,
                             save_schema,
                             exclude_keys,
@@ -1926,31 +1994,6 @@ class Database(pymongo.database.Database):
                             alg_name,
                             alg_id,
                         )
-                        if saved_datum.live:
-                            if storage_mode == "object_store":
-                                staged_object_store_data.pop(0)
-            except Exception as original_error:
-                cleanup_failures = self._cleanup_staged_object_store_data(
-                    object_store_client, staged_object_store_data
-                )
-                if cleanup_failures:
-                    raise MsPASSError(
-                        "Database.save_data failed and object-store compensation "
-                        "could not remove: {}".format(", ".join(cleanup_failures)),
-                        "Fatal",
-                    ) from original_error
-                raise
-            cleanup_failures = self._cleanup_staged_object_store_data(
-                object_store_client, staged_object_store_data
-            )
-            if cleanup_failures:
-                raise MsPASSError(
-                    "Waveform documents were not committed and object-store "
-                    "compensation could not remove: {}".format(
-                        ", ".join(cleanup_failures)
-                    ),
-                    "Fatal",
-                )
         elif not overwrite_handled:
             # may need to clean Metadata before calling this method
             # to assure there are not values that will cause MongoDB
@@ -3556,7 +3599,7 @@ class Database(pymongo.database.Database):
         if "_id" in mspass_object:
             persisted_document = wf_collection.find_one(
                 {"_id": mspass_object["_id"]},
-                {"storage_mode": 1, "object_store": 1},
+                {"storage_mode": 1, "object_store": 1, "gridfs_id": 1},
             )
         if persisted_document is not None and (
             persisted_document.get("storage_mode") == "object_store"
@@ -3647,7 +3690,16 @@ class Database(pymongo.database.Database):
             original_gridfs_id = (
                 mspass_object["gridfs_id"] if original_has_gridfs_id else None
             )
-            transition_to_gridfs = original_storage_mode != "gridfs"
+            caller_storage_mode_changed = original_storage_mode != "gridfs"
+            if persisted_document is not None:
+                persisted_storage_mode = persisted_document.get(
+                    "storage_mode", "gridfs"
+                )
+                persisted_gridfs_id = persisted_document.get("gridfs_id")
+            else:
+                persisted_storage_mode = original_storage_mode
+                persisted_gridfs_id = original_gridfs_id
+            transition_to_gridfs = persisted_storage_mode != "gridfs"
             if "storage_mode" in mspass_object:
                 storage_mode = mspass_object["storage_mode"]
                 if not storage_mode == "gridfs":
@@ -3670,11 +3722,12 @@ class Database(pymongo.database.Database):
                 update_record["storage_mode"] = "gridfs"
             # Supplying the replacement id lets rollback remove a blob even
             # when GridFS writes it and then raises an exception.
-            # A datum transitioning from another mode never treats a stale
-            # gridfs_id as its active sample reference; storage_mode remains
-            # authoritative.
-            active_old_gridfs_id = None if transition_to_gridfs else old_gridfs_id
-            staged_gridfs_id = ObjectId() if active_old_gridfs_id is not None else None
+            # Only the durable waveform document can identify the active old
+            # sample object.  Caller metadata is mutable and may be stale or
+            # incomplete, so it must never select the object used by the CAS
+            # or the object deleted after a successful reference change.
+            active_old_gridfs_id = None if transition_to_gridfs else persisted_gridfs_id
+            staged_gridfs_id = ObjectId()
             new_gridfs_id = None
             elog_id = None
             old_elog_id = None
@@ -3732,17 +3785,18 @@ class Database(pymongo.database.Database):
                     else:
                         filter_["storage_mode"] = {"$exists": False}
                     filter_["object_store"] = {"$exists": False}
-                if active_old_gridfs_id is not None:
-                    filter_["gridfs_id"] = active_old_gridfs_id
+                    if persisted_storage_mode == "gridfs":
+                        if active_old_gridfs_id is None:
+                            filter_["gridfs_id"] = {"$exists": False}
+                        else:
+                            filter_["gridfs_id"] = active_old_gridfs_id
                 update_operation = {"$set": update_record}
                 inactive_pointer_keys = Database._inactive_storage_pointer_keys(
                     "gridfs"
                 )
                 update_operation["$unset"] = {key: "" for key in inactive_pointer_keys}
                 result = wf_collection.update_one(filter_, update_operation)
-                if (
-                    active_old_gridfs_id is not None or transition_to_gridfs
-                ) and result.matched_count != 1:
+                if persisted_document is not None and result.matched_count != 1:
                     raise MsPASSError(
                         "Database.update_data could not commit the new GridFS "
                         "reference",
@@ -3770,7 +3824,7 @@ class Database(pymongo.database.Database):
                         mspass_object["gridfs_id"] = original_gridfs_id
                     elif "gridfs_id" in mspass_object:
                         mspass_object.erase("gridfs_id")
-                    if transition_to_gridfs:
+                    if caller_storage_mode_changed:
                         if original_has_storage_mode:
                             mspass_object["storage_mode"] = original_storage_mode
                         elif "storage_mode" in mspass_object:
@@ -4287,7 +4341,9 @@ class Database(pymongo.database.Database):
         # Resolve every child reference before starting cleanup.  The waveform
         # document remains the durable retry record until all referenced
         # children have been removed or confirmed absent.
-        storage_mode = object_doc.get("storage_mode")
+        # Match the reader's compatibility rule: legacy waveform documents
+        # without an explicit mode are GridFS documents.
+        storage_mode = object_doc.get("storage_mode", "gridfs")
         object_store_location = object_doc.get("object_store")
         gridfs_id = object_doc.get("gridfs_id")
         dir_name = object_doc.get("dir")
@@ -4389,9 +4445,36 @@ class Database(pymongo.database.Database):
                 except FileNotFoundError:
                     pass
 
-        # Remove the durable retry record only after all requested child
-        # cleanup operations have completed successfully.
-        self[wf_collection_name].delete_one({"_id": oid})
+        # Remove the durable retry record only if it still names the exact
+        # sample location deleted above.  A concurrent storage transition
+        # must retain its new waveform reference.
+        final_delete_filter = {"_id": oid}
+        if "storage_mode" in object_doc:
+            final_delete_filter["storage_mode"] = storage_mode
+        else:
+            final_delete_filter["storage_mode"] = {"$exists": False}
+        if storage_mode == "object_store":
+            final_delete_filter["object_store"] = object_store_location
+        elif storage_mode == "gridfs":
+            final_delete_filter["gridfs_id"] = (
+                gridfs_id if gridfs_id is not None else {"$exists": False}
+            )
+        elif storage_mode == "file":
+            for key in ("dir", "dfile", "foff"):
+                final_delete_filter[key] = (
+                    object_doc[key] if key in object_doc else {"$exists": False}
+                )
+        elif storage_mode == "url":
+            final_delete_filter["url"] = (
+                object_doc["url"] if "url" in object_doc else {"$exists": False}
+            )
+        result = self[wf_collection_name].delete_one(final_delete_filter)
+        if result.deleted_count != 1:
+            raise MsPASSError(
+                "Waveform storage metadata changed during delete_data; the "
+                "current waveform document was retained",
+                ErrorSeverity.Invalid,
+            )
 
     def _load_collection_metadata(
         self, mspass_object, exclude_keys, include_undefined=False, collection=None
@@ -5736,11 +5819,12 @@ class Database(pymongo.database.Database):
             elif key in mspass_object:
                 mspass_object.erase(key)
 
-    @staticmethod
-    def _cleanup_staged_object_store_data(object_store_client, staged_data):
+    def _cleanup_staged_object_store_data(self, object_store_client, staged_data):
         """Delete uploaded objects that have no committed waveform document."""
         failures = []
-        for datum, location, metadata_snapshot in staged_data:
+        for staged_item in staged_data:
+            datum, location, metadata_snapshot = staged_item[:3]
+            stage_id = staged_item[3] if len(staged_item) > 3 else None
             bucket = location["bucket"]
             object_name = location["object_name"]
             try:
@@ -5749,7 +5833,113 @@ class Database(pymongo.database.Database):
                 failures.append("s3://{}/{}".format(bucket, object_name))
                 continue
             Database._restore_object_store_metadata(datum, metadata_snapshot)
+            if stage_id is not None:
+                try:
+                    self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(
+                        {"_id": stage_id, "object_store": location}
+                    )
+                except Exception:
+                    failures.append("staging record {}".format(stage_id))
         return failures
+
+    def _complete_object_store_stage(self, stage_id, location):
+        """Remove a staging record after its waveform reference is durable."""
+        try:
+            result = self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(
+                {"_id": stage_id, "object_store": location}
+            )
+            return result.deleted_count == 1
+        except Exception:
+            return False
+
+    def reconcile_object_store_staging(
+        self, object_store_client, delete_uncommitted=False
+    ):
+        """Report or remove durable object-store staging records.
+
+        A staging record is written before each S3 upload and removed only
+        after the corresponding waveform document has been committed.  A
+        record whose waveform document contains the exact same object-store
+        location is committed; reconciliation removes only the stale staging
+        record and never its sample object.  Other records are reported as
+        uncommitted by default.
+
+        Set ``delete_uncommitted=True`` only while object-store writers are
+        quiescent.  MongoDB and S3 cannot provide a cross-system transaction,
+        so an active writer could otherwise commit between the waveform check
+        and the S3 delete.
+
+        :return: a dictionary containing deterministic URI lists named
+          ``committed``, ``uncommitted``, ``deleted``, and ``failures``.
+        """
+        if object_store_client is None:
+            raise ValueError("object_store_client is required for reconciliation")
+        report = {
+            "committed": [],
+            "uncommitted": [],
+            "deleted": [],
+            "failures": [],
+        }
+        staging_collection = self[_OBJECT_STORE_STAGING_COLLECTION]
+        for stage in staging_collection.find({}).sort("_id", pymongo.ASCENDING):
+            stage_id = stage.get("_id")
+            waveform_id = stage.get("waveform_id")
+            waveform_collection = stage.get("waveform_collection")
+            location = stage.get("object_store")
+            if (
+                waveform_id is None
+                or not isinstance(waveform_collection, str)
+                or not isinstance(location, dict)
+                or location.get("provider") != "s3"
+                or not isinstance(location.get("bucket"), str)
+                or not isinstance(location.get("object_name"), str)
+            ):
+                report["failures"].append(
+                    "staging record {} is invalid".format(stage_id)
+                )
+                continue
+            uri = "s3://{}/{}".format(location["bucket"], location["object_name"])
+            waveform = self[waveform_collection].find_one(
+                {"_id": waveform_id}, {"storage_mode": 1, "object_store": 1}
+            )
+            if waveform is not None and (
+                waveform.get("storage_mode") == "object_store"
+                and waveform.get("object_store") == location
+            ):
+                try:
+                    result = staging_collection.delete_one(
+                        {"_id": stage_id, "object_store": location}
+                    )
+                    if result.deleted_count == 1:
+                        report["committed"].append(uri)
+                    else:
+                        report["failures"].append(
+                            "staging record {} changed during reconciliation".format(
+                                stage_id
+                            )
+                        )
+                except Exception as error:
+                    report["failures"].append("{}: {}".format(uri, error))
+                continue
+            if not delete_uncommitted:
+                report["uncommitted"].append(uri)
+                continue
+            try:
+                object_store_client.delete_object(
+                    Bucket=location["bucket"], Key=location["object_name"]
+                )
+                result = staging_collection.delete_one(
+                    {"_id": stage_id, "object_store": location}
+                )
+                if result.deleted_count == 1:
+                    report["deleted"].append(uri)
+                else:
+                    report["failures"].append(
+                        "{}: staging record changed during reconciliation".format(uri)
+                    )
+            except Exception as error:
+                report["failures"].append("{}: {}".format(uri, error))
+        return report
 
     @staticmethod
     def _read_data_from_object_store(
@@ -7573,6 +7763,8 @@ class Database(pymongo.database.Database):
         object_store_client,
         format=None,
         metadata_snapshots=None,
+        waveform_id=None,
+        waveform_collection=None,
     ):
         """Write sample data to independent objects in an S3-compatible store."""
         if mspass_object.dead():
@@ -7653,7 +7845,9 @@ class Database(pymongo.database.Database):
             payload = buffer.getvalue()
             suffix = "." + format.lower()
 
-        object_name = uuid.uuid4().hex + suffix
+        object_name = (
+            str(waveform_id) if waveform_id is not None else uuid.uuid4().hex
+        ) + suffix
         if key_prefix:
             object_name = key_prefix.rstrip("/") + "/" + object_name
         location = {
@@ -7663,25 +7857,37 @@ class Database(pymongo.database.Database):
         }
         if format == "binary":
             location["encoding"] = _OBJECT_STORE_BINARY_ENCODING
-        mspass_object["storage_mode"] = "object_store"
-        mspass_object["object_store"] = location
-        mspass_object["format"] = format
-        mspass_object["nbytes"] = len(payload)
-        Database._normalize_storage_pointers(mspass_object, "object_store")
+        stage_id = None
+        if waveform_id is not None or waveform_collection is not None:
+            if waveform_id is None or not isinstance(waveform_collection, str):
+                raise ValueError(
+                    "waveform_id and waveform_collection must be supplied together"
+                )
+            stage_id = waveform_id
+            self[_OBJECT_STORE_STAGING_COLLECTION].insert_one(
+                {
+                    "_id": stage_id,
+                    "waveform_id": waveform_id,
+                    "waveform_collection": waveform_collection,
+                    "object_store": copy.deepcopy(location),
+                    "created_at": datetime.now(timezone.utc),
+                }
+            )
         try:
+            mspass_object["storage_mode"] = "object_store"
+            mspass_object["object_store"] = location
+            mspass_object["format"] = format
+            mspass_object["nbytes"] = len(payload)
+            Database._normalize_storage_pointers(mspass_object, "object_store")
             object_store_client.put_object(
                 Bucket=bucket,
                 Key=object_name,
                 Body=payload,
             )
-        except (
-            botocore.exceptions.BotoCoreError,
-            botocore.exceptions.ClientError,
-            OSError,
-        ) as err:
+        except Exception as err:
             cleanup_failures = self._cleanup_staged_object_store_data(
                 object_store_client,
-                [(mspass_object, location, metadata_snapshot)],
+                [(mspass_object, location, metadata_snapshot, stage_id)],
             )
             if cleanup_failures:
                 raise MsPASSError(
@@ -7782,6 +7988,7 @@ class Database(pymongo.database.Database):
         normalizing_collections,
         alg_name,
         alg_id,
+        waveform_id=None,
     ):
         """
         Does all the MongoDB operations needed to save an atomic
@@ -7888,9 +8095,13 @@ class Database(pymongo.database.Database):
             insertion_dict[elog_id_name] = elog_id
 
         if mspass_object.live:
-            wfid = None
+            wfid = waveform_id
+            waveform_inserted = False
             try:
+                if wfid is not None:
+                    insertion_dict["_id"] = wfid
                 wfid = wf_collection.insert_one(insertion_dict).inserted_id
+                waveform_inserted = True
                 if history_object_id is not None:
                     wf_id_name = wf_collection.name + "_id"
                     history_result = self[history_collection_name].update_one(
@@ -7904,7 +8115,7 @@ class Database(pymongo.database.Database):
                             ErrorSeverity.Invalid,
                         )
             except Exception:
-                if wfid is not None:
+                if waveform_inserted:
                     wf_collection.delete_one({"_id": wfid})
                 if history_object_id is not None:
                     self[history_collection_name].delete_one({"_id": history_object_id})

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -28,6 +28,7 @@ except ImportError:
 import gridfs
 import pymongo
 import pymongo.errors
+from pymongo.read_concern import ReadConcern
 from bson import ObjectId
 import numpy as np
 import obspy
@@ -1797,20 +1798,8 @@ class Database(pymongo.database.Database):
                             "_id and gridfs_id for every previously saved member"
                         )
                 if any("_id" in d for d in live_members):
-                    ownership_keys = _OBJECT_STORE_STORAGE_KEYS + (
-                        self.database_schema.default_name("history_object") + "_id",
-                        self.database_schema.default_name("elog") + "_id",
-                    )
                     member_storage_snapshots = [
-                        {
-                            key: (
-                                (True, copy.deepcopy(d[key]))
-                                if key in d
-                                else (False, None)
-                            )
-                            for key in ownership_keys
-                        }
-                        for d in live_members
+                        self._snapshot_object_store_metadata(d) for d in live_members
                     ]
                     mspass_object, bodies = self.stedronsky.bring_out_your_dead(
                         mspass_object
@@ -2101,6 +2090,9 @@ class Database(pymongo.database.Database):
                 mspass_object = self._kill_zero_length_live(mspass_object)
                 for index, datum in enumerate(atomic_data):
                     if datum.dead():
+                        self._restore_object_store_metadata(
+                            datum, storage_metadata_snapshots[index]
+                        )
                         buried_datum = self._atomic_save_all_documents(
                             datum,
                             save_schema,
@@ -2148,8 +2140,7 @@ class Database(pymongo.database.Database):
                     datum["storage_mode"] = "gridfs"
                     datum["gridfs_id"] = new_gridfs_id
                     Database._normalize_storage_pointers(datum, "gridfs")
-                    if _DELETE_CLAIM_KEY in datum:
-                        datum.erase(_DELETE_CLAIM_KEY)
+                    self._clear_inherited_owner_metadata(datum)
                     try:
                         self._save_sample_data_to_gridfs(
                             datum,
@@ -4846,13 +4837,25 @@ class Database(pymongo.database.Database):
         :param clear_history: if ``True``, we will clear the processing history of the associated wf object, default to be ``True``
         :param clear_elog: if ``True``, we will clear the elog entries of the associated wf object, default to be ``True``
         :param collection: explicit waveform collection containing the object. If
-          omitted, use the default collection for ``object_type``.
+          omitted, use the default collection for ``object_type``.  Literal
+          alternate collections accepted by :meth:`save_data` are supported
+          even when absent from DatabaseSchema; in that case ``object_type``
+          supplies the atomic waveform type.
         :param object_store_client: boto3-compatible S3 client required to delete
           data whose persisted ``storage_mode`` is ``object_store``.  Client
           construction, credentials, and lifetime remain caller-owned.
         """
         if object_type not in ["TimeSeries", "Seismogram"]:
             raise TypeError("only TimeSeries and Seismogram are supported")
+
+        # User code sometimes passes a datum instead of its ObjectId.  Resolve
+        # that before interpreting ``collection`` because literal names that
+        # also happen to be schema default aliases must be disambiguated by
+        # the persisted owner.
+        try:
+            oid = object_id["_id"]
+        except:
+            oid = object_id
 
         if collection is None:
             schema = self.metadata_schema
@@ -4862,10 +4865,27 @@ class Database(pymongo.database.Database):
                 delete_schema = schema.Seismogram
             wf_collection_name = delete_schema.collection("_id")
         else:
-            wf_collection_name = self.database_schema.default_name(collection)
             expected_type = TimeSeries if object_type == "TimeSeries" else Seismogram
+            if collection in self.database_schema:
+                wf_collection_name = collection
+            else:
+                literal_collection = self._object_store_lifecycle_collection(collection)
+                if literal_collection.find_one({"_id": oid}, {"_id": 1}) is not None:
+                    wf_collection_name = collection
+                else:
+                    try:
+                        wf_collection_name = self.database_schema.default_name(
+                            collection
+                        )
+                    except MsPASSError:
+                        # ``save_data`` accepts a literal export collection that
+                        # is not present in DatabaseSchema.  Preserve that
+                        # contract for the matching delete lifecycle;
+                        # object_type supplies the atomic waveform type.
+                        wf_collection_name = collection
             if (
-                self.database_schema[wf_collection_name].data_type()
+                wf_collection_name in self.database_schema
+                and self.database_schema[wf_collection_name].data_type()
                 is not expected_type
             ):
                 raise MsPASSError(
@@ -4874,12 +4894,6 @@ class Database(pymongo.database.Database):
                     ),
                     ErrorSeverity.Invalid,
                 )
-
-        # user might pass a mspass object by mistake
-        try:
-            oid = object_id["_id"]
-        except:
-            oid = object_id
 
         # Fetch the owner from the primary.  ``delete_data`` may authorize an
         # irreversible external-object deletion from this state, so a stale
@@ -5059,7 +5073,9 @@ class Database(pymongo.database.Database):
             # checking every schema-defined waveform collection for another
             # reference to the same file.
             file_is_referenced = False
-            for collection_name in self._waveform_collection_names():
+            waveform_collections = self._waveform_collection_names()
+            waveform_collections.add(wf_collection_name)
+            for collection_name in waveform_collections:
                 reference_query = {"dir": dir_name, "dfile": dfile_name}
                 if collection_name == wf_collection_name:
                     reference_query["_id"] = {"$ne": oid}
@@ -6490,17 +6506,19 @@ class Database(pymongo.database.Database):
         }
 
     def _object_store_lifecycle_collection(self, name):
-        """Return a primary/majority collection for lifecycle decisions."""
+        """Return a majority-committed collection for lifecycle decisions."""
         return self.get_collection(
             name,
             read_preference=pymongo.ReadPreference.PRIMARY,
+            read_concern=ReadConcern("majority"),
             write_concern=pymongo.write_concern.WriteConcern(w="majority"),
         )
 
     def _gridfs_lifecycle_handle(self):
-        """Return a primary/majority GridFS handle for pointer replacement."""
+        """Return a majority-committed GridFS handle for pointer replacement."""
         database = self.with_options(
             read_preference=pymongo.ReadPreference.PRIMARY,
+            read_concern=ReadConcern("majority"),
             write_concern=pymongo.write_concern.WriteConcern(w="majority"),
         )
         return gridfs.GridFS(database)
@@ -6754,17 +6772,32 @@ class Database(pymongo.database.Database):
                 "schema: {}".format(", ".join(problems))
             )
 
-    @staticmethod
-    def _snapshot_object_store_metadata(mspass_object):
-        """Capture storage metadata so a failed staged write can be undone."""
+    def _snapshot_object_store_metadata(self, mspass_object):
+        """Capture owner metadata so a failed staged write can be undone."""
+        ownership_keys = _OBJECT_STORE_STORAGE_KEYS + (
+            self.database_schema.default_name("history_object") + "_id",
+            self.database_schema.default_name("elog") + "_id",
+            _DELETE_CLAIM_KEY,
+        )
         return {
             key: (
                 (True, copy.deepcopy(mspass_object[key]))
                 if key in mspass_object
                 else (False, None)
             )
-            for key in _OBJECT_STORE_STORAGE_KEYS
+            for key in ownership_keys
         }
+
+    def _clear_inherited_owner_metadata(self, mspass_object):
+        """Detach a staged owner from auxiliary pointers owned by the source."""
+        inherited_keys = (
+            self.database_schema.default_name("history_object") + "_id",
+            self.database_schema.default_name("elog") + "_id",
+            _DELETE_CLAIM_KEY,
+        )
+        for key in inherited_keys:
+            if key in mspass_object:
+                mspass_object.erase(key)
 
     @staticmethod
     def _restore_object_store_metadata(mspass_object, snapshot):
@@ -9213,8 +9246,7 @@ class Database(pymongo.database.Database):
             mspass_object["format"] = format
             mspass_object["nbytes"] = len(payload)
             Database._normalize_storage_pointers(mspass_object, "object_store")
-            if _DELETE_CLAIM_KEY in mspass_object:
-                mspass_object.erase(_DELETE_CLAIM_KEY)
+            self._clear_inherited_owner_metadata(mspass_object)
             upload_invoked = True
             object_store_client.put_object(
                 Bucket=bucket,

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -75,6 +75,17 @@ from mspasspy.util.converter import Textfile2Dataframe
 _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS = 300.0
 _GRIDFS_IO_CHUNK_BYTES = 1024 * 1024
 _OBJECT_STORE_BINARY_ENCODING = "float64-le-v1"
+_OBJECT_STORE_STORAGE_KEYS = (
+    "storage_mode",
+    "object_store",
+    "gridfs_id",
+    "dir",
+    "dfile",
+    "foff",
+    "url",
+    "format",
+    "nbytes",
+)
 
 
 class _NativeSampleReader(io.RawIOBase):
@@ -1817,6 +1828,18 @@ class Database(pymongo.database.Database):
                 # A weird construct
                 wf_collection_name = save_schema.collection("_id")
             wf_collection = self[wf_collection_name]
+            atomic_data = (
+                [mspass_object]
+                if isinstance(mspass_object, (TimeSeries, Seismogram))
+                else mspass_object.member
+            )
+            object_store_metadata_snapshots = []
+            if storage_mode == "object_store":
+                object_store_metadata_snapshots = [
+                    self._snapshot_object_store_metadata(datum) if datum.live else None
+                    for datum in atomic_data
+                ]
+
             # We need to make sure storage_mode is set in all live data
             if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
                 mspass_object.sync_metadata()
@@ -1827,11 +1850,6 @@ class Database(pymongo.database.Database):
                 # only atomic data can land here
                 mspass_object["storage_mode"] = storage_mode
 
-            atomic_data = (
-                [mspass_object]
-                if isinstance(mspass_object, (TimeSeries, Seismogram))
-                else mspass_object.member
-            )
             for datum in atomic_data:
                 if datum.live:
                     self._sync_metadata_before_update(datum)
@@ -1859,12 +1877,17 @@ class Database(pymongo.database.Database):
                 overwrite=overwrite,
                 object_store=object_store,
                 object_store_client=object_store_client,
+                object_store_metadata_snapshots=object_store_metadata_snapshots,
             )
             staged_object_store_data = []
             if storage_mode == "object_store":
                 staged_object_store_data = [
-                    (datum, copy.deepcopy(datum["object_store"]))
-                    for datum in atomic_data
+                    (
+                        datum,
+                        copy.deepcopy(datum["object_store"]),
+                        object_store_metadata_snapshots[index],
+                    )
+                    for index, datum in enumerate(atomic_data)
                     if datum.live and "object_store" in datum
                 ]
             try:
@@ -1904,11 +1927,8 @@ class Database(pymongo.database.Database):
                             alg_id,
                         )
                         if saved_datum.live:
-                            staged_object_store_data = [
-                                staged
-                                for staged in staged_object_store_data
-                                if staged[0] is not datum
-                            ]
+                            if storage_mode == "object_store":
+                                staged_object_store_data.pop(0)
             except Exception as original_error:
                 cleanup_failures = self._cleanup_staged_object_store_data(
                     object_store_client, staged_object_store_data
@@ -3527,10 +3547,30 @@ class Database(pymongo.database.Database):
             save_schema = schema.TimeSeries
         else:
             save_schema = schema.Seismogram
+        if collection:
+            wf_collection_name = collection
+        else:
+            wf_collection_name = save_schema.collection("_id")
+        wf_collection = self[wf_collection_name]
+        persisted_document = None
+        if "_id" in mspass_object:
+            persisted_document = wf_collection.find_one(
+                {"_id": mspass_object["_id"]},
+                {"storage_mode": 1, "object_store": 1},
+            )
+        if persisted_document is not None and (
+            persisted_document.get("storage_mode") == "object_store"
+            or "object_store" in persisted_document
+        ):
+            raise ValueError(
+                "Database.update_data does not support sample updates for "
+                "persisted object_store data; save a new datum with "
+                "Database.save_data instead"
+            )
         if (
             "storage_mode" in mspass_object
             and mspass_object["storage_mode"] == "object_store"
-        ):
+        ) or "object_store" in mspass_object:
             raise ValueError(
                 "Database.update_data does not support sample updates for "
                 "object_store data; save a new datum with Database.save_data instead"
@@ -3640,14 +3680,6 @@ class Database(pymongo.database.Database):
                 new_gridfs_id = mspass_object["gridfs_id"]
                 update_record["gridfs_id"] = new_gridfs_id
 
-                # should define wf_collection here because if the mspass_object is dead
-                if collection:
-                    wf_collection_name = collection
-                else:
-                    # This returns a string that is the collection name for this atomic data type
-                    # A weird construct
-                    wf_collection_name = save_schema.collection("_id")
-                wf_collection = self[wf_collection_name]
                 if history_object_id is not None:
                     wf_id_name = wf_collection_name + "_id"
                     history_result = self[
@@ -3686,6 +3718,12 @@ class Database(pymongo.database.Database):
                     )
 
                 filter_ = {"_id": mspass_object["_id"]}
+                if persisted_document is not None:
+                    if "storage_mode" in persisted_document:
+                        filter_["storage_mode"] = persisted_document["storage_mode"]
+                    else:
+                        filter_["storage_mode"] = {"$exists": False}
+                    filter_["object_store"] = {"$exists": False}
                 if active_old_gridfs_id is not None:
                     filter_["gridfs_id"] = active_old_gridfs_id
                 update_operation = {"$set": update_record}
@@ -4156,6 +4194,7 @@ class Database(pymongo.database.Database):
         clear_history=True,
         clear_elog=True,
         collection=None,
+        object_store_client=None,
     ):
         """
         Delete method for handling mspass data objects (TimeSeries and Seismograms).
@@ -4170,7 +4209,9 @@ class Database(pymongo.database.Database):
         collections, it will delete the wf document entry and manage the
         waveform data.  If the data are stored in gridfs the deletion of
         the waveform data will be immediate.  If the data are stored in
-        disk files the file will be deleted when there are no more references
+        object store the independent object is deleted through the caller-owned
+        client.  If the data are stored in disk files the file will be deleted
+        when there are no more references
         in any schema-defined waveform collection for the exact combination
         of dir and dfile associated with an atomic deletion.  Requested
         history and error-log cleanup precedes sample deletion, and the
@@ -4193,6 +4234,9 @@ class Database(pymongo.database.Database):
         :param clear_elog: if ``True``, we will clear the elog entries of the associated wf object, default to be ``True``
         :param collection: explicit waveform collection containing the object. If
           omitted, use the default collection for ``object_type``.
+        :param object_store_client: boto3-compatible S3 client required to delete
+          data whose persisted ``storage_mode`` is ``object_store``.  Client
+          construction, credentials, and lifetime remain caller-owned.
         """
         if object_type not in ["TimeSeries", "Seismogram"]:
             raise TypeError("only TimeSeries and Seismogram are supported")
@@ -4236,6 +4280,7 @@ class Database(pymongo.database.Database):
         # document remains the durable retry record until all referenced
         # children have been removed or confirmed absent.
         storage_mode = object_doc.get("storage_mode")
+        object_store_location = object_doc.get("object_store")
         gridfs_id = object_doc.get("gridfs_id")
         dir_name = object_doc.get("dir")
         dfile_name = object_doc.get("dfile")
@@ -4246,6 +4291,33 @@ class Database(pymongo.database.Database):
         elog_collection = self.database_schema.default_name("elog")
         elog_id_name = elog_collection + "_id"
         elog_id = object_doc.get(elog_id_name)
+
+        # Validate external deletion before touching database-owned children.
+        # A malformed location or missing client must leave the complete
+        # waveform document available for a corrected retry.
+        if storage_mode == "object_store":
+            if not isinstance(object_store_location, dict):
+                raise ValueError(
+                    "object_store metadata must be a dictionary to delete data"
+                )
+            if object_store_location.get("provider") != "s3":
+                raise ValueError("object_store provider must be 's3'")
+            bucket = object_store_location.get("bucket")
+            object_name = object_store_location.get("object_name")
+            if not isinstance(bucket, str) or not bucket:
+                raise ValueError("object_store bucket must be a nonempty string")
+            if not isinstance(object_name, str) or not object_name:
+                raise ValueError("object_store object_name must be a nonempty string")
+            if object_store_client is None:
+                raise ValueError(
+                    "object_store_client is required to delete object_store data"
+                )
+        elif "object_store" in object_doc:
+            raise MsPASSError(
+                "Waveform document has an object_store location but "
+                "storage_mode is not object_store",
+                ErrorSeverity.Invalid,
+            )
 
         # Clear database-owned auxiliary records before removing samples.  If
         # one of these operations fails, the parent still identifies every
@@ -4265,6 +4337,20 @@ class Database(pymongo.database.Database):
             gfsh = gridfs.GridFS(self)
             if gfsh.exists(gridfs_id):
                 gfsh.delete(gridfs_id)
+
+        elif storage_mode == "object_store":
+            try:
+                object_store_client.delete_object(
+                    Bucket=bucket,
+                    Key=object_name,
+                )
+            except Exception as error:
+                raise MsPASSError(
+                    "Could not delete object-store samples at "
+                    "s3://{}/{}; the waveform document was retained for "
+                    "retry".format(bucket, object_name),
+                    ErrorSeverity.Fatal,
+                ) from error
 
         elif (
             storage_mode == "file"
@@ -5622,10 +5708,31 @@ class Database(pymongo.database.Database):
             )
 
     @staticmethod
+    def _snapshot_object_store_metadata(mspass_object):
+        """Capture storage metadata so a failed staged write can be undone."""
+        return {
+            key: (
+                (True, copy.deepcopy(mspass_object[key]))
+                if key in mspass_object
+                else (False, None)
+            )
+            for key in _OBJECT_STORE_STORAGE_KEYS
+        }
+
+    @staticmethod
+    def _restore_object_store_metadata(mspass_object, snapshot):
+        """Restore storage metadata captured before an object-store write."""
+        for key, (was_defined, value) in snapshot.items():
+            if was_defined:
+                mspass_object[key] = copy.deepcopy(value)
+            elif key in mspass_object:
+                mspass_object.erase(key)
+
+    @staticmethod
     def _cleanup_staged_object_store_data(object_store_client, staged_data):
         """Delete uploaded objects that have no committed waveform document."""
         failures = []
-        for datum, location in staged_data:
+        for datum, location, metadata_snapshot in staged_data:
             bucket = location["bucket"]
             object_name = location["object_name"]
             try:
@@ -5633,8 +5740,7 @@ class Database(pymongo.database.Database):
             except Exception:
                 failures.append("s3://{}/{}".format(bucket, object_name))
                 continue
-            if "object_store" in datum and datum["object_store"] == location:
-                datum.erase("object_store")
+            Database._restore_object_store_metadata(datum, metadata_snapshot)
         return failures
 
     @staticmethod
@@ -7020,6 +7126,7 @@ class Database(pymongo.database.Database):
         overwrite=False,
         object_store=None,
         object_store_client=None,
+        object_store_metadata_snapshots=None,
     ):
         """
         Function to save sample data arrays for any MsPASS data objects.
@@ -7136,6 +7243,7 @@ class Database(pymongo.database.Database):
                     object_store,
                     object_store_client,
                     format,
+                    metadata_snapshots=object_store_metadata_snapshots,
                 )
             else:
                 message = (
@@ -7456,6 +7564,7 @@ class Database(pymongo.database.Database):
         object_store,
         object_store_client,
         format=None,
+        metadata_snapshots=None,
     ):
         """Write sample data to independent objects in an S3-compatible store."""
         if mspass_object.dead():
@@ -7478,18 +7587,29 @@ class Database(pymongo.database.Database):
             )
 
         if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
+            if metadata_snapshots is None:
+                metadata_snapshots = [
+                    self._snapshot_object_store_metadata(datum) if datum.live else None
+                    for datum in mspass_object.member
+                ]
             staged_data = []
             try:
-                for datum in mspass_object.member:
+                for index, datum in enumerate(mspass_object.member):
                     if datum.live:
+                        metadata_snapshot = metadata_snapshots[index]
                         self._save_sample_data_to_object_store(
                             datum,
                             object_store,
                             object_store_client,
                             format,
+                            metadata_snapshots=[metadata_snapshot],
                         )
                         staged_data.append(
-                            (datum, copy.deepcopy(datum["object_store"]))
+                            (
+                                datum,
+                                copy.deepcopy(datum["object_store"]),
+                                metadata_snapshot,
+                            )
                         )
             except Exception as original_error:
                 cleanup_failures = self._cleanup_staged_object_store_data(
@@ -7506,6 +7626,10 @@ class Database(pymongo.database.Database):
 
         if not isinstance(mspass_object, (TimeSeries, Seismogram)):
             raise TypeError("only MsPASS seismic data objects are supported")
+        if metadata_snapshots is None:
+            metadata_snapshot = self._snapshot_object_store_metadata(mspass_object)
+        else:
+            metadata_snapshot = metadata_snapshots[0]
 
         if format is None:
             format = "binary"
@@ -7531,6 +7655,11 @@ class Database(pymongo.database.Database):
         }
         if format == "binary":
             location["encoding"] = _OBJECT_STORE_BINARY_ENCODING
+        mspass_object["storage_mode"] = "object_store"
+        mspass_object["object_store"] = location
+        mspass_object["format"] = format
+        mspass_object["nbytes"] = len(payload)
+        Database._normalize_storage_pointers(mspass_object, "object_store")
         try:
             object_store_client.put_object(
                 Bucket=bucket,
@@ -7543,7 +7672,8 @@ class Database(pymongo.database.Database):
             OSError,
         ) as err:
             cleanup_failures = self._cleanup_staged_object_store_data(
-                object_store_client, [(mspass_object, location)]
+                object_store_client,
+                [(mspass_object, location, metadata_snapshot)],
             )
             if cleanup_failures:
                 raise MsPASSError(
@@ -7558,11 +7688,6 @@ class Database(pymongo.database.Database):
                 "Fatal",
             ) from err
 
-        mspass_object["storage_mode"] = "object_store"
-        mspass_object["object_store"] = location
-        mspass_object["format"] = format
-        mspass_object["nbytes"] = len(payload)
-        Database._normalize_storage_pointers(mspass_object, "object_store")
         return mspass_object
 
     def _save_sample_data_to_gridfs(

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -581,6 +581,7 @@ class Database(pymongo.database.Database):
         merge_interpolation_samples=0,
         aws_access_key_id=None,
         aws_secret_access_key=None,
+        object_store_client=None,
     ):
         """
         Top-level MsPASS reader for seismic waveform data objects.
@@ -646,6 +647,11 @@ class Database(pymongo.database.Database):
           slow and unreliable response to FDSN data queries.  It is likely,
           however, to become a major component with FDSN services moving to
           cloud systems.
+        - `object_store` reads an object managed by a cloud object store.  The
+          waveform document must contain an ``object_store`` subdocument with
+          ``provider``, ``bucket``, and ``object_name`` fields.  Currently the
+          only supported provider is ``s3`` and a boto3-compatible client must
+          be supplied with ``object_store_client``.
         - This reader has prototype support for reading SCEC data stored on
           AWS s3.   The two valid values for defining those "storage_mode"s
           are "s3_continuous" and "s3_event", which map to two different
@@ -918,6 +924,10 @@ class Database(pymongo.database.Database):
           for details.
         :type interpolation_samples: :class:`int`
 
+        :param object_store_client: boto3-compatible S3 client used only for
+          data whose ``storage_mode`` is ``object_store``.  Authentication and
+          client lifetime remain the caller's responsibility.
+
         :return: for ObjectId python dictionary values of arg0 will return
           either a :class:`mspasspy.ccore.seismic.TimeSeries`
           or :class:`mspasspy.ccore.seismic.Seismogram` object.
@@ -1088,6 +1098,7 @@ class Database(pymongo.database.Database):
                 merge_interpolation_samples,
                 aws_access_key_id,
                 aws_secret_access_key,
+                object_store_client,
             )
             if elog.size() > 0:
                 # Any messages posted here will be out of order if there are
@@ -1181,6 +1192,7 @@ class Database(pymongo.database.Database):
                     merge_interpolation_samples,
                     aws_access_key_id,
                     aws_secret_access_key,
+                    object_store_client,
                 )
                 if normalize or normalize_ensemble:
                     import mspasspy.db.normalize as normalize_module
@@ -1268,6 +1280,8 @@ class Database(pymongo.database.Database):
         normalizing_collections=["channel", "site", "source"],
         alg_name="save_data",
         alg_id="0",
+        object_store=None,
+        object_store_client=None,
     ):
         """
         Standard method to save all seismic data objects to be managed by
@@ -1299,8 +1313,9 @@ class Database(pymongo.database.Database):
             an abstraction that even in FORTRAN days hid a lot of complexity.
             A call to this function supports multiple save mechanisms we
             define through the `storage_mode` keyword. At present
-            "storage_mode" can be only one of two options:  "file" and
-            "gridfs".  Note this class has prototype code for reading data
+            "storage_mode" can be "file", "gridfs", or "object_store".
+            ``object_store`` currently supports S3 through a caller-supplied
+            boto3-compatible client.  Note this class has prototype code for reading data
             in AWS s3 cloud storage that is not yet part of this interface.
             The API, however, was designed to allow adding one or more
             "storage_mode" options that allow other mechanisms to save
@@ -1550,11 +1565,13 @@ class Database(pymongo.database.Database):
           being the default.  See the User's manual for more details on
           the concepts and how to use this option.
         :type mode: :class:`str`
-        :param storage_mode: Current must be either "gridfs" or "file.  When set to
+        :param storage_mode: Must be "gridfs", "file", or "object_store".  When set to
           "gridfs" the waveform data are stored internally and managed by
           MongoDB.  If set to "file" the data will be stored in a file system
           with the dir and dfile arguments defining a file name.   The
-          default is "gridfs".  See above for more details.
+          default is "gridfs".  ``object_store`` writes each atomic datum to
+          an independent object at the destination given by ``object_store``.
+          See above for more details.
         :type storage_mode: :class:`str`
         :param dir: file directory for storage.  This argument is ignored if
           storage_mode is set to "gridfs".  When storage_mode is "file" it
@@ -1609,6 +1626,15 @@ class Database(pymongo.database.Database):
           set before more extensive processing.  It can only be used when
           storage_mode is set to gridfs.
         :type overwrite:  boolean
+
+        :param object_store: destination description required when
+          ``storage_mode="object_store"``.  It must be a dictionary containing
+          ``provider="s3"`` and ``bucket``.  The optional ``key_prefix`` is
+          prepended to the unique object name generated for each atomic datum.
+        :type object_store: :class:`dict`
+        :param object_store_client: boto3-compatible S3 client used to write
+          object-store sample data.  Authentication and client lifetime remain
+          the caller's responsibility.
 
         :param exclude_keys: Metadata can often become contaminated with
           attributes that are no longer needed or a mismatch with the data.
@@ -1670,10 +1696,14 @@ class Database(pymongo.database.Database):
             )
             message += "Must be a MsPASS seismic data object"
             raise TypeError(message)
-        # WARNING - if we add a storage_mode this will need to change
-        if storage_mode not in ["file", "gridfs"]:
+        if storage_mode not in ["file", "gridfs", "object_store"]:
             raise TypeError(
                 "Database.save_data:  Unsupported storage_mode={}".format(storage_mode)
+            )
+        if storage_mode == "object_store" and overwrite:
+            raise ValueError(
+                "Database.save_data: overwrite=True is not supported for "
+                "storage_mode=object_store"
             )
         if mode not in ["promiscuous", "cautious", "pedantic"]:
             message = "Database.save_data:  Illegal value of mode={}\n".format(mode)
@@ -1822,6 +1852,8 @@ class Database(pymongo.database.Database):
                 dfile=dfile,
                 format=format,
                 overwrite=overwrite,
+                object_store=object_store,
+                object_store_client=object_store_client,
             )
             # ensembles need to loop over members to do the atomic operations
             # remaining.  Hence, this conditional
@@ -5438,6 +5470,30 @@ class Database(pymongo.database.Database):
             mspass_object.kill()
 
     @staticmethod
+    def _load_data_from_formatted_bytes(mspass_object, payload, format=None):
+        """Load one formatted waveform payload into an atomic MsPASS object."""
+        st = obspy.read(io.BytesIO(payload), format=format)
+        if isinstance(mspass_object, TimeSeries):
+            # The index for URL and object-store data is expected to identify
+            # one net, sta, chan, loc grouping, so only one Trace is loaded.
+            # Convert its NumPy array to double to match DoubleVector.
+            tr_data = st[0].data.astype("float64")
+            mspass_object.npts = len(tr_data)
+            mspass_object.data = DoubleVector(tr_data)
+        elif isinstance(mspass_object, Seismogram):
+            # This conversion assumes the stream contains three traces in
+            # E, N, Z order, matching the prior URL-reader behavior.
+            sm = st.toSeismogram(cardinal=True)
+            mspass_object.npts = sm.data.columns()
+            mspass_object.data = sm.data
+        else:
+            raise TypeError("only TimeSeries and Seismogram are supported")
+        if mspass_object.npts > 0:
+            mspass_object.set_live()
+        else:
+            mspass_object.kill()
+
+    @staticmethod
     def _read_data_from_url(mspass_object, url, format=None):
         """
         Read a file from url and loads it into a mspasspy object.
@@ -5456,31 +5512,74 @@ class Database(pymongo.database.Database):
         except Exception as e:
             raise MsPASSError("Error while downloading: %s" % url, "Fatal") from e
 
-        flh = io.BytesIO(payload)
-        st = obspy.read(flh, format=format)
+        Database._load_data_from_formatted_bytes(mspass_object, payload, format)
+
+    @staticmethod
+    def _read_data_from_object_store(
+        mspass_object, object_store, object_store_client, format=None
+    ):
+        """Read one atomic datum from an S3-compatible object store."""
+        if not isinstance(object_store, dict):
+            raise TypeError("object_store metadata must be a dictionary")
+        if object_store.get("provider") != "s3":
+            raise ValueError("object_store provider must be 's3'")
+        bucket = object_store.get("bucket")
+        object_name = object_store.get("object_name")
+        if not isinstance(bucket, str) or not bucket:
+            raise ValueError("object_store bucket must be a nonempty string")
+        if not isinstance(object_name, str) or not object_name:
+            raise ValueError("object_store object_name must be a nonempty string")
+        if object_store_client is None:
+            raise ValueError(
+                "object_store_client is required to read object_store data"
+            )
+
+        try:
+            response = object_store_client.get_object(Bucket=bucket, Key=object_name)
+            body = response["Body"]
+            try:
+                payload = body.read()
+            finally:
+                body.close()
+        except (
+            botocore.exceptions.BotoCoreError,
+            botocore.exceptions.ClientError,
+            OSError,
+        ) as err:
+            raise MsPASSError(
+                "Error while reading s3://{}/{}".format(bucket, object_name),
+                "Fatal",
+            ) from err
+
+        if format is not None and format != "binary":
+            Database._load_data_from_formatted_bytes(
+                mspass_object, payload, format=format
+            )
+            return
+
         if isinstance(mspass_object, TimeSeries):
-            # st is a "stream" but it only has one member here because we are
-            # reading single net,sta,chan,loc grouping defined by the index
-            # We only want the Trace object not the stream to convert
-            tr = st[0]
-            # Now we convert this to a TimeSeries and load other Metadata
-            # Note the exclusion copy and the test verifying net,sta,chan,
-            # loc, and startime all match
-            tr_data = tr.data.astype(
-                "float64"
-            )  #   Convert the nparray type to double, to match the DoubleVector
-            mspass_object.npts = len(tr_data)
-            mspass_object.data = DoubleVector(tr_data)
+            sample_count = mspass_object.npts
         elif isinstance(mspass_object, Seismogram):
-            # Note that the following convertion could be problematic because
-            # it assumes there are three traces in the file, and they are in
-            # the order of E, N, Z.
-            sm = st.toSeismogram(cardinal=True)
-            mspass_object.npts = sm.data.columns()
-            mspass_object.data = sm.data
+            sample_count = 3 * mspass_object.npts
         else:
             raise TypeError("only TimeSeries and Seismogram are supported")
-        # this is not a error proof test for validity, but best I can do here
+        expected_nbytes = sample_count * 8
+        if len(payload) != expected_nbytes:
+            raise MsPASSError(
+                "Object-store payload size is {} bytes but {} bytes are required".format(
+                    len(payload), expected_nbytes
+                ),
+                "Invalid",
+            )
+        if isinstance(mspass_object, TimeSeries):
+            float_array = array("d")
+            float_array.frombytes(payload)
+            mspass_object.data = DoubleVector(float_array)
+        else:
+            np_arr = np.frombuffer(payload, dtype=np.float64).reshape(
+                3, mspass_object.npts
+            )
+            mspass_object.data = dmatrix(np_arr)
         if mspass_object.npts > 0:
             mspass_object.set_live()
         else:
@@ -6792,6 +6891,8 @@ class Database(pymongo.database.Database):
         dfile=None,
         format=None,
         overwrite=False,
+        object_store=None,
+        object_store_client=None,
     ):
         """
         Function to save sample data arrays for any MsPASS data objects.
@@ -6812,9 +6913,8 @@ class Database(pymongo.database.Database):
         See description below of "use_member_dfile_value" parameter.
 
         2) The "storage_mode" argument determines what medium will hold the
-        sample data.  Currently accepted values are "file" and "gridfs"
-        but other options may be added in the near future to support cloud
-        computing.
+        sample data.  Currently accepted values are "file", "gridfs", and
+        "object_store".
 
         3) The "format" argument can be used to specify an alternative
         format for the output.  Most formats mix up metadata and sample
@@ -6842,6 +6942,8 @@ class Database(pymongo.database.Database):
           (1) "file" causes data to be written to external files.
           (2) "gridfs" (the default) causes the sample data to be stored
                within the gridfs file system of MongoDB.
+          (3) "object_store" writes each atomic datum to an independent
+               object using a boto3-compatible S3 client.
           See User's manuals for guidance on storage option tradeoffs.
 
         :param dir:  directory file is to be written. Just be writable
@@ -6900,6 +7002,13 @@ class Database(pymongo.database.Database):
                 mspass_object = self._save_sample_data_to_gridfs(
                     mspass_object,
                     overwrite,
+                )
+            elif storage_mode == "object_store":
+                mspass_object = self._save_sample_data_to_object_store(
+                    mspass_object,
+                    object_store,
+                    object_store_client,
+                    format,
                 )
             else:
                 message = (
@@ -7204,6 +7313,90 @@ class Database(pymongo.database.Database):
                         # make sure we are at the end of file
                         fh.seek(0, 2)
                         foff = fh.tell()
+        return mspass_object
+
+    def _save_sample_data_to_object_store(
+        self,
+        mspass_object,
+        object_store,
+        object_store_client,
+        format=None,
+    ):
+        """Write sample data to independent objects in an S3-compatible store."""
+        if mspass_object.dead():
+            return mspass_object
+        if not isinstance(object_store, dict):
+            raise TypeError(
+                "object_store must be a dictionary for storage_mode=object_store"
+            )
+        if object_store.get("provider") != "s3":
+            raise ValueError("object_store provider must be 's3'")
+        bucket = object_store.get("bucket")
+        if not isinstance(bucket, str) or not bucket:
+            raise ValueError("object_store bucket must be a nonempty string")
+        key_prefix = object_store.get("key_prefix", "")
+        if not isinstance(key_prefix, str):
+            raise TypeError("object_store key_prefix must be a string")
+        if object_store_client is None:
+            raise ValueError(
+                "object_store_client is required for storage_mode=object_store"
+            )
+
+        if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
+            for datum in mspass_object.member:
+                if datum.live:
+                    self._save_sample_data_to_object_store(
+                        datum,
+                        object_store,
+                        object_store_client,
+                        format,
+                    )
+            return mspass_object
+
+        if not isinstance(mspass_object, (TimeSeries, Seismogram)):
+            raise TypeError("only MsPASS seismic data objects are supported")
+
+        if format is None:
+            format = "binary"
+        if format == "binary":
+            payload = bytes(np.array(mspass_object.data))
+            suffix = ".bin"
+        else:
+            buffer = io.BytesIO()
+            if isinstance(mspass_object, TimeSeries):
+                mspass_object.toTrace().write(buffer, format=format)
+            else:
+                mspass_object.toStream().write(buffer, format=format)
+            payload = buffer.getvalue()
+            suffix = "." + format.lower()
+
+        object_name = uuid.uuid4().hex + suffix
+        if key_prefix:
+            object_name = key_prefix.rstrip("/") + "/" + object_name
+        try:
+            object_store_client.put_object(
+                Bucket=bucket,
+                Key=object_name,
+                Body=payload,
+            )
+        except (
+            botocore.exceptions.BotoCoreError,
+            botocore.exceptions.ClientError,
+            OSError,
+        ) as err:
+            raise MsPASSError(
+                "Error while writing s3://{}/{}".format(bucket, object_name),
+                "Fatal",
+            ) from err
+
+        mspass_object["storage_mode"] = "object_store"
+        mspass_object["object_store"] = {
+            "provider": "s3",
+            "bucket": bucket,
+            "object_name": object_name,
+        }
+        mspass_object["format"] = format
+        mspass_object["nbytes"] = len(payload)
         return mspass_object
 
     def _save_sample_data_to_gridfs(
@@ -7834,6 +8027,7 @@ class Database(pymongo.database.Database):
         merge_interpolation_samples,
         aws_access_key_id,
         aws_secret_access_key,
+        object_store_client,
     ):
         func = "Database._construct_atomic_object"
         try:
@@ -7929,6 +8123,18 @@ class Database(pymongo.database.Database):
             self._read_data_from_url(
                 mspass_object,
                 md["url"],
+                format=None if "format" not in md else md["format"],
+            )
+        elif storage_mode == "object_store":
+            if not md.is_defined("object_store"):
+                raise MsPASSError(
+                    "object_store storage mode requires object_store metadata",
+                    "Invalid",
+                )
+            self._read_data_from_object_store(
+                mspass_object,
+                md["object_store"],
+                object_store_client,
                 format=None if "format" not in md else md["format"],
             )
         elif storage_mode == "s3_continuous":
@@ -8255,6 +8461,7 @@ class Database(pymongo.database.Database):
         merge_interpolation_samples,
         aws_access_key_id,
         aws_secret_access_key,
+        object_store_client,
     ):
         """
         Private method to create an ensemble from a list of Metadata
@@ -8320,6 +8527,7 @@ class Database(pymongo.database.Database):
                                     merge_interpolation_samples,
                                     aws_access_key_id,
                                     aws_secret_access_key,
+                                    object_store_client,
                                 )
                                 if d.live:
                                     ensemble.member.append(d)
@@ -8345,6 +8553,7 @@ class Database(pymongo.database.Database):
                                 merge_interpolation_samples,
                                 aws_access_key_id,
                                 aws_secret_access_key,
+                                object_store_client,
                             )
                             if d.live:
                                 ensemble.member.append(d)
@@ -8362,6 +8571,7 @@ class Database(pymongo.database.Database):
                             merge_interpolation_samples,
                             aws_access_key_id,
                             aws_secret_access_key,
+                            object_store_client,
                         )
                         if d.live:
                             ensemble.member.append(d)

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -7368,11 +7368,8 @@ class Database(pymongo.database.Database):
 
         try:
             response = object_store_client.get_object(Bucket=bucket, Key=object_name)
-            body = response["Body"]
-            try:
+            with _managed_response_stream(response["Body"]) as body:
                 payload = body.read()
-            finally:
-                body.close()
         except (
             botocore.exceptions.BotoCoreError,
             botocore.exceptions.ClientError,

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1871,6 +1871,7 @@ class Database(pymongo.database.Database):
                         datum.kill()
 
             if storage_mode == "object_store":
+                mspass_object = self._kill_zero_length_live(mspass_object)
                 # Each live member is serialized, durably staged, uploaded,
                 # and committed before the next member starts.  This both
                 # gives interrupted writes a persistent reconciliation record
@@ -4426,12 +4427,7 @@ class Database(pymongo.database.Database):
             # checking every schema-defined waveform collection for another
             # reference to the same file.
             file_is_referenced = False
-            waveform_collections = {
-                collection_name
-                for collection_name, definition in self.database_schema._attr_dict.items()
-                if definition.data_type() in (TimeSeries, Seismogram)
-            }
-            for collection_name in waveform_collections:
+            for collection_name in self._waveform_collection_names():
                 reference_query = {"dir": dir_name, "dfile": dfile_name}
                 if collection_name == wf_collection_name:
                     reference_query["_id"] = {"$ne": oid}
@@ -4454,7 +4450,9 @@ class Database(pymongo.database.Database):
         else:
             final_delete_filter["storage_mode"] = {"$exists": False}
         if storage_mode == "object_store":
-            final_delete_filter["object_store"] = object_store_location
+            final_delete_filter.update(
+                self._object_store_identity_filter(object_store_location)
+            )
         elif storage_mode == "gridfs":
             final_delete_filter["gridfs_id"] = (
                 gridfs_id if gridfs_id is not None else {"$exists": False}
@@ -5772,6 +5770,41 @@ class Database(pymongo.database.Database):
                 mspass_object.erase(key)
 
     @staticmethod
+    def _object_store_identity(location):
+        """Return the fields that uniquely identify one supported S3 object."""
+        return (
+            location.get("provider"),
+            location.get("bucket"),
+            location.get("object_name"),
+        )
+
+    @staticmethod
+    def _object_store_identity_filter(location, field="object_store"):
+        """Build a MongoDB filter for an S3 object's canonical identity."""
+        provider, bucket, object_name = Database._object_store_identity(location)
+        return {
+            "{}.provider".format(field): provider,
+            "{}.bucket".format(field): bucket,
+            "{}.object_name".format(field): object_name,
+        }
+
+    def _waveform_collection_names(self):
+        """Return every schema-defined atomic waveform collection."""
+        return {
+            collection_name
+            for collection_name, definition in self.database_schema._attr_dict.items()
+            if definition.data_type() in (TimeSeries, Seismogram)
+        }
+
+    def _object_store_is_referenced(self, location):
+        """Return True if any waveform document names this S3 object."""
+        query = self._object_store_identity_filter(location)
+        return any(
+            self[collection_name].find_one(query, {"_id": 1}) is not None
+            for collection_name in self._waveform_collection_names()
+        )
+
+    @staticmethod
     def _validate_object_store_schema(save_schema, mode, exclude_keys=None):
         """Reject schemas that would discard object-store location metadata."""
         required_attributes = {
@@ -5835,9 +5868,9 @@ class Database(pymongo.database.Database):
             Database._restore_object_store_metadata(datum, metadata_snapshot)
             if stage_id is not None:
                 try:
-                    self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(
-                        {"_id": stage_id, "object_store": location}
-                    )
+                    stage_filter = {"_id": stage_id}
+                    stage_filter.update(self._object_store_identity_filter(location))
+                    self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(stage_filter)
                 except Exception:
                     failures.append("staging record {}".format(stage_id))
         return failures
@@ -5845,9 +5878,9 @@ class Database(pymongo.database.Database):
     def _complete_object_store_stage(self, stage_id, location):
         """Remove a staging record after its waveform reference is durable."""
         try:
-            result = self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(
-                {"_id": stage_id, "object_store": location}
-            )
+            stage_filter = {"_id": stage_id}
+            stage_filter.update(self._object_store_identity_filter(location))
+            result = self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(stage_filter)
             return result.deleted_count == 1
         except Exception:
             return False
@@ -5859,10 +5892,11 @@ class Database(pymongo.database.Database):
 
         A staging record is written before each S3 upload and removed only
         after the corresponding waveform document has been committed.  A
-        record whose waveform document contains the exact same object-store
-        location is committed; reconciliation removes only the stale staging
-        record and never its sample object.  Other records are reported as
-        uncommitted by default.
+        record whose canonical S3 identity (provider, bucket, and object
+        name) is referenced by any schema-defined waveform collection is
+        committed; reconciliation removes only the stale staging record and
+        never its sample object.  Other records are reported as uncommitted by
+        default.
 
         Set ``delete_uncommitted=True`` only while object-store writers are
         quiescent.  MongoDB and S3 cannot provide a cross-system transaction,
@@ -5899,17 +5933,11 @@ class Database(pymongo.database.Database):
                 )
                 continue
             uri = "s3://{}/{}".format(location["bucket"], location["object_name"])
-            waveform = self[waveform_collection].find_one(
-                {"_id": waveform_id}, {"storage_mode": 1, "object_store": 1}
-            )
-            if waveform is not None and (
-                waveform.get("storage_mode") == "object_store"
-                and waveform.get("object_store") == location
-            ):
+            if self._object_store_is_referenced(location):
                 try:
-                    result = staging_collection.delete_one(
-                        {"_id": stage_id, "object_store": location}
-                    )
+                    stage_filter = {"_id": stage_id}
+                    stage_filter.update(self._object_store_identity_filter(location))
+                    result = staging_collection.delete_one(stage_filter)
                     if result.deleted_count == 1:
                         report["committed"].append(uri)
                     else:
@@ -5928,9 +5956,9 @@ class Database(pymongo.database.Database):
                 object_store_client.delete_object(
                     Bucket=location["bucket"], Key=location["object_name"]
                 )
-                result = staging_collection.delete_one(
-                    {"_id": stage_id, "object_store": location}
-                )
+                stage_filter = {"_id": stage_id}
+                stage_filter.update(self._object_store_identity_filter(location))
+                result = staging_collection.delete_one(stage_filter)
                 if result.deleted_count == 1:
                     report["deleted"].append(uri)
                 else:

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -3582,8 +3582,14 @@ class Database(pymongo.database.Database):
         old_gridfs_id = (
             mspass_object["gridfs_id"] if "gridfs_id" in mspass_object else None
         )
+        metadata_had_storage_mode = "storage_mode" in mspass_object
+        metadata_storage_mode = (
+            mspass_object["storage_mode"] if metadata_had_storage_mode else None
+        )
         if old_gridfs_id is not None:
             mspass_object.erase("gridfs_id")
+        if metadata_had_storage_mode:
+            mspass_object.erase("storage_mode")
         try:
             self.update_metadata(
                 mspass_object,
@@ -3597,6 +3603,8 @@ class Database(pymongo.database.Database):
         finally:
             if old_gridfs_id is not None:
                 mspass_object["gridfs_id"] = old_gridfs_id
+            if metadata_had_storage_mode:
+                mspass_object["storage_mode"] = metadata_storage_mode
         logsize = mspass_object.elog.size()
         # A bit verbose, but we post this warning to make it clear the
         # problem originated from update_data - probably not really needed

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -77,7 +77,10 @@ _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS = 300.0
 _GRIDFS_IO_CHUNK_BYTES = 1024 * 1024
 _OBJECT_STORE_BINARY_ENCODING = "float64-le-v1"
 _OBJECT_STORE_STAGING_COLLECTION = "object_store_staging"
+_GRIDFS_STAGING_COLLECTION = "gridfs_staging"
+_DELETE_CLAIM_KEY = "_mspass_delete_token"
 _OBJECT_STORE_STORAGE_KEYS = (
+    "_id",
     "storage_mode",
     "object_store",
     "gridfs_id",
@@ -200,12 +203,20 @@ def _managed_response_stream(stream):
         stream.close()
 
 
-class _ObjectStoreWaveformCommitUncertain(Exception):
-    """Signal that an attempted waveform insert may still become durable."""
+class _ObjectStoreMongoCommitUncertain(Exception):
+    """Signal that an attempted MongoDB write may still become durable."""
 
 
-def _waveform_insert_result_is_uncertain(error):
-    """Return True when PyMongo cannot prove an attempted insert was rejected."""
+class _ObjectStoreUploadCommitUncertain(Exception):
+    """Signal that an attempted object-store upload may still become durable."""
+
+
+class _GridFSReplacementCommitUncertain(Exception):
+    """Signal that a GridFS replacement write may still become durable."""
+
+
+def _mongodb_write_result_is_uncertain(error):
+    """Return True when PyMongo cannot prove an attempted write was rejected."""
     if not isinstance(error, pymongo.errors.PyMongoError):
         return False
     if error.has_error_label("NoWritesPerformed"):
@@ -1312,6 +1323,8 @@ class Database(pymongo.database.Database):
         alg_id="0",
         object_store=None,
         object_store_client=None,
+        _post_elog=False,
+        _post_history=False,
     ):
         """
         Standard method to save all seismic data objects to be managed by
@@ -1518,8 +1531,8 @@ class Database(pymongo.database.Database):
             we split them because action required by an abortion is
             very different from a normal kill.   See the User Manual
             section on "CRUD Operations" for information on this topic.
-        6.  Object-level history is not saved unless the argument
-            "save_history" is set True (default is False).   When enabled
+        6.  Object-level history is saved by default.  Set the argument
+            "save_history" False to disable it.  When enabled
             the history data (if defined) is saved to a collection called
             "history".   The document saved, like elog, has the ObjectId of
             the wf document with which it is associated.  Be aware that there
@@ -1661,12 +1674,14 @@ class Database(pymongo.database.Database):
           ``storage_mode="object_store"``.  It must be a dictionary containing
           ``provider="s3"`` and ``bucket``.  The optional ``key_prefix`` is
           prepended to the unique object name generated for each atomic datum.
+          Only unversioned buckets are supported by the current lifecycle.
         :type object_store: :class:`dict`
         :param object_store_client: boto3-compatible S3 client used to write
           object-store sample data.  Authentication and client lifetime remain
-          the caller's responsibility.  If an attempted waveform insert ends
-          with an uncertain MongoDB result, the uploaded samples, durable
-          staging record, and new caller metadata are retained for later
+          the caller's responsibility.  After ``put_object`` is invoked, any
+          exception is treated as an uncertain upload result.  Uncertain S3 or
+          MongoDB writes retain the samples, durable staging record,
+          preallocated waveform ``_id``, and new caller metadata for later
           reconciliation instead of being compensated in process.
 
         :param exclude_keys: Metadata can often become contaminated with
@@ -1745,6 +1760,9 @@ class Database(pymongo.database.Database):
             )
             raise MsPASSError(message, "Fatal")
 
+        if overwrite and storage_mode == "gridfs":
+            mspass_object = self._kill_zero_length_live(mspass_object)
+
         overwrite_handled = False
         if overwrite and storage_mode == "gridfs" and mspass_object.live:
             if isinstance(mspass_object, (TimeSeries, Seismogram)):
@@ -1779,12 +1797,35 @@ class Database(pymongo.database.Database):
                             "_id and gridfs_id for every previously saved member"
                         )
                 if any("_id" in d for d in live_members):
+                    ownership_keys = _OBJECT_STORE_STORAGE_KEYS + (
+                        self.database_schema.default_name("history_object") + "_id",
+                        self.database_schema.default_name("elog") + "_id",
+                    )
+                    member_storage_snapshots = [
+                        {
+                            key: (
+                                (True, copy.deepcopy(d[key]))
+                                if key in d
+                                else (False, None)
+                            )
+                            for key in ownership_keys
+                        }
+                        for d in live_members
+                    ]
                     mspass_object, bodies = self.stedronsky.bring_out_your_dead(
                         mspass_object
                     )
                     if not cremate and len(bodies.member) > 0:
                         self.stedronsky.bury(bodies)
                     mspass_object.sync_metadata()
+                    # Ensemble metadata are shared context, never ownership.
+                    # Preserve every member's waveform id and sample location
+                    # across sync_metadata so an ensemble-level pointer cannot
+                    # redirect multiple members to the same persisted owner.
+                    for datum, snapshot in zip(
+                        mspass_object.member, member_storage_snapshots
+                    ):
+                        self._restore_object_store_metadata(datum, snapshot)
                     for d in mspass_object.member:
                         if d.live:
                             if "_id" in d:
@@ -1841,6 +1882,10 @@ class Database(pymongo.database.Database):
                 self._validate_object_store_schema(
                     save_schema, mode, exclude_keys=exclude_keys
                 )
+            elif storage_mode == "gridfs":
+                self._validate_gridfs_schema(
+                    save_schema, mode, exclude_keys=exclude_keys
+                )
 
             if collection:
                 wf_collection_name = collection
@@ -1854,20 +1899,20 @@ class Database(pymongo.database.Database):
                 if isinstance(mspass_object, (TimeSeries, Seismogram))
                 else mspass_object.member
             )
-            object_store_metadata_snapshots = []
-            if storage_mode == "object_store":
-                object_store_metadata_snapshots = [
+            storage_metadata_snapshots = []
+            if storage_mode in ("object_store", "gridfs"):
+                storage_metadata_snapshots = [
                     self._snapshot_object_store_metadata(datum) if datum.live else None
                     for datum in atomic_data
                 ]
 
             if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
                 mspass_object.sync_metadata()
-                if storage_mode == "object_store":
+                if storage_mode in ("object_store", "gridfs"):
                     for index, datum in enumerate(atomic_data):
                         if datum.live:
                             self._restore_object_store_metadata(
-                                datum, object_store_metadata_snapshots[index]
+                                datum, storage_metadata_snapshots[index]
                             )
                 else:
                     for datum in atomic_data:
@@ -1910,21 +1955,48 @@ class Database(pymongo.database.Database):
                             normalizing_collections,
                             alg_name,
                             alg_id,
+                            cremate=cremate,
                         )
                         if isinstance(mspass_object, (TimeSeries, Seismogram)):
                             mspass_object = buried_datum
                         continue
                     waveform_id = ObjectId()
-                    snapshot = object_store_metadata_snapshots[index]
-                    self._save_sample_data_to_object_store(
-                        datum,
-                        object_store,
-                        object_store_client,
-                        format=format,
-                        metadata_snapshots=[snapshot],
-                        waveform_id=waveform_id,
-                        waveform_collection=wf_collection_name,
-                    )
+                    staged_auxiliary = {
+                        "history": {
+                            "collection": self.database_schema.default_name(
+                                "history_object"
+                            ),
+                            "_id": ObjectId(),
+                        },
+                        "elog": {
+                            "collection": self.database_schema.default_name("elog"),
+                            "_id": ObjectId(),
+                        },
+                    }
+                    snapshot = storage_metadata_snapshots[index]
+                    try:
+                        self._save_sample_data_to_object_store(
+                            datum,
+                            object_store,
+                            object_store_client,
+                            format=format,
+                            metadata_snapshots=[snapshot],
+                            waveform_id=waveform_id,
+                            waveform_collection=wf_collection_name,
+                            staged_auxiliary=staged_auxiliary,
+                        )
+                    except _ObjectStoreUploadCommitUncertain as original_error:
+                        location = copy.deepcopy(datum["object_store"])
+                        raise MsPASSError(
+                            "Database.save_data could not determine whether the "
+                            "object-store upload committed; the S3 location, "
+                            "staging record, staged waveform _id, and new caller "
+                            "metadata were retained for reconciliation: "
+                            "s3://{}/{}".format(
+                                location["bucket"], location["object_name"]
+                            ),
+                            "Fatal",
+                        ) from original_error
                     location = copy.deepcopy(datum["object_store"])
                     staged_data = [
                         (
@@ -1949,13 +2021,18 @@ class Database(pymongo.database.Database):
                             alg_name,
                             alg_id,
                             waveform_id=waveform_id,
+                            staged_auxiliary=staged_auxiliary,
+                            durable=True,
+                            post_elog=_post_elog,
+                            post_history=_post_history,
+                            cremate=cremate,
                         )
-                    except _ObjectStoreWaveformCommitUncertain as original_error:
+                    except _ObjectStoreMongoCommitUncertain as original_error:
                         raise MsPASSError(
                             "Database.save_data could not determine whether the "
-                            "waveform insert committed; the object-store samples, "
-                            "staging record, and new caller metadata were retained "
-                            "for reconciliation: "
+                            "MongoDB save committed; the object-store samples, "
+                            "staging record, staged waveform _id, and new caller "
+                            "metadata were retained for reconciliation: "
                             "s3://{}/{}".format(
                                 location["bucket"], location["object_name"]
                             ),
@@ -2020,6 +2097,184 @@ class Database(pymongo.database.Database):
                                 ),
                                 "Fatal",
                             )
+            elif storage_mode == "gridfs":
+                mspass_object = self._kill_zero_length_live(mspass_object)
+                for index, datum in enumerate(atomic_data):
+                    if datum.dead():
+                        buried_datum = self._atomic_save_all_documents(
+                            datum,
+                            save_schema,
+                            exclude_keys,
+                            mode,
+                            wf_collection,
+                            save_history,
+                            data_tag,
+                            storage_mode,
+                            normalizing_collections,
+                            alg_name,
+                            alg_id,
+                            cremate=cremate,
+                        )
+                        if isinstance(mspass_object, (TimeSeries, Seismogram)):
+                            mspass_object = buried_datum
+                        continue
+                    waveform_id = ObjectId()
+                    new_gridfs_id = ObjectId()
+                    staged_auxiliary = {
+                        "history": {
+                            "collection": self.database_schema.default_name(
+                                "history_object"
+                            ),
+                            "_id": ObjectId(),
+                        },
+                        "elog": {
+                            "collection": self.database_schema.default_name("elog"),
+                            "_id": ObjectId(),
+                        },
+                    }
+                    snapshot = storage_metadata_snapshots[index]
+                    try:
+                        stage = self._create_gridfs_stage(
+                            "insert",
+                            waveform_id,
+                            wf_collection_name,
+                            new_gridfs_id,
+                            staged_auxiliary,
+                        )
+                    except Exception:
+                        self._restore_object_store_metadata(datum, snapshot)
+                        raise
+                    datum["_id"] = waveform_id
+                    datum["storage_mode"] = "gridfs"
+                    datum["gridfs_id"] = new_gridfs_id
+                    Database._normalize_storage_pointers(datum, "gridfs")
+                    if _DELETE_CLAIM_KEY in datum:
+                        datum.erase(_DELETE_CLAIM_KEY)
+                    try:
+                        self._save_sample_data_to_gridfs(
+                            datum,
+                            overwrite=False,
+                            gridfs_id=new_gridfs_id,
+                            durable=True,
+                        )
+                    except Exception as original_error:
+                        if _mongodb_write_result_is_uncertain(original_error):
+                            raise MsPASSError(
+                                "Database.save_data could not determine whether "
+                                "the staged GridFS write committed; waveform _id={}, "
+                                "gridfs_id={}, and staging record {} were retained "
+                                "for reconciliation".format(
+                                    waveform_id, new_gridfs_id, stage["_id"]
+                                ),
+                                ErrorSeverity.Fatal,
+                            ) from original_error
+                        failures, retained = self._cleanup_gridfs_stage(
+                            stage, datum, snapshot
+                        )
+                        if retained or failures:
+                            raise MsPASSError(
+                                "Database.save_data could not fully compensate "
+                                "GridFS stage {}; staged gridfs_id={} requires "
+                                "reconciliation: {}".format(
+                                    stage["_id"],
+                                    new_gridfs_id,
+                                    ", ".join(failures) if failures else "referenced",
+                                ),
+                                ErrorSeverity.Fatal,
+                            ) from original_error
+                        raise
+                    try:
+                        saved_datum = self._atomic_save_all_documents(
+                            datum,
+                            save_schema,
+                            exclude_keys,
+                            mode,
+                            wf_collection,
+                            save_history,
+                            data_tag,
+                            storage_mode,
+                            normalizing_collections,
+                            alg_name,
+                            alg_id,
+                            waveform_id=waveform_id,
+                            staged_auxiliary=staged_auxiliary,
+                            durable=True,
+                            post_elog=_post_elog,
+                            post_history=_post_history,
+                            cremate=cremate,
+                        )
+                    except _ObjectStoreMongoCommitUncertain as original_error:
+                        if save_history and not _post_history and not datum.is_empty():
+                            datum[
+                                self.database_schema.default_name("history_object")
+                                + "_id"
+                            ] = staged_auxiliary["history"]["_id"]
+                        if not _post_elog and datum.elog.size() > 0:
+                            datum[self.database_schema.default_name("elog") + "_id"] = (
+                                staged_auxiliary["elog"]["_id"]
+                            )
+                        raise MsPASSError(
+                            "Database.save_data could not determine whether the "
+                            "staged GridFS MongoDB save committed; waveform _id={}, "
+                            "gridfs_id={}, and staging record {} were retained "
+                            "for reconciliation".format(
+                                waveform_id, new_gridfs_id, stage["_id"]
+                            ),
+                            ErrorSeverity.Fatal,
+                        ) from original_error
+                    except Exception as original_error:
+                        failures, retained = self._cleanup_gridfs_stage(
+                            stage, datum, snapshot
+                        )
+                        if retained or failures:
+                            raise MsPASSError(
+                                "Database.save_data could not fully compensate "
+                                "GridFS stage {}; staged gridfs_id={} requires "
+                                "reconciliation: {}".format(
+                                    stage["_id"],
+                                    new_gridfs_id,
+                                    ", ".join(failures) if failures else "referenced",
+                                ),
+                                ErrorSeverity.Fatal,
+                            ) from original_error
+                        raise
+                    if saved_datum.live:
+                        committed_owner = self._object_store_lifecycle_collection(
+                            wf_collection_name
+                        ).find_one(
+                            {"_id": waveform_id},
+                            {"storage_mode": 1, "gridfs_id": 1},
+                        )
+                        if committed_owner is None or not (
+                            committed_owner.get("storage_mode") == "gridfs"
+                            and committed_owner.get("gridfs_id") == new_gridfs_id
+                        ):
+                            raise MsPASSError(
+                                "GridFS waveform owner did not persist the staged "
+                                "sample pointer; staging record {} and gridfs_id={} "
+                                "were retained".format(stage["_id"], new_gridfs_id),
+                                ErrorSeverity.Fatal,
+                            )
+                        if not self._complete_gridfs_stage(stage):
+                            saved_datum.elog.log_error(
+                                "Database.save_data",
+                                "GridFS samples and waveform were committed, but "
+                                "the durable staging record could not be removed; "
+                                "reconcile_gridfs_staging will preserve the data",
+                                ErrorSeverity.Complaint,
+                            )
+                    else:
+                        failures, retained = self._cleanup_gridfs_stage(
+                            stage, datum, snapshot
+                        )
+                        if retained or failures:
+                            raise MsPASSError(
+                                "Dead GridFS save could not be fully compensated for "
+                                "stage {}; staged gridfs_id={} requires reconciliation".format(
+                                    stage["_id"], new_gridfs_id
+                                ),
+                                ErrorSeverity.Fatal,
+                            )
             else:
                 mspass_object = self._save_sample_data(
                     mspass_object,
@@ -2042,6 +2297,7 @@ class Database(pymongo.database.Database):
                         normalizing_collections,
                         alg_name,
                         alg_id,
+                        cremate=cremate,
                     )
                 else:
                     for datum in mspass_object.member:
@@ -2057,6 +2313,7 @@ class Database(pymongo.database.Database):
                             normalizing_collections,
                             alg_name,
                             alg_id,
+                            cremate=cremate,
                         )
         elif not overwrite_handled:
             # may need to clean Metadata before calling this method
@@ -2067,6 +2324,17 @@ class Database(pymongo.database.Database):
                 mspass_object = self.stedronsky.bury(
                     mspass_object, save_history=save_history
                 )
+
+        # Members can be killed after the initial Undertaker pass by schema
+        # validation or the live-zero-length invariant.  Cremation of an
+        # ensemble means those newly dead bodies must also be removed from
+        # the returned live ensemble, without creating cemetery documents.
+        if (
+            cremate
+            and mspass_object.live
+            and isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble))
+        ):
+            mspass_object, _ = self.stedronsky.bring_out_your_dead(mspass_object)
 
         if return_data:
             return mspass_object
@@ -3268,6 +3536,8 @@ class Database(pymongo.database.Database):
         force_keys=None,
         normalizing_collections=["channel", "site", "source"],
         alg_name="Database.update_metadata",
+        upsert=True,
+        _lifecycle_managed=False,
     ):
         """
         Use this method if you want to save the output of a processing algorithm
@@ -3303,6 +3573,9 @@ class Database(pymongo.database.Database):
 
         :param mspass_object: the object you want to update.
         :type mspass_object: either :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`
+        :param upsert: preserve the historical metadata-only behavior when
+          True.  Internal full-data updates set this False so a concurrent
+          deletion cannot recreate a waveform without sample pointers.
         :param exclude_keys: a list of metadata attributes you want to exclude from being updated.
         :type exclude_keys: a :class:`list` of :class:`str`
         :param force_keys: a list of metadata attributes you want to force
@@ -3372,7 +3645,7 @@ class Database(pymongo.database.Database):
             # This returns a string that is the collection name for this atomic data type
             # A weird construct
             wf_collection_name = save_schema.collection("_id")
-        wf_collection = self[wf_collection_name]
+        wf_collection = self._object_store_lifecycle_collection(wf_collection_name)
         # One last check.  Make sure a document with the _id in mspass_object
         # exists.  If it doesn't exist, post an elog about this
         test_doc = wf_collection.find_one({"_id": wfid})
@@ -3392,6 +3665,64 @@ class Database(pymongo.database.Database):
         if force_keys:
             for k in force_keys:
                 changed_key_list.add(k)
+        protected_storage_keys = {_DELETE_CLAIM_KEY}
+        persisted_storage_mode = None
+        if test_doc is not None:
+            persisted_storage_mode = test_doc.get("storage_mode", "gridfs")
+        if persisted_storage_mode in ("gridfs", "object_store"):
+            protected_storage_keys.update(
+                {
+                    "storage_mode",
+                    "object_store",
+                    "gridfs_id",
+                    "dir",
+                    "dfile",
+                    "foff",
+                    "url",
+                    self.database_schema.default_name("history_object") + "_id",
+                    self.database_schema.default_name("elog") + "_id",
+                }
+            )
+        attempted_storage_changes = []
+        allowed_object_store_metadata_update = False
+        protected_changed_keys = protected_storage_keys.intersection(changed_key_list)
+        for key in protected_changed_keys:
+            if key == _DELETE_CLAIM_KEY:
+                attempted_storage_changes.append(key)
+                continue
+            caller_has_key = key in mspass_object
+            persisted_has_key = test_doc is not None and key in test_doc
+            if key == "object_store" and persisted_storage_mode == "object_store":
+                if (
+                    caller_has_key
+                    and persisted_has_key
+                    and isinstance(mspass_object[key], dict)
+                    and isinstance(test_doc[key], dict)
+                    and self._object_store_identity(mspass_object[key])
+                    == self._object_store_identity(test_doc[key])
+                ):
+                    allowed_object_store_metadata_update = True
+                    continue
+            elif caller_has_key == persisted_has_key and (
+                not caller_has_key or mspass_object[key] == test_doc[key]
+            ):
+                continue
+            attempted_storage_changes.append(key)
+        attempted_storage_changes.sort()
+        if attempted_storage_changes and not _lifecycle_managed:
+            raise ValueError(
+                "Database.update_metadata cannot change sample ownership "
+                "fields: {}.  Use save_data, "
+                "update_data, or delete_data so storage lifecycle records "
+                "remain consistent.".format(", ".join(attempted_storage_changes))
+            )
+        # The internal flag only suppresses the user-facing rejection while
+        # update_data saves unrelated metadata.  It can never authorize an
+        # ownership write, even if supplied directly by a caller.
+        for key in protected_changed_keys:
+            if key == "object_store" and allowed_object_store_metadata_update:
+                continue
+            changed_key_list.discard(key)
         copied_metadata = Metadata(mspass_object)
 
         # clear all the aliases
@@ -3551,9 +3882,26 @@ class Database(pymongo.database.Database):
         # any mode when we've passed over the entire metadata dict
         # if it is dead, it's considered something really bad happens, we should not update the object
         if mspass_object.live:
-            wf_collection.update_one(
-                {"_id": wfid}, {"$set": insertion_dict}, upsert=True
+            effective_upsert = upsert and test_doc is None
+            update_filter = {
+                "_id": wfid,
+                _DELETE_CLAIM_KEY: {"$exists": False},
+            }
+            if allowed_object_store_metadata_update:
+                update_filter["storage_mode"] = "object_store"
+                update_filter.update(
+                    self._object_store_identity_filter(test_doc["object_store"])
+                )
+            result = wf_collection.update_one(
+                update_filter,
+                {"$set": insertion_dict},
+                upsert=effective_upsert,
             )
+            if not effective_upsert and result.matched_count != 1:
+                raise MsPASSError(
+                    "Database.update_metadata could not find the persisted waveform",
+                    ErrorSeverity.Invalid,
+                )
         return mspass_object
 
     def update_data(
@@ -3597,6 +3945,12 @@ class Database(pymongo.database.Database):
         after that reference is durable is the old GridFS object deleted.
         Consequently, a put or reference-update failure leaves the old
         waveform readable instead of destroying its only sample copy.
+        The persisted location is read from the primary and both the staged
+        GridFS write and pointer compare-and-swap use majority write concern.
+        If either write returns an uncertain result, both old and staged
+        sample objects and a durable staging record are retained.  After
+        outstanding writes complete, call ``reconcile_gridfs_staging`` and
+        reload the waveform by ``_id`` from the primary.
 
         :param mspass_object: the object you want to update.
         :type mspass_object: either :class:`mspasspy.ccore.seismic.TimeSeries` or :class:`mspasspy.ccore.seismic.Seismogram`
@@ -3654,18 +4008,58 @@ class Database(pymongo.database.Database):
             save_schema = schema.TimeSeries
         else:
             save_schema = schema.Seismogram
+        self._validate_gridfs_schema(save_schema, mode, exclude_keys=exclude_keys)
+        if mspass_object.live and mspass_object.npts <= 0:
+            self._kill_zero_length_live(mspass_object)
+            raise MsPASSError(
+                "Database.update_data cannot replace persisted samples with a "
+                "zero-length live datum; the persisted waveform is unchanged",
+                ErrorSeverity.Invalid,
+            )
         if collection:
             wf_collection_name = collection
         else:
             wf_collection_name = save_schema.collection("_id")
         wf_collection = self[wf_collection_name]
-        persisted_document = None
-        if "_id" in mspass_object:
-            persisted_document = wf_collection.find_one(
-                {"_id": mspass_object["_id"]},
-                {"storage_mode": 1, "object_store": 1, "gridfs_id": 1},
+        history_obj_id_name = (
+            self.database_schema.default_name("history_object") + "_id"
+        )
+        elog_id_name = self.database_schema.default_name("elog") + "_id"
+        if "_id" not in mspass_object:
+            raise ValueError(
+                "Database.update_data requires the _id of an existing waveform"
             )
-        if persisted_document is not None and (
+        waveform_id = mspass_object["_id"]
+        waveform_commit_collection = self._object_store_lifecycle_collection(
+            wf_collection_name
+        )
+        persisted_document = waveform_commit_collection.find_one(
+            {"_id": waveform_id},
+            {
+                "storage_mode": 1,
+                "object_store": 1,
+                "gridfs_id": 1,
+                "dir": 1,
+                "dfile": 1,
+                "foff": 1,
+                "url": 1,
+                history_obj_id_name: 1,
+                elog_id_name: 1,
+                _DELETE_CLAIM_KEY: 1,
+            },
+        )
+        if persisted_document is None:
+            raise ValueError(
+                "Database.update_data could not find the persisted waveform "
+                "document for _id={}".format(waveform_id)
+            )
+        if _DELETE_CLAIM_KEY in persisted_document:
+            raise MsPASSError(
+                "Database.update_data cannot modify a waveform claimed by "
+                "delete_data; retry or complete the pending deletion",
+                ErrorSeverity.Invalid,
+            )
+        if (
             persisted_document.get("storage_mode") == "object_store"
             or "object_store" in persisted_document
         ):
@@ -3682,21 +4076,36 @@ class Database(pymongo.database.Database):
                 "Database.update_data does not support sample updates for "
                 "object_store data; save a new datum with Database.save_data instead"
             )
+        self._resolve_committed_stages_for_waveform(
+            wf_collection_name, waveform_id, persisted_document
+        )
         # First update metadata.  update_metadata will throw an exception
         # only for usage errors.   We test the elog size to check if there
         # are other warning messages and add a summary if there were any
         logsize0 = mspass_object.elog.size()
-        old_gridfs_id = (
-            mspass_object["gridfs_id"] if "gridfs_id" in mspass_object else None
-        )
-        metadata_had_storage_mode = "storage_mode" in mspass_object
-        metadata_storage_mode = (
-            mspass_object["storage_mode"] if metadata_had_storage_mode else None
-        )
-        if old_gridfs_id is not None:
-            mspass_object.erase("gridfs_id")
-        if metadata_had_storage_mode:
-            mspass_object.erase("storage_mode")
+        caller_storage_snapshot = self._snapshot_object_store_metadata(mspass_object)
+        storage_pointer_keys = {
+            "storage_mode",
+            "object_store",
+            "gridfs_id",
+            "dir",
+            "dfile",
+            "foff",
+            "url",
+            history_obj_id_name,
+            elog_id_name,
+        }
+        metadata_storage_snapshot = {
+            key: (
+                (True, copy.deepcopy(mspass_object[key]))
+                if key in mspass_object
+                else (False, None)
+            )
+            for key in storage_pointer_keys
+        }
+        for key, (was_defined, _) in metadata_storage_snapshot.items():
+            if was_defined:
+                mspass_object.erase(key)
         try:
             self.update_metadata(
                 mspass_object,
@@ -3706,12 +4115,15 @@ class Database(pymongo.database.Database):
                 force_keys=force_keys,
                 normalizing_collections=normalizing_collections,
                 alg_name=alg_name,
+                upsert=False,
+                _lifecycle_managed=True,
             )
         finally:
-            if old_gridfs_id is not None:
-                mspass_object["gridfs_id"] = old_gridfs_id
-            if metadata_had_storage_mode:
-                mspass_object["storage_mode"] = metadata_storage_mode
+            for key, (was_defined, value) in metadata_storage_snapshot.items():
+                if was_defined:
+                    mspass_object[key] = copy.deepcopy(value)
+                elif key in mspass_object:
+                    mspass_object.erase(key)
         logsize = mspass_object.elog.size()
         # A bit verbose, but we post this warning to make it clear the
         # problem originated from update_data - probably not really needed
@@ -3728,41 +4140,14 @@ class Database(pymongo.database.Database):
         # optional handle history - we need to update the wf record later with this value
         # if it is set
         update_record = dict()
-        history_obj_id_name = (
-            self.database_schema.default_name("history_object") + "_id"
-        )
         history_object_id = None
         history_save_uuid = None
-        if save_history and not mspass_object.is_empty():
-            history_save_uuid = ProcessingHistory(mspass_object).id()
-            history_object_id = self._save_history(
-                mspass_object,
-                alg_name,
-                alg_id,
-                reset_history=not mspass_object.live,
-            )
-            update_record[history_obj_id_name] = history_object_id
 
         # Now handle update of sample data.  The gridfs method used here
         # handles that correctly based on the gridfs id.
         if mspass_object.live:
-            original_has_storage_mode = "storage_mode" in mspass_object
-            original_storage_mode = (
-                mspass_object["storage_mode"] if original_has_storage_mode else None
-            )
-            original_has_gridfs_id = "gridfs_id" in mspass_object
-            original_gridfs_id = (
-                mspass_object["gridfs_id"] if original_has_gridfs_id else None
-            )
-            caller_storage_mode_changed = original_storage_mode != "gridfs"
-            if persisted_document is not None:
-                persisted_storage_mode = persisted_document.get(
-                    "storage_mode", "gridfs"
-                )
-                persisted_gridfs_id = persisted_document.get("gridfs_id")
-            else:
-                persisted_storage_mode = original_storage_mode
-                persisted_gridfs_id = original_gridfs_id
+            persisted_storage_mode = persisted_document.get("storage_mode", "gridfs")
+            persisted_gridfs_id = persisted_document.get("gridfs_id")
             transition_to_gridfs = persisted_storage_mode != "gridfs"
             if "storage_mode" in mspass_object:
                 storage_mode = mspass_object["storage_mode"]
@@ -3775,7 +4160,6 @@ class Database(pymongo.database.Database):
                         ErrorSeverity.Complaint,
                     )
                     mspass_object["storage_mode"] = "gridfs"
-                    update_record["storage_mode"] = "gridfs"
             else:
                 mspass_object.elog.log_error(
                     alg_name,
@@ -3783,7 +4167,9 @@ class Database(pymongo.database.Database):
                     ErrorSeverity.Complaint,
                 )
                 mspass_object["storage_mode"] = "gridfs"
-                update_record["storage_mode"] = "gridfs"
+            # The committed destination is determined by this API, never by
+            # mutable caller metadata or the persisted source mode.
+            update_record["storage_mode"] = "gridfs"
             # Supplying the replacement id lets rollback remove a blob even
             # when GridFS writes it and then raises an exception.
             # Only the durable waveform document can identify the active old
@@ -3792,133 +4178,229 @@ class Database(pymongo.database.Database):
             # or the object deleted after a successful reference change.
             active_old_gridfs_id = None if transition_to_gridfs else persisted_gridfs_id
             staged_gridfs_id = ObjectId()
+            staged_auxiliary = {
+                "history": {
+                    "collection": self.database_schema.default_name("history_object"),
+                    "_id": ObjectId(),
+                },
+                "elog": {
+                    "collection": self.database_schema.default_name("elog"),
+                    "_id": ObjectId(),
+                },
+            }
+            try:
+                stage = self._create_gridfs_stage(
+                    "replace",
+                    waveform_id,
+                    wf_collection_name,
+                    staged_gridfs_id,
+                    staged_auxiliary,
+                    old_location=self._sample_location_snapshot(persisted_document),
+                )
+            except Exception:
+                self._restore_object_store_metadata(
+                    mspass_object, caller_storage_snapshot
+                )
+                raise
             new_gridfs_id = None
             elog_id = None
             old_elog_id = None
-            created_elog_id = None
             try:
-                mspass_object = self._save_sample_data_to_gridfs(
-                    mspass_object,
-                    overwrite=False,
-                    gridfs_id=staged_gridfs_id,
-                )
+                try:
+                    mspass_object = self._save_sample_data_to_gridfs(
+                        mspass_object,
+                        overwrite=False,
+                        gridfs_id=staged_gridfs_id,
+                        durable=True,
+                    )
+                except Exception as error:
+                    if _mongodb_write_result_is_uncertain(error):
+                        mspass_object["gridfs_id"] = staged_gridfs_id
+                        mspass_object["storage_mode"] = "gridfs"
+                        raise _GridFSReplacementCommitUncertain() from error
+                    raise
                 new_gridfs_id = mspass_object["gridfs_id"]
                 update_record["gridfs_id"] = new_gridfs_id
 
-                if history_object_id is not None:
-                    wf_id_name = wf_collection_name + "_id"
-                    history_result = self[
-                        self.database_schema.default_name("history_object")
-                    ].update_one(
-                        {"_id": history_object_id},
-                        {"$set": {wf_id_name: mspass_object["_id"]}},
-                    )
-                    if history_result.matched_count != 1:
-                        raise MsPASSError(
-                            "Database.update_data could not link the saved history "
-                            "to the waveform",
-                            ErrorSeverity.Invalid,
+                if save_history and not mspass_object.is_empty():
+                    history_save_uuid = ProcessingHistory(mspass_object).id()
+                    try:
+                        history_object_id = self._save_history(
+                            mspass_object,
+                            alg_name,
+                            alg_id,
+                            reset_history=False,
+                            new_history_id=staged_auxiliary["history"]["_id"],
+                            waveform_collection=wf_collection_name,
+                            waveform_id=waveform_id,
+                            durable=True,
                         )
+                    except Exception as error:
+                        if _mongodb_write_result_is_uncertain(error):
+                            raise _GridFSReplacementCommitUncertain() from error
+                        raise
+                    update_record[history_obj_id_name] = history_object_id
                 if mspass_object.elog.size() > 0:
-                    elog_id_name = self.database_schema.default_name("elog") + "_id"
-                    # FIXME I think here we should check if elog_id field exists in the mspass_object
-                    # and we should update the elog entry if mspass_object already had one
-                    if elog_id_name in mspass_object:
-                        old_elog_id = mspass_object[elog_id_name]
+                    old_elog_id = persisted_document.get(elog_id_name)
                     # elog ids will be updated in the wf col when saving metadata
-                    elog_id = self._save_elog(
-                        mspass_object, elog_id=old_elog_id, data_tag=data_tag
-                    )
-                    if old_elog_id is None:
-                        created_elog_id = elog_id
+                    try:
+                        elog_id = self._save_elog(
+                            mspass_object,
+                            elog_id=old_elog_id,
+                            data_tag=data_tag,
+                            new_elog_id=staged_auxiliary["elog"]["_id"],
+                            waveform_collection=wf_collection_name,
+                            waveform_id=waveform_id,
+                            durable=True,
+                        )
+                    except Exception as error:
+                        if _mongodb_write_result_is_uncertain(error):
+                            raise _GridFSReplacementCommitUncertain() from error
+                        raise
                     update_record[elog_id_name] = elog_id
 
-                    # update elog collection
-                    # we have to do the xref to wf collection like this too
-                    elog_col = self[self.database_schema.default_name("elog")]
-                    wf_id_name = wf_collection_name + "_id"
-                    filter_ = {"_id": elog_id}
-                    elog_col.update_one(
-                        filter_, {"$set": {wf_id_name: mspass_object["_id"]}}
+                filter_ = {
+                    "_id": waveform_id,
+                    _DELETE_CLAIM_KEY: {"$exists": False},
+                }
+                if "storage_mode" in persisted_document:
+                    filter_["storage_mode"] = persisted_document["storage_mode"]
+                else:
+                    filter_["storage_mode"] = {"$exists": False}
+                for pointer_key in (
+                    "object_store",
+                    "gridfs_id",
+                    "dir",
+                    "dfile",
+                    "foff",
+                    "url",
+                    history_obj_id_name,
+                    elog_id_name,
+                ):
+                    filter_[pointer_key] = (
+                        persisted_document[pointer_key]
+                        if pointer_key in persisted_document
+                        else {"$exists": False}
                     )
-
-                filter_ = {"_id": mspass_object["_id"]}
-                if persisted_document is not None:
-                    if "storage_mode" in persisted_document:
-                        filter_["storage_mode"] = persisted_document["storage_mode"]
-                    else:
-                        filter_["storage_mode"] = {"$exists": False}
-                    filter_["object_store"] = {"$exists": False}
-                    if persisted_storage_mode == "gridfs":
-                        if active_old_gridfs_id is None:
-                            filter_["gridfs_id"] = {"$exists": False}
-                        else:
-                            filter_["gridfs_id"] = active_old_gridfs_id
                 update_operation = {"$set": update_record}
                 inactive_pointer_keys = Database._inactive_storage_pointer_keys(
                     "gridfs"
                 )
                 update_operation["$unset"] = {key: "" for key in inactive_pointer_keys}
-                result = wf_collection.update_one(filter_, update_operation)
-                if persisted_document is not None and result.matched_count != 1:
+                try:
+                    result = waveform_commit_collection.update_one(
+                        filter_, update_operation
+                    )
+                except Exception as error:
+                    if _mongodb_write_result_is_uncertain(error):
+                        raise _GridFSReplacementCommitUncertain() from error
+                    raise
+                if result.matched_count != 1:
                     raise MsPASSError(
                         "Database.update_data could not commit the new GridFS "
                         "reference",
                         ErrorSeverity.Invalid,
                     )
+            except _GridFSReplacementCommitUncertain as original_error:
+                Database._normalize_storage_pointers(mspass_object, "gridfs")
+                if history_object_id is not None:
+                    mspass_object[history_obj_id_name] = history_object_id
+                elif history_obj_id_name in persisted_document:
+                    mspass_object[history_obj_id_name] = persisted_document[
+                        history_obj_id_name
+                    ]
+                elif history_obj_id_name in mspass_object:
+                    mspass_object.erase(history_obj_id_name)
+                if elog_id is not None:
+                    mspass_object[elog_id_name] = elog_id
+                elif elog_id_name in persisted_document:
+                    mspass_object[elog_id_name] = persisted_document[elog_id_name]
+                elif elog_id_name in mspass_object:
+                    mspass_object.erase(elog_id_name)
+                raise MsPASSError(
+                    "Database.update_data could not determine whether the GridFS "
+                    "replacement committed for waveform _id={}; both the previous "
+                    "and staged sample objects plus staging record {} were retained.  "
+                    "After outstanding "
+                    "MongoDB writes have completed, reload this waveform by _id "
+                    "from the primary before deciding which unreferenced GridFS "
+                    "object to remove.  The staged gridfs_id is {}".format(
+                        waveform_id, stage["_id"], staged_gridfs_id
+                    ),
+                    ErrorSeverity.Fatal,
+                ) from original_error
             except Exception as original_error:
-                try:
-                    gridfs_id_to_remove = staged_gridfs_id or new_gridfs_id
-                    if gridfs_id_to_remove is not None:
-                        gfsh = gridfs.GridFS(self)
-                        if gfsh.exists(gridfs_id_to_remove):
-                            gfsh.delete(gridfs_id_to_remove)
-                    if history_object_id is not None:
-                        history_collection = self.database_schema.default_name(
-                            "history_object"
-                        )
-                        self[history_collection].delete_one({"_id": history_object_id})
-                    if created_elog_id is not None:
-                        elog_collection = self.database_schema.default_name("elog")
-                        self[elog_collection].delete_one({"_id": created_elog_id})
-                except Exception as cleanup_error:
-                    raise original_error from cleanup_error
-                finally:
-                    if original_has_gridfs_id:
-                        mspass_object["gridfs_id"] = original_gridfs_id
-                    elif "gridfs_id" in mspass_object:
-                        mspass_object.erase("gridfs_id")
-                    if caller_storage_mode_changed:
-                        if original_has_storage_mode:
-                            mspass_object["storage_mode"] = original_storage_mode
-                        elif "storage_mode" in mspass_object:
-                            mspass_object.erase("storage_mode")
+                failures, retained = self._cleanup_gridfs_stage(
+                    stage, mspass_object, caller_storage_snapshot
+                )
+                if retained or failures:
+                    Database._normalize_storage_pointers(mspass_object, "gridfs")
+                    raise MsPASSError(
+                        "Database.update_data could not fully compensate GridFS stage "
+                        "{}; waveform _id={} and staged gridfs_id={} require "
+                        "reconciliation: {}".format(
+                            stage["_id"],
+                            waveform_id,
+                            staged_gridfs_id,
+                            ", ".join(failures) if failures else "referenced",
+                        ),
+                        ErrorSeverity.Fatal,
+                    ) from original_error
                 raise
             Database._normalize_storage_pointers(mspass_object, "gridfs")
             # we may probably set the elog_id field in the mspass_object
             if elog_id:
                 mspass_object[elog_id_name] = elog_id
+            elif elog_id_name in persisted_document:
+                mspass_object[elog_id_name] = persisted_document[elog_id_name]
+            elif elog_id_name in mspass_object:
+                mspass_object.erase(elog_id_name)
             # we may probably set the history_object_id field in the mspass_object
             if history_object_id:
                 mspass_object[history_obj_id_name] = history_object_id
+            elif history_obj_id_name in persisted_document:
+                mspass_object[history_obj_id_name] = persisted_document[
+                    history_obj_id_name
+                ]
+            elif history_obj_id_name in mspass_object:
+                mspass_object.erase(history_obj_id_name)
             if history_save_uuid is not None:
                 self._reset_processing_history(
                     mspass_object, alg_name, alg_id, history_save_uuid
                 )
+            stage_resolved = True
             if active_old_gridfs_id is not None:
                 try:
-                    gfsh = gridfs.GridFS(self)
-                    if gfsh.exists(active_old_gridfs_id):
-                        gfsh.delete(active_old_gridfs_id)
+                    self._delete_gridfs_id_if_unreferenced(
+                        active_old_gridfs_id,
+                        expected_collection=wf_collection_name,
+                        expected_id=waveform_id,
+                    )
                 except Exception as error:
+                    stage_resolved = False
                     mspass_object.elog.log_error(
                         alg_name,
                         "GridFS replacement was committed, but the previous "
                         f"sample object could not be deleted: {error}",
                         ErrorSeverity.Complaint,
                     )
+            if stage_resolved and not self._complete_gridfs_stage(stage):
+                mspass_object.elog.log_error(
+                    alg_name,
+                    "GridFS replacement committed, but its durable staging "
+                    "record could not be removed; reconcile_gridfs_staging "
+                    "will preserve the referenced data",
+                    ErrorSeverity.Complaint,
+                )
         else:
             # Dead data land here
+            if save_history and not mspass_object.is_empty():
+                history_object_id = self._save_history(
+                    mspass_object,
+                    alg_name,
+                    alg_id,
+                    reset_history=True,
+                )
             elog_id_name = self.database_schema.default_name("elog") + "_id"
             if elog_id_name in mspass_object:
                 old_elog_id = mspass_object[elog_id_name]
@@ -4399,8 +4881,14 @@ class Database(pymongo.database.Database):
         except:
             oid = object_id
 
-        # fetch the document by the given object id
-        object_doc = self[wf_collection_name].find_one({"_id": oid})
+        # Fetch the owner from the primary.  ``delete_data`` may authorize an
+        # irreversible external-object deletion from this state, so a stale
+        # secondary read is not safe even when the Database was constructed
+        # with a secondary-preferring read preference.
+        lifecycle_wf_collection = self._object_store_lifecycle_collection(
+            wf_collection_name
+        )
+        object_doc = lifecycle_wf_collection.find_one({"_id": oid})
         if not object_doc:
             raise MsPASSError(
                 "Could not find document in wf collection by _id: {}.".format(oid),
@@ -4452,24 +4940,86 @@ class Database(pymongo.database.Database):
                 ErrorSeverity.Invalid,
             )
 
+        self._resolve_committed_stages_for_waveform(wf_collection_name, oid, object_doc)
+
+        # Claim the parent before deleting any child.  Every supported writer
+        # includes the absence of this token in its final MongoDB predicate,
+        # so a successful claim is a durable barrier against a concurrent
+        # sample replacement or metadata update.  A token retained after a
+        # partial failure deliberately makes a later delete_data call resume
+        # the same idempotent cleanup.
+        if _DELETE_CLAIM_KEY in object_doc:
+            delete_token = object_doc[_DELETE_CLAIM_KEY]
+        else:
+            delete_token = ObjectId()
+            claim_filter = {
+                "_id": oid,
+                _DELETE_CLAIM_KEY: {"$exists": False},
+            }
+            if "storage_mode" in object_doc:
+                claim_filter["storage_mode"] = storage_mode
+            else:
+                claim_filter["storage_mode"] = {"$exists": False}
+            if storage_mode == "object_store":
+                claim_filter.update(
+                    self._object_store_identity_filter(object_store_location)
+                )
+            elif storage_mode == "gridfs":
+                claim_filter["gridfs_id"] = (
+                    gridfs_id if gridfs_id is not None else {"$exists": False}
+                )
+            elif storage_mode == "file":
+                for key in ("dir", "dfile", "foff"):
+                    claim_filter[key] = (
+                        object_doc[key] if key in object_doc else {"$exists": False}
+                    )
+            elif storage_mode == "url":
+                claim_filter["url"] = (
+                    object_doc["url"] if "url" in object_doc else {"$exists": False}
+                )
+            for key, value in (
+                (history_obj_id_name, history_obj_id),
+                (elog_id_name, elog_id),
+            ):
+                claim_filter[key] = value if value is not None else {"$exists": False}
+            claim_result = lifecycle_wf_collection.update_one(
+                claim_filter,
+                {"$set": {_DELETE_CLAIM_KEY: delete_token}},
+            )
+            if claim_result.matched_count != 1:
+                raise MsPASSError(
+                    "Waveform storage or auxiliary metadata changed before "
+                    "delete_data could claim it; no child data were deleted",
+                    ErrorSeverity.Invalid,
+                )
+
         # Clear database-owned auxiliary records before removing samples.  If
         # one of these operations fails, the parent still identifies every
         # remaining child and its waveform samples are still readable.
+        delete_history_collection = self._object_store_lifecycle_collection(
+            history_collection
+        )
+        delete_elog_collection = self._object_store_lifecycle_collection(
+            elog_collection
+        )
+
         if clear_history and history_obj_id is not None:
-            self[history_collection].delete_one({"_id": history_obj_id})
+            delete_history_collection.delete_one({"_id": history_obj_id})
 
         if clear_elog:
             if elog_id is not None:
-                self[elog_collection].delete_one({"_id": elog_id})
-            self[elog_collection].delete_many({wf_id_name: oid})
+                delete_elog_collection.delete_one({"_id": elog_id})
+            delete_elog_collection.delete_many({wf_id_name: oid})
 
         # Remove samples only after the requested history and elog cleanup.
         # Missing children are the expected state when retrying a partially
         # completed deletion.
         if storage_mode == "gridfs" and gridfs_id is not None:
-            gfsh = gridfs.GridFS(self)
-            if gfsh.exists(gridfs_id):
-                gfsh.delete(gridfs_id)
+            self._delete_gridfs_id_if_unreferenced(
+                gridfs_id,
+                exclude_collection=wf_collection_name,
+                exclude_id=oid,
+            )
 
         elif storage_mode == "object_store":
             try:
@@ -4513,7 +5063,10 @@ class Database(pymongo.database.Database):
                 reference_query = {"dir": dir_name, "dfile": dfile_name}
                 if collection_name == wf_collection_name:
                     reference_query["_id"] = {"$ne": oid}
-                if self[collection_name].count_documents(reference_query) > 0:
+                reference_collection = self._object_store_lifecycle_collection(
+                    collection_name
+                )
+                if reference_collection.count_documents(reference_query) > 0:
                     file_is_referenced = True
                     break
             if not file_is_referenced:
@@ -4526,7 +5079,7 @@ class Database(pymongo.database.Database):
         # Remove the durable retry record only if it still names the exact
         # sample location deleted above.  A concurrent storage transition
         # must retain its new waveform reference.
-        final_delete_filter = {"_id": oid}
+        final_delete_filter = {"_id": oid, _DELETE_CLAIM_KEY: delete_token}
         if "storage_mode" in object_doc:
             final_delete_filter["storage_mode"] = storage_mode
         else:
@@ -4548,7 +5101,7 @@ class Database(pymongo.database.Database):
             final_delete_filter["url"] = (
                 object_doc["url"] if "url" in object_doc else {"$exists": False}
             )
-        result = self[wf_collection_name].delete_one(final_delete_filter)
+        result = lifecycle_wf_collection.delete_one(final_delete_filter)
         if result.deleted_count != 1:
             raise MsPASSError(
                 "Waveform storage metadata changed during delete_data; the "
@@ -4825,6 +5378,10 @@ class Database(pymongo.database.Database):
         alg_id=None,
         collection=None,
         reset_history=True,
+        new_history_id=None,
+        waveform_collection=None,
+        waveform_id=None,
+        durable=False,
     ):
         """
         Save the processing history of a mspasspy object.
@@ -4839,6 +5396,11 @@ class Database(pymongo.database.Database):
           False only when the caller will reset it after committing its waveform
           reference.
         :type reset_history: bool
+        :param new_history_id: optional preallocated ObjectId for durable saves.
+        :param waveform_collection: optional waveform collection used to create
+          the reverse-reference field before insertion.
+        :param waveform_id: optional waveform id for that reverse reference.
+        :param durable: use primary reads and majority writes when True.
         :return: current history_object_id.
         """
         if isinstance(mspass_object, TimeSeries):
@@ -4850,7 +5412,10 @@ class Database(pymongo.database.Database):
 
         if not collection:
             collection = self.database_schema.default_name("history_object")
-        history_col = self[collection]
+        if durable:
+            history_col = self._object_store_lifecycle_collection(collection)
+        else:
+            history_col = self[collection]
 
         proc_history = ProcessingHistory(mspass_object)
         current_nodedata = proc_history.current_nodedata()
@@ -4863,6 +5428,10 @@ class Database(pymongo.database.Database):
         # Global History implemetnation should allow adding job_name
         # and job_id to this function call.  For now they are dropped
         insert_dict = history2doc(proc_history, alg_id=alg_id, alg_name=alg_name)
+        if new_history_id is not None:
+            insert_dict["_id"] = new_history_id
+        if waveform_collection is not None and waveform_id is not None:
+            insert_dict[waveform_collection + "_id"] = waveform_id
         # We need this below, but history2doc sets it with the "_id" key
         current_uuid = insert_dict["save_uuid"]
         history_id = history_col.insert_one(insert_dict).inserted_id
@@ -4983,6 +5552,10 @@ class Database(pymongo.database.Database):
         collection=None,
         create_tombstone=True,
         data_tag=None,
+        new_elog_id=None,
+        waveform_collection=None,
+        waveform_id=None,
+        durable=False,
     ):
         """
         Save error log for a data object. Data objects in MsPASS contain an error log object used to post any
@@ -4995,6 +5568,17 @@ class Database(pymongo.database.Database):
         :type elog_id: :class:`bson.ObjectId.ObjectId`
         :param collection: the collection that you want to save the elogs. If not specified, use the defined
           collection in the schema.
+        :param new_elog_id: optional preallocated id for a new elog document.
+          Normally this is mutually exclusive with ``elog_id``.  Durable
+          replacement paths supply both so a missing old elog can fall back
+          only to the staged id.
+        :param waveform_collection: waveform collection name used for the
+          reverse-reference field.  Defaults to the metadata schema's normal
+          waveform collection.
+        :param waveform_id: explicit waveform id used for the reverse
+          reference.  Defaults to the id carried by ``mspass_object``.
+        :param durable: when True, use the object-store lifecycle's primary
+          read preference and majority write concern.
         :return: updated elog_id.
         """
         if isinstance(mspass_object, TimeSeries):
@@ -5003,16 +5587,25 @@ class Database(pymongo.database.Database):
             update_metadata_def = self.metadata_schema.Seismogram
         else:
             raise TypeError("only TimeSeries and Seismogram are supported")
-        wf_id_name = update_metadata_def.collection("_id") + "_id"
+        if waveform_collection is None:
+            waveform_collection = update_metadata_def.collection("_id")
+        wf_id_name = waveform_collection + "_id"
 
         if not collection:
             collection = self.database_schema.default_name("elog")
+        if durable:
+            elog_collection = self._object_store_lifecycle_collection(collection)
+        else:
+            elog_collection = self[collection]
 
         # TODO: Need to discuss whether the _id should be linked in a dead elog entry. It
         # might be confusing to link the dead elog to an alive wf record.
-        oid = None
-        if "_id" in mspass_object:
+        oid = waveform_id
+        if oid is None and "_id" in mspass_object:
             oid = mspass_object["_id"]
+
+        if elog_id is not None and new_elog_id is not None and not durable:
+            raise ValueError("elog_id and new_elog_id are mutually exclusive")
 
         if mspass_object.dead() and mspass_object.elog.size() == 0:
             message = (
@@ -5036,7 +5629,7 @@ class Database(pymongo.database.Database):
 
             if elog_id:
                 # append elog
-                elog_doc = self[collection].find_one({"_id": elog_id})
+                elog_doc = elog_collection.find_one({"_id": elog_id})
                 # only append when previous elog exists
                 if elog_doc:
                     # extract contents from this datum for comparison to elog_doc
@@ -5052,14 +5645,32 @@ class Database(pymongo.database.Database):
                     if wf_id_name not in docentry and wf_id_name in elog_doc:
                         docentry[wf_id_name] = elog_doc[wf_id_name]
                     docentry["_id"] = elog_id
-                    self[collection].replace_one({"_id": elog_id}, docentry)
+                    replace_result = elog_collection.replace_one(
+                        {"_id": elog_id}, docentry
+                    )
+                    if durable and replace_result.matched_count != 1:
+                        raise MsPASSError(
+                            "Database._save_elog could not replace the existing "
+                            "elog document",
+                            ErrorSeverity.Invalid,
+                        )
                     return elog_id
                 # note that is should be impossible for the old elog to have tombstone entry
                 # so we ignore the handling of that attribute here.
-                ret_elog_id = self[collection].insert_one(docentry).inserted_id
+                if durable:
+                    if new_elog_id is None:
+                        raise ValueError(
+                            "new_elog_id is required when a durable elog target "
+                            "is missing"
+                        )
+                    docentry["_id"] = new_elog_id
+                ret_elog_id = elog_collection.insert_one(docentry).inserted_id
+            elif new_elog_id is not None:
+                docentry["_id"] = new_elog_id
+                ret_elog_id = elog_collection.insert_one(docentry).inserted_id
             else:
                 # new insertion
-                ret_elog_id = self[collection].insert_one(docentry).inserted_id
+                ret_elog_id = elog_collection.insert_one(docentry).inserted_id
             return ret_elog_id
 
     @staticmethod
@@ -5878,6 +6489,173 @@ class Database(pymongo.database.Database):
             if definition.data_type() in (TimeSeries, Seismogram)
         }
 
+    def _object_store_lifecycle_collection(self, name):
+        """Return a primary/majority collection for lifecycle decisions."""
+        return self.get_collection(
+            name,
+            read_preference=pymongo.ReadPreference.PRIMARY,
+            write_concern=pymongo.write_concern.WriteConcern(w="majority"),
+        )
+
+    def _gridfs_lifecycle_handle(self):
+        """Return a primary/majority GridFS handle for pointer replacement."""
+        database = self.with_options(
+            read_preference=pymongo.ReadPreference.PRIMARY,
+            write_concern=pymongo.write_concern.WriteConcern(w="majority"),
+        )
+        return gridfs.GridFS(database)
+
+    @staticmethod
+    def _sample_location_snapshot(document):
+        """Capture the existence and value of every persisted sample pointer."""
+        keys = (
+            "storage_mode",
+            "object_store",
+            "gridfs_id",
+            "dir",
+            "dfile",
+            "foff",
+            "url",
+        )
+        return {
+            key: {
+                "defined": key in document,
+                "value": copy.deepcopy(document[key]) if key in document else None,
+            }
+            for key in keys
+        }
+
+    @staticmethod
+    def _sample_location_filter(snapshot):
+        """Build an exact MongoDB CAS filter from a location snapshot."""
+        return {
+            key: (
+                copy.deepcopy(entry["value"])
+                if entry["defined"]
+                else {"$exists": False}
+            )
+            for key, entry in snapshot.items()
+        }
+
+    @staticmethod
+    def _sample_location_matches(document, snapshot):
+        """Return True when a document has exactly the staged location state."""
+        for key, entry in snapshot.items():
+            if entry["defined"] != (key in document):
+                return False
+            if entry["defined"] and document[key] != entry["value"]:
+                return False
+        return True
+
+    def _gridfs_is_referenced(
+        self,
+        gridfs_id,
+        expected_collection=None,
+        expected_id=None,
+        exclude_collection=None,
+        exclude_id=None,
+    ):
+        """Return True when any primary waveform document names ``gridfs_id``."""
+        collection_names = self._waveform_collection_names()
+        if expected_collection is not None:
+            collection_names.add(expected_collection)
+        if exclude_collection is not None:
+            collection_names.add(exclude_collection)
+        for collection_name in collection_names:
+            query = {"gridfs_id": gridfs_id}
+            if collection_name == exclude_collection:
+                query["_id"] = {"$ne": exclude_id}
+            collection = self._object_store_lifecycle_collection(collection_name)
+            if collection.find_one(query, {"_id": 1}) is not None:
+                return True
+        return False
+
+    def _create_gridfs_stage(
+        self,
+        operation,
+        waveform_id,
+        waveform_collection,
+        new_gridfs_id,
+        auxiliary_documents,
+        old_location=None,
+    ):
+        """Persist a GridFS save/replace intent before writing sample bytes."""
+        stage = {
+            "_id": ObjectId(),
+            "operation": operation,
+            "waveform_id": waveform_id,
+            "waveform_collection": waveform_collection,
+            "new_gridfs_id": new_gridfs_id,
+            "auxiliary_documents": copy.deepcopy(auxiliary_documents),
+            "created_at": datetime.now(timezone.utc),
+        }
+        if old_location is not None:
+            stage["old_location"] = copy.deepcopy(old_location)
+        collection = self._object_store_lifecycle_collection(_GRIDFS_STAGING_COLLECTION)
+        collection.insert_one(stage)
+        return stage
+
+    def _delete_gridfs_id_if_unreferenced(
+        self,
+        gridfs_id,
+        expected_collection=None,
+        expected_id=None,
+        exclude_collection=None,
+        exclude_id=None,
+    ):
+        """Delete files and partial chunks only after a primary reference scan."""
+        if self._gridfs_is_referenced(
+            gridfs_id,
+            expected_collection=expected_collection,
+            expected_id=expected_id,
+            exclude_collection=exclude_collection,
+            exclude_id=exclude_id,
+        ):
+            return False
+        self._gridfs_lifecycle_handle().delete(gridfs_id)
+        return True
+
+    def _cleanup_gridfs_stage(self, stage, datum=None, metadata_snapshot=None):
+        """Compensate a known failed GridFS operation without losing its identity."""
+        try:
+            stage_collection = self._object_store_lifecycle_collection(
+                _GRIDFS_STAGING_COLLECTION
+            )
+            durable_stage = stage_collection.find_one({"_id": stage["_id"]})
+            if durable_stage is None:
+                return ["missing gridfs staging record {}".format(stage["_id"])], False
+            new_gridfs_id = durable_stage["new_gridfs_id"]
+            waveform_collection = durable_stage["waveform_collection"]
+            waveform_id = durable_stage["waveform_id"]
+            if self._gridfs_is_referenced(
+                new_gridfs_id,
+                expected_collection=waveform_collection,
+                expected_id=waveform_id,
+            ):
+                return [], True
+            # GridFS.delete is deliberately unconditional: it removes chunks
+            # even when a failed put never created the fs.files document.
+            self._gridfs_lifecycle_handle().delete(new_gridfs_id)
+            if datum is not None and metadata_snapshot is not None:
+                self._restore_object_store_metadata(datum, metadata_snapshot)
+            self._delete_staged_auxiliary_documents(durable_stage)
+            result = stage_collection.delete_one({"_id": durable_stage["_id"]})
+            if result.deleted_count != 1:
+                return ["gridfs staging record {}".format(stage["_id"])], False
+        except Exception as error:
+            return ["gridfs staging record {}: {}".format(stage["_id"], error)], False
+        return [], False
+
+    def _complete_gridfs_stage(self, stage):
+        """Remove a resolved GridFS stage with majority acknowledgement."""
+        try:
+            collection = self._object_store_lifecycle_collection(
+                _GRIDFS_STAGING_COLLECTION
+            )
+            return collection.delete_one({"_id": stage["_id"]}).deleted_count == 1
+        except Exception:
+            return False
+
     def _object_store_is_referenced(
         self,
         location,
@@ -5907,7 +6685,10 @@ class Database(pymongo.database.Database):
         if expected_collection is not None:
             owner_query = {"_id": expected_id}
             owner_query.update(identity_query)
-            if self[expected_collection].find_one(owner_query, {"_id": 1}) is not None:
+            owner_collection = self._object_store_lifecycle_collection(
+                expected_collection
+            )
+            if owner_collection.find_one(owner_query, {"_id": 1}) is not None:
                 return True
 
         collection_names = self._waveform_collection_names()
@@ -5919,7 +6700,8 @@ class Database(pymongo.database.Database):
             query = dict(identity_query)
             if collection_name == exclude_collection:
                 query["_id"] = {"$ne": exclude_id}
-            if self[collection_name].find_one(query, {"_id": 1}) is not None:
+            collection = self._object_store_lifecycle_collection(collection_name)
+            if collection.find_one(query, {"_id": 1}) is not None:
                 return True
         return False
 
@@ -5951,6 +6733,28 @@ class Database(pymongo.database.Database):
             )
 
     @staticmethod
+    def _validate_gridfs_schema(save_schema, mode, exclude_keys=None):
+        """Reject schemas that cannot persist the active GridFS pointer."""
+        required_attributes = {"storage_mode": str, "gridfs_id": ObjectId}
+        problems = []
+        for key, required_type in required_attributes.items():
+            if exclude_keys and key in exclude_keys:
+                problems.append("{} is excluded".format(key))
+            elif mode == "promiscuous":
+                continue
+            elif key not in save_schema.keys():
+                problems.append("{} is undefined".format(key))
+            elif save_schema.type(key) is not required_type:
+                problems.append("{} has the wrong type".format(key))
+            elif save_schema.readonly(key):
+                problems.append("{} is readonly".format(key))
+        if problems:
+            raise ValueError(
+                "storage_mode=gridfs is incompatible with the selected metadata "
+                "schema: {}".format(", ".join(problems))
+            )
+
+    @staticmethod
     def _snapshot_object_store_metadata(mspass_object):
         """Capture storage metadata so a failed staged write can be undone."""
         return {
@@ -5971,6 +6775,83 @@ class Database(pymongo.database.Database):
             elif key in mspass_object:
                 mspass_object.erase(key)
 
+    @staticmethod
+    def _staged_auxiliary_documents(stage):
+        """Return validated auxiliary-document plans from a staging record."""
+        auxiliary = stage.get("auxiliary_documents", {})
+        if not isinstance(auxiliary, dict):
+            raise ValueError("auxiliary_documents must be a dictionary")
+        entries = []
+        for kind in ("history", "elog"):
+            entry = auxiliary.get(kind)
+            if entry is None:
+                continue
+            if (
+                not isinstance(entry, dict)
+                or not isinstance(entry.get("collection"), str)
+                or not entry["collection"]
+                or entry.get("_id") is None
+            ):
+                raise ValueError("invalid staged {} document".format(kind))
+            entries.append((kind, entry))
+        return entries
+
+    def _delete_staged_auxiliary_documents(self, stage):
+        """Delete auxiliary documents preallocated for one failed staged save."""
+        for _, entry in self._staged_auxiliary_documents(stage):
+            collection = self._object_store_lifecycle_collection(entry["collection"])
+            collection.delete_one({"_id": entry["_id"]})
+
+    def _repair_staged_auxiliary_documents(self, stage, waveform):
+        """Validate and repair auxiliary links for a committed staged owner."""
+        waveform_collection = stage["waveform_collection"]
+        waveform_id = stage["waveform_id"]
+        reverse_key = waveform_collection + "_id"
+        for kind, entry in self._staged_auxiliary_documents(stage):
+            collection_name = entry["collection"]
+            collection = self._object_store_lifecycle_collection(collection_name)
+            auxiliary_id = entry["_id"]
+            waveform_pointer = collection_name + "_id"
+            auxiliary_document = collection.find_one(
+                {"_id": auxiliary_id}, {"_id": 1, reverse_key: 1}
+            )
+            if waveform.get(waveform_pointer) == auxiliary_id:
+                if auxiliary_document is None:
+                    raise MsPASSError(
+                        "Committed waveform references a missing staged {} "
+                        "document".format(kind),
+                        ErrorSeverity.Invalid,
+                    )
+                existing_owner = auxiliary_document.get(reverse_key)
+                if existing_owner is not None and existing_owner != waveform_id:
+                    raise MsPASSError(
+                        "Staged {} document is linked to a different waveform".format(
+                            kind
+                        ),
+                        ErrorSeverity.Invalid,
+                    )
+                result = collection.update_one(
+                    {
+                        "_id": auxiliary_id,
+                        "$or": [
+                            {reverse_key: {"$exists": False}},
+                            {reverse_key: waveform_id},
+                        ],
+                    },
+                    {"$set": {reverse_key: waveform_id}},
+                )
+                if result.matched_count != 1:
+                    raise MsPASSError(
+                        "Could not repair the staged {} waveform link".format(kind),
+                        ErrorSeverity.Invalid,
+                    )
+            elif auxiliary_document is not None:
+                raise MsPASSError(
+                    "A staged {} document exists but the committed waveform "
+                    "does not reference it".format(kind),
+                    ErrorSeverity.Invalid,
+                )
+
     def _cleanup_staged_object_store_data(self, object_store_client, staged_data):
         """Delete uploads only after MongoDB proves they are unreferenced."""
         failures = []
@@ -5984,10 +6865,33 @@ class Database(pymongo.database.Database):
             uri = "s3://{}/{}".format(bucket, object_name)
             if stage_id is not None and waveform_collection is not None:
                 try:
+                    intended_owner_collection = self._object_store_lifecycle_collection(
+                        waveform_collection
+                    )
+                    intended_owner = intended_owner_collection.find_one(
+                        {"_id": stage_id},
+                        {"storage_mode": 1, "object_store": 1},
+                    )
+                    if intended_owner is not None:
+                        if intended_owner.get("storage_mode") != "object_store":
+                            identity_matches = False
+                        elif isinstance(intended_owner.get("object_store"), dict):
+                            identity_matches = self._object_store_identity(
+                                intended_owner["object_store"]
+                            ) == self._object_store_identity(location)
+                        else:
+                            identity_matches = False
+                        if identity_matches:
+                            durable_references.append(uri)
+                        else:
+                            failures.append(
+                                "staged owner {} changed storage state".format(stage_id)
+                            )
+                        continue
                     referenced = self._object_store_is_referenced(
                         location,
-                        expected_collection=waveform_collection,
-                        expected_id=stage_id,
+                        exclude_collection=waveform_collection,
+                        exclude_id=stage_id,
                     )
                 except Exception:
                     failures.append("reference status for {}".format(uri))
@@ -6005,40 +6909,156 @@ class Database(pymongo.database.Database):
                 try:
                     stage_filter = {"_id": stage_id}
                     stage_filter.update(self._object_store_identity_filter(location))
-                    self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(stage_filter)
+                    staging_collection = self._object_store_lifecycle_collection(
+                        _OBJECT_STORE_STAGING_COLLECTION
+                    )
+                    stage = staging_collection.find_one(stage_filter)
+                    if stage is None:
+                        failures.append("staging record {}".format(stage_id))
+                        continue
+                    self._delete_staged_auxiliary_documents(stage)
+                    result = staging_collection.delete_one(stage_filter)
+                    if result.deleted_count != 1:
+                        failures.append("staging record {}".format(stage_id))
+                        continue
                 except Exception:
                     failures.append("staging record {}".format(stage_id))
+                    continue
         return failures, durable_references
 
     def _complete_object_store_stage(self, stage_id, location):
-        """Remove a staging record after its waveform reference is durable."""
+        """Remove a stage only while its intended owner names this object."""
         try:
             stage_filter = {"_id": stage_id}
             stage_filter.update(self._object_store_identity_filter(location))
-            result = self[_OBJECT_STORE_STAGING_COLLECTION].delete_one(stage_filter)
+            staging_collection = self._object_store_lifecycle_collection(
+                _OBJECT_STORE_STAGING_COLLECTION
+            )
+            stage = staging_collection.find_one(stage_filter)
+            if stage is None:
+                return False
+            waveform_collection = self._object_store_lifecycle_collection(
+                stage["waveform_collection"]
+            )
+            owner_filter = {
+                "_id": stage["waveform_id"],
+                "storage_mode": "object_store",
+            }
+            owner_filter.update(self._object_store_identity_filter(location))
+            if waveform_collection.find_one(owner_filter, {"_id": 1}) is None:
+                return False
+            result = staging_collection.delete_one(stage_filter)
             return result.deleted_count == 1
         except Exception:
             return False
+
+    def _resolve_committed_stages_for_waveform(
+        self, waveform_collection, waveform_id, waveform
+    ):
+        """Finish durable stages owned by one primary waveform document.
+
+        This guard runs before a later update or delete.  It prevents a
+        completion failure from turning into an ambiguous predecessor stage
+        after the waveform location changes again.
+        """
+        object_stages = self._object_store_lifecycle_collection(
+            _OBJECT_STORE_STAGING_COLLECTION
+        ).find(
+            {
+                "waveform_collection": waveform_collection,
+                "waveform_id": waveform_id,
+            }
+        )
+        for stage in object_stages:
+            location = stage.get("object_store")
+            if not isinstance(location, dict) or not (
+                waveform.get("storage_mode") == "object_store"
+                and isinstance(waveform.get("object_store"), dict)
+                and self._object_store_identity(waveform["object_store"])
+                == self._object_store_identity(location)
+            ):
+                raise MsPASSError(
+                    "An unresolved object-store stage conflicts with the "
+                    "persisted waveform; run reconciliation before changing it",
+                    ErrorSeverity.Fatal,
+                )
+            self._repair_staged_auxiliary_documents(stage, waveform)
+            if not self._complete_object_store_stage(stage["_id"], location):
+                raise MsPASSError(
+                    "Could not resolve the waveform's committed object-store "
+                    "stage; retry reconciliation before changing it",
+                    ErrorSeverity.Fatal,
+                )
+
+        gridfs_stages = self._object_store_lifecycle_collection(
+            _GRIDFS_STAGING_COLLECTION
+        ).find(
+            {
+                "waveform_collection": waveform_collection,
+                "waveform_id": waveform_id,
+            }
+        )
+        for stage in gridfs_stages:
+            new_gridfs_id = stage.get("new_gridfs_id")
+            if not (
+                waveform.get("storage_mode", "gridfs") == "gridfs"
+                and waveform.get("gridfs_id") == new_gridfs_id
+            ):
+                raise MsPASSError(
+                    "An unresolved GridFS stage conflicts with the persisted "
+                    "waveform; run reconciliation before changing it",
+                    ErrorSeverity.Fatal,
+                )
+            self._repair_staged_auxiliary_documents(stage, waveform)
+            old_location = stage.get("old_location", {})
+            old_gridfs = old_location.get("gridfs_id", {})
+            if (
+                stage.get("operation") == "replace"
+                and isinstance(old_gridfs, dict)
+                and old_gridfs.get("defined")
+                and old_gridfs.get("value") != new_gridfs_id
+            ):
+                self._delete_gridfs_id_if_unreferenced(
+                    old_gridfs["value"],
+                    expected_collection=waveform_collection,
+                    expected_id=waveform_id,
+                )
+            if not self._complete_gridfs_stage(stage):
+                raise MsPASSError(
+                    "Could not resolve the waveform's committed GridFS stage; "
+                    "retry reconciliation before changing it",
+                    ErrorSeverity.Fatal,
+                )
 
     def reconcile_object_store_staging(
         self, object_store_client, delete_uncommitted=False
     ):
         """Report or remove durable object-store staging records.
 
-        A staging record is written before each S3 upload and removed only
-        after the corresponding waveform document has been committed.  A
+        A staging record containing preallocated waveform, history, and elog
+        ids is written before each S3 upload and removed only after the
+        corresponding waveform document and auxiliary links have been
+        committed.  A
         record whose intended owner has the same canonical S3 identity
         (provider, bucket, and object name) is committed, including owners in
         alternate collections not present in ``DatabaseSchema``.  If that
         exact owner is absent, every schema-defined waveform collection is
         checked for a shared reference.  Reconciliation removes only the
         stale staging record for committed objects and never their samples.
-        Other records are reported as uncommitted by default.
+        It repairs the intended owner's auxiliary reverse links before
+        clearing staging.  If only another waveform shares the identity, its
+        samples are preserved while the failed owner's staged auxiliary
+        documents are removed.  Other records are reported as uncommitted by
+        default.
 
-        Set ``delete_uncommitted=True`` only while object-store writers are
-        quiescent.  MongoDB and S3 cannot provide a cross-system transaction,
-        so an active writer could otherwise commit between the waveform check
-        and the S3 delete.
+        Call this method only after every object-store reference writer is
+        quiescent and every outstanding S3 and MongoDB request has completed.
+        Even the default mode repairs auxiliary links and removes resolved
+        staging records.  MongoDB and S3 cannot provide a cross-system
+        transaction, so an active or in-flight writer could otherwise change
+        ownership between the reference check and cleanup.  This lifecycle
+        supports unversioned S3 buckets only because version ids are not
+        persisted.
 
         :return: a dictionary containing deterministic URI lists named
           ``committed``, ``uncommitted``, ``deleted``, and ``failures``.
@@ -6051,7 +7071,9 @@ class Database(pymongo.database.Database):
             "deleted": [],
             "failures": [],
         }
-        staging_collection = self[_OBJECT_STORE_STAGING_COLLECTION]
+        staging_collection = self._object_store_lifecycle_collection(
+            _OBJECT_STORE_STAGING_COLLECTION
+        )
         for stage in staging_collection.find({}).sort("_id", pymongo.ASCENDING):
             stage_id = stage.get("_id")
             waveform_id = stage.get("waveform_id")
@@ -6071,18 +7093,59 @@ class Database(pymongo.database.Database):
                 continue
             uri = "s3://{}/{}".format(location["bucket"], location["object_name"])
             try:
-                referenced = self._object_store_is_referenced(
-                    location,
-                    expected_collection=waveform_collection,
-                    expected_id=waveform_id,
+                self._staged_auxiliary_documents(stage)
+                owner_collection = self._object_store_lifecycle_collection(
+                    waveform_collection
                 )
+                waveform = owner_collection.find_one({"_id": waveform_id})
+                shared_reference = False
+                if waveform is not None:
+                    if waveform.get("storage_mode") != "object_store":
+                        owner_identity_matches = False
+                    elif isinstance(waveform.get("object_store"), dict):
+                        owner_identity_matches = self._object_store_identity(
+                            waveform["object_store"]
+                        ) == self._object_store_identity(location)
+                    else:
+                        owner_identity_matches = False
+                    if not owner_identity_matches:
+                        report["failures"].append(
+                            "{}: staged owner {} changed storage state".format(
+                                uri, waveform_id
+                            )
+                        )
+                        continue
+                else:
+                    shared_reference = self._object_store_is_referenced(
+                        location,
+                        exclude_collection=waveform_collection,
+                        exclude_id=waveform_id,
+                    )
             except Exception as error:
                 report["failures"].append(
-                    "{}: could not determine waveform references: {}".format(uri, error)
+                    "{}: could not determine staged state: {}".format(uri, error)
                 )
                 continue
-            if referenced:
+            if waveform is not None:
                 try:
+                    self._repair_staged_auxiliary_documents(stage, waveform)
+                    stage_filter = {"_id": stage_id}
+                    stage_filter.update(self._object_store_identity_filter(location))
+                    result = staging_collection.delete_one(stage_filter)
+                    if result.deleted_count == 1:
+                        report["committed"].append(uri)
+                    else:
+                        report["failures"].append(
+                            "staging record {} changed during reconciliation".format(
+                                stage_id
+                            )
+                        )
+                except Exception as error:
+                    report["failures"].append("{}: {}".format(uri, error))
+                continue
+            if shared_reference:
+                try:
+                    self._delete_staged_auxiliary_documents(stage)
                     stage_filter = {"_id": stage_id}
                     stage_filter.update(self._object_store_identity_filter(location))
                     result = staging_collection.delete_one(stage_filter)
@@ -6104,6 +7167,7 @@ class Database(pymongo.database.Database):
                 object_store_client.delete_object(
                     Bucket=location["bucket"], Key=location["object_name"]
                 )
+                self._delete_staged_auxiliary_documents(stage)
                 stage_filter = {"_id": stage_id}
                 stage_filter.update(self._object_store_identity_filter(location))
                 result = staging_collection.delete_one(stage_filter)
@@ -6115,6 +7179,132 @@ class Database(pymongo.database.Database):
                     )
             except Exception as error:
                 report["failures"].append("{}: {}".format(uri, error))
+        return report
+
+    def reconcile_gridfs_staging(self, delete_uncommitted=False):
+        """Resolve durable GridFS save and replacement staging records.
+
+        Call this method only after GridFS writers and their outstanding
+        MongoDB requests are quiescent.  The default repairs committed
+        auxiliary links and removes resolved stages, but only reports
+        uncommitted records.  ``delete_uncommitted=True`` also removes their
+        preallocated GridFS files/chunks and staged auxiliary documents.
+        """
+        report = {
+            "committed": [],
+            "uncommitted": [],
+            "deleted": [],
+            "failures": [],
+        }
+        staging_collection = self._object_store_lifecycle_collection(
+            _GRIDFS_STAGING_COLLECTION
+        )
+        for stage in staging_collection.find({}).sort("_id", pymongo.ASCENDING):
+            stage_id = stage.get("_id")
+            operation = stage.get("operation")
+            waveform_id = stage.get("waveform_id")
+            waveform_collection = stage.get("waveform_collection")
+            new_gridfs_id = stage.get("new_gridfs_id")
+            label = str(new_gridfs_id)
+            if (
+                operation not in ("insert", "replace")
+                or waveform_id is None
+                or not isinstance(waveform_collection, str)
+                or not waveform_collection
+                or new_gridfs_id is None
+            ):
+                report["failures"].append(
+                    "gridfs staging record {} is invalid".format(stage_id)
+                )
+                continue
+            try:
+                self._staged_auxiliary_documents(stage)
+                owner_collection = self._object_store_lifecycle_collection(
+                    waveform_collection
+                )
+                waveform = owner_collection.find_one({"_id": waveform_id})
+                owner_committed = waveform is not None and (
+                    waveform.get("storage_mode", "gridfs") == "gridfs"
+                    and waveform.get("gridfs_id") == new_gridfs_id
+                )
+                owner_conflict = False
+                if waveform is not None and not owner_committed:
+                    if operation == "insert":
+                        owner_conflict = True
+                    else:
+                        old_location = stage.get("old_location")
+                        owner_conflict = not isinstance(
+                            old_location, dict
+                        ) or not self._sample_location_matches(waveform, old_location)
+                shared_reference = False
+                if not owner_committed and not owner_conflict:
+                    shared_reference = self._gridfs_is_referenced(
+                        new_gridfs_id,
+                        exclude_collection=waveform_collection,
+                        exclude_id=waveform_id,
+                    )
+            except Exception as error:
+                report["failures"].append(
+                    "{}: could not determine staged state: {}".format(label, error)
+                )
+                continue
+
+            if owner_conflict:
+                report["failures"].append(
+                    "{}: staged owner {} changed storage state".format(
+                        label, waveform_id
+                    )
+                )
+                continue
+
+            if owner_committed:
+                try:
+                    self._repair_staged_auxiliary_documents(stage, waveform)
+                    old_location = stage.get("old_location", {})
+                    old_gridfs = old_location.get("gridfs_id", {})
+                    if (
+                        operation == "replace"
+                        and old_gridfs.get("defined")
+                        and old_gridfs.get("value") != new_gridfs_id
+                    ):
+                        self._delete_gridfs_id_if_unreferenced(
+                            old_gridfs["value"],
+                            expected_collection=waveform_collection,
+                            expected_id=waveform_id,
+                        )
+                    if self._complete_gridfs_stage(stage):
+                        report["committed"].append(label)
+                    else:
+                        report["failures"].append(
+                            "gridfs staging record {} changed".format(stage_id)
+                        )
+                except Exception as error:
+                    report["failures"].append("{}: {}".format(label, error))
+                continue
+
+            if shared_reference:
+                try:
+                    self._delete_staged_auxiliary_documents(stage)
+                    if self._complete_gridfs_stage(stage):
+                        report["committed"].append(label)
+                    else:
+                        report["failures"].append(
+                            "gridfs staging record {} changed".format(stage_id)
+                        )
+                except Exception as error:
+                    report["failures"].append("{}: {}".format(label, error))
+                continue
+
+            if not delete_uncommitted:
+                report["uncommitted"].append(label)
+                continue
+            failures, retained = self._cleanup_gridfs_stage(stage)
+            if retained:
+                report["committed"].append(label)
+            elif failures:
+                report["failures"].extend(failures)
+            else:
+                report["deleted"].append(label)
         return report
 
     @staticmethod
@@ -7521,8 +8711,8 @@ class Database(pymongo.database.Database):
         See description below of "use_member_dfile_value" parameter.
 
         2) The "storage_mode" argument determines what medium will hold the
-        sample data.  Currently accepted values are "file", "gridfs", and
-        "object_store".
+        sample data.  This low-level helper accepts "file" and "gridfs".
+        Object-store writes require owner staging and must use ``save_data``.
 
         3) The "format" argument can be used to specify an alternative
         format for the output.  Most formats mix up metadata and sample
@@ -7550,8 +8740,8 @@ class Database(pymongo.database.Database):
           (1) "file" causes data to be written to external files.
           (2) "gridfs" (the default) causes the sample data to be stored
                within the gridfs file system of MongoDB.
-          (3) "object_store" writes each atomic datum to an independent
-               object using a boto3-compatible S3 client.
+          "object_store" is rejected here because this helper cannot establish
+          a durable owner stage; use ``Database.save_data`` for that mode.
           See User's manuals for guidance on storage option tradeoffs.
 
         :param dir:  directory file is to be written. Just be writable
@@ -7612,12 +8802,9 @@ class Database(pymongo.database.Database):
                     overwrite,
                 )
             elif storage_mode == "object_store":
-                mspass_object = self._save_sample_data_to_object_store(
-                    mspass_object,
-                    object_store,
-                    object_store_client,
-                    format,
-                    metadata_snapshots=object_store_metadata_snapshots,
+                raise ValueError(
+                    "Object-store sample writes require durable owner staging; "
+                    "use Database.save_data"
                 )
             else:
                 message = (
@@ -7941,10 +9128,23 @@ class Database(pymongo.database.Database):
         metadata_snapshots=None,
         waveform_id=None,
         waveform_collection=None,
+        staged_auxiliary=None,
     ):
         """Write sample data to independent objects in an S3-compatible store."""
         if mspass_object.dead():
             return mspass_object
+        if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
+            raise ValueError(
+                "Object-store ensembles must be saved through Database.save_data "
+                "so each live member receives a durable owner stage"
+            )
+        if not isinstance(mspass_object, (TimeSeries, Seismogram)):
+            raise TypeError("only atomic MsPASS seismic data objects are supported")
+        if waveform_id is None or not isinstance(waveform_collection, str):
+            raise ValueError(
+                "waveform_id and waveform_collection are required for durable "
+                "object-store staging"
+            )
         if not isinstance(object_store, dict):
             raise TypeError(
                 "object_store must be a dictionary for storage_mode=object_store"
@@ -7962,60 +9162,6 @@ class Database(pymongo.database.Database):
                 "object_store_client is required for storage_mode=object_store"
             )
 
-        if isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
-            if metadata_snapshots is None:
-                metadata_snapshots = [
-                    self._snapshot_object_store_metadata(datum) if datum.live else None
-                    for datum in mspass_object.member
-                ]
-            staged_data = []
-            try:
-                for index, datum in enumerate(mspass_object.member):
-                    if datum.live:
-                        metadata_snapshot = metadata_snapshots[index]
-                        self._save_sample_data_to_object_store(
-                            datum,
-                            object_store,
-                            object_store_client,
-                            format,
-                            metadata_snapshots=[metadata_snapshot],
-                        )
-                        staged_data.append(
-                            (
-                                datum,
-                                copy.deepcopy(datum["object_store"]),
-                                metadata_snapshot,
-                            )
-                        )
-            except Exception as original_error:
-                (
-                    cleanup_failures,
-                    durable_references,
-                ) = self._cleanup_staged_object_store_data(
-                    object_store_client, staged_data
-                )
-                if durable_references:
-                    raise MsPASSError(
-                        "Object-store ensemble upload failed after a waveform "
-                        "reference became durable; samples and staging were "
-                        "retained for reconciliation: {}".format(
-                            ", ".join(durable_references)
-                        ),
-                        "Fatal",
-                    ) from original_error
-                if cleanup_failures:
-                    raise MsPASSError(
-                        "Object-store ensemble upload failed and compensation "
-                        "could not safely remove: {}".format(
-                            ", ".join(cleanup_failures)
-                        ),
-                        "Fatal",
-                    ) from original_error
-                raise
-            return mspass_object
-
-        if not isinstance(mspass_object, (TimeSeries, Seismogram)):
-            raise TypeError("only MsPASS seismic data objects are supported")
         if metadata_snapshots is None:
             metadata_snapshot = self._snapshot_object_store_metadata(mspass_object)
         else:
@@ -8035,9 +9181,7 @@ class Database(pymongo.database.Database):
             payload = buffer.getvalue()
             suffix = "." + format.lower()
 
-        object_name = (
-            str(waveform_id) if waveform_id is not None else uuid.uuid4().hex
-        ) + suffix
+        object_name = str(waveform_id) + suffix
         if key_prefix:
             object_name = key_prefix.rstrip("/") + "/" + object_name
         location = {
@@ -8047,34 +9191,39 @@ class Database(pymongo.database.Database):
         }
         if format == "binary":
             location["encoding"] = _OBJECT_STORE_BINARY_ENCODING
-        stage_id = None
-        if waveform_id is not None or waveform_collection is not None:
-            if waveform_id is None or not isinstance(waveform_collection, str):
-                raise ValueError(
-                    "waveform_id and waveform_collection must be supplied together"
-                )
-            stage_id = waveform_id
-            self[_OBJECT_STORE_STAGING_COLLECTION].insert_one(
-                {
-                    "_id": stage_id,
-                    "waveform_id": waveform_id,
-                    "waveform_collection": waveform_collection,
-                    "object_store": copy.deepcopy(location),
-                    "created_at": datetime.now(timezone.utc),
-                }
-            )
+        stage_id = waveform_id
+        stage_document = {
+            "_id": stage_id,
+            "waveform_id": waveform_id,
+            "waveform_collection": waveform_collection,
+            "object_store": copy.deepcopy(location),
+            "created_at": datetime.now(timezone.utc),
+        }
+        if staged_auxiliary is not None:
+            stage_document["auxiliary_documents"] = copy.deepcopy(staged_auxiliary)
+        staging_collection = self._object_store_lifecycle_collection(
+            _OBJECT_STORE_STAGING_COLLECTION
+        )
+        staging_collection.insert_one(stage_document)
+        upload_invoked = False
         try:
+            mspass_object["_id"] = waveform_id
             mspass_object["storage_mode"] = "object_store"
             mspass_object["object_store"] = location
             mspass_object["format"] = format
             mspass_object["nbytes"] = len(payload)
             Database._normalize_storage_pointers(mspass_object, "object_store")
+            if _DELETE_CLAIM_KEY in mspass_object:
+                mspass_object.erase(_DELETE_CLAIM_KEY)
+            upload_invoked = True
             object_store_client.put_object(
                 Bucket=bucket,
                 Key=object_name,
                 Body=payload,
             )
         except Exception as err:
+            if upload_invoked:
+                raise _ObjectStoreUploadCommitUncertain() from err
             (
                 cleanup_failures,
                 durable_references,
@@ -8118,6 +9267,7 @@ class Database(pymongo.database.Database):
         mspass_object,
         overwrite=False,
         gridfs_id=None,
+        durable=False,
     ):
         """
         Saves the sample data array for a mspass seismic data object using
@@ -8150,12 +9300,16 @@ class Database(pymongo.database.Database):
           object.  Used by update_data so a failed staged write can be rolled
           back even if GridFS raises after creating the object.
 
+        :param durable: when True, write through a primary/majority GridFS
+          handle.  Pointer-replacement paths require this before committing a
+          majority waveform reference to the new object.
+
         :return: edited version of input (mspass_object).  Return changed
           only by adding metadata attributes "storage_mode" and "gridfs_id"
         """
         if mspass_object.dead():
             return mspass_object
-        gfsh = gridfs.GridFS(self)
+        gfsh = self._gridfs_lifecycle_handle() if durable else gridfs.GridFS(self)
 
         if isinstance(mspass_object, (TimeSeries, Seismogram)):
             sample_reader = _NativeSampleReader(mspass_object.data)
@@ -8163,7 +9317,9 @@ class Database(pymongo.database.Database):
                 gridfs_id = ObjectId()
             try:
                 gridfs_id = gfsh.put(sample_reader, _id=gridfs_id)
-            except BaseException:
+            except BaseException as error:
+                if durable and _mongodb_write_result_is_uncertain(error):
+                    raise
                 try:
                     gfsh.delete(gridfs_id)
                 except BaseException:
@@ -8174,7 +9330,9 @@ class Database(pymongo.database.Database):
         elif isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):
             for d in mspass_object.member:
                 if d.live:
-                    self._save_sample_data_to_gridfs(d, overwrite=overwrite)
+                    self._save_sample_data_to_gridfs(
+                        d, overwrite=overwrite, durable=durable
+                    )
         else:
             message = (
                 "_save_sample_data_to_gridfs:  arg0 must be a MsPASS data object\n"
@@ -8198,6 +9356,11 @@ class Database(pymongo.database.Database):
         alg_name,
         alg_id,
         waveform_id=None,
+        staged_auxiliary=None,
+        durable=False,
+        post_elog=False,
+        post_history=False,
+        cremate=False,
     ):
         """
         Does all the MongoDB operations needed to save an atomic
@@ -8219,6 +9382,10 @@ class Database(pymongo.database.Database):
             mode=mode,
             normalizing_collections=normalizing_collections,
         )
+        # A delete claim belongs only to its original waveform.  Never copy
+        # it into a newly inserted waveform when saving a previously read
+        # datum under a new identity.
+        insertion_dict.pop(_DELETE_CLAIM_KEY, None)
         # exclude_keys edits insertion_dict but we need to do the same to mspass_object
         # to assure whem data is returned it is identical to what would
         # come from reading it back
@@ -8227,7 +9394,15 @@ class Database(pymongo.database.Database):
                 # erase is harmless if k is not defined so we don't
                 # guard this with an is_defined conditional
                 mspass_object.erase(k)
-        if elog.size() > 0:
+        if not aok and elog.size() > 0:
+            mspass_object.elog += elog
+        elif aok and post_elog:
+            combined_elog = ErrorLogger(mspass_object.elog)
+            if elog.size() > 0:
+                combined_elog += elog
+            if combined_elog.size() > 0:
+                insertion_dict["error_log"] = elog2doc(combined_elog)
+        elif elog.size() > 0:
             mspass_object.elog += elog
         if not aok:
             # aok false currently means the result is invalid and should be killed
@@ -8257,44 +9432,99 @@ class Database(pymongo.database.Database):
         history_object_id = None
         history_save_uuid = None
         history_collection_name = self.database_schema.default_name("history_object")
-        if save_history and mspass_object.live:
-            history_obj_id_name = history_collection_name + "_id"
-            if mspass_object.is_empty():
-                insertion_dict.pop(history_obj_id_name, None)
+        history_obj_id_name = history_collection_name + "_id"
+        # A new waveform must never inherit an auxiliary-document pointer
+        # from the input datum.  Such a pointer belongs to the waveform from
+        # which the datum may have been read and would make two waveforms
+        # appear to own the same history record.
+        insertion_dict.pop(history_obj_id_name, None)
+        if durable:
+            history_collection = self._object_store_lifecycle_collection(
+                history_collection_name
+            )
+        else:
+            history_collection = self[history_collection_name]
+        history_plan = staged_auxiliary.get("history", {}) if staged_auxiliary else {}
+        if history_plan and history_plan.get("collection") != history_collection_name:
+            raise ValueError("staged history collection does not match the save schema")
+        planned_history_id = history_plan.get("_id")
+        if (
+            save_history
+            and post_history
+            and mspass_object.live
+            and not mspass_object.is_empty()
+        ):
+            insertion_dict["history_data"] = history2doc(mspass_object)
+        elif save_history and mspass_object.live and not mspass_object.is_empty():
+            if isinstance(mspass_object, TimeSeries):
+                atomic_type = AtomicType.TIMESERIES
+            elif isinstance(mspass_object, Seismogram):
+                atomic_type = AtomicType.SEISMOGRAM
             else:
-                if isinstance(mspass_object, TimeSeries):
-                    atomic_type = AtomicType.TIMESERIES
-                elif isinstance(mspass_object, Seismogram):
-                    atomic_type = AtomicType.SEISMOGRAM
-                else:
-                    raise TypeError("only TimeSeries and Seismogram are supported")
-                history_source = ProcessingHistory(mspass_object)
-                history_source.new_map(
-                    alg_name, alg_id, atomic_type, ProcessingStatus.SAVED
-                )
-                history_save_uuid = history_source.id()
-                history_document = history2doc(
-                    history_source, alg_id=alg_id, alg_name=alg_name
-                )
-                history_object_id = (
-                    self[history_collection_name]
-                    .insert_one(history_document)
-                    .inserted_id
-                )
-                insertion_dict[history_obj_id_name] = history_object_id
+                raise TypeError("only TimeSeries and Seismogram are supported")
+            history_source = ProcessingHistory(mspass_object)
+            history_source.new_map(
+                alg_name, alg_id, atomic_type, ProcessingStatus.SAVED
+            )
+            history_save_uuid = history_source.id()
+            history_document = history2doc(
+                history_source, alg_id=alg_id, alg_name=alg_name
+            )
+            if planned_history_id is not None:
+                history_document["_id"] = planned_history_id
+            if durable and waveform_id is not None:
+                history_document[wf_collection.name + "_id"] = waveform_id
+            try:
+                history_object_id = history_collection.insert_one(
+                    history_document
+                ).inserted_id
+            except Exception as error:
+                if durable and _mongodb_write_result_is_uncertain(error):
+                    raise _ObjectStoreMongoCommitUncertain() from error
+                raise
+            insertion_dict[history_obj_id_name] = history_object_id
 
         elog_id = None
         elog_collection_name = self.database_schema.default_name("elog")
-        if mspass_object.elog.size() > 0:
-            elog_id_name = elog_collection_name + "_id"
+        elog_id_name = elog_collection_name + "_id"
+        # Apply the same ownership rule to error logs.  Only an elog created
+        # by this save may be referenced by the new waveform document.
+        insertion_dict.pop(elog_id_name, None)
+        if durable:
+            elog_collection = self._object_store_lifecycle_collection(
+                elog_collection_name
+            )
+            waveform_commit_collection = self._object_store_lifecycle_collection(
+                wf_collection.name
+            )
+        else:
+            elog_collection = self[elog_collection_name]
+            waveform_commit_collection = wf_collection
+        elog_plan = staged_auxiliary.get("elog", {}) if staged_auxiliary else {}
+        if elog_plan and elog_plan.get("collection") != elog_collection_name:
+            raise ValueError("staged elog collection does not match the save schema")
+        planned_elog_id = elog_plan.get("_id")
+        if not post_elog and mspass_object.elog.size() > 0:
             try:
                 elog_id = self._save_elog(
-                    mspass_object, elog_id=None, data_tag=data_tag
+                    mspass_object,
+                    elog_id=None,
+                    data_tag=data_tag,
+                    new_elog_id=planned_elog_id,
+                    waveform_collection=wf_collection.name,
+                    waveform_id=waveform_id,
+                    durable=durable,
                 )
-            except Exception:
+            except Exception as error:
+                if durable and _mongodb_write_result_is_uncertain(error):
+                    raise _ObjectStoreMongoCommitUncertain() from error
                 if history_object_id is not None:
-                    self[history_collection_name].delete_one({"_id": history_object_id})
-                if storage_mode == "gridfs" and "gridfs_id" in mspass_object:
+                    history_collection.delete_one({"_id": history_object_id})
+                if (
+                    not durable
+                    and storage_mode == "gridfs"
+                    and "gridfs_id" in mspass_object
+                ):
                     gfsh = gridfs.GridFS(self)
                     gridfs_id = mspass_object["gridfs_id"]
                     if gfsh.exists(gridfs_id):
@@ -8310,17 +9540,19 @@ class Database(pymongo.database.Database):
                 if wfid is not None:
                     insertion_dict["_id"] = wfid
                 try:
-                    wfid = wf_collection.insert_one(insertion_dict).inserted_id
+                    wfid = waveform_commit_collection.insert_one(
+                        insertion_dict
+                    ).inserted_id
                 except Exception as error:
-                    if storage_mode == "object_store" and (
-                        _waveform_insert_result_is_uncertain(error)
-                    ):
-                        raise _ObjectStoreWaveformCommitUncertain() from error
+                    if durable and _mongodb_write_result_is_uncertain(error):
+                        raise _ObjectStoreMongoCommitUncertain() from error
                     raise
                 waveform_inserted = True
-                if history_object_id is not None:
+                if history_object_id is not None and not (
+                    durable and waveform_id is not None
+                ):
                     wf_id_name = wf_collection.name + "_id"
-                    history_result = self[history_collection_name].update_one(
+                    history_result = history_collection.update_one(
                         {"_id": history_object_id},
                         {"$set": {wf_id_name: wfid}},
                     )
@@ -8330,16 +9562,20 @@ class Database(pymongo.database.Database):
                             "to the waveform",
                             ErrorSeverity.Invalid,
                         )
-            except _ObjectStoreWaveformCommitUncertain:
+            except _ObjectStoreMongoCommitUncertain:
                 raise
             except Exception:
                 if waveform_inserted:
-                    wf_collection.delete_one({"_id": wfid})
+                    waveform_commit_collection.delete_one({"_id": wfid})
                 if history_object_id is not None:
-                    self[history_collection_name].delete_one({"_id": history_object_id})
+                    history_collection.delete_one({"_id": history_object_id})
                 if elog_id is not None:
-                    self[elog_collection_name].delete_one({"_id": elog_id})
-                if storage_mode == "gridfs" and "gridfs_id" in mspass_object:
+                    elog_collection.delete_one({"_id": elog_id})
+                if (
+                    not durable
+                    and storage_mode == "gridfs"
+                    and "gridfs_id" in mspass_object
+                ):
                     gfsh = gridfs.GridFS(self)
                     gridfs_id = mspass_object["gridfs_id"]
                     if gfsh.exists(gridfs_id):
@@ -8348,17 +9584,24 @@ class Database(pymongo.database.Database):
                 raise
 
             mspass_object["_id"] = wfid
+            if _DELETE_CLAIM_KEY in mspass_object:
+                mspass_object.erase(_DELETE_CLAIM_KEY)
             if history_object_id is not None:
                 mspass_object[history_obj_id_name] = history_object_id
                 self._reset_processing_history(
                     mspass_object, alg_name, alg_id, history_save_uuid
                 )
+            elif history_obj_id_name in mspass_object:
+                mspass_object.erase(history_obj_id_name)
             if elog_id is not None:
                 mspass_object[elog_id_name] = elog_id
+            elif elog_id_name in mspass_object:
+                mspass_object.erase(elog_id_name)
         else:
-            mspass_object = self.stedronsky.bury(
-                mspass_object, save_history=save_history
-            )
+            if not cremate:
+                mspass_object = self.stedronsky.bury(
+                    mspass_object, save_history=save_history
+                )
         return mspass_object
 
     @staticmethod

--- a/python/mspasspy/io/distributed.py
+++ b/python/mspasspy/io/distributed.py
@@ -1321,7 +1321,7 @@ def _atomic_extract_wf_document(
 
 def _save_distributed_gridfs_item(
     item,
-    db,
+    dbname_or_handle,
     mode,
     exclude_keys,
     collection,
@@ -1335,6 +1335,7 @@ def _save_distributed_gridfs_item(
     alg_id,
 ):
     """Save one distributed item through Database's durable GridFS saga."""
+    db = fetch_dbhandle(dbname_or_handle)
     saved = db.save_data(
         item,
         return_data=True,
@@ -1695,8 +1696,9 @@ def write_distributed_data(
 
     if storage_mode == "gridfs":
         db._validate_gridfs_schema(save_schema, mode, exclude_keys=exclude_keys)
+        db_reference = db if scheduler == "spark" else _WorkerDatabaseReference(db)
         save_kwargs = {
-            "db": db,
+            "dbname_or_handle": db_reference,
             "mode": mode,
             "exclude_keys": exclude_keys,
             "collection": collection,

--- a/python/mspasspy/io/distributed.py
+++ b/python/mspasspy/io/distributed.py
@@ -22,6 +22,12 @@ from mspasspy.util.db_utils import fetch_dbhandle, _WorkerDatabaseReference
 from mspasspy.ccore.utility import (
     ErrorLogger,
 )
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
 
 try:
     import dask
@@ -1313,6 +1319,46 @@ def _atomic_extract_wf_document(
     return doc
 
 
+def _save_distributed_gridfs_item(
+    item,
+    db,
+    mode,
+    exclude_keys,
+    collection,
+    data_tag,
+    post_elog,
+    save_history,
+    post_history,
+    cremate,
+    normalizing_collections,
+    alg_name,
+    alg_id,
+):
+    """Save one distributed item through Database's durable GridFS saga."""
+    saved = db.save_data(
+        item,
+        return_data=True,
+        mode=mode,
+        storage_mode="gridfs",
+        overwrite=False,
+        exclude_keys=exclude_keys,
+        collection=collection,
+        data_tag=data_tag,
+        cremate=cremate,
+        save_history=save_history,
+        normalizing_collections=normalizing_collections,
+        alg_name=alg_name,
+        alg_id=alg_id,
+        _post_elog=post_elog,
+        _post_history=post_history,
+    )
+    if isinstance(saved, (TimeSeries, Seismogram)):
+        return saved["_id"] if saved.live and "_id" in saved else None
+    if saved.dead():
+        return []
+    return [datum["_id"] for datum in saved.member if datum.live and "_id" in datum]
+
+
 def write_distributed_data(
     data,
     db,
@@ -1354,12 +1400,13 @@ def write_distributed_data(
              also abstracts how the data are written with different
              things done depending on the "storage_mode" attribute
              that can optionally be defined for each atomic object.
-        2.   After the sample data are saved we use a MongoDB
-             "update_many" operator with the "many" defined by the
-             partition size.  That reduces database transaction delays
-             by 1/object_per_partition.  For ensembles the partitioning
-             is natural with bulk writes controlled by the number of
-             ensemble members.
+        2.   File-backed output keeps the partitioned bulk-document writer
+             to reduce database transaction delays.  GridFS output instead
+             saves each atomic datum through :meth:`Database.save_data` so a
+             durable staging record exists before its sample bytes and its
+             waveform document are written.  This gives up GridFS bulk inserts
+             in exchange for crash-safe reconciliation; workers still process
+             different data in parallel.
 
     The function also handles data marked dead in a standardized way
     though the use of the :class:`mspasspy.util.Undertaker` now
@@ -1468,7 +1515,9 @@ def write_distributed_data(
 
     :param storage_mode: Must be either "gridfs" or "file.  When set to
         "gridfs" the waveform data are stored internally and managed by
-        MongoDB.  If set to "file" the data will be stored in a file system.
+        MongoDB using the same durable staging lifecycle as
+        :meth:`Database.save_data`.  If set to "file" the data will be stored
+        in a file system.
         File names are derived from attributes with the tags "dir" and
         "dfile" in the standard way.   Any datum for which dir or dfile
         aren't defined will default to the behaviour of the Database
@@ -1643,6 +1692,32 @@ def write_distributed_data(
         )
         message += "Currently must be either wf_TimeSeries, wf_Seismogram, or default that implies wf_TimeSeries"
         raise ValueError(message)
+
+    if storage_mode == "gridfs":
+        db._validate_gridfs_schema(save_schema, mode, exclude_keys=exclude_keys)
+        save_kwargs = {
+            "db": db,
+            "mode": mode,
+            "exclude_keys": exclude_keys,
+            "collection": collection,
+            "data_tag": data_tag,
+            "post_elog": post_elog,
+            "save_history": save_history,
+            "post_history": post_history,
+            "cremate": cremate,
+            "normalizing_collections": normalizing_collections,
+            "alg_name": alg_name,
+            "alg_id": alg_id,
+        }
+        if scheduler == "spark":
+            data = data.map(
+                lambda item: _save_distributed_gridfs_item(item, **save_kwargs)
+            )
+            return data.collect()
+        data = data.map(_save_distributed_gridfs_item, **save_kwargs)
+        if dask_client is not None:
+            return data.compute(scheduler=dask_client)
+        return data.compute()
 
     stedronsky = Undertaker(db)
     if scheduler == "spark":

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -539,6 +539,32 @@ class TestDatabase:
         assert len(s3_client.list_objects_v2(Bucket=bucket)["Contents"]) == 2
 
     @mock_aws
+    def test_object_store_mseed_round_trip(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-mseed-test"
+        s3_client.create_bucket(Bucket=bucket)
+        original = get_live_timeseries()
+        saved = self.db.save_data(
+            original,
+            storage_mode="object_store",
+            format="MSEED",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            return_data=True,
+        )
+
+        assert saved["format"] == "MSEED"
+        assert saved["object_store"]["object_name"].endswith(".mseed")
+        document = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        loaded = self.db.read_data(
+            document,
+            collection="wf_TimeSeries",
+            object_store_client=s3_client,
+        )
+        assert loaded.live
+        np.testing.assert_allclose(np.asarray(loaded.data), np.asarray(original.data))
+
+    @mock_aws
     def test_object_store_reports_client_and_payload_errors(self):
         s3_client = boto3.client("s3", region_name="us-east-1")
         bucket = "mspass-object-store-error-test"

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -718,24 +718,41 @@ class TestDatabase:
     @mock_aws
     def test_object_store_mongodb_failure_is_compensated(self):
         s3_client = boto3.client("s3", region_name="us-east-1")
-        bucket = "mspass-object-store-mongodb-failure-test"
-        s3_client.create_bucket(Bucket=bucket)
-
-        with patch.object(
-            Collection,
-            "insert_one",
-            side_effect=pymongo.errors.OperationFailure("forced failure"),
-        ):
-            with pytest.raises(pymongo.errors.OperationFailure, match="forced"):
-                self.db.save_data(
-                    get_live_timeseries(),
-                    storage_mode="object_store",
-                    object_store={"provider": "s3", "bucket": bucket},
-                    object_store_client=s3_client,
-                    save_history=False,
+        original_insert_one = Collection.insert_one
+        failure_cases = (
+            ("history_object", True, False),
+            ("elog", False, True),
+            ("wf_TimeSeries", False, False),
+        )
+        for failed_collection, save_history, add_elog in failure_cases:
+            bucket = "mspass-object-store-{}-failure-test".format(
+                failed_collection.lower().replace("_", "-")
+            )
+            s3_client.create_bucket(Bucket=bucket)
+            datum = get_live_timeseries()
+            if save_history:
+                logging_helper.info(datum, "history-test", "test_save_data")
+            if add_elog:
+                datum.elog.log_error(
+                    "test_save_data", "forced elog save", ErrorSeverity.Complaint
                 )
 
-        assert s3_client.list_objects_v2(Bucket=bucket)["KeyCount"] == 0
+            def fail_selected_insert(collection, *args, **kwargs):
+                if collection.name == failed_collection:
+                    raise pymongo.errors.OperationFailure("forced failure")
+                return original_insert_one(collection, *args, **kwargs)
+
+            with patch.object(Collection, "insert_one", new=fail_selected_insert):
+                with pytest.raises(pymongo.errors.OperationFailure, match="forced"):
+                    self.db.save_data(
+                        datum,
+                        storage_mode="object_store",
+                        object_store={"provider": "s3", "bucket": bucket},
+                        object_store_client=s3_client,
+                        save_history=save_history,
+                    )
+
+            assert s3_client.list_objects_v2(Bucket=bucket)["KeyCount"] == 0
 
     @mock_aws
     def test_update_data_rejects_object_store_and_ignores_stale_gridfs_id(self):

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -602,6 +602,7 @@ class TestDatabase:
         bucket = "mspass-object-store-error-test"
         s3_client.create_bucket(Bucket=bucket)
         datum = get_live_timeseries()
+        original_storage_metadata = self.db._snapshot_object_store_metadata(datum)
 
         with pytest.raises(ValueError, match="object_store_client is required"):
             self.db.save_data(
@@ -609,6 +610,9 @@ class TestDatabase:
                 storage_mode="object_store",
                 object_store={"provider": "s3", "bucket": bucket},
             )
+        assert (
+            self.db._snapshot_object_store_metadata(datum) == original_storage_metadata
+        )
         with pytest.raises(ValueError, match="provider must be 's3'"):
             self.db.save_data(
                 datum,
@@ -616,6 +620,22 @@ class TestDatabase:
                 object_store={"provider": "gcs", "bucket": bucket},
                 object_store_client=s3_client,
             )
+        assert (
+            self.db._snapshot_object_store_metadata(datum) == original_storage_metadata
+        )
+        with pytest.raises(ValueError, match="Writing format"):
+            self.db.save_data(
+                datum,
+                storage_mode="object_store",
+                format="NOT_A_REAL_OBSPY_FORMAT",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+            )
+        assert (
+            self.db._snapshot_object_store_metadata(datum) == original_storage_metadata
+        )
+        assert self.db["object_store_staging"].count_documents({}) == 0
+        assert s3_client.list_objects_v2(Bucket=bucket)["KeyCount"] == 0
 
         missing_document = dict(datum)
         missing_document.update(
@@ -919,13 +939,18 @@ class TestDatabase:
         s3_client = boto3.client("s3", region_name="us-east-1")
         bucket = "mspass-object-store-delete-failure-test"
         s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "delete-failure-test", "test_delete_data")
+        datum.elog.log_error(
+            "test_delete_data", "delete failure lifecycle", ErrorSeverity.Complaint
+        )
         saved = self.db.save_data(
-            get_live_timeseries(),
+            datum,
             storage_mode="object_store",
             object_store={"provider": "s3", "bucket": bucket},
             object_store_client=s3_client,
             return_data=True,
-            save_history=False,
+            save_history=True,
         )
         document = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
         failing_client = Mock()
@@ -943,9 +968,144 @@ class TestDatabase:
             )
 
         assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) == document
+        assert not self.db["history_object"].find_one(
+            {"_id": document["history_object_id"]}
+        )
+        assert not self.db["elog"].find_one({"_id": document["elog_id"]})
         location = document["object_store"]
         response = s3_client.get_object(
             Bucket=location["bucket"], Key=location["object_name"]
+        )
+        response["Body"].close()
+
+    @mock_aws
+    def test_delete_data_retains_concurrently_changed_object_store_reference(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-delete-concurrent-test"
+        s3_client.create_bucket(Bucket=bucket)
+        saved = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            return_data=True,
+            save_history=False,
+        )
+        old_location = copy.deepcopy(saved["object_store"])
+        new_location = {
+            "provider": "s3",
+            "bucket": bucket,
+            "object_name": "concurrent.bin",
+            "encoding": "float64-le-v1",
+        }
+        s3_client.put_object(Bucket=bucket, Key="concurrent.bin", Body=b"new")
+        concurrent_client = Mock()
+
+        def delete_then_change_reference(Bucket, Key):
+            s3_client.delete_object(Bucket=Bucket, Key=Key)
+            self.db["wf_TimeSeries"].update_one(
+                {"_id": saved["_id"]},
+                {"$set": {"object_store": copy.deepcopy(new_location)}},
+            )
+
+        concurrent_client.delete_object.side_effect = delete_then_change_reference
+        with pytest.raises(MsPASSError, match="changed during delete_data"):
+            self.db.delete_data(
+                saved["_id"],
+                "TimeSeries",
+                object_store_client=concurrent_client,
+            )
+
+        document = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        assert document["object_store"] == new_location
+        with pytest.raises(botocore.exceptions.ClientError):
+            s3_client.head_object(
+                Bucket=old_location["bucket"], Key=old_location["object_name"]
+            )
+        response = s3_client.get_object(Bucket=bucket, Key="concurrent.bin")
+        response["Body"].close()
+
+    @mock_aws
+    def test_object_store_staging_reconciles_interrupted_and_committed_writes(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-staging-test"
+        s3_client.create_bucket(Bucket=bucket)
+        interrupted = get_live_timeseries()
+
+        with patch.object(
+            Database,
+            "_atomic_save_all_documents",
+            side_effect=KeyboardInterrupt("simulated process interruption"),
+        ):
+            with pytest.raises(KeyboardInterrupt, match="process interruption"):
+                self.db.save_data(
+                    interrupted,
+                    storage_mode="object_store",
+                    object_store={"provider": "s3", "bucket": bucket},
+                    object_store_client=s3_client,
+                    return_data=True,
+                    save_history=False,
+                )
+
+        stage = self.db["object_store_staging"].find_one({})
+        assert stage is not None
+        assert stage["waveform_id"] == stage["_id"]
+        assert stage["waveform_collection"] == "wf_TimeSeries"
+        assert self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]}) is None
+        interrupted_uri = "s3://{}/{}".format(
+            stage["object_store"]["bucket"], stage["object_store"]["object_name"]
+        )
+        report = self.db.reconcile_object_store_staging(s3_client)
+        assert report == {
+            "committed": [],
+            "uncommitted": [interrupted_uri],
+            "deleted": [],
+            "failures": [],
+        }
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert report == {
+            "committed": [],
+            "uncommitted": [],
+            "deleted": [interrupted_uri],
+            "failures": [],
+        }
+        assert self.db["object_store_staging"].count_documents({}) == 0
+        assert s3_client.list_objects_v2(Bucket=bucket)["KeyCount"] == 0
+
+        committed = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            return_data=True,
+            save_history=False,
+        )
+        committed_location = copy.deepcopy(committed["object_store"])
+        self.db["object_store_staging"].insert_one(
+            {
+                "_id": committed["_id"],
+                "waveform_id": committed["_id"],
+                "waveform_collection": "wf_TimeSeries",
+                "object_store": committed_location,
+            }
+        )
+        committed_uri = "s3://{}/{}".format(
+            committed_location["bucket"], committed_location["object_name"]
+        )
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert report == {
+            "committed": [committed_uri],
+            "uncommitted": [],
+            "deleted": [],
+            "failures": [],
+        }
+        response = s3_client.get_object(
+            Bucket=committed_location["bucket"],
+            Key=committed_location["object_name"],
         )
         response["Body"].close()
 

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import gridfs
 import numpy as np
 import obspy
+import pymongo.errors
 import pytest
 import sys
 import re
@@ -482,6 +483,11 @@ class TestDatabase:
         originals = [get_live_timeseries(), get_live_seismogram()]
         collections = ["wf_TimeSeries", "wf_Seismogram"]
         for original, collection in zip(originals, collections):
+            original["gridfs_id"] = ObjectId()
+            original["dir"] = "/stale"
+            original["dfile"] = "stale.dat"
+            original["foff"] = 100
+            original["url"] = "https://invalid.example/stale"
             saved = self.db.save_data(
                 original,
                 storage_mode="object_store",
@@ -494,13 +500,33 @@ class TestDatabase:
             assert location["provider"] == "s3"
             assert location["bucket"] == bucket
             assert location["object_name"].startswith("waveforms/")
+            assert location["encoding"] == "float64-le-v1"
+            assert "gridfs_id" not in saved
+            assert "dir" not in saved
+            assert "dfile" not in saved
+            assert "foff" not in saved
+            assert "url" not in saved
             assert saved["nbytes"] == 8 * saved.npts * (
                 1 if isinstance(saved, TimeSeries) else 3
             )
+            response = s3_client.get_object(
+                Bucket=location["bucket"], Key=location["object_name"]
+            )
+            try:
+                assert response["Body"].read() == np.asarray(
+                    original.data, dtype="<f8"
+                ).tobytes(order="C")
+            finally:
+                response["Body"].close()
 
             document = self.db[collection].find_one({"_id": saved["_id"]})
             assert document["storage_mode"] == "object_store"
             assert document["object_store"] == location
+            assert "gridfs_id" not in document
+            assert "dir" not in document
+            assert "dfile" not in document
+            assert "foff" not in document
+            assert "url" not in document
             loaded = self.db.read_data(
                 document,
                 collection=collection,
@@ -543,26 +569,32 @@ class TestDatabase:
         s3_client = boto3.client("s3", region_name="us-east-1")
         bucket = "mspass-object-store-mseed-test"
         s3_client.create_bucket(Bucket=bucket)
-        original = get_live_timeseries()
-        saved = self.db.save_data(
-            original,
-            storage_mode="object_store",
-            format="MSEED",
-            object_store={"provider": "s3", "bucket": bucket},
-            object_store_client=s3_client,
-            return_data=True,
-        )
+        for original, collection in (
+            (get_live_timeseries(), "wf_TimeSeries"),
+            (get_live_seismogram(), "wf_Seismogram"),
+        ):
+            saved = self.db.save_data(
+                original,
+                storage_mode="object_store",
+                format="MSEED",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                return_data=True,
+            )
 
-        assert saved["format"] == "MSEED"
-        assert saved["object_store"]["object_name"].endswith(".mseed")
-        document = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
-        loaded = self.db.read_data(
-            document,
-            collection="wf_TimeSeries",
-            object_store_client=s3_client,
-        )
-        assert loaded.live
-        np.testing.assert_allclose(np.asarray(loaded.data), np.asarray(original.data))
+            assert saved["format"] == "MSEED"
+            assert saved["object_store"]["object_name"].endswith(".mseed")
+            assert "encoding" not in saved["object_store"]
+            document = self.db[collection].find_one({"_id": saved["_id"]})
+            loaded = self.db.read_data(
+                document,
+                collection=collection,
+                object_store_client=s3_client,
+            )
+            assert loaded.live
+            np.testing.assert_allclose(
+                np.asarray(loaded.data), np.asarray(original.data)
+            )
 
     @mock_aws
     def test_object_store_reports_client_and_payload_errors(self):
@@ -594,6 +626,7 @@ class TestDatabase:
                     "provider": "s3",
                     "bucket": bucket,
                     "object_name": "missing.bin",
+                    "encoding": "float64-le-v1",
                 },
             }
         )
@@ -625,6 +658,174 @@ class TestDatabase:
                 collection="wf_TimeSeries",
                 object_store_client=unavailable_client,
             )
+
+    def test_object_store_partial_ensemble_upload_is_compensated(self):
+        ensemble = TimeSeriesEnsemble()
+        ensemble.member.append(get_live_timeseries())
+        ensemble.member.append(get_live_timeseries())
+        ensemble.set_live()
+        object_store_client = Mock()
+        object_store_client.put_object.side_effect = [
+            {},
+            botocore.exceptions.EndpointConnectionError(
+                endpoint_url="https://s3.invalid"
+            ),
+        ]
+
+        with pytest.raises(MsPASSError, match="Error while writing"):
+            self.db._save_sample_data_to_object_store(
+                ensemble,
+                {"provider": "s3", "bucket": "test-bucket"},
+                object_store_client,
+            )
+
+        uploads = [
+            call.kwargs for call in object_store_client.put_object.call_args_list
+        ]
+        deletions = [
+            call.kwargs for call in object_store_client.delete_object.call_args_list
+        ]
+        assert {(deletion["Bucket"], deletion["Key"]) for deletion in deletions} == {
+            (upload["Bucket"], upload["Key"]) for upload in uploads
+        }
+        assert "object_store" not in ensemble.member[0]
+
+    def test_object_store_compensation_reports_unreconciled_object(self):
+        ensemble = TimeSeriesEnsemble()
+        ensemble.member.append(get_live_timeseries())
+        ensemble.member.append(get_live_timeseries())
+        ensemble.set_live()
+        object_store_client = Mock()
+        object_store_client.put_object.side_effect = [
+            {},
+            botocore.exceptions.EndpointConnectionError(
+                endpoint_url="https://s3.invalid"
+            ),
+        ]
+        object_store_client.delete_object.side_effect = (
+            botocore.exceptions.EndpointConnectionError(
+                endpoint_url="https://s3.invalid"
+            )
+        )
+
+        with pytest.raises(MsPASSError, match="could not remove: s3://test-bucket/"):
+            self.db._save_sample_data_to_object_store(
+                ensemble,
+                {"provider": "s3", "bucket": "test-bucket"},
+                object_store_client,
+            )
+
+    @mock_aws
+    def test_object_store_mongodb_failure_is_compensated(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-mongodb-failure-test"
+        s3_client.create_bucket(Bucket=bucket)
+
+        with patch.object(
+            Collection,
+            "insert_one",
+            side_effect=pymongo.errors.OperationFailure("forced failure"),
+        ):
+            with pytest.raises(pymongo.errors.OperationFailure, match="forced"):
+                self.db.save_data(
+                    get_live_timeseries(),
+                    storage_mode="object_store",
+                    object_store={"provider": "s3", "bucket": bucket},
+                    object_store_client=s3_client,
+                    save_history=False,
+                )
+
+        assert s3_client.list_objects_v2(Bucket=bucket)["KeyCount"] == 0
+
+    @mock_aws
+    def test_update_data_rejects_object_store_and_ignores_stale_gridfs_id(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-update-test"
+        s3_client.create_bucket(Bucket=bucket)
+        saved = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            return_data=True,
+            save_history=False,
+        )
+        gfsh = gridfs.GridFS(self.db)
+        unrelated_gridfs_id = gfsh.put(b"unrelated")
+        saved["gridfs_id"] = unrelated_gridfs_id
+
+        with pytest.raises(ValueError, match="does not support sample updates"):
+            self.db.update_data(saved, save_history=False)
+
+        assert gfsh.exists(unrelated_gridfs_id)
+        document = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        assert document["storage_mode"] == "object_store"
+        assert document["object_store"] == saved["object_store"]
+        gfsh.delete(unrelated_gridfs_id)
+
+    @mock_aws
+    def test_object_store_lite_schema_round_trip(self):
+        alternate_db_name = "dbtest_object_store_lite"
+        alternate_db = Database(
+            self.db.client, alternate_db_name, schema="mspass_lite.yaml"
+        )
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-lite-schema-test"
+        s3_client.create_bucket(Bucket=bucket)
+        try:
+            original = get_live_timeseries()
+            saved = alternate_db.save_data(
+                original,
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                return_data=True,
+                mode="pedantic",
+            )
+            document = alternate_db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+            loaded = alternate_db.read_data(
+                document,
+                collection="wf_TimeSeries",
+                mode="pedantic",
+                object_store_client=s3_client,
+            )
+            np.testing.assert_allclose(
+                np.asarray(loaded.data), np.asarray(original.data)
+            )
+        finally:
+            self.db.client.drop_database(alternate_db_name)
+
+    def test_object_store_rejects_incapable_custom_schema_before_upload(self):
+        custom_schema = copy.deepcopy(self.db.metadata_schema)
+        custom_schema.TimeSeries._main_dic.pop("object_store")
+        custom_db = Database(
+            self.db.client,
+            "dbtest_object_store_custom_schema",
+            db_schema=self.db.database_schema,
+            md_schema=custom_schema,
+        )
+        object_store_client = Mock()
+
+        with pytest.raises(ValueError, match="object_store is undefined"):
+            custom_db.save_data(
+                get_live_timeseries(),
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": "test-bucket"},
+                object_store_client=object_store_client,
+                mode="cautious",
+            )
+
+        object_store_client.put_object.assert_not_called()
+        with pytest.raises(ValueError, match="object_store is excluded"):
+            self.db.save_data(
+                get_live_timeseries(),
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": "test-bucket"},
+                object_store_client=object_store_client,
+                exclude_keys=["object_store"],
+                mode="promiscuous",
+            )
+        object_store_client.put_object.assert_not_called()
 
     def test_mspass_type_helper(self):
         schema = self.metadata_def.Seismogram

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -564,6 +564,56 @@ class TestDatabase:
         assert all(name.startswith("ensemble/") for name in object_names)
         assert len(s3_client.list_objects_v2(Bucket=bucket)["Contents"]) == 2
 
+    def test_object_store_zero_length_atomic_is_buried_without_upload(self):
+        datum = get_live_timeseries(ts_size=0)
+        object_store_client = Mock()
+        cemetery_count = self.db["cemetery"].count_documents({})
+        staging_count = self.db["object_store_staging"].count_documents({})
+        waveform_count = self.db["wf_TimeSeries"].count_documents({})
+
+        saved = self.db.save_data(
+            datum,
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": "unused"},
+            object_store_client=object_store_client,
+            return_data=True,
+        )
+
+        assert saved.dead()
+        assert saved.npts == 0
+        assert self.db["cemetery"].count_documents({}) == cemetery_count + 1
+        assert self.db["object_store_staging"].count_documents({}) == staging_count
+        assert self.db["wf_TimeSeries"].count_documents({}) == waveform_count
+        object_store_client.put_object.assert_not_called()
+
+    def test_object_store_zero_length_ensemble_member_is_buried_without_upload(self):
+        zero_length = get_live_timeseries(ts_size=0)
+        live = get_live_timeseries()
+        ensemble = TimeSeriesEnsemble()
+        ensemble.member.append(zero_length)
+        ensemble.member.append(live)
+        ensemble.set_live()
+        object_store_client = Mock()
+        cemetery_count = self.db["cemetery"].count_documents({})
+        staging_count = self.db["object_store_staging"].count_documents({})
+        waveform_count = self.db["wf_TimeSeries"].count_documents({})
+
+        saved = self.db.save_data(
+            ensemble,
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": "unused"},
+            object_store_client=object_store_client,
+            return_data=True,
+        )
+
+        assert saved.member[0].dead()
+        assert saved.member[0].npts == 0
+        assert saved.member[1].live
+        assert self.db["cemetery"].count_documents({}) == cemetery_count + 1
+        assert self.db["object_store_staging"].count_documents({}) == staging_count
+        assert self.db["wf_TimeSeries"].count_documents({}) == waveform_count + 1
+        assert object_store_client.put_object.call_count == 1
+
     @mock_aws
     def test_object_store_mseed_round_trip(self):
         s3_client = boto3.client("s3", region_name="us-east-1")
@@ -1026,6 +1076,42 @@ class TestDatabase:
         response["Body"].close()
 
     @mock_aws
+    def test_delete_data_ignores_concurrent_nonidentity_metadata_change(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-delete-etag-test"
+        s3_client.create_bucket(Bucket=bucket)
+        saved = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            return_data=True,
+            save_history=False,
+        )
+        location = copy.deepcopy(saved["object_store"])
+        concurrent_client = Mock()
+
+        def delete_then_add_etag(Bucket, Key):
+            s3_client.delete_object(Bucket=Bucket, Key=Key)
+            self.db["wf_TimeSeries"].update_one(
+                {"_id": saved["_id"]},
+                {"$set": {"object_store.etag": "concurrent-etag"}},
+            )
+
+        concurrent_client.delete_object.side_effect = delete_then_add_etag
+        self.db.delete_data(
+            saved["_id"],
+            "TimeSeries",
+            object_store_client=concurrent_client,
+        )
+
+        assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) is None
+        with pytest.raises(botocore.exceptions.ClientError):
+            s3_client.head_object(
+                Bucket=location["bucket"], Key=location["object_name"]
+            )
+
+    @mock_aws
     def test_object_store_staging_reconciles_interrupted_and_committed_writes(self):
         s3_client = boto3.client("s3", region_name="us-east-1")
         bucket = "mspass-object-store-staging-test"
@@ -1091,6 +1177,10 @@ class TestDatabase:
                 "object_store": committed_location,
             }
         )
+        self.db["wf_TimeSeries"].update_one(
+            {"_id": committed["_id"]},
+            {"$set": {"object_store.etag": "added-after-commit"}},
+        )
         committed_uri = "s3://{}/{}".format(
             committed_location["bucket"], committed_location["object_name"]
         )
@@ -1108,6 +1198,57 @@ class TestDatabase:
             Key=committed_location["object_name"],
         )
         response["Body"].close()
+
+        shared_location = {
+            "provider": "s3",
+            "bucket": bucket,
+            "object_name": "referenced-by-another-waveform.bin",
+            "encoding": "float64-le-v1",
+        }
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=shared_location["object_name"],
+            Body=b"shared",
+        )
+        abandoned_waveform_id = ObjectId()
+        referenced_waveform_id = (
+            self.db["wf_Seismogram"]
+            .insert_one(
+                {
+                    "storage_mode": "object_store",
+                    "object_store": {
+                        **shared_location,
+                        "etag": "nonidentity-metadata",
+                    },
+                }
+            )
+            .inserted_id
+        )
+        self.db["object_store_staging"].insert_one(
+            {
+                "_id": abandoned_waveform_id,
+                "waveform_id": abandoned_waveform_id,
+                "waveform_collection": "wf_TimeSeries",
+                "object_store": shared_location,
+            }
+        )
+        shared_uri = "s3://{}/{}".format(
+            shared_location["bucket"], shared_location["object_name"]
+        )
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert report == {
+            "committed": [shared_uri],
+            "uncommitted": [],
+            "deleted": [],
+            "failures": [],
+        }
+        response = s3_client.get_object(
+            Bucket=shared_location["bucket"], Key=shared_location["object_name"]
+        )
+        response["Body"].close()
+        self.db["wf_Seismogram"].delete_one({"_id": referenced_waveform_id})
 
     @mock_aws
     def test_object_store_lite_schema_round_trip(self):

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -14,6 +14,7 @@ import re
 
 import boto3
 from moto import mock_aws
+import botocore.exceptions
 import botocore.session
 from unittest.mock import patch, Mock
 import json
@@ -466,6 +467,138 @@ class TestDatabase:
         with patch("urllib.request.urlopen", new=self.mock_urlopen_failure):
             with pytest.raises(MsPASSError, match="Error while downloading"):
                 self.db._read_data_from_url(tmp_ts, bad_url)
+
+    @mock_aws
+    def test_object_store_binary_round_trip(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-test"
+        s3_client.create_bucket(Bucket=bucket)
+        destination = {
+            "provider": "s3",
+            "bucket": bucket,
+            "key_prefix": "waveforms",
+        }
+
+        originals = [get_live_timeseries(), get_live_seismogram()]
+        collections = ["wf_TimeSeries", "wf_Seismogram"]
+        for original, collection in zip(originals, collections):
+            saved = self.db.save_data(
+                original,
+                storage_mode="object_store",
+                object_store=destination,
+                object_store_client=s3_client,
+                return_data=True,
+                mode="cautious",
+            )
+            location = saved["object_store"]
+            assert location["provider"] == "s3"
+            assert location["bucket"] == bucket
+            assert location["object_name"].startswith("waveforms/")
+            assert saved["nbytes"] == 8 * saved.npts * (
+                1 if isinstance(saved, TimeSeries) else 3
+            )
+
+            document = self.db[collection].find_one({"_id": saved["_id"]})
+            assert document["storage_mode"] == "object_store"
+            assert document["object_store"] == location
+            loaded = self.db.read_data(
+                document,
+                collection=collection,
+                mode="cautious",
+                object_store_client=s3_client,
+            )
+            assert loaded.live
+            np.testing.assert_allclose(
+                np.asarray(loaded.data), np.asarray(original.data)
+            )
+
+    @mock_aws
+    def test_object_store_ensemble_uses_independent_objects(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-ensemble-test"
+        s3_client.create_bucket(Bucket=bucket)
+        ensemble = TimeSeriesEnsemble()
+        ensemble.member.append(get_live_timeseries())
+        ensemble.member.append(get_live_timeseries())
+        ensemble.set_live()
+
+        saved = self.db.save_data(
+            ensemble,
+            storage_mode="object_store",
+            object_store={
+                "provider": "s3",
+                "bucket": bucket,
+                "key_prefix": "ensemble",
+            },
+            object_store_client=s3_client,
+            return_data=True,
+        )
+        object_names = [d["object_store"]["object_name"] for d in saved.member]
+        assert len(set(object_names)) == 2
+        assert all(name.startswith("ensemble/") for name in object_names)
+        assert len(s3_client.list_objects_v2(Bucket=bucket)["Contents"]) == 2
+
+    @mock_aws
+    def test_object_store_reports_client_and_payload_errors(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-error-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+
+        with pytest.raises(ValueError, match="object_store_client is required"):
+            self.db.save_data(
+                datum,
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+            )
+        with pytest.raises(ValueError, match="provider must be 's3'"):
+            self.db.save_data(
+                datum,
+                storage_mode="object_store",
+                object_store={"provider": "gcs", "bucket": bucket},
+                object_store_client=s3_client,
+            )
+
+        missing_document = dict(datum)
+        missing_document.update(
+            {
+                "storage_mode": "object_store",
+                "format": "binary",
+                "object_store": {
+                    "provider": "s3",
+                    "bucket": bucket,
+                    "object_name": "missing.bin",
+                },
+            }
+        )
+        with pytest.raises(MsPASSError, match="Error while reading"):
+            self.db.read_data(
+                missing_document,
+                collection="wf_TimeSeries",
+                object_store_client=s3_client,
+            )
+
+        s3_client.put_object(Bucket=bucket, Key="short.bin", Body=b"short")
+        missing_document["object_store"]["object_name"] = "short.bin"
+        with pytest.raises(MsPASSError, match="payload size"):
+            self.db.read_data(
+                missing_document,
+                collection="wf_TimeSeries",
+                object_store_client=s3_client,
+            )
+
+        unavailable_client = Mock()
+        unavailable_client.get_object.side_effect = (
+            botocore.exceptions.EndpointConnectionError(
+                endpoint_url="https://s3.invalid"
+            )
+        )
+        with pytest.raises(MsPASSError, match="Error while reading"):
+            self.db.read_data(
+                missing_document,
+                collection="wf_TimeSeries",
+                object_store_client=unavailable_client,
+            )
 
     def test_mspass_type_helper(self):
         schema = self.metadata_def.Seismogram

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -742,95 +742,38 @@ class TestDatabase:
                 object_store_client=unavailable_client,
             )
 
-    def test_object_store_partial_ensemble_upload_is_compensated(self):
+    def test_object_store_unstaged_writes_are_rejected(self):
+        datum = get_live_timeseries()
         ensemble = TimeSeriesEnsemble()
         ensemble.member.append(get_live_timeseries())
         ensemble.member.append(get_live_timeseries())
         ensemble.set_live()
-        storage_keys = (
-            "storage_mode",
-            "object_store",
-            "gridfs_id",
-            "dir",
-            "dfile",
-            "foff",
-            "url",
-            "format",
-            "nbytes",
-        )
-        for index, member in enumerate(ensemble.member):
-            member["storage_mode"] = "gridfs"
-            member["object_store"] = {"old": index}
-            member["gridfs_id"] = ObjectId()
-            member["dir"] = "/old/{}".format(index)
-            member["dfile"] = "old-{}.dat".format(index)
-            member["foff"] = index
-            member["url"] = "https://old.example/{}".format(index)
-            member["format"] = "old-format"
-            member["nbytes"] = index + 1
-        original_storage_metadata = [
-            {key: copy.deepcopy(member[key]) for key in storage_keys}
-            for member in ensemble.member
+        original_metadata = [
+            self.db._snapshot_object_store_metadata(target)
+            for target in [datum, *ensemble.member]
         ]
+        staging_count = self.db["object_store_staging"].count_documents({})
         object_store_client = Mock()
-        object_store_client.put_object.side_effect = [
-            {},
-            botocore.exceptions.EndpointConnectionError(
-                endpoint_url="https://s3.invalid"
-            ),
-        ]
-
-        with pytest.raises(MsPASSError, match="Error while writing"):
-            self.db._save_sample_data_to_object_store(
-                ensemble,
-                {"provider": "s3", "bucket": "test-bucket"},
-                object_store_client,
+        for target in (datum, ensemble):
+            with pytest.raises(ValueError, match="durable .*stag"):
+                self.db._save_sample_data_to_object_store(
+                    target,
+                    {"provider": "s3", "bucket": "test-bucket"},
+                    object_store_client,
+                )
+        with pytest.raises(ValueError, match="durable .*stag"):
+            self.db._save_sample_data(
+                datum,
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": "test-bucket"},
+                object_store_client=object_store_client,
             )
 
-        uploads = [
-            call.kwargs for call in object_store_client.put_object.call_args_list
-        ]
-        deletions = [
-            call.kwargs for call in object_store_client.delete_object.call_args_list
-        ]
-        assert {(deletion["Bucket"], deletion["Key"]) for deletion in deletions} == {
-            (upload["Bucket"], upload["Key"]) for upload in uploads
-        }
-        for member, original_metadata in zip(
-            ensemble.member, original_storage_metadata
-        ):
-            assert {key: member[key] for key in storage_keys} == original_metadata
-
-    def test_object_store_compensation_reports_unreconciled_object(self):
-        ensemble = TimeSeriesEnsemble()
-        ensemble.member.append(get_live_timeseries())
-        ensemble.member.append(get_live_timeseries())
-        ensemble.set_live()
-        object_store_client = Mock()
-        object_store_client.put_object.side_effect = [
-            {},
-            botocore.exceptions.EndpointConnectionError(
-                endpoint_url="https://s3.invalid"
-            ),
-        ]
-        object_store_client.delete_object.side_effect = (
-            botocore.exceptions.EndpointConnectionError(
-                endpoint_url="https://s3.invalid"
-            )
-        )
-
-        with pytest.raises(
-            MsPASSError, match="could not safely remove: s3://test-bucket/"
-        ):
-            self.db._save_sample_data_to_object_store(
-                ensemble,
-                {"provider": "s3", "bucket": "test-bucket"},
-                object_store_client,
-            )
-        for member in ensemble.member:
-            assert member["storage_mode"] == "object_store"
-            assert member["object_store"]["bucket"] == "test-bucket"
-            assert member["object_store"]["object_name"]
+        object_store_client.put_object.assert_not_called()
+        object_store_client.delete_object.assert_not_called()
+        assert self.db["object_store_staging"].count_documents({}) == staging_count
+        for target, snapshot in zip([datum, *ensemble.member], original_metadata):
+            assert self.db._snapshot_object_store_metadata(target) == snapshot
 
     @mock_aws
     def test_object_store_mongodb_failure_is_compensated(self):
@@ -847,6 +790,7 @@ class TestDatabase:
             )
             s3_client.create_bucket(Bucket=bucket)
             datum = get_live_timeseries()
+            datum["_id"] = ObjectId()
             datum["storage_mode"] = "gridfs"
             datum["gridfs_id"] = ObjectId()
             datum["dir"] = "/old"
@@ -856,6 +800,7 @@ class TestDatabase:
             datum["format"] = "old-format"
             datum["nbytes"] = 456
             storage_keys = (
+                "_id",
                 "storage_mode",
                 "object_store",
                 "gridfs_id",
@@ -897,6 +842,106 @@ class TestDatabase:
                 assert (key in datum) is was_defined
                 if was_defined:
                     assert datum[key] == value
+
+    @mock_aws
+    def test_object_store_inflight_upload_is_retained_for_reconciliation(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        tracking_client = Mock(wraps=s3_client)
+        bucket = "mspass-object-store-inflight-upload-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        old_waveform_id = ObjectId()
+        old_gridfs_id = ObjectId()
+        datum["_id"] = old_waveform_id
+        datum["storage_mode"] = "gridfs"
+        datum["gridfs_id"] = old_gridfs_id
+        old_waveform = {
+            "_id": old_waveform_id,
+            "storage_mode": "gridfs",
+            "gridfs_id": old_gridfs_id,
+        }
+        self.db["wf_TimeSeries"].insert_one(copy.deepcopy(old_waveform))
+        allow_upload = threading.Event()
+        worker = None
+        worker_errors = []
+
+        def upload_later(arguments):
+            try:
+                if not allow_upload.wait(timeout=10):
+                    raise TimeoutError("test did not release delayed S3 upload")
+                s3_client.put_object(**arguments)
+            except BaseException as error:
+                worker_errors.append(error)
+
+        def start_upload_then_raise(**kwargs):
+            nonlocal worker
+            worker = threading.Thread(
+                target=upload_later,
+                args=(copy.deepcopy(kwargs),),
+                name="delayed-object-store-upload",
+            )
+            worker.start()
+            raise botocore.exceptions.ReadTimeoutError(
+                endpoint_url="https://s3.amazonaws.com"
+            )
+
+        tracking_client.put_object.side_effect = start_upload_then_raise
+        stage = None
+        try:
+            with pytest.raises(
+                MsPASSError, match="could not determine whether.*upload committed"
+            ):
+                self.db.save_data(
+                    datum,
+                    storage_mode="object_store",
+                    object_store={"provider": "s3", "bucket": bucket},
+                    object_store_client=tracking_client,
+                    save_history=False,
+                )
+
+            stage = self.db["object_store_staging"].find_one(
+                {"object_store.bucket": bucket}
+            )
+            assert stage is not None
+            assert datum["_id"] == stage["waveform_id"]
+            assert datum["_id"] != old_waveform_id
+            assert datum["storage_mode"] == "object_store"
+            assert datum["object_store"] == stage["object_store"]
+            tracking_client.delete_object.assert_not_called()
+            with pytest.raises(botocore.exceptions.ClientError):
+                s3_client.head_object(
+                    Bucket=bucket, Key=stage["object_store"]["object_name"]
+                )
+        finally:
+            allow_upload.set()
+            if worker is not None:
+                worker.join(timeout=10)
+
+        assert worker is not None
+        assert not worker.is_alive()
+        assert worker_errors == []
+        assert stage is not None
+        s3_client.head_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+        assert (
+            self.db["wf_TimeSeries"].find_one({"_id": old_waveform_id}) == old_waveform
+        )
+
+        uri = "s3://{}/{}".format(bucket, stage["object_store"]["object_name"])
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert report == {
+            "committed": [],
+            "uncommitted": [],
+            "deleted": [uri],
+            "failures": [],
+        }
+        assert self.db["object_store_staging"].find_one({"_id": stage["_id"]}) is None
+        with pytest.raises(botocore.exceptions.ClientError):
+            s3_client.head_object(
+                Bucket=bucket, Key=stage["object_store"]["object_name"]
+            )
+        self.db["wf_TimeSeries"].delete_one({"_id": old_waveform_id})
 
     @mock_aws
     def test_object_store_unknown_waveform_insert_preserves_durable_samples(self):
@@ -965,6 +1010,12 @@ class TestDatabase:
         bucket = "mspass-object-store-inflight-insert-test"
         s3_client.create_bucket(Bucket=bucket)
         datum = get_live_timeseries()
+        logging_helper.info(datum, "history-test", "test_save_data")
+        datum.elog.log_error(
+            "test_save_data",
+            "staged elog test",
+            ErrorSeverity.Complaint,
+        )
         original_insert_one = Collection.insert_one
         allow_insert = threading.Event()
         worker = None
@@ -1001,13 +1052,26 @@ class TestDatabase:
                         storage_mode="object_store",
                         object_store={"provider": "s3", "bucket": bucket},
                         object_store_client=s3_client,
-                        save_history=False,
+                        save_history=True,
                     )
 
             stage = self.db["object_store_staging"].find_one(
                 {"object_store.bucket": bucket}
             )
             assert stage is not None
+            assert datum["_id"] == stage["waveform_id"]
+            history_plan = stage["auxiliary_documents"]["history"]
+            elog_plan = stage["auxiliary_documents"]["elog"]
+            history_document = self.db[history_plan["collection"]].find_one(
+                {"_id": history_plan["_id"]}
+            )
+            elog_document = self.db[elog_plan["collection"]].find_one(
+                {"_id": elog_plan["_id"]}
+            )
+            assert history_document is not None
+            assert elog_document is not None
+            assert history_document["wf_TimeSeries_id"] == stage["waveform_id"]
+            assert elog_document["wf_TimeSeries_id"] == stage["waveform_id"]
             assert (
                 self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]}) is None
             )
@@ -1026,6 +1090,8 @@ class TestDatabase:
         assert stage is not None
         waveform = self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]})
         assert waveform
+        assert waveform["history_object_id"] == history_plan["_id"]
+        assert waveform["elog_id"] == elog_plan["_id"]
         assert datum["storage_mode"] == "object_store"
         assert datum["object_store"] == stage["object_store"]
         response = s3_client.get_object(
@@ -1039,8 +1105,177 @@ class TestDatabase:
         assert len(report["committed"]) == 1
         assert report["deleted"] == []
         assert report["failures"] == []
+        history_document = self.db[history_plan["collection"]].find_one(
+            {"_id": history_plan["_id"]}
+        )
+        elog_document = self.db[elog_plan["collection"]].find_one(
+            {"_id": elog_plan["_id"]}
+        )
+        assert history_document["wf_TimeSeries_id"] == stage["waveform_id"]
+        assert elog_document["wf_TimeSeries_id"] == stage["waveform_id"]
         self.db["wf_TimeSeries"].delete_one({"_id": stage["waveform_id"]})
+        self.db[history_plan["collection"]].delete_one({"_id": history_plan["_id"]})
+        self.db[elog_plan["collection"]].delete_one({"_id": elog_plan["_id"]})
         s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+
+    @mock_aws
+    def test_object_store_uncertain_waveform_reconciliation_removes_auxiliary_orphans(
+        self,
+    ):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-uncertain-waveform-aux-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "history-test", "test_save_data")
+        datum.elog.log_error(
+            "test_save_data",
+            "staged elog test",
+            ErrorSeverity.Complaint,
+        )
+        original_insert_one = Collection.insert_one
+
+        def reject_waveform_result(collection, *args, **kwargs):
+            if collection.name == "wf_TimeSeries":
+                raise pymongo.errors.AutoReconnect("waveform result unknown")
+            return original_insert_one(collection, *args, **kwargs)
+
+        with patch.object(Collection, "insert_one", new=reject_waveform_result):
+            with pytest.raises(
+                MsPASSError, match="could not determine whether.*MongoDB save committed"
+            ):
+                self.db.save_data(
+                    datum,
+                    storage_mode="object_store",
+                    object_store={"provider": "s3", "bucket": bucket},
+                    object_store_client=s3_client,
+                    save_history=True,
+                )
+
+        stage = self.db["object_store_staging"].find_one(
+            {"object_store.bucket": bucket}
+        )
+        assert stage is not None
+        history_plan = stage["auxiliary_documents"]["history"]
+        elog_plan = stage["auxiliary_documents"]["elog"]
+        assert self.db[history_plan["collection"]].find_one(
+            {"_id": history_plan["_id"]}
+        )
+        assert self.db[elog_plan["collection"]].find_one({"_id": elog_plan["_id"]})
+        assert self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]}) is None
+        s3_client.head_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+
+        uri = "s3://{}/{}".format(bucket, stage["object_store"]["object_name"])
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert report == {
+            "committed": [],
+            "uncommitted": [],
+            "deleted": [uri],
+            "failures": [],
+        }
+        assert (
+            self.db[history_plan["collection"]].find_one({"_id": history_plan["_id"]})
+            is None
+        )
+        assert (
+            self.db[elog_plan["collection"]].find_one({"_id": elog_plan["_id"]}) is None
+        )
+
+    @pytest.mark.parametrize("uncertain_collection", ["history_object", "elog"])
+    @mock_aws
+    def test_object_store_uncertain_auxiliary_insert_is_durably_reconciled(
+        self, uncertain_collection
+    ):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-uncertain-{}-test".format(
+            uncertain_collection.replace("_", "-")
+        )
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        save_history = uncertain_collection == "history_object"
+        if save_history:
+            logging_helper.info(datum, "history-test", "test_save_data")
+        else:
+            datum.elog.log_error(
+                "test_save_data",
+                "staged elog test",
+                ErrorSeverity.Complaint,
+            )
+        original_insert_one = Collection.insert_one
+        allow_insert = threading.Event()
+        worker = None
+        worker_errors = []
+
+        def insert_later(collection, document):
+            try:
+                if not allow_insert.wait(timeout=10):
+                    raise TimeoutError("test did not release delayed auxiliary insert")
+                original_insert_one(collection, document)
+            except BaseException as error:
+                worker_errors.append(error)
+
+        def start_insert_then_raise(collection, document, *args, **kwargs):
+            nonlocal worker
+            if collection.name == uncertain_collection:
+                worker = threading.Thread(
+                    target=insert_later,
+                    args=(collection, copy.deepcopy(document)),
+                    name="delayed-{}-insert".format(uncertain_collection),
+                )
+                worker.start()
+                raise pymongo.errors.AutoReconnect("auxiliary result unknown")
+            return original_insert_one(collection, document, *args, **kwargs)
+
+        stage = None
+        try:
+            with patch.object(Collection, "insert_one", new=start_insert_then_raise):
+                with pytest.raises(
+                    MsPASSError,
+                    match="could not determine whether.*MongoDB save committed",
+                ):
+                    self.db.save_data(
+                        datum,
+                        storage_mode="object_store",
+                        object_store={"provider": "s3", "bucket": bucket},
+                        object_store_client=s3_client,
+                        save_history=save_history,
+                    )
+            stage = self.db["object_store_staging"].find_one(
+                {"object_store.bucket": bucket}
+            )
+            assert stage is not None
+            assert (
+                self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]}) is None
+            )
+            s3_client.head_object(
+                Bucket=bucket, Key=stage["object_store"]["object_name"]
+            )
+        finally:
+            allow_insert.set()
+            if worker is not None:
+                worker.join(timeout=10)
+
+        assert worker is not None
+        assert not worker.is_alive()
+        assert worker_errors == []
+        assert stage is not None
+        plan = stage["auxiliary_documents"][
+            "history" if uncertain_collection == "history_object" else "elog"
+        ]
+        assert self.db[plan["collection"]].find_one({"_id": plan["_id"]})
+
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert len(report["deleted"]) == 1
+        assert report["committed"] == []
+        assert report["failures"] == []
+        assert self.db[plan["collection"]].find_one({"_id": plan["_id"]}) is None
+        with pytest.raises(botocore.exceptions.ClientError):
+            s3_client.head_object(
+                Bucket=bucket, Key=stage["object_store"]["object_name"]
+            )
 
     @mock_aws
     def test_object_store_compensation_reference_failure_is_fail_safe(self):
@@ -1088,46 +1323,96 @@ class TestDatabase:
         s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
 
     @mock_aws
-    def test_object_store_rollback_failure_preserves_durable_samples(self):
+    def test_object_store_cleanup_restores_caller_before_stage_cleanup_failure(self):
         s3_client = boto3.client("s3", region_name="us-east-1")
-        bucket = "mspass-object-store-rollback-failure-test"
+        bucket = "mspass-object-store-stage-cleanup-failure-test"
         s3_client.create_bucket(Bucket=bucket)
         datum = get_live_timeseries()
-        logging_helper.info(datum, "history-test", "test_save_data")
-        original_update_one = Collection.update_one
+        datum["storage_mode"] = "file"
+        datum["dir"] = "/original"
+        datum["dfile"] = "original.dat"
+        snapshot = self.db._snapshot_object_store_metadata(datum)
+        original_insert_one = Collection.insert_one
         original_delete_one = Collection.delete_one
-        history_ids_before = {
-            document["_id"] for document in self.db["history_object"].find({})
-        }
 
-        def fail_history_link(collection, *args, **kwargs):
-            if collection.name == "history_object":
-                raise pymongo.errors.OperationFailure("forced history link failure")
-            return original_update_one(collection, *args, **kwargs)
-
-        def fail_waveform_rollback(collection, *args, **kwargs):
+        def fail_waveform_insert(collection, *args, **kwargs):
             if collection.name == "wf_TimeSeries":
-                raise pymongo.errors.AutoReconnect("forced rollback failure")
-            return original_delete_one(collection, *args, **kwargs)
+                raise pymongo.errors.OperationFailure("known waveform rejection")
+            return original_insert_one(collection, *args, **kwargs)
+
+        def fail_stage_delete(collection, query, *args, **kwargs):
+            if collection.name == "object_store_staging":
+                return Mock(deleted_count=0)
+            return original_delete_one(collection, query, *args, **kwargs)
 
         with (
-            patch.object(Collection, "update_one", new=fail_history_link),
-            patch.object(Collection, "delete_one", new=fail_waveform_rollback),
+            patch.object(Collection, "insert_one", new=fail_waveform_insert),
+            patch.object(Collection, "delete_one", new=fail_stage_delete),
         ):
-            with pytest.raises(MsPASSError, match="reference became durable"):
+            with pytest.raises(
+                MsPASSError, match="compensation could not safely remove"
+            ):
                 self.db.save_data(
                     datum,
                     storage_mode="object_store",
                     object_store={"provider": "s3", "bucket": bucket},
                     object_store_client=s3_client,
-                    save_history=True,
+                    save_history=False,
                 )
+
+        assert self.db._snapshot_object_store_metadata(datum) == snapshot
+        stage = self.db["object_store_staging"].find_one(
+            {"object_store.bucket": bucket}
+        )
+        assert stage is not None
+        with pytest.raises(botocore.exceptions.ClientError):
+            s3_client.head_object(
+                Bucket=bucket, Key=stage["object_store"]["object_name"]
+            )
+
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert report["deleted"] == [
+            "s3://{}/{}".format(bucket, stage["object_store"]["object_name"])
+        ]
+        assert report["failures"] == []
+        assert self.db["object_store_staging"].find_one({"_id": stage["_id"]}) is None
+
+    @mock_aws
+    def test_object_store_reconciliation_repairs_auxiliary_links(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-auxiliary-repair-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "history-test", "test_save_data")
+        datum.elog.log_error(
+            "test_save_data",
+            "staged elog test",
+            ErrorSeverity.Complaint,
+        )
+        with patch.object(Database, "_complete_object_store_stage", return_value=False):
+            saved = self.db.save_data(
+                datum,
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                save_history=True,
+                return_data=True,
+            )
 
         stage = self.db["object_store_staging"].find_one(
             {"object_store.bucket": bucket}
         )
         assert stage is not None
-        assert self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]})
+        history_plan = stage["auxiliary_documents"]["history"]
+        elog_plan = stage["auxiliary_documents"]["elog"]
+        self.db[history_plan["collection"]].update_one(
+            {"_id": history_plan["_id"]}, {"$unset": {"wf_TimeSeries_id": ""}}
+        )
+        self.db[elog_plan["collection"]].update_one(
+            {"_id": elog_plan["_id"]}, {"$unset": {"wf_TimeSeries_id": ""}}
+        )
         response = s3_client.get_object(
             Bucket=bucket, Key=stage["object_store"]["object_name"]
         )
@@ -1138,11 +1423,18 @@ class TestDatabase:
         assert len(report["committed"]) == 1
         assert report["deleted"] == []
         assert report["failures"] == []
-
-        self.db["wf_TimeSeries"].delete_one({"_id": stage["waveform_id"]})
-        self.db["history_object"].delete_many(
-            {"_id": {"$nin": list(history_ids_before)}}
+        history_document = self.db[history_plan["collection"]].find_one(
+            {"_id": history_plan["_id"]}
         )
+        elog_document = self.db[elog_plan["collection"]].find_one(
+            {"_id": elog_plan["_id"]}
+        )
+        assert history_document["wf_TimeSeries_id"] == stage["waveform_id"]
+        assert elog_document["wf_TimeSeries_id"] == stage["waveform_id"]
+
+        self.db["wf_TimeSeries"].delete_one({"_id": saved["_id"]})
+        self.db[history_plan["collection"]].delete_one({"_id": history_plan["_id"]})
+        self.db[elog_plan["collection"]].delete_one({"_id": elog_plan["_id"]})
         s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
 
     @mock_aws
@@ -1279,7 +1571,9 @@ class TestDatabase:
                 object_store_client=failing_client,
             )
 
-        assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) == document
+        retained = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        assert isinstance(retained.pop("_mspass_delete_token"), ObjectId)
+        assert retained == document
         assert not self.db["history_object"].find_one(
             {"_id": document["history_object_id"]}
         )
@@ -1289,6 +1583,17 @@ class TestDatabase:
             Bucket=location["bucket"], Key=location["object_name"]
         )
         response["Body"].close()
+
+        self.db.delete_data(
+            saved["_id"],
+            "TimeSeries",
+            object_store_client=s3_client,
+        )
+        assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) is None
+        with pytest.raises(botocore.exceptions.ClientError):
+            s3_client.head_object(
+                Bucket=location["bucket"], Key=location["object_name"]
+            )
 
     @mock_aws
     def test_delete_data_retains_concurrently_changed_object_store_reference(self):
@@ -1515,6 +1820,8 @@ class TestDatabase:
             Body=b"shared",
         )
         abandoned_waveform_id = ObjectId()
+        abandoned_history_id = ObjectId()
+        abandoned_elog_id = ObjectId()
         referenced_waveform_id = (
             self.db["wf_Seismogram"]
             .insert_one(
@@ -1534,8 +1841,20 @@ class TestDatabase:
                 "waveform_id": abandoned_waveform_id,
                 "waveform_collection": "wf_TimeSeries",
                 "object_store": shared_location,
+                "auxiliary_documents": {
+                    "history": {
+                        "collection": "history_object",
+                        "_id": abandoned_history_id,
+                    },
+                    "elog": {
+                        "collection": "elog",
+                        "_id": abandoned_elog_id,
+                    },
+                },
             }
         )
+        self.db["history_object"].insert_one({"_id": abandoned_history_id})
+        self.db["elog"].insert_one({"_id": abandoned_elog_id})
         shared_uri = "s3://{}/{}".format(
             shared_location["bucket"], shared_location["object_name"]
         )
@@ -1552,7 +1871,222 @@ class TestDatabase:
             Bucket=shared_location["bucket"], Key=shared_location["object_name"]
         )
         response["Body"].close()
+        assert self.db["history_object"].find_one({"_id": abandoned_history_id}) is None
+        assert self.db["elog"].find_one({"_id": abandoned_elog_id}) is None
         self.db["wf_Seismogram"].delete_one({"_id": referenced_waveform_id})
+
+    @pytest.mark.parametrize("owner_conflict", ["identity", "mode"])
+    @mock_aws
+    def test_object_store_staging_retains_changed_intended_owner(self, owner_conflict):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        tracking_client = Mock(wraps=s3_client)
+        bucket = "mspass-object-store-owner-conflict-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "history-test", "test_save_data")
+        datum.elog.log_error(
+            "test_save_data",
+            "owner conflict elog test",
+            ErrorSeverity.Complaint,
+        )
+        with patch.object(Database, "_complete_object_store_stage", return_value=False):
+            saved = self.db.save_data(
+                datum,
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                save_history=True,
+                return_data=True,
+            )
+
+        stage = self.db["object_store_staging"].find_one({"_id": saved["_id"]})
+        assert stage is not None
+        history_plan = stage["auxiliary_documents"]["history"]
+        elog_plan = stage["auxiliary_documents"]["elog"]
+        changed_location = copy.deepcopy(stage["object_store"])
+        if owner_conflict == "identity":
+            changed_location["object_name"] = "replacement-owner-object.bin"
+            update = {"object_store": changed_location}
+        else:
+            update = {"storage_mode": "gridfs"}
+        self.db["wf_TimeSeries"].update_one({"_id": saved["_id"]}, {"$set": update})
+
+        failures, durable_references = self.db._cleanup_staged_object_store_data(
+            tracking_client,
+            [
+                (
+                    saved,
+                    stage["object_store"],
+                    self.db._snapshot_object_store_metadata(saved),
+                    stage["waveform_id"],
+                    stage["waveform_collection"],
+                )
+            ],
+        )
+        assert durable_references == []
+        assert failures == [
+            "staged owner {} changed storage state".format(stage["waveform_id"])
+        ]
+        tracking_client.delete_object.assert_not_called()
+
+        uri = "s3://{}/{}".format(bucket, stage["object_store"]["object_name"])
+        report = self.db.reconcile_object_store_staging(
+            tracking_client, delete_uncommitted=True
+        )
+        assert report == {
+            "committed": [],
+            "uncommitted": [],
+            "deleted": [],
+            "failures": [
+                "{}: staged owner {} changed storage state".format(
+                    uri, stage["waveform_id"]
+                )
+            ],
+        }
+        tracking_client.delete_object.assert_not_called()
+        assert self.db["object_store_staging"].find_one({"_id": stage["_id"]})
+        assert self.db[history_plan["collection"]].find_one(
+            {"_id": history_plan["_id"]}
+        )
+        assert self.db[elog_plan["collection"]].find_one({"_id": elog_plan["_id"]})
+        s3_client.head_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+
+        self.db["wf_TimeSeries"].delete_one({"_id": saved["_id"]})
+        self.db[history_plan["collection"]].delete_one({"_id": history_plan["_id"]})
+        self.db[elog_plan["collection"]].delete_one({"_id": elog_plan["_id"]})
+        self.db["object_store_staging"].delete_one({"_id": stage["_id"]})
+        s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+
+    @mock_aws
+    def test_object_store_lifecycle_forces_primary_and_majority_options(self):
+        configured_db = Database(
+            self.db.client,
+            self.db.name,
+            read_preference=pymongo.ReadPreference.SECONDARY_PREFERRED,
+            write_concern=pymongo.write_concern.WriteConcern(w=1),
+        )
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-lifecycle-options-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "history-test", "test_save_data")
+        datum.elog.log_error(
+            "test_save_data",
+            "lifecycle options elog test",
+            ErrorSeverity.Complaint,
+        )
+        original_insert_one = Collection.insert_one
+        original_delete_one = Collection.delete_one
+        write_options = []
+
+        def capture_insert(collection, *args, **kwargs):
+            if collection.name in {
+                "object_store_staging",
+                "history_object",
+                "elog",
+                "wf_TimeSeries",
+            }:
+                write_options.append(
+                    (
+                        collection.name,
+                        collection.read_preference,
+                        collection.write_concern.document,
+                    )
+                )
+            return original_insert_one(collection, *args, **kwargs)
+
+        def capture_delete(collection, *args, **kwargs):
+            if collection.name == "object_store_staging":
+                write_options.append(
+                    (
+                        collection.name,
+                        collection.read_preference,
+                        collection.write_concern.document,
+                    )
+                )
+            return original_delete_one(collection, *args, **kwargs)
+
+        with (
+            patch.object(Collection, "insert_one", new=capture_insert),
+            patch.object(Collection, "delete_one", new=capture_delete),
+        ):
+            saved = configured_db.save_data(
+                datum,
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                save_history=True,
+                return_data=True,
+            )
+
+        assert {name for name, _, _ in write_options} == {
+            "object_store_staging",
+            "history_object",
+            "elog",
+            "wf_TimeSeries",
+        }
+        for _, read_preference, write_concern in write_options:
+            assert read_preference == pymongo.ReadPreference.PRIMARY
+            assert write_concern == {"w": "majority"}
+
+        original_find_one = Collection.find_one
+        read_options = []
+
+        def capture_find(collection, *args, **kwargs):
+            read_options.append(collection.read_preference)
+            return original_find_one(collection, *args, **kwargs)
+
+        lifecycle_delete_options = []
+        original_delete_many = Collection.delete_many
+
+        def capture_lifecycle_delete(collection, *args, **kwargs):
+            lifecycle_delete_options.append(
+                (
+                    collection.name,
+                    collection.read_preference,
+                    collection.write_concern.document,
+                )
+            )
+            return original_delete_one(collection, *args, **kwargs)
+
+        def capture_lifecycle_delete_many(collection, *args, **kwargs):
+            lifecycle_delete_options.append(
+                (
+                    collection.name,
+                    collection.read_preference,
+                    collection.write_concern.document,
+                )
+            )
+            return original_delete_many(collection, *args, **kwargs)
+
+        with patch.object(Collection, "find_one", new=capture_find):
+            assert configured_db._object_store_is_referenced(
+                saved["object_store"],
+                expected_collection="wf_TimeSeries",
+                expected_id=saved["_id"],
+            )
+            with (
+                patch.object(Collection, "delete_one", new=capture_lifecycle_delete),
+                patch.object(
+                    Collection, "delete_many", new=capture_lifecycle_delete_many
+                ),
+            ):
+                configured_db.delete_data(
+                    saved["_id"], "TimeSeries", object_store_client=s3_client
+                )
+        assert read_options
+        assert all(
+            read_preference == pymongo.ReadPreference.PRIMARY
+            for read_preference in read_options
+        )
+        assert {name for name, _, _ in lifecycle_delete_options} == {
+            "history_object",
+            "elog",
+            "wf_TimeSeries",
+        }
+        for _, read_preference, write_concern in lifecycle_delete_options:
+            assert read_preference == pymongo.ReadPreference.PRIMARY
+            assert write_concern == {"w": "majority"}
 
     @mock_aws
     def test_object_store_staging_recognizes_alternate_collection_owner(self):
@@ -1560,23 +2094,42 @@ class TestDatabase:
         bucket = "mspass-object-store-alternate-owner-test"
         collection = "export_waveforms"
         s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "history-test", "test_save_data")
+        datum.elog.log_error(
+            "test_save_data",
+            "alternate collection elog test",
+            ErrorSeverity.Complaint,
+        )
 
         with patch.object(Database, "_complete_object_store_stage", return_value=False):
             saved = self.db.save_data(
-                get_live_timeseries(),
+                datum,
                 collection=collection,
                 storage_mode="object_store",
                 object_store={"provider": "s3", "bucket": bucket},
                 object_store_client=s3_client,
                 return_data=True,
-                save_history=False,
+                save_history=True,
             )
 
         stage = self.db["object_store_staging"].find_one(
             {"waveform_collection": collection, "waveform_id": saved["_id"]}
         )
         assert stage is not None
-        assert self.db[collection].find_one({"_id": saved["_id"]})
+        waveform = self.db[collection].find_one({"_id": saved["_id"]})
+        history_plan = stage["auxiliary_documents"]["history"]
+        elog_plan = stage["auxiliary_documents"]["elog"]
+        assert waveform["history_object_id"] == history_plan["_id"]
+        assert waveform["elog_id"] == elog_plan["_id"]
+        self.db[history_plan["collection"]].update_one(
+            {"_id": history_plan["_id"]},
+            {"$unset": {collection + "_id": ""}},
+        )
+        self.db[elog_plan["collection"]].update_one(
+            {"_id": elog_plan["_id"]},
+            {"$unset": {collection + "_id": ""}},
+        )
         uri = "s3://{}/{}".format(bucket, stage["object_store"]["object_name"])
         report = self.db.reconcile_object_store_staging(
             s3_client, delete_uncommitted=True
@@ -1588,12 +2141,24 @@ class TestDatabase:
             "failures": [],
         }
         assert self.db["object_store_staging"].find_one({"_id": stage["_id"]}) is None
+        history_document = self.db[history_plan["collection"]].find_one(
+            {"_id": history_plan["_id"]}
+        )
+        elog_document = self.db[elog_plan["collection"]].find_one(
+            {"_id": elog_plan["_id"]}
+        )
+        assert history_document[collection + "_id"] == saved["_id"]
+        assert elog_document[collection + "_id"] == saved["_id"]
+        assert "wf_TimeSeries_id" not in history_document
+        assert "wf_TimeSeries_id" not in elog_document
         response = s3_client.get_object(
             Bucket=bucket, Key=stage["object_store"]["object_name"]
         )
         response["Body"].close()
 
         self.db[collection].delete_one({"_id": saved["_id"]})
+        self.db[history_plan["collection"]].delete_one({"_id": history_plan["_id"]})
+        self.db[elog_plan["collection"]].delete_one({"_id": elog_plan["_id"]})
         s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
 
     @mock_aws
@@ -1659,6 +2224,171 @@ class TestDatabase:
                 mode="promiscuous",
             )
         object_store_client.put_object.assert_not_called()
+
+    @mock_aws
+    def test_new_object_store_save_does_not_inherit_auxiliary_pointers(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-stale-aux-test"
+        s3_client.create_bucket(Bucket=bucket)
+        stale_history_id = (
+            self.db["history_object"].insert_one({"old": True}).inserted_id
+        )
+        stale_elog_id = self.db["elog"].insert_one({"logdata": []}).inserted_id
+        datum = get_live_timeseries()
+        datum["history_object_id"] = stale_history_id
+        datum["elog_id"] = stale_elog_id
+
+        saved = self.db.save_data(
+            datum,
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            save_history=False,
+            return_data=True,
+        )
+
+        waveform = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        assert "history_object_id" not in waveform
+        assert "elog_id" not in waveform
+        assert "history_object_id" not in saved
+        assert "elog_id" not in saved
+        assert self.db["history_object"].find_one({"_id": stale_history_id})
+        assert self.db["elog"].find_one({"_id": stale_elog_id})
+
+    @mock_aws
+    def test_object_store_completion_rechecks_intended_owner(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-completion-owner-test"
+        s3_client.create_bucket(Bucket=bucket)
+        original_complete = Database._complete_object_store_stage
+
+        def change_owner_then_complete(database, stage_id, location):
+            database["wf_TimeSeries"].update_one(
+                {"_id": stage_id},
+                {"$set": {"storage_mode": "gridfs", "gridfs_id": ObjectId()}},
+            )
+            return original_complete(database, stage_id, location)
+
+        with patch.object(
+            Database,
+            "_complete_object_store_stage",
+            new=change_owner_then_complete,
+        ):
+            saved = self.db.save_data(
+                get_live_timeseries(),
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                save_history=False,
+                return_data=True,
+            )
+
+        stage = self.db["object_store_staging"].find_one({"_id": saved["_id"]})
+        assert stage is not None
+        response = s3_client.get_object(
+            Bucket=stage["object_store"]["bucket"],
+            Key=stage["object_store"]["object_name"],
+        )
+        response["Body"].close()
+        self.db["object_store_staging"].delete_one({"_id": stage["_id"]})
+        self.db["wf_TimeSeries"].delete_one({"_id": saved["_id"]})
+        s3_client.delete_object(
+            Bucket=stage["object_store"]["bucket"],
+            Key=stage["object_store"]["object_name"],
+        )
+
+    @mock_aws
+    def test_object_store_delete_resolves_stage_and_honors_clear_flags(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-delete-stage-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "history", "test")
+        datum.elog.log_error("test", "retain", ErrorSeverity.Complaint)
+        with patch.object(Database, "_complete_object_store_stage", return_value=False):
+            saved = self.db.save_data(
+                datum,
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                save_history=True,
+                return_data=True,
+            )
+        history_id = saved["history_object_id"]
+        elog_id = saved["elog_id"]
+        assert (
+            self.db["object_store_staging"].count_documents(
+                {"waveform_id": saved["_id"]}
+            )
+            == 1
+        )
+
+        self.db.delete_data(
+            saved["_id"],
+            "TimeSeries",
+            clear_history=False,
+            clear_elog=False,
+            object_store_client=s3_client,
+        )
+
+        assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) is None
+        assert self.db["history_object"].find_one({"_id": history_id})
+        assert self.db["elog"].find_one({"_id": elog_id})
+        assert (
+            self.db["object_store_staging"].count_documents(
+                {"waveform_id": saved["_id"]}
+            )
+            == 0
+        )
+
+    @mock_aws
+    def test_update_metadata_rejects_object_store_identity_changes(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-metadata-identity-test"
+        s3_client.create_bucket(Bucket=bucket)
+        saved = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            save_history=False,
+            return_data=True,
+        )
+        persisted = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        saved["object_store"] = {
+            **saved["object_store"],
+            "object_name": "changed.bin",
+        }
+
+        with pytest.raises(ValueError, match="cannot change sample ownership"):
+            self.db.update_metadata(saved, mode="promiscuous")
+        self.db.update_metadata(
+            saved,
+            mode="promiscuous",
+            _lifecycle_managed=True,
+        )
+
+        assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) == persisted
+
+    @mock_aws
+    def test_update_metadata_allows_object_store_nonidentity_fields(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-metadata-etag-test"
+        s3_client.create_bucket(Bucket=bucket)
+        saved = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            save_history=False,
+            return_data=True,
+        )
+        saved["object_store"] = {**saved["object_store"], "etag": "metadata-only"}
+
+        self.db.update_metadata(saved, mode="promiscuous")
+
+        persisted = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        assert persisted["object_store"]["etag"] == "metadata-only"
 
     def test_mspass_type_helper(self):
         schema = self.metadata_def.Seismogram

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -585,6 +585,9 @@ class TestDatabase:
         assert self.db["object_store_staging"].count_documents({}) == staging_count
         assert self.db["wf_TimeSeries"].count_documents({}) == waveform_count
         object_store_client.put_object.assert_not_called()
+        assert "cemetery_id" in saved
+        cleanup = self.db["cemetery"].delete_one({"_id": saved["cemetery_id"]})
+        assert cleanup.deleted_count == 1
 
     def test_object_store_zero_length_ensemble_member_is_buried_without_upload(self):
         zero_length = get_live_timeseries(ts_size=0)
@@ -613,6 +616,15 @@ class TestDatabase:
         assert self.db["object_store_staging"].count_documents({}) == staging_count
         assert self.db["wf_TimeSeries"].count_documents({}) == waveform_count + 1
         assert object_store_client.put_object.call_count == 1
+        assert "cemetery_id" in saved.member[0]
+        cemetery_cleanup = self.db["cemetery"].delete_one(
+            {"_id": saved.member[0]["cemetery_id"]}
+        )
+        waveform_cleanup = self.db["wf_TimeSeries"].delete_one(
+            {"_id": saved.member[1]["_id"]}
+        )
+        assert cemetery_cleanup.deleted_count == 1
+        assert waveform_cleanup.deleted_count == 1
 
     @mock_aws
     def test_object_store_mseed_round_trip(self):

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -818,7 +818,9 @@ class TestDatabase:
             )
         )
 
-        with pytest.raises(MsPASSError, match="could not remove: s3://test-bucket/"):
+        with pytest.raises(
+            MsPASSError, match="could not safely remove: s3://test-bucket/"
+        ):
             self.db._save_sample_data_to_object_store(
                 ensemble,
                 {"provider": "s3", "bucket": "test-bucket"},
@@ -894,6 +896,168 @@ class TestDatabase:
                 assert (key in datum) is was_defined
                 if was_defined:
                     assert datum[key] == value
+
+    @mock_aws
+    def test_object_store_unknown_waveform_insert_preserves_durable_samples(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-unknown-insert-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        datum["storage_mode"] = "gridfs"
+        datum["gridfs_id"] = ObjectId()
+        original_insert_one = Collection.insert_one
+
+        def insert_then_raise(collection, document, *args, **kwargs):
+            if collection.name == "wf_TimeSeries":
+                original_insert_one(collection, document, *args, **kwargs)
+                raise pymongo.errors.AutoReconnect("waveform result unknown")
+            return original_insert_one(collection, document, *args, **kwargs)
+
+        with patch.object(Collection, "insert_one", new=insert_then_raise):
+            with pytest.raises(MsPASSError, match="reference became durable"):
+                self.db.save_data(
+                    datum,
+                    storage_mode="object_store",
+                    object_store={"provider": "s3", "bucket": bucket},
+                    object_store_client=s3_client,
+                    save_history=False,
+                )
+
+        stage = self.db["object_store_staging"].find_one(
+            {"object_store.bucket": bucket}
+        )
+        assert stage is not None
+        waveform = self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]})
+        assert waveform is not None
+        assert self.db._object_store_identity(waveform["object_store"]) == (
+            self.db._object_store_identity(stage["object_store"])
+        )
+        assert datum["storage_mode"] == "object_store"
+        assert datum["object_store"] == stage["object_store"]
+        response = s3_client.get_object(
+            Bucket=bucket, Key=stage["object_store"]["object_name"]
+        )
+        response["Body"].close()
+
+        uri = "s3://{}/{}".format(bucket, stage["object_store"]["object_name"])
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert report == {
+            "committed": [uri],
+            "uncommitted": [],
+            "deleted": [],
+            "failures": [],
+        }
+        response = s3_client.get_object(
+            Bucket=bucket, Key=stage["object_store"]["object_name"]
+        )
+        response["Body"].close()
+        self.db["wf_TimeSeries"].delete_one({"_id": stage["waveform_id"]})
+        s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+
+    @mock_aws
+    def test_object_store_compensation_reference_failure_is_fail_safe(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-reference-failure-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        original_insert_one = Collection.insert_one
+
+        def fail_waveform_insert(collection, *args, **kwargs):
+            if collection.name == "wf_TimeSeries":
+                raise pymongo.errors.OperationFailure("forced waveform failure")
+            return original_insert_one(collection, *args, **kwargs)
+
+        with (
+            patch.object(Collection, "insert_one", new=fail_waveform_insert),
+            patch.object(
+                Database,
+                "_object_store_is_referenced",
+                side_effect=pymongo.errors.AutoReconnect("reference status unknown"),
+            ),
+        ):
+            with pytest.raises(MsPASSError, match="could not safely remove"):
+                self.db.save_data(
+                    datum,
+                    storage_mode="object_store",
+                    object_store={"provider": "s3", "bucket": bucket},
+                    object_store_client=s3_client,
+                    save_history=False,
+                )
+
+        stage = self.db["object_store_staging"].find_one(
+            {"object_store.bucket": bucket}
+        )
+        assert stage is not None
+        assert self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]}) is None
+        assert datum["storage_mode"] == "object_store"
+        assert datum["object_store"] == stage["object_store"]
+        response = s3_client.get_object(
+            Bucket=bucket, Key=stage["object_store"]["object_name"]
+        )
+        response["Body"].close()
+
+        self.db["object_store_staging"].delete_one({"_id": stage["_id"]})
+        s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+
+    @mock_aws
+    def test_object_store_rollback_failure_preserves_durable_samples(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-rollback-failure-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "history-test", "test_save_data")
+        original_update_one = Collection.update_one
+        original_delete_one = Collection.delete_one
+        history_ids_before = {
+            document["_id"] for document in self.db["history_object"].find({})
+        }
+
+        def fail_history_link(collection, *args, **kwargs):
+            if collection.name == "history_object":
+                raise pymongo.errors.OperationFailure("forced history link failure")
+            return original_update_one(collection, *args, **kwargs)
+
+        def fail_waveform_rollback(collection, *args, **kwargs):
+            if collection.name == "wf_TimeSeries":
+                raise pymongo.errors.AutoReconnect("forced rollback failure")
+            return original_delete_one(collection, *args, **kwargs)
+
+        with (
+            patch.object(Collection, "update_one", new=fail_history_link),
+            patch.object(Collection, "delete_one", new=fail_waveform_rollback),
+        ):
+            with pytest.raises(MsPASSError, match="reference became durable"):
+                self.db.save_data(
+                    datum,
+                    storage_mode="object_store",
+                    object_store={"provider": "s3", "bucket": bucket},
+                    object_store_client=s3_client,
+                    save_history=True,
+                )
+
+        stage = self.db["object_store_staging"].find_one(
+            {"object_store.bucket": bucket}
+        )
+        assert stage is not None
+        assert self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]})
+        response = s3_client.get_object(
+            Bucket=bucket, Key=stage["object_store"]["object_name"]
+        )
+        response["Body"].close()
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert len(report["committed"]) == 1
+        assert report["deleted"] == []
+        assert report["failures"] == []
+
+        self.db["wf_TimeSeries"].delete_one({"_id": stage["waveform_id"]})
+        self.db["history_object"].delete_many(
+            {"_id": {"$nin": list(history_ids_before)}}
+        )
+        s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
 
     @mock_aws
     def test_update_data_rejects_persisted_object_store_after_metadata_tampering(
@@ -1124,6 +1288,48 @@ class TestDatabase:
             )
 
     @mock_aws
+    def test_delete_data_preserves_shared_object_store_samples(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-delete-shared-test"
+        s3_client.create_bucket(Bucket=bucket)
+        saved = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            return_data=True,
+            save_history=False,
+        )
+        location = copy.deepcopy(saved["object_store"])
+        shared_id = (
+            self.db["wf_Seismogram"]
+            .insert_one(
+                {
+                    "storage_mode": "object_store",
+                    "object_store": {**location, "etag": "shared-reference"},
+                }
+            )
+            .inserted_id
+        )
+        tracking_client = Mock(wraps=s3_client)
+
+        self.db.delete_data(
+            saved["_id"],
+            "TimeSeries",
+            object_store_client=tracking_client,
+        )
+
+        assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) is None
+        assert self.db["wf_Seismogram"].find_one({"_id": shared_id}) is not None
+        tracking_client.delete_object.assert_not_called()
+        response = s3_client.get_object(
+            Bucket=location["bucket"], Key=location["object_name"]
+        )
+        response["Body"].close()
+        self.db["wf_Seismogram"].delete_one({"_id": shared_id})
+        s3_client.delete_object(Bucket=location["bucket"], Key=location["object_name"])
+
+    @mock_aws
     def test_object_store_staging_reconciles_interrupted_and_committed_writes(self):
         s3_client = boto3.client("s3", region_name="us-east-1")
         bucket = "mspass-object-store-staging-test"
@@ -1261,6 +1467,49 @@ class TestDatabase:
         )
         response["Body"].close()
         self.db["wf_Seismogram"].delete_one({"_id": referenced_waveform_id})
+
+    @mock_aws
+    def test_object_store_staging_recognizes_alternate_collection_owner(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-alternate-owner-test"
+        collection = "export_waveforms"
+        s3_client.create_bucket(Bucket=bucket)
+
+        with patch.object(Database, "_complete_object_store_stage", return_value=False):
+            saved = self.db.save_data(
+                get_live_timeseries(),
+                collection=collection,
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                return_data=True,
+                save_history=False,
+            )
+
+        stage = self.db["object_store_staging"].find_one(
+            {"waveform_collection": collection, "waveform_id": saved["_id"]}
+        )
+        assert stage is not None
+        assert self.db[collection].find_one({"_id": saved["_id"]})
+        uri = "s3://{}/{}".format(bucket, stage["object_store"]["object_name"])
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert report == {
+            "committed": [uri],
+            "uncommitted": [],
+            "deleted": [],
+            "failures": [],
+        }
+        assert self.db["object_store_staging"].find_one({"_id": stage["_id"]}) is None
+        response = s3_client.get_object(
+            Bucket=bucket, Key=stage["object_store"]["object_name"]
+        )
+        response["Body"].close()
+
+        self.db[collection].delete_one({"_id": saved["_id"]})
+        s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+        self.db[collection].drop()
 
     @mock_aws
     def test_object_store_lite_schema_round_trip(self):

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -664,6 +664,31 @@ class TestDatabase:
         ensemble.member.append(get_live_timeseries())
         ensemble.member.append(get_live_timeseries())
         ensemble.set_live()
+        storage_keys = (
+            "storage_mode",
+            "object_store",
+            "gridfs_id",
+            "dir",
+            "dfile",
+            "foff",
+            "url",
+            "format",
+            "nbytes",
+        )
+        for index, member in enumerate(ensemble.member):
+            member["storage_mode"] = "gridfs"
+            member["object_store"] = {"old": index}
+            member["gridfs_id"] = ObjectId()
+            member["dir"] = "/old/{}".format(index)
+            member["dfile"] = "old-{}.dat".format(index)
+            member["foff"] = index
+            member["url"] = "https://old.example/{}".format(index)
+            member["format"] = "old-format"
+            member["nbytes"] = index + 1
+        original_storage_metadata = [
+            {key: copy.deepcopy(member[key]) for key in storage_keys}
+            for member in ensemble.member
+        ]
         object_store_client = Mock()
         object_store_client.put_object.side_effect = [
             {},
@@ -688,7 +713,10 @@ class TestDatabase:
         assert {(deletion["Bucket"], deletion["Key"]) for deletion in deletions} == {
             (upload["Bucket"], upload["Key"]) for upload in uploads
         }
-        assert "object_store" not in ensemble.member[0]
+        for member, original_metadata in zip(
+            ensemble.member, original_storage_metadata
+        ):
+            assert {key: member[key] for key in storage_keys} == original_metadata
 
     def test_object_store_compensation_reports_unreconciled_object(self):
         ensemble = TimeSeriesEnsemble()
@@ -714,6 +742,10 @@ class TestDatabase:
                 {"provider": "s3", "bucket": "test-bucket"},
                 object_store_client,
             )
+        for member in ensemble.member:
+            assert member["storage_mode"] == "object_store"
+            assert member["object_store"]["bucket"] == "test-bucket"
+            assert member["object_store"]["object_name"]
 
     @mock_aws
     def test_object_store_mongodb_failure_is_compensated(self):
@@ -730,6 +762,29 @@ class TestDatabase:
             )
             s3_client.create_bucket(Bucket=bucket)
             datum = get_live_timeseries()
+            datum["storage_mode"] = "gridfs"
+            datum["gridfs_id"] = ObjectId()
+            datum["dir"] = "/old"
+            datum["dfile"] = "old.dat"
+            datum["foff"] = 123
+            datum["url"] = "https://old.example/data"
+            datum["format"] = "old-format"
+            datum["nbytes"] = 456
+            storage_keys = (
+                "storage_mode",
+                "object_store",
+                "gridfs_id",
+                "dir",
+                "dfile",
+                "foff",
+                "url",
+                "format",
+                "nbytes",
+            )
+            original_storage_metadata = {
+                key: (key in datum, copy.deepcopy(datum[key]) if key in datum else None)
+                for key in storage_keys
+            }
             if save_history:
                 logging_helper.info(datum, "history-test", "test_save_data")
             if add_elog:
@@ -753,11 +808,116 @@ class TestDatabase:
                     )
 
             assert s3_client.list_objects_v2(Bucket=bucket)["KeyCount"] == 0
+            for key, (was_defined, value) in original_storage_metadata.items():
+                assert (key in datum) is was_defined
+                if was_defined:
+                    assert datum[key] == value
 
     @mock_aws
-    def test_update_data_rejects_object_store_and_ignores_stale_gridfs_id(self):
+    def test_update_data_rejects_persisted_object_store_after_metadata_tampering(
+        self,
+    ):
         s3_client = boto3.client("s3", region_name="us-east-1")
         bucket = "mspass-object-store-update-test"
+        s3_client.create_bucket(Bucket=bucket)
+        for tampering in (
+            "change",
+            "erase",
+            "erase_all_storage_fields",
+            "persisted_mode_changed",
+        ):
+            saved = self.db.save_data(
+                get_live_timeseries(),
+                storage_mode="object_store",
+                object_store={"provider": "s3", "bucket": bucket},
+                object_store_client=s3_client,
+                return_data=True,
+                save_history=False,
+            )
+            original_document = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+            original_location = copy.deepcopy(original_document["object_store"])
+            if tampering == "persisted_mode_changed":
+                self.db["wf_TimeSeries"].update_one(
+                    {"_id": saved["_id"]}, {"$set": {"storage_mode": "gridfs"}}
+                )
+                original_document = self.db["wf_TimeSeries"].find_one(
+                    {"_id": saved["_id"]}
+                )
+            original_gridfs_count = self.db["fs.files"].count_documents({})
+            if tampering == "change":
+                saved["storage_mode"] = "gridfs"
+            else:
+                saved.erase("storage_mode")
+            if tampering in ("erase_all_storage_fields", "persisted_mode_changed"):
+                saved.erase("object_store")
+
+            with pytest.raises(ValueError, match="does not support sample updates"):
+                self.db.update_data(saved, save_history=False)
+
+            assert (
+                self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+                == original_document
+            )
+            assert self.db["fs.files"].count_documents({}) == original_gridfs_count
+            response = s3_client.get_object(
+                Bucket=original_location["bucket"],
+                Key=original_location["object_name"],
+            )
+            response["Body"].close()
+
+    @mock_aws
+    def test_delete_data_removes_object_store_samples_last(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-delete-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        logging_helper.info(datum, "delete-test", "test_delete_data")
+        datum.elog.log_error(
+            "test_delete_data", "delete lifecycle", ErrorSeverity.Complaint
+        )
+        saved = self.db.save_data(
+            datum,
+            storage_mode="object_store",
+            object_store={"provider": "s3", "bucket": bucket},
+            object_store_client=s3_client,
+            return_data=True,
+            save_history=True,
+        )
+        document = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        location = document["object_store"]
+
+        with pytest.raises(ValueError, match="object_store_client is required"):
+            self.db.delete_data(
+                saved["_id"],
+                "TimeSeries",
+                remove_unreferenced_files=True,
+            )
+        assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) == document
+        assert self.db["history_object"].find_one(
+            {"_id": document["history_object_id"]}
+        )
+        assert self.db["elog"].find_one({"_id": document["elog_id"]})
+
+        self.db.delete_data(
+            saved["_id"],
+            "TimeSeries",
+            remove_unreferenced_files=True,
+            object_store_client=s3_client,
+        )
+        assert not self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+        assert not self.db["history_object"].find_one(
+            {"_id": document["history_object_id"]}
+        )
+        assert not self.db["elog"].find_one({"_id": document["elog_id"]})
+        with pytest.raises(botocore.exceptions.ClientError):
+            s3_client.head_object(
+                Bucket=location["bucket"], Key=location["object_name"]
+            )
+
+    @mock_aws
+    def test_delete_data_retains_waveform_when_object_store_delete_fails(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-delete-failure-test"
         s3_client.create_bucket(Bucket=bucket)
         saved = self.db.save_data(
             get_live_timeseries(),
@@ -767,18 +927,27 @@ class TestDatabase:
             return_data=True,
             save_history=False,
         )
-        gfsh = gridfs.GridFS(self.db)
-        unrelated_gridfs_id = gfsh.put(b"unrelated")
-        saved["gridfs_id"] = unrelated_gridfs_id
-
-        with pytest.raises(ValueError, match="does not support sample updates"):
-            self.db.update_data(saved, save_history=False)
-
-        assert gfsh.exists(unrelated_gridfs_id)
         document = self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]})
-        assert document["storage_mode"] == "object_store"
-        assert document["object_store"] == saved["object_store"]
-        gfsh.delete(unrelated_gridfs_id)
+        failing_client = Mock()
+        failing_client.delete_object.side_effect = (
+            botocore.exceptions.EndpointConnectionError(
+                endpoint_url="https://s3.invalid"
+            )
+        )
+
+        with pytest.raises(MsPASSError, match="waveform document was retained"):
+            self.db.delete_data(
+                saved["_id"],
+                "TimeSeries",
+                object_store_client=failing_client,
+            )
+
+        assert self.db["wf_TimeSeries"].find_one({"_id": saved["_id"]}) == document
+        location = document["object_store"]
+        response = s3_client.get_object(
+            Bucket=location["bucket"], Key=location["object_name"]
+        )
+        response["Body"].close()
 
     @mock_aws
     def test_object_store_lite_schema_round_trip(self):

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -1509,7 +1509,6 @@ class TestDatabase:
 
         self.db[collection].delete_one({"_id": saved["_id"]})
         s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
-        self.db[collection].drop()
 
     @mock_aws
     def test_object_store_lite_schema_round_trip(self):

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -855,10 +855,19 @@ class TestDatabase:
         datum["_id"] = old_waveform_id
         datum["storage_mode"] = "gridfs"
         datum["gridfs_id"] = old_gridfs_id
+        old_history_id = ObjectId()
+        old_elog_id = ObjectId()
+        old_delete_token = ObjectId()
+        datum["history_object_id"] = old_history_id
+        datum["elog_id"] = old_elog_id
+        datum["_mspass_delete_token"] = old_delete_token
         old_waveform = {
             "_id": old_waveform_id,
             "storage_mode": "gridfs",
             "gridfs_id": old_gridfs_id,
+            "history_object_id": old_history_id,
+            "elog_id": old_elog_id,
+            "_mspass_delete_token": old_delete_token,
         }
         self.db["wf_TimeSeries"].insert_one(copy.deepcopy(old_waveform))
         allow_upload = threading.Event()
@@ -907,6 +916,9 @@ class TestDatabase:
             assert datum["_id"] != old_waveform_id
             assert datum["storage_mode"] == "object_store"
             assert datum["object_store"] == stage["object_store"]
+            assert "history_object_id" not in datum
+            assert "elog_id" not in datum
+            assert "_mspass_delete_token" not in datum
             tracking_client.delete_object.assert_not_called()
             with pytest.raises(botocore.exceptions.ClientError):
                 s3_client.head_object(
@@ -1990,6 +2002,7 @@ class TestDatabase:
                     (
                         collection.name,
                         collection.read_preference,
+                        collection.read_concern.level,
                         collection.write_concern.document,
                     )
                 )
@@ -2001,6 +2014,7 @@ class TestDatabase:
                     (
                         collection.name,
                         collection.read_preference,
+                        collection.read_concern.level,
                         collection.write_concern.document,
                     )
                 )
@@ -2019,21 +2033,24 @@ class TestDatabase:
                 return_data=True,
             )
 
-        assert {name for name, _, _ in write_options} == {
+        assert {name for name, _, _, _ in write_options} == {
             "object_store_staging",
             "history_object",
             "elog",
             "wf_TimeSeries",
         }
-        for _, read_preference, write_concern in write_options:
+        for _, read_preference, read_concern, write_concern in write_options:
             assert read_preference == pymongo.ReadPreference.PRIMARY
+            assert read_concern == "majority"
             assert write_concern == {"w": "majority"}
 
         original_find_one = Collection.find_one
         read_options = []
 
         def capture_find(collection, *args, **kwargs):
-            read_options.append(collection.read_preference)
+            read_options.append(
+                (collection.read_preference, collection.read_concern.level)
+            )
             return original_find_one(collection, *args, **kwargs)
 
         lifecycle_delete_options = []
@@ -2044,6 +2061,7 @@ class TestDatabase:
                 (
                     collection.name,
                     collection.read_preference,
+                    collection.read_concern.level,
                     collection.write_concern.document,
                 )
             )
@@ -2054,6 +2072,7 @@ class TestDatabase:
                 (
                     collection.name,
                     collection.read_preference,
+                    collection.read_concern.level,
                     collection.write_concern.document,
                 )
             )
@@ -2077,15 +2096,22 @@ class TestDatabase:
         assert read_options
         assert all(
             read_preference == pymongo.ReadPreference.PRIMARY
-            for read_preference in read_options
+            and read_concern == "majority"
+            for read_preference, read_concern in read_options
         )
-        assert {name for name, _, _ in lifecycle_delete_options} == {
+        assert {name for name, _, _, _ in lifecycle_delete_options} == {
             "history_object",
             "elog",
             "wf_TimeSeries",
         }
-        for _, read_preference, write_concern in lifecycle_delete_options:
+        for (
+            _,
+            read_preference,
+            read_concern,
+            write_concern,
+        ) in lifecycle_delete_options:
             assert read_preference == pymongo.ReadPreference.PRIMARY
+            assert read_concern == "majority"
             assert write_concern == {"w": "majority"}
 
     @mock_aws
@@ -2156,10 +2182,24 @@ class TestDatabase:
         )
         response["Body"].close()
 
-        self.db[collection].delete_one({"_id": saved["_id"]})
-        self.db[history_plan["collection"]].delete_one({"_id": history_plan["_id"]})
-        self.db[elog_plan["collection"]].delete_one({"_id": elog_plan["_id"]})
-        s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+        self.db.delete_data(
+            saved["_id"],
+            "TimeSeries",
+            collection=collection,
+            object_store_client=s3_client,
+        )
+        assert self.db[collection].find_one({"_id": saved["_id"]}) is None
+        assert (
+            self.db[history_plan["collection"]].find_one({"_id": history_plan["_id"]})
+            is None
+        )
+        assert (
+            self.db[elog_plan["collection"]].find_one({"_id": elog_plan["_id"]}) is None
+        )
+        with pytest.raises(botocore.exceptions.ClientError):
+            s3_client.head_object(
+                Bucket=bucket, Key=stage["object_store"]["object_name"]
+            )
 
     @mock_aws
     def test_object_store_lite_schema_round_trip(self):
@@ -3755,6 +3795,49 @@ class TestDatabase:
         # file not exists
         fname = os.path.join(res2["dir"], res2["dfile"])
         assert not os.path.exists(fname)
+
+    def test_delete_literal_collection_preserves_shared_file(self, tmp_path):
+        collection = "export_file_waveforms"
+        dfile = "shared.bin"
+        first = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="file",
+            dir=str(tmp_path),
+            dfile=dfile,
+            collection=collection,
+            save_history=False,
+            return_data=True,
+        )
+        second = self.db.save_data(
+            get_live_timeseries(),
+            storage_mode="file",
+            dir=str(tmp_path),
+            dfile=dfile,
+            collection=collection,
+            save_history=False,
+            return_data=True,
+        )
+        path = tmp_path / dfile
+        assert path.exists()
+
+        self.db.delete_data(
+            first["_id"],
+            "TimeSeries",
+            collection=collection,
+            remove_unreferenced_files=True,
+        )
+        assert path.exists()
+        assert self.db[collection].find_one({"_id": first["_id"]}) is None
+        assert self.db[collection].find_one({"_id": second["_id"]}) is not None
+
+        self.db.delete_data(
+            second["_id"],
+            "TimeSeries",
+            collection=collection,
+            remove_unreferenced_files=True,
+        )
+        assert not path.exists()
+        assert self.db[collection].find_one({"_id": second["_id"]}) is None
 
     def test_clean_collection(self):
         # clear all the wf collection documents

--- a/python/tests/db/test_database.py
+++ b/python/tests/db/test_database.py
@@ -12,6 +12,7 @@ import pymongo.errors
 import pytest
 import sys
 import re
+import threading
 
 import boto3
 from moto import mock_aws
@@ -914,7 +915,9 @@ class TestDatabase:
             return original_insert_one(collection, document, *args, **kwargs)
 
         with patch.object(Collection, "insert_one", new=insert_then_raise):
-            with pytest.raises(MsPASSError, match="reference became durable"):
+            with pytest.raises(
+                MsPASSError, match="could not determine whether.*committed"
+            ):
                 self.db.save_data(
                     datum,
                     storage_mode="object_store",
@@ -953,6 +956,89 @@ class TestDatabase:
             Bucket=bucket, Key=stage["object_store"]["object_name"]
         )
         response["Body"].close()
+        self.db["wf_TimeSeries"].delete_one({"_id": stage["waveform_id"]})
+        s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
+
+    @mock_aws
+    def test_object_store_inflight_waveform_insert_is_not_compensated(self):
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        bucket = "mspass-object-store-inflight-insert-test"
+        s3_client.create_bucket(Bucket=bucket)
+        datum = get_live_timeseries()
+        original_insert_one = Collection.insert_one
+        allow_insert = threading.Event()
+        worker = None
+        worker_errors = []
+
+        def insert_later(collection, document):
+            try:
+                if not allow_insert.wait(timeout=10):
+                    raise TimeoutError("test did not release delayed waveform insert")
+                original_insert_one(collection, document)
+            except BaseException as error:
+                worker_errors.append(error)
+
+        def start_insert_then_raise(collection, document, *args, **kwargs):
+            nonlocal worker
+            if collection.name == "wf_TimeSeries":
+                worker = threading.Thread(
+                    target=insert_later,
+                    args=(collection, copy.deepcopy(document)),
+                    name="delayed-waveform-insert",
+                )
+                worker.start()
+                raise pymongo.errors.AutoReconnect("waveform result unknown")
+            return original_insert_one(collection, document, *args, **kwargs)
+
+        stage = None
+        try:
+            with patch.object(Collection, "insert_one", new=start_insert_then_raise):
+                with pytest.raises(
+                    MsPASSError, match="could not determine whether.*committed"
+                ):
+                    self.db.save_data(
+                        datum,
+                        storage_mode="object_store",
+                        object_store={"provider": "s3", "bucket": bucket},
+                        object_store_client=s3_client,
+                        save_history=False,
+                    )
+
+            stage = self.db["object_store_staging"].find_one(
+                {"object_store.bucket": bucket}
+            )
+            assert stage is not None
+            assert (
+                self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]}) is None
+            )
+            response = s3_client.get_object(
+                Bucket=bucket, Key=stage["object_store"]["object_name"]
+            )
+            response["Body"].close()
+        finally:
+            allow_insert.set()
+            if worker is not None:
+                worker.join(timeout=10)
+
+        assert worker is not None
+        assert not worker.is_alive()
+        assert worker_errors == []
+        assert stage is not None
+        waveform = self.db["wf_TimeSeries"].find_one({"_id": stage["waveform_id"]})
+        assert waveform
+        assert datum["storage_mode"] == "object_store"
+        assert datum["object_store"] == stage["object_store"]
+        response = s3_client.get_object(
+            Bucket=bucket, Key=stage["object_store"]["object_name"]
+        )
+        response["Body"].close()
+
+        report = self.db.reconcile_object_store_staging(
+            s3_client, delete_uncommitted=True
+        )
+        assert len(report["committed"]) == 1
+        assert report["deleted"] == []
+        assert report["failures"] == []
         self.db["wf_TimeSeries"].delete_one({"_id": stage["waveform_id"]})
         s3_client.delete_object(Bucket=bucket, Key=stage["object_store"]["object_name"])
 

--- a/python/tests/db/test_delete_data_cleanup_order.py
+++ b/python/tests/db/test_delete_data_cleanup_order.py
@@ -165,9 +165,9 @@ def test_child_cleanup_failure_keeps_parent_and_retry_finishes_deletion(
             )
 
     assert error.value is failure
-    assert (
-        database[collection].find_one({"_id": graph.parent_id}) == graph.parent_document
-    )
+    retained_parent = database[collection].find_one({"_id": graph.parent_id})
+    assert isinstance(retained_parent.pop("_mspass_delete_token"), ObjectId)
+    assert retained_parent == graph.parent_document
     assert sample_exists(database, graph)
     assert bool(database["history_object"].find_one({"_id": graph.history_id})) is (
         failure_stage == "history"

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -1,12 +1,19 @@
 import os
+import copy
 import pickle
+import threading
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import gridfs
+import dask
+import dask.bag
 import numpy as np
+import pymongo
 import pytest
+from bson import Binary, ObjectId
 
 from mspasspy.ccore.seismic import (
     DoubleVector,
@@ -127,6 +134,7 @@ def test_successful_overwrite_commits_new_reference_before_removing_old_blob(
     new_gridfs_id = document["gridfs_id"]
     assert result is datum
     assert database[collection].count_documents({}) == 1
+    assert database["gridfs_staging"].count_documents({}) == 0
     if entrypoint == "save_data":
         assert database["history_object"].count_documents({}) == 0
     assert new_gridfs_id == datum["gridfs_id"]
@@ -204,6 +212,601 @@ def test_update_uses_persisted_gridfs_id_when_caller_metadata_loses_it(
     assert storage.exists(document["gridfs_id"])
 
 
+def test_update_rejects_stale_secondary_object_store_owner_before_side_effects(
+    database, monkeypatch
+):
+    waveform_id = ObjectId()
+    location = {
+        "provider": "s3",
+        "bucket": "existing-bucket",
+        "object_name": "existing-object.bin",
+        "encoding": "float64-le-v1",
+    }
+    database["wf_TimeSeries"].insert_one(
+        {
+            "_id": waveform_id,
+            "storage_mode": "object_store",
+            "object_store": location,
+        }
+    )
+    datum = make_timeseries([5.0, 6.0, 7.0, 8.0])
+    datum["_id"] = waveform_id
+    configured_database = Database(
+        database.client,
+        database.name,
+        read_preference=pymongo.ReadPreference.SECONDARY_PREFERRED,
+        write_concern=pymongo.write_concern.WriteConcern(w=1),
+    )
+    original_find_one = Collection.find_one
+    owner_reads = []
+
+    def stale_secondary_find(collection, query, *args, **kwargs):
+        if collection.name == "wf_TimeSeries" and query == {"_id": waveform_id}:
+            owner_reads.append(collection.read_preference)
+            if collection.read_preference != pymongo.ReadPreference.PRIMARY:
+                return None
+        return original_find_one(collection, query, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "find_one", stale_secondary_find)
+    counts_before = {
+        name: database[name].count_documents({})
+        for name in ("wf_TimeSeries", "history_object", "elog", "fs.files")
+    }
+
+    with pytest.raises(ValueError, match="persisted object_store"):
+        configured_database.update_data(datum, save_history=True)
+
+    assert owner_reads == [pymongo.ReadPreference.PRIMARY]
+    assert database["wf_TimeSeries"].find_one({"_id": waveform_id}) == {
+        "_id": waveform_id,
+        "storage_mode": "object_store",
+        "object_store": location,
+    }
+    assert {
+        name: database[name].count_documents({})
+        for name in ("wf_TimeSeries", "history_object", "elog", "fs.files")
+    } == counts_before
+
+
+def test_update_rejects_nonexistent_waveform_before_side_effects(database):
+    datum = make_timeseries([5.0, 6.0, 7.0, 8.0])
+    datum["_id"] = ObjectId()
+    datum["storage_mode"] = "gridfs"
+    counts_before = {
+        name: database[name].count_documents({})
+        for name in ("wf_TimeSeries", "history_object", "elog", "fs.files")
+    }
+
+    with pytest.raises(ValueError, match="could not find the persisted waveform"):
+        database.update_data(datum, mode="promiscuous", save_history=True)
+
+    assert datum["storage_mode"] == "gridfs"
+    assert "gridfs_id" not in datum
+    assert {
+        name: database[name].count_documents({})
+        for name in ("wf_TimeSeries", "history_object", "elog", "fs.files")
+    } == counts_before
+
+
+@pytest.mark.parametrize(
+    "persisted_mode,pointers",
+    [
+        ("file", {"dir": "/tmp", "dfile": "old.dat", "foff": 32}),
+        ("url", {"url": "https://example.invalid/old-data"}),
+    ],
+)
+def test_update_transition_uses_gridfs_mode_despite_tampered_caller(
+    database, persisted_mode, pointers
+):
+    waveform_id = ObjectId()
+    database["wf_TimeSeries"].insert_one(
+        {"_id": waveform_id, "storage_mode": persisted_mode, **pointers}
+    )
+    datum = make_timeseries([5.0, 6.0, 7.0, 8.0])
+    datum["_id"] = waveform_id
+    datum["storage_mode"] = "gridfs"
+
+    database.update_data(datum, mode="promiscuous", save_history=False)
+
+    document = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+    assert document["storage_mode"] == "gridfs"
+    assert document["gridfs_id"] == datum["gridfs_id"]
+    for pointer in ("object_store", "dir", "dfile", "foff", "url"):
+        assert pointer not in document
+    assert gridfs.GridFS(database).exists(document["gridfs_id"])
+
+
+def test_gridfs_stage_insert_failure_restores_update_caller(database, monkeypatch):
+    waveform_id = ObjectId()
+    database["wf_TimeSeries"].insert_one(
+        {
+            "_id": waveform_id,
+            "storage_mode": "file",
+            "dir": "/old",
+            "dfile": "old.dat",
+            "foff": 12,
+        }
+    )
+    datum = make_timeseries([5.0, 6.0, 7.0, 8.0])
+    datum["_id"] = waveform_id
+    datum["storage_mode"] = "file"
+    datum["dir"] = "/old"
+    datum["dfile"] = "old.dat"
+    datum["foff"] = 12
+    original_insert_one = Collection.insert_one
+
+    def fail_stage_insert(collection, document, *args, **kwargs):
+        if collection.name == "gridfs_staging":
+            raise RuntimeError("injected stage insert failure")
+        return original_insert_one(collection, document, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "insert_one", fail_stage_insert)
+    with pytest.raises(RuntimeError, match="stage insert failure"):
+        database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert datum["storage_mode"] == "file"
+    assert datum["dir"] == "/old"
+    assert datum["dfile"] == "old.dat"
+    assert datum["foff"] == 12
+    assert "gridfs_id" not in datum
+    assert database["fs.files"].count_documents({}) == 0
+
+
+def test_gridfs_stage_insert_failure_restores_new_save_caller(database, monkeypatch):
+    datum = make_timeseries([5.0, 6.0, 7.0, 8.0])
+    datum["storage_mode"] = "file"
+    datum["dir"] = "/old"
+    datum["dfile"] = "old.dat"
+    datum["foff"] = 12
+    original_insert_one = Collection.insert_one
+
+    def fail_stage_insert(collection, document, *args, **kwargs):
+        if collection.name == "gridfs_staging":
+            raise RuntimeError("injected stage insert failure")
+        return original_insert_one(collection, document, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "insert_one", fail_stage_insert)
+    with pytest.raises(RuntimeError, match="stage insert failure"):
+        database.save_data(
+            datum,
+            mode="promiscuous",
+            storage_mode="gridfs",
+            save_history=False,
+            return_data=True,
+        )
+
+    assert datum["storage_mode"] == "file"
+    assert datum["dir"] == "/old"
+    assert datum["dfile"] == "old.dat"
+    assert datum["foff"] == 12
+    assert "gridfs_id" not in datum
+    assert "_id" not in datum
+    assert database["fs.files"].count_documents({}) == 0
+
+
+def test_update_gridfs_pointer_lifecycle_forces_primary_and_majority(
+    database, monkeypatch
+):
+    datum = save_original(database, make_timeseries)
+    old_gridfs_id = datum["gridfs_id"]
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    configured_database = Database(
+        database.client,
+        database.name,
+        read_preference=pymongo.ReadPreference.SECONDARY_PREFERRED,
+        write_concern=pymongo.write_concern.WriteConcern(w=1),
+    )
+    original_find_one = Collection.find_one
+    original_update_one = Collection.update_one
+    original_put = gridfs.GridFS.put
+    owner_read_options = []
+    cas_options = []
+    gridfs_write_options = []
+
+    def capture_find(collection, query, *args, **kwargs):
+        if (
+            collection.name == "wf_TimeSeries"
+            and query == {"_id": datum["_id"]}
+            and args
+            and "storage_mode" in args[0]
+        ):
+            owner_read_options.append(collection.read_preference)
+        return original_find_one(collection, query, *args, **kwargs)
+
+    def capture_update(collection, query, update, *args, **kwargs):
+        new_gridfs_id = update.get("$set", {}).get("gridfs_id")
+        if collection.name == "wf_TimeSeries" and new_gridfs_id is not None:
+            cas_options.append(
+                (
+                    collection.read_preference,
+                    collection.write_concern.document,
+                )
+            )
+        return original_update_one(collection, query, update, *args, **kwargs)
+
+    def capture_put(handle, *args, **kwargs):
+        gridfs_write_options.append(
+            (
+                handle._files.read_preference,
+                handle._files.write_concern.document,
+            )
+        )
+        return original_put(handle, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "find_one", capture_find)
+    monkeypatch.setattr(Collection, "update_one", capture_update)
+    monkeypatch.setattr(gridfs.GridFS, "put", capture_put)
+
+    configured_database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert owner_read_options == [pymongo.ReadPreference.PRIMARY]
+    assert cas_options == [(pymongo.ReadPreference.PRIMARY, {"w": "majority"})]
+    assert gridfs_write_options == [(pymongo.ReadPreference.PRIMARY, {"w": "majority"})]
+    document = database["wf_TimeSeries"].find_one({"_id": datum["_id"]})
+    assert document["gridfs_id"] == datum["gridfs_id"]
+    assert document["gridfs_id"] != old_gridfs_id
+
+
+@pytest.mark.parametrize("eventual_commit", [True, False])
+def test_update_uncertain_cas_reconciles_samples_history_and_elog(
+    database, monkeypatch, eventual_commit
+):
+    datum = save_original(database, make_timeseries)
+    waveform_id = datum["_id"]
+    old_gridfs_id = datum["gridfs_id"]
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    datum.elog.log_error("test", "uncertain update elog", ErrorSeverity.Complaint)
+    original_update_one = Collection.update_one
+    release_update = threading.Event()
+    update_started = threading.Event()
+    update_threads = []
+
+    def delayed_uncertain_update(collection, query, update, *args, **kwargs):
+        new_gridfs_id = update.get("$set", {}).get("gridfs_id")
+        if (
+            collection.name == "wf_TimeSeries"
+            and new_gridfs_id is not None
+            and new_gridfs_id != old_gridfs_id
+        ):
+
+            def finish_update():
+                update_started.set()
+                if release_update.wait(timeout=10):
+                    original_update_one(collection, query, update, *args, **kwargs)
+
+            if eventual_commit:
+                thread = threading.Thread(target=finish_update)
+                thread.start()
+                update_threads.append(thread)
+                assert update_started.wait(timeout=5)
+            raise pymongo.errors.AutoReconnect("GridFS CAS result unknown")
+        return original_update_one(collection, query, update, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "update_one", delayed_uncertain_update)
+    try:
+        with pytest.raises(
+            MsPASSError, match="could not determine whether the GridFS replacement"
+        ) as error:
+            database.update_data(datum, mode="promiscuous", save_history=True)
+
+        assert error.value.severity == ErrorSeverity.Fatal
+        staged_gridfs_id = datum["gridfs_id"]
+        assert staged_gridfs_id != old_gridfs_id
+        storage = gridfs.GridFS(database)
+        assert storage.exists(old_gridfs_id)
+        assert storage.exists(staged_gridfs_id)
+        stage = database["gridfs_staging"].find_one(
+            {"waveform_id": waveform_id, "new_gridfs_id": staged_gridfs_id}
+        )
+        assert stage is not None
+        history_id = stage["auxiliary_documents"]["history"]["_id"]
+        elog_id = stage["auxiliary_documents"]["elog"]["_id"]
+        assert database["history_object"].find_one({"_id": history_id})
+        assert database["elog"].find_one({"_id": elog_id})
+        assert (
+            database["wf_TimeSeries"].find_one({"_id": waveform_id})["gridfs_id"]
+            == old_gridfs_id
+        )
+
+        if eventual_commit:
+            release_update.set()
+            for thread in update_threads:
+                thread.join(timeout=10)
+                assert not thread.is_alive()
+
+        report = database.reconcile_gridfs_staging(delete_uncommitted=True)
+        document = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+        if eventual_commit:
+            assert report["committed"] == [str(staged_gridfs_id)]
+            assert document["gridfs_id"] == staged_gridfs_id
+            assert not storage.exists(old_gridfs_id)
+            assert storage.exists(staged_gridfs_id)
+            assert document["history_object_id"] == history_id
+            assert document["elog_id"] == elog_id
+            assert (
+                database["history_object"].find_one({"_id": history_id})[
+                    "wf_TimeSeries_id"
+                ]
+                == waveform_id
+            )
+            assert (
+                database["elog"].find_one({"_id": elog_id})["wf_TimeSeries_id"]
+                == waveform_id
+            )
+        else:
+            assert report["deleted"] == [str(staged_gridfs_id)]
+            assert document["gridfs_id"] == old_gridfs_id
+            assert storage.exists(old_gridfs_id)
+            assert not storage.exists(staged_gridfs_id)
+            assert database["history_object"].find_one({"_id": history_id}) is None
+            assert database["elog"].find_one({"_id": elog_id}) is None
+        assert database["gridfs_staging"].find_one({"_id": stage["_id"]}) is None
+    finally:
+        release_update.set()
+        for thread in update_threads:
+            thread.join(timeout=10)
+
+
+def test_update_uncertain_gridfs_put_stages_before_auxiliary_writes(
+    database, monkeypatch
+):
+    datum = save_original(database, make_timeseries)
+    old_gridfs_id = datum["gridfs_id"]
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    datum.elog.log_error("test", "put uncertainty elog", ErrorSeverity.Complaint)
+    original_put = gridfs.GridFS.put
+
+    def put_then_lose_result(handle, *args, **kwargs):
+        original_put(handle, *args, **kwargs)
+        raise pymongo.errors.AutoReconnect("GridFS put result unknown")
+
+    monkeypatch.setattr(gridfs.GridFS, "put", put_then_lose_result)
+    with pytest.raises(MsPASSError, match="GridFS replacement"):
+        database.update_data(datum, mode="promiscuous", save_history=True)
+
+    staged_gridfs_id = datum["gridfs_id"]
+    stage = database["gridfs_staging"].find_one({"new_gridfs_id": staged_gridfs_id})
+    assert stage is not None
+    assert database["history_object"].count_documents({}) == 0
+    assert database["elog"].count_documents({}) == 0
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    assert gridfs.GridFS(database).exists(staged_gridfs_id)
+
+    report = database.reconcile_gridfs_staging()
+    assert report["uncommitted"] == [str(staged_gridfs_id)]
+    assert gridfs.GridFS(database).exists(staged_gridfs_id)
+    assert database["gridfs_staging"].find_one({"_id": stage["_id"]})
+
+    report = database.reconcile_gridfs_staging(delete_uncommitted=True)
+    assert report["deleted"] == [str(staged_gridfs_id)]
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    assert not gridfs.GridFS(database).exists(staged_gridfs_id)
+    assert database["gridfs_staging"].find_one({"_id": stage["_id"]}) is None
+
+
+def test_missing_old_elog_fallback_uses_staged_id_and_cleans_on_cas_miss(
+    database, monkeypatch
+):
+    datum = save_original(database, make_timeseries)
+    old_gridfs_id = datum["gridfs_id"]
+    missing_elog_id = ObjectId()
+    datum["elog_id"] = missing_elog_id
+    database["wf_TimeSeries"].update_one(
+        {"_id": datum["_id"]}, {"$set": {"elog_id": missing_elog_id}}
+    )
+    datum.elog.log_error("test", "missing old elog", ErrorSeverity.Complaint)
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    original_update_one = Collection.update_one
+
+    def miss_sample_cas(collection, query, update, *args, **kwargs):
+        if collection.name == "wf_TimeSeries" and "gridfs_id" in update.get("$set", {}):
+            return SimpleNamespace(matched_count=0)
+        return original_update_one(collection, query, update, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "update_one", miss_sample_cas)
+    with pytest.raises(MsPASSError, match="could not commit the new GridFS"):
+        database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert database["elog"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+    assert (
+        database["wf_TimeSeries"].find_one({"_id": datum["_id"]})["gridfs_id"]
+        == old_gridfs_id
+    )
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+
+
+def test_missing_old_elog_uncertain_fallback_insert_is_reconcilable(
+    database, monkeypatch
+):
+    datum = save_original(database, make_timeseries)
+    old_gridfs_id = datum["gridfs_id"]
+    missing_elog_id = ObjectId()
+    datum["elog_id"] = missing_elog_id
+    database["wf_TimeSeries"].update_one(
+        {"_id": datum["_id"]}, {"$set": {"elog_id": missing_elog_id}}
+    )
+    datum.elog.log_error("test", "uncertain elog fallback", ErrorSeverity.Complaint)
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    original_insert_one = Collection.insert_one
+
+    def insert_elog_then_lose_result(collection, document, *args, **kwargs):
+        result = original_insert_one(collection, document, *args, **kwargs)
+        if collection.name == "elog":
+            raise pymongo.errors.AutoReconnect("elog insert result unknown")
+        return result
+
+    monkeypatch.setattr(Collection, "insert_one", insert_elog_then_lose_result)
+    with pytest.raises(MsPASSError, match="GridFS replacement"):
+        database.update_data(datum, mode="promiscuous", save_history=False)
+
+    stage = database["gridfs_staging"].find_one({"waveform_id": datum["_id"]})
+    assert stage is not None
+    planned_elog_id = stage["auxiliary_documents"]["elog"]["_id"]
+    assert database["elog"].find_one({"_id": planned_elog_id})
+    assert database["elog"].count_documents({}) == 1
+    report = database.reconcile_gridfs_staging(delete_uncommitted=True)
+    assert report["deleted"] == [str(stage["new_gridfs_id"])]
+    assert database["elog"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+
+
+def test_durable_elog_replace_detects_concurrent_delete(database, monkeypatch):
+    datum = save_original(database, make_timeseries)
+    old_gridfs_id = datum["gridfs_id"]
+    old_elog_id = database["elog"].insert_one({"logdata": []}).inserted_id
+    datum["elog_id"] = old_elog_id
+    database["wf_TimeSeries"].update_one(
+        {"_id": datum["_id"]}, {"$set": {"elog_id": old_elog_id}}
+    )
+    datum.elog.log_error("test", "concurrent elog delete", ErrorSeverity.Complaint)
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    original_replace_one = Collection.replace_one
+    original_delete_one = Collection.delete_one
+
+    def delete_before_replace(collection, query, document, *args, **kwargs):
+        if collection.name == "elog":
+            original_delete_one(collection, query)
+        return original_replace_one(collection, query, document, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "replace_one", delete_before_replace)
+    with pytest.raises(MsPASSError, match="could not replace the existing elog"):
+        database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert database["elog"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+    assert (
+        database["wf_TimeSeries"].find_one({"_id": datum["_id"]})["gridfs_id"]
+        == old_gridfs_id
+    )
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+
+
+def test_new_gridfs_save_uncertain_delayed_waveform_insert_reconciles(
+    database, monkeypatch
+):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum.elog.log_error("test", "new save uncertainty", ErrorSeverity.Complaint)
+    original_insert_one = Collection.insert_one
+    release_insert = threading.Event()
+    insert_started = threading.Event()
+    insert_threads = []
+
+    def delayed_waveform_insert(collection, document, *args, **kwargs):
+        if collection.name == "wf_TimeSeries":
+
+            def finish_insert():
+                insert_started.set()
+                if release_insert.wait(timeout=10):
+                    original_insert_one(collection, document, *args, **kwargs)
+
+            thread = threading.Thread(target=finish_insert)
+            thread.start()
+            insert_threads.append(thread)
+            assert insert_started.wait(timeout=5)
+            raise pymongo.errors.AutoReconnect("waveform insert result unknown")
+        return original_insert_one(collection, document, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "insert_one", delayed_waveform_insert)
+    try:
+        with pytest.raises(MsPASSError, match="staged GridFS MongoDB save"):
+            database.save_data(
+                datum,
+                mode="promiscuous",
+                storage_mode="gridfs",
+                save_history=True,
+                return_data=True,
+            )
+
+        waveform_id = datum["_id"]
+        new_gridfs_id = datum["gridfs_id"]
+        stage = database["gridfs_staging"].find_one(
+            {"waveform_id": waveform_id, "new_gridfs_id": new_gridfs_id}
+        )
+        assert stage is not None
+        assert gridfs.GridFS(database).exists(new_gridfs_id)
+        assert database["wf_TimeSeries"].find_one({"_id": waveform_id}) is None
+
+        release_insert.set()
+        for thread in insert_threads:
+            thread.join(timeout=10)
+            assert not thread.is_alive()
+
+        report = database.reconcile_gridfs_staging(delete_uncommitted=True)
+        assert report["committed"] == [str(new_gridfs_id)]
+        document = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+        assert document["gridfs_id"] == new_gridfs_id
+        assert gridfs.GridFS(database).exists(new_gridfs_id)
+        assert database["gridfs_staging"].find_one({"_id": stage["_id"]}) is None
+    finally:
+        release_insert.set()
+        for thread in insert_threads:
+            thread.join(timeout=10)
+
+
+def test_known_partial_gridfs_put_failure_removes_chunks_and_stage(
+    database, monkeypatch
+):
+    datum = save_original(database, make_timeseries)
+    old_gridfs_id = datum["gridfs_id"]
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+
+    def write_chunk_then_fail(handle, *args, **kwargs):
+        staged_id = kwargs["_id"]
+        handle._chunks.insert_one(
+            {"files_id": staged_id, "n": 0, "data": Binary(b"partial")}
+        )
+        raise RuntimeError("known partial GridFS failure")
+
+    monkeypatch.setattr(gridfs.GridFS, "put", write_chunk_then_fail)
+    with pytest.raises(RuntimeError, match="known partial GridFS failure"):
+        database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert datum["gridfs_id"] == old_gridfs_id
+    assert (
+        database["fs.chunks"].count_documents({"files_id": {"$ne": old_gridfs_id}}) == 0
+    )
+    assert database["gridfs_staging"].count_documents({}) == 0
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+
+
+def test_compensation_delete_failure_retains_gridfs_recovery_identity(
+    database, monkeypatch
+):
+    datum = save_original(database, make_timeseries)
+    old_gridfs_id = datum["gridfs_id"]
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    original_update_one = Collection.update_one
+    original_delete = gridfs.GridFS.delete
+    staged_ids = []
+
+    def miss_reference_update(collection, query, update, *args, **kwargs):
+        new_gridfs_id = update.get("$set", {}).get("gridfs_id")
+        if collection.name == "wf_TimeSeries" and new_gridfs_id is not None:
+            staged_ids.append(new_gridfs_id)
+            return SimpleNamespace(matched_count=0)
+        return original_update_one(collection, query, update, *args, **kwargs)
+
+    def fail_staged_delete(handle, gridfs_id, *args, **kwargs):
+        if gridfs_id != old_gridfs_id:
+            raise RuntimeError("injected compensation delete failure")
+        return original_delete(handle, gridfs_id, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "update_one", miss_reference_update)
+    monkeypatch.setattr(gridfs.GridFS, "delete", fail_staged_delete)
+    with pytest.raises(MsPASSError, match="could not fully compensate.*GridFS stage"):
+        database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert len(staged_ids) == 1
+    staged_gridfs_id = staged_ids[0]
+    assert datum["gridfs_id"] == staged_gridfs_id
+    stage = database["gridfs_staging"].find_one({"new_gridfs_id": staged_gridfs_id})
+    assert stage is not None
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    assert gridfs.GridFS(database).exists(staged_gridfs_id)
+
+
 @pytest.mark.parametrize("factory,collection", CASES)
 def test_update_gridfs_cas_rejects_concurrent_reference_change(
     database, monkeypatch, factory, collection
@@ -245,6 +848,36 @@ def test_update_gridfs_cas_rejects_concurrent_reference_change(
     assert storage.exists(old_gridfs_id)
     assert storage.exists(concurrent_gridfs_id)
     assert database["fs.files"].count_documents({}) == 2
+
+
+def test_gridfs_replacement_and_delete_preserve_shared_reference(database):
+    datum = save_original(database, make_timeseries)
+    old_gridfs_id = datum["gridfs_id"]
+    shared_waveform_id = (
+        database["wf_TimeSeries"]
+        .insert_one(
+            {
+                "storage_mode": "gridfs",
+                "gridfs_id": old_gridfs_id,
+                "npts": datum.npts,
+                "starttime": datum.t0,
+                "delta": datum.dt,
+            }
+        )
+        .inserted_id
+    )
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+
+    database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    assert (
+        database["wf_TimeSeries"].find_one({"_id": shared_waveform_id})["gridfs_id"]
+        == old_gridfs_id
+    )
+    database.delete_data(shared_waveform_id, "TimeSeries")
+    assert database["wf_TimeSeries"].find_one({"_id": shared_waveform_id}) is None
+    assert not gridfs.GridFS(database).exists(old_gridfs_id)
 
 
 @pytest.mark.parametrize("factory,collection", CASES)
@@ -341,9 +974,16 @@ def test_reference_compare_miss_removes_new_blob_without_overwriting_current_ref
     assert final_queries == [
         {
             "_id": waveform_id,
+            "_mspass_delete_token": {"$exists": False},
             "storage_mode": "gridfs",
             "object_store": {"$exists": False},
             "gridfs_id": old_gridfs_id,
+            "dir": {"$exists": False},
+            "dfile": {"$exists": False},
+            "foff": {"$exists": False},
+            "url": {"$exists": False},
+            "history_object_id": {"$exists": False},
+            "elog_id": {"$exists": False},
         }
     ]
     assert datum["gridfs_id"] == old_gridfs_id
@@ -487,6 +1127,47 @@ def test_save_schema_preflight_precedes_sample_write(database, monkeypatch):
     assert sample_writes == []
 
 
+def test_gridfs_schema_preflight_rejects_excluded_pointer(database):
+    with pytest.raises(ValueError, match="gridfs_id is excluded"):
+        database.save_data(
+            make_timeseries([1.0, 2.0, 3.0, 4.0]),
+            storage_mode="gridfs",
+            exclude_keys=["gridfs_id"],
+            mode="promiscuous",
+            return_data=True,
+        )
+
+    assert database["wf_TimeSeries"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+    assert database["fs.chunks"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_gridfs_schema_preflight_rejects_incapable_custom_schema(database):
+    custom_schema = copy.deepcopy(database.metadata_schema)
+    custom_schema.TimeSeries._main_dic.pop("gridfs_id")
+    custom_name = "test_gridfs_incapable_schema_" + uuid.uuid4().hex
+    custom_database = Database(
+        database.client,
+        custom_name,
+        db_schema=database.database_schema,
+        md_schema=custom_schema,
+    )
+    try:
+        with pytest.raises(ValueError, match="gridfs_id is undefined"):
+            custom_database.save_data(
+                make_timeseries([1.0, 2.0, 3.0, 4.0]),
+                storage_mode="gridfs",
+                mode="cautious",
+                return_data=True,
+            )
+        assert custom_database["wf_TimeSeries"].count_documents({}) == 0
+        assert custom_database["fs.files"].count_documents({}) == 0
+        assert custom_database["gridfs_staging"].count_documents({}) == 0
+    finally:
+        database.client.drop_database(custom_name)
+
+
 @pytest.mark.parametrize("factory,collection", CASES)
 def test_update_failure_preserves_history_and_removes_new_children(
     database, monkeypatch, factory, collection
@@ -561,36 +1242,38 @@ def test_history_resets_only_after_durable_waveform_references(
 
 
 @pytest.mark.parametrize("factory,collection", CASES)
-def test_save_history_link_miss_removes_created_resources(
+def test_save_history_is_prelinked_before_waveform_insert(
     database, monkeypatch, factory, collection
 ):
     datum = factory([1.0, 2.0, 3.0, 4.0])
-    history_before = _history_snapshot(datum)
-    original_update_one = Collection.update_one
+    original_insert_one = Collection.insert_one
+    observed_history_documents = []
 
-    def miss_history_link(self, query, update, *args, **kwargs):
-        if self.name == "history_object" and collection + "_id" in update.get(
-            "$set", {}
-        ):
-            return SimpleNamespace(matched_count=0)
-        return original_update_one(self, query, update, *args, **kwargs)
+    def capture_insert(target, document, *args, **kwargs):
+        if target.name == "history_object":
+            assert collection + "_id" in document
+            assert (
+                database[collection].find_one({"_id": document[collection + "_id"]})
+                is None
+            )
+            observed_history_documents.append(document.copy())
+        return original_insert_one(target, document, *args, **kwargs)
 
-    monkeypatch.setattr(Collection, "update_one", miss_history_link)
+    monkeypatch.setattr(Collection, "insert_one", capture_insert)
 
-    with pytest.raises(MsPASSError, match="could not link the saved history"):
-        database.save_data(
-            datum,
-            mode="promiscuous",
-            storage_mode="gridfs",
-            save_history=True,
-            return_data=True,
-        )
+    result = database.save_data(
+        datum,
+        mode="promiscuous",
+        storage_mode="gridfs",
+        save_history=True,
+        return_data=True,
+    )
 
-    assert _history_snapshot(datum) == history_before
-    assert "gridfs_id" not in datum
-    assert database[collection].count_documents({}) == 0
-    assert database["history_object"].count_documents({}) == 0
-    assert database["fs.files"].count_documents({}) == 0
+    assert result is datum
+    assert len(observed_history_documents) == 1
+    document = database[collection].find_one({"_id": datum["_id"]})
+    assert document["history_object_id"] == observed_history_documents[0]["_id"]
+    assert observed_history_documents[0][collection + "_id"] == datum["_id"]
 
 
 @pytest.mark.parametrize("factory,collection", CASES)
@@ -644,3 +1327,853 @@ def test_save_history_can_defer_reset_without_database_io(monkeypatch):
     assert history_id == "history-id"
     assert len(inserted_documents) == 1
     assert _history_snapshot(datum) == history_before
+
+
+def test_new_gridfs_save_does_not_inherit_auxiliary_pointers(database):
+    stale_history_id = database["history_object"].insert_one({"old": True}).inserted_id
+    stale_elog_id = database["elog"].insert_one({"logdata": []}).inserted_id
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum["history_object_id"] = stale_history_id
+    datum["elog_id"] = stale_elog_id
+
+    saved = database.save_data(
+        datum,
+        storage_mode="gridfs",
+        save_history=False,
+        return_data=True,
+    )
+
+    waveform = database["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+    assert "history_object_id" not in waveform
+    assert "elog_id" not in waveform
+    assert "history_object_id" not in saved
+    assert "elog_id" not in saved
+    assert database["history_object"].find_one({"_id": stale_history_id})
+    assert database["elog"].find_one({"_id": stale_elog_id})
+
+
+def test_update_uses_persisted_auxiliary_owners(database):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum.elog.log_error("test", "original elog", ErrorSeverity.Complaint)
+    datum = database.save_data(
+        datum,
+        storage_mode="gridfs",
+        save_history=True,
+        return_data=True,
+    )
+    waveform_before = database["wf_TimeSeries"].find_one({"_id": datum["_id"]})
+    original_history_id = waveform_before["history_object_id"]
+    original_elog_id = waveform_before["elog_id"]
+    unrelated_history_id = (
+        database["history_object"].insert_one({"other": True}).inserted_id
+    )
+    unrelated_elog = {"logdata": [{"marker": "unrelated"}]}
+    unrelated_elog_id = database["elog"].insert_one(unrelated_elog).inserted_id
+    datum["history_object_id"] = unrelated_history_id
+    datum["elog_id"] = unrelated_elog_id
+    datum.elog.clear()
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+
+    database.update_data(datum, mode="promiscuous", save_history=False)
+
+    waveform = database["wf_TimeSeries"].find_one({"_id": datum["_id"]})
+    assert waveform["history_object_id"] == original_history_id
+    assert waveform["elog_id"] == original_elog_id
+    assert datum["history_object_id"] == original_history_id
+    assert datum["elog_id"] == original_elog_id
+    assert database["history_object"].find_one({"_id": unrelated_history_id}) == {
+        "_id": unrelated_history_id,
+        "other": True,
+    }
+    assert database["elog"].find_one({"_id": unrelated_elog_id})["logdata"] == [
+        {"marker": "unrelated"}
+    ]
+
+
+@pytest.mark.parametrize("entrypoint", ["update", "overwrite"])
+def test_zero_length_replacement_preserves_old_gridfs_data(database, entrypoint):
+    datum = save_original(database, make_timeseries)
+    waveform_id = datum["_id"]
+    old_gridfs_id = datum["gridfs_id"]
+    old_document = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+    datum.data = DoubleVector()
+    datum.npts = 0
+    datum.set_live()
+
+    if entrypoint == "update":
+        with pytest.raises(MsPASSError, match="zero-length"):
+            database.update_data(datum, mode="promiscuous", save_history=False)
+    else:
+        result = database.save_data(
+            datum,
+            storage_mode="gridfs",
+            overwrite=True,
+            save_history=False,
+            return_data=True,
+        )
+        assert result.dead()
+
+    assert database["wf_TimeSeries"].find_one({"_id": waveform_id}) == old_document
+    assert gridfs.GridFS(database).exists(old_gridfs_id)
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_ensemble_overwrite_preserves_each_member_ownership(database):
+    members = []
+    original_ids = []
+    original_aux = []
+    for offset in (0.0, 10.0):
+        datum = make_timeseries([1.0 + offset, 2.0 + offset, 3.0 + offset])
+        datum.elog.log_error("test", "member", ErrorSeverity.Complaint)
+        datum = database.save_data(
+            datum,
+            storage_mode="gridfs",
+            save_history=True,
+            return_data=True,
+        )
+        datum.elog.clear()
+        members.append(datum)
+        original_ids.append(datum["_id"])
+        original_aux.append((datum["history_object_id"], datum["elog_id"]))
+    ensemble = TimeSeriesEnsemble()
+    for datum in members:
+        ensemble.member.append(datum)
+    ensemble.set_live()
+    ensemble["_id"] = members[0]["_id"]
+    ensemble["gridfs_id"] = members[0]["gridfs_id"]
+    ensemble["storage_mode"] = "gridfs"
+    ensemble["history_object_id"] = members[0]["history_object_id"]
+    ensemble["elog_id"] = members[0]["elog_id"]
+    replacements = ([20.0, 21.0, 22.0], [30.0, 31.0, 32.0])
+    for datum, values in zip(ensemble.member, replacements):
+        datum.data = make_timeseries(values).data
+
+    database.save_data(
+        ensemble,
+        storage_mode="gridfs",
+        overwrite=True,
+        save_history=False,
+        return_data=True,
+    )
+
+    for index, waveform_id in enumerate(original_ids):
+        waveform = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+        assert waveform["history_object_id"] == original_aux[index][0]
+        assert waveform["elog_id"] == original_aux[index][1]
+        reread = database.read_data(waveform_id, collection="wf_TimeSeries")
+        np.testing.assert_allclose(samples(reread), replacements[index])
+
+
+@pytest.mark.parametrize("entrypoint", ["update", "overwrite"])
+def test_gridfs_replacement_schema_preflight_rejects_excluded_pointer(
+    database, entrypoint
+):
+    datum = save_original(database, make_timeseries)
+    old_document = database["wf_TimeSeries"].find_one({"_id": datum["_id"]})
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+
+    with pytest.raises(ValueError, match="gridfs_id is excluded"):
+        if entrypoint == "update":
+            database.update_data(datum, mode="promiscuous", exclude_keys=["gridfs_id"])
+        else:
+            database.save_data(
+                datum,
+                storage_mode="gridfs",
+                overwrite=True,
+                mode="promiscuous",
+                exclude_keys=["gridfs_id"],
+            )
+
+    assert database["wf_TimeSeries"].find_one({"_id": datum["_id"]}) == old_document
+    assert database["fs.files"].count_documents({}) == 1
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+@pytest.mark.parametrize("entrypoint", ["update", "overwrite"])
+def test_gridfs_replacement_rejects_incapable_custom_schema(database, entrypoint):
+    custom_schema = copy.deepcopy(database.metadata_schema)
+    custom_schema.TimeSeries._main_dic.pop("gridfs_id")
+    custom_name = "test_gridfs_update_schema_" + uuid.uuid4().hex
+    custom_database = Database(
+        database.client,
+        custom_name,
+        db_schema=database.database_schema,
+        md_schema=custom_schema,
+    )
+    try:
+        datum = custom_database.save_data(
+            make_timeseries([1.0, 2.0, 3.0, 4.0]),
+            storage_mode="gridfs",
+            mode="promiscuous",
+            save_history=False,
+            return_data=True,
+        )
+        old_document = custom_database["wf_TimeSeries"].find_one({"_id": datum["_id"]})
+        datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+
+        with pytest.raises(ValueError, match="gridfs_id is undefined"):
+            if entrypoint == "update":
+                custom_database.update_data(datum, mode="cautious", save_history=False)
+            else:
+                custom_database.save_data(
+                    datum,
+                    storage_mode="gridfs",
+                    overwrite=True,
+                    mode="cautious",
+                    save_history=False,
+                )
+
+        assert (
+            custom_database["wf_TimeSeries"].find_one({"_id": datum["_id"]})
+            == old_document
+        )
+        assert custom_database["fs.files"].count_documents({}) == 1
+        assert custom_database["gridfs_staging"].count_documents({}) == 0
+    finally:
+        database.client.drop_database(custom_name)
+
+
+def test_gridfs_cleanup_stage_query_failure_retains_recovery_state(
+    database, monkeypatch
+):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    sample_failure = RuntimeError("injected sample failure")
+    query_failure = pymongo.errors.AutoReconnect("stage query unavailable")
+    original_find_one = Collection.find_one
+
+    def fail_sample_save(*args, **kwargs):
+        raise sample_failure
+
+    def fail_stage_query(self, *args, **kwargs):
+        if self.name == "gridfs_staging":
+            raise query_failure
+        return original_find_one(self, *args, **kwargs)
+
+    monkeypatch.setattr(Database, "_save_sample_data_to_gridfs", fail_sample_save)
+    monkeypatch.setattr(Collection, "find_one", fail_stage_query)
+
+    with pytest.raises(MsPASSError, match="could not fully compensate.*GridFS stage"):
+        database.save_data(
+            datum,
+            storage_mode="gridfs",
+            save_history=False,
+            return_data=True,
+        )
+
+    assert "_id" in datum
+    assert "gridfs_id" in datum
+    assert datum["storage_mode"] == "gridfs"
+
+
+def test_gridfs_cleanup_restores_caller_before_stage_cleanup_failure(
+    database, monkeypatch
+):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum["storage_mode"] = "file"
+    datum["dir"] = "/original"
+    datum["dfile"] = "original.dat"
+    snapshot = database._snapshot_object_store_metadata(datum)
+    waveform_id = ObjectId()
+    new_gridfs_id = ObjectId()
+    staged_auxiliary = {
+        "history": {"collection": "history_object", "_id": ObjectId()},
+        "elog": {"collection": "elog", "_id": ObjectId()},
+    }
+    stage = database._create_gridfs_stage(
+        "insert",
+        waveform_id,
+        "wf_TimeSeries",
+        new_gridfs_id,
+        staged_auxiliary,
+    )
+    database._gridfs_lifecycle_handle().put(b"staged", _id=new_gridfs_id)
+    for entry in staged_auxiliary.values():
+        database[entry["collection"]].insert_one({"_id": entry["_id"]})
+    datum["_id"] = waveform_id
+    datum["storage_mode"] = "gridfs"
+    datum["gridfs_id"] = new_gridfs_id
+    Database._normalize_storage_pointers(datum, "gridfs")
+    original_delete_one = Collection.delete_one
+
+    def fail_stage_delete(collection, query, *args, **kwargs):
+        if collection.name == "gridfs_staging":
+            return SimpleNamespace(deleted_count=0)
+        return original_delete_one(collection, query, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "delete_one", fail_stage_delete)
+
+    failures, retained = database._cleanup_gridfs_stage(stage, datum, snapshot)
+
+    assert failures
+    assert not retained
+    assert database._snapshot_object_store_metadata(datum) == snapshot
+    assert not gridfs.GridFS(database).exists(new_gridfs_id)
+    assert database["gridfs_staging"].find_one({"_id": stage["_id"]})
+    for entry in staged_auxiliary.values():
+        assert database[entry["collection"]].find_one({"_id": entry["_id"]}) is None
+
+    monkeypatch.undo()
+    report = database.reconcile_gridfs_staging(delete_uncommitted=True)
+    assert report["deleted"] == [str(new_gridfs_id)]
+    assert database["gridfs_staging"].find_one({"_id": stage["_id"]}) is None
+
+
+def test_durable_elog_failure_never_deletes_shared_gridfs_data(database, monkeypatch):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum.elog.log_error("test", "force elog", ErrorSeverity.Complaint)
+    failure = RuntimeError("injected elog failure after shared reference")
+
+    def create_shared_reference_then_fail(self, target, *args, **kwargs):
+        database["wf_TimeSeries"].insert_one(
+            {
+                "storage_mode": "gridfs",
+                "gridfs_id": target["gridfs_id"],
+            }
+        )
+        raise failure
+
+    monkeypatch.setattr(Database, "_save_elog", create_shared_reference_then_fail)
+
+    with pytest.raises(MsPASSError, match="could not fully compensate"):
+        database.save_data(
+            datum,
+            storage_mode="gridfs",
+            save_history=False,
+            return_data=True,
+        )
+
+    shared = database["wf_TimeSeries"].find_one({"gridfs_id": datum["gridfs_id"]})
+    assert shared is not None
+    assert gridfs.GridFS(database).exists(datum["gridfs_id"])
+    assert database["gridfs_staging"].count_documents({}) == 1
+
+
+def test_committed_stage_is_resolved_before_next_update(database, monkeypatch):
+    monkeypatch.setattr(Database, "_complete_gridfs_stage", lambda *args: False)
+    datum = database.save_data(
+        make_timeseries([1.0, 2.0, 3.0, 4.0]),
+        storage_mode="gridfs",
+        save_history=False,
+        return_data=True,
+    )
+    assert database["gridfs_staging"].count_documents({}) == 1
+    monkeypatch.undo()
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+
+    database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert database["gridfs_staging"].count_documents({}) == 0
+    reread = database.read_data(datum["_id"], collection="wf_TimeSeries")
+    np.testing.assert_allclose(samples(reread), [5.0, 6.0, 7.0, 8.0])
+
+
+def test_delete_resolves_committed_stage_and_honors_clear_flags(database, monkeypatch):
+    monkeypatch.setattr(Database, "_complete_gridfs_stage", lambda *args: False)
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum.elog.log_error("test", "retain me", ErrorSeverity.Complaint)
+    datum = database.save_data(
+        datum,
+        storage_mode="gridfs",
+        save_history=True,
+        return_data=True,
+    )
+    history_id = datum["history_object_id"]
+    elog_id = datum["elog_id"]
+    assert database["gridfs_staging"].count_documents({}) == 1
+    monkeypatch.undo()
+
+    database.delete_data(
+        datum["_id"],
+        "TimeSeries",
+        clear_history=False,
+        clear_elog=False,
+    )
+
+    assert database["wf_TimeSeries"].find_one({"_id": datum["_id"]}) is None
+    assert database["history_object"].find_one({"_id": history_id})
+    assert database["elog"].find_one({"_id": elog_id})
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_delete_claim_blocks_update_after_auxiliary_cleanup(database, monkeypatch):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum.elog.log_error("test", "delete claim elog", ErrorSeverity.Complaint)
+    datum = database.save_data(
+        datum,
+        storage_mode="gridfs",
+        save_history=True,
+        return_data=True,
+    )
+    waveform_id = datum["_id"]
+    history_id = datum["history_object_id"]
+    elog_id = datum["elog_id"]
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    original_delete = Database._delete_gridfs_id_if_unreferenced
+    update_was_rejected = False
+
+    def attempt_update_after_auxiliary_cleanup(handle, *args, **kwargs):
+        nonlocal update_was_rejected
+        assert database["history_object"].find_one({"_id": history_id}) is None
+        assert database["elog"].find_one({"_id": elog_id}) is None
+        with pytest.raises(MsPASSError, match="claimed by delete_data"):
+            database.update_data(datum, mode="promiscuous", save_history=False)
+        update_was_rejected = True
+        return original_delete(handle, *args, **kwargs)
+
+    monkeypatch.setattr(
+        Database,
+        "_delete_gridfs_id_if_unreferenced",
+        attempt_update_after_auxiliary_cleanup,
+    )
+
+    database.delete_data(waveform_id, "TimeSeries")
+
+    assert update_was_rejected
+    assert database["wf_TimeSeries"].find_one({"_id": waveform_id}) is None
+    assert database["fs.files"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_update_metadata_cannot_inject_or_bypass_delete_claim(database):
+    datum = save_original(database, make_timeseries)
+    waveform_id = datum["_id"]
+    datum["_mspass_delete_token"] = ObjectId()
+
+    with pytest.raises(ValueError, match="cannot change sample ownership"):
+        database.update_metadata(datum, mode="promiscuous")
+    database.update_metadata(
+        datum,
+        mode="promiscuous",
+        _lifecycle_managed=True,
+    )
+
+    document = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+    assert "_mspass_delete_token" not in document
+
+
+def test_file_metadata_repairs_remain_backward_compatible(database):
+    waveform_id = (
+        database["wf_TimeSeries"]
+        .insert_one(
+            {
+                "storage_mode": "file",
+                "dir": "/old",
+                "dfile": "old.dat",
+                "foff": 0,
+                "history_object_id": ObjectId(),
+            }
+        )
+        .inserted_id
+    )
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum["_id"] = waveform_id
+    datum["storage_mode"] = "file"
+    datum["dir"] = "/old"
+    datum["dfile"] = "old.dat"
+    datum["foff"] = 0
+    datum["history_object_id"] = ObjectId()
+    datum.clear_modified()
+    repaired_history_id = ObjectId()
+    datum["dir"] = "/repaired"
+    datum["dfile"] = "repaired.dat"
+    datum["foff"] = 128
+    datum["history_object_id"] = repaired_history_id
+
+    database.update_metadata(datum, mode="promiscuous")
+
+    document = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+    assert document["dir"] == "/repaired"
+    assert document["dfile"] == "repaired.dat"
+    assert document["foff"] == 128
+    assert document["history_object_id"] == repaired_history_id
+
+
+def test_new_waveform_does_not_inherit_delete_claim(database):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    datum["_mspass_delete_token"] = ObjectId()
+
+    saved = database.save_data(
+        datum,
+        storage_mode="gridfs",
+        mode="promiscuous",
+        save_history=False,
+        return_data=True,
+    )
+
+    document = database["wf_TimeSeries"].find_one({"_id": saved["_id"]})
+    assert "_mspass_delete_token" not in document
+    assert "_mspass_delete_token" not in saved
+
+
+def test_serial_gridfs_cremate_discards_live_zero_length(database):
+    datum = TimeSeries(0)
+    datum.set_live()
+
+    result = database.save_data(
+        datum,
+        storage_mode="gridfs",
+        mode="promiscuous",
+        cremate=True,
+        save_history=False,
+        return_data=True,
+    )
+
+    assert result.dead()
+    assert database["cemetery"].count_documents({}) == 0
+    assert database["wf_TimeSeries"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_serial_gridfs_cremate_removes_new_zero_length_ensemble_member(database):
+    ensemble = TimeSeriesEnsemble()
+    zero_length = TimeSeries(0)
+    zero_length.set_live()
+    zero_length["member_marker"] = "zero"
+    live_member = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    live_member["member_marker"] = "saved"
+    ensemble.member.extend([zero_length, live_member])
+    ensemble.set_live()
+
+    result = database.save_data(
+        ensemble,
+        storage_mode="gridfs",
+        mode="promiscuous",
+        cremate=True,
+        save_history=False,
+        return_data=True,
+    )
+
+    assert result.live
+    assert len(result.member) == 1
+    assert result.member[0].live
+    assert result.member[0]["member_marker"] == "saved"
+    assert database["cemetery"].count_documents({}) == 0
+    assert database["wf_TimeSeries"].count_documents({}) == 1
+    assert database["fs.files"].count_documents({}) == 1
+
+
+def test_serial_gridfs_cremate_removes_new_schema_rejection(database, monkeypatch):
+    ensemble = TimeSeriesEnsemble()
+    rejected = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    rejected["member_marker"] = "reject"
+    saved_member = make_timeseries([5.0, 6.0, 7.0, 8.0])
+    saved_member["member_marker"] = "saved"
+    ensemble.member.extend([rejected, saved_member])
+    ensemble.set_live()
+    original_md2doc = database_module.md2doc
+
+    def reject_marked(datum, *args, **kwargs):
+        if "member_marker" in datum and datum["member_marker"] == "reject":
+            return dict(datum), False, database_module.ErrorLogger()
+        return original_md2doc(datum, *args, **kwargs)
+
+    monkeypatch.setattr(database_module, "md2doc", reject_marked)
+
+    result = database.save_data(
+        ensemble,
+        storage_mode="gridfs",
+        mode="pedantic",
+        cremate=True,
+        save_history=False,
+        return_data=True,
+    )
+
+    assert result.live
+    assert len(result.member) == 1
+    assert result.member[0].live
+    assert result.member[0]["member_marker"] == "saved"
+    assert database["cemetery"].count_documents({}) == 0
+    assert database["wf_TimeSeries"].count_documents({}) == 1
+    assert database["fs.files"].count_documents({}) == 1
+
+
+def test_gridfs_ensemble_failure_restores_unattempted_member_storage(
+    database, monkeypatch
+):
+    ensemble = TimeSeriesEnsemble()
+    for offset in range(3):
+        ensemble.member.append(
+            make_timeseries([1.0 + offset, 2.0 + offset, 3.0 + offset])
+        )
+    ensemble.set_live()
+    ensemble.member[0]["storage_mode"] = "file"
+    ensemble.member[0]["dir"] = "/first"
+    ensemble.member[0]["dfile"] = "first.dat"
+    ensemble.member[1]["storage_mode"] = "url"
+    ensemble.member[1]["url"] = "https://example.invalid/second"
+    ensemble.member[2]["storage_mode"] = "object_store"
+    ensemble.member[2]["object_store"] = {
+        "provider": "s3",
+        "bucket": "third-bucket",
+        "object_name": "third.bin",
+        "encoding": "float64-le-v1",
+    }
+    ownership_keys = database_module._OBJECT_STORE_STORAGE_KEYS
+
+    def snapshot(datum):
+        return {
+            key: (True, copy.deepcopy(datum[key])) if key in datum else (False, None)
+            for key in ownership_keys
+        }
+
+    before_second = snapshot(ensemble.member[1])
+    before_third = snapshot(ensemble.member[2])
+    original_put = gridfs.GridFS.put
+    put_count = 0
+
+    def fail_second_put(handle, *args, **kwargs):
+        nonlocal put_count
+        put_count += 1
+        if put_count == 2:
+            raise RuntimeError("known second-member GridFS failure")
+        return original_put(handle, *args, **kwargs)
+
+    monkeypatch.setattr(gridfs.GridFS, "put", fail_second_put)
+
+    with pytest.raises(RuntimeError, match="second-member"):
+        database.save_data(
+            ensemble,
+            storage_mode="gridfs",
+            mode="promiscuous",
+            save_history=False,
+            return_data=True,
+        )
+
+    assert put_count == 2
+    assert snapshot(ensemble.member[1]) == before_second
+    assert snapshot(ensemble.member[2]) == before_third
+
+
+def test_file_delete_forces_primary_and_majority_lifecycle_options(
+    database, monkeypatch, tmp_path
+):
+    sample_file = Path(tmp_path) / "file-delete-majority.bin"
+    sample_file.write_bytes(b"samples")
+    history_id = database["history_object"].insert_one({"history": True}).inserted_id
+    elog_id = database["elog"].insert_one({"elog": True}).inserted_id
+    waveform_id = (
+        database["wf_TimeSeries"]
+        .insert_one(
+            {
+                "storage_mode": "file",
+                "dir": str(tmp_path),
+                "dfile": sample_file.name,
+                "foff": 0,
+                "history_object_id": history_id,
+                "elog_id": elog_id,
+            }
+        )
+        .inserted_id
+    )
+    configured_database = Database(
+        database.client,
+        database.name,
+        read_preference=pymongo.ReadPreference.SECONDARY_PREFERRED,
+        write_concern=pymongo.write_concern.WriteConcern(w=1),
+    )
+    original_delete_one = Collection.delete_one
+    original_delete_many = Collection.delete_many
+    original_count_documents = Collection.count_documents
+    delete_options = []
+    reference_reads = []
+
+    def capture_delete_one(collection, *args, **kwargs):
+        delete_options.append((collection.name, collection.write_concern.document))
+        return original_delete_one(collection, *args, **kwargs)
+
+    def capture_delete_many(collection, *args, **kwargs):
+        delete_options.append((collection.name, collection.write_concern.document))
+        return original_delete_many(collection, *args, **kwargs)
+
+    def capture_count(collection, *args, **kwargs):
+        if collection.name.startswith("wf_"):
+            reference_reads.append(collection.read_preference)
+        return original_count_documents(collection, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "delete_one", capture_delete_one)
+    monkeypatch.setattr(Collection, "delete_many", capture_delete_many)
+    monkeypatch.setattr(Collection, "count_documents", capture_count)
+
+    configured_database.delete_data(
+        waveform_id,
+        "TimeSeries",
+        remove_unreferenced_files=True,
+    )
+
+    assert not sample_file.exists()
+    assert {name for name, _ in delete_options} >= {
+        "wf_TimeSeries",
+        "history_object",
+        "elog",
+    }
+    assert all(options.get("w") == "majority" for _, options in delete_options)
+    assert reference_reads
+    assert all(
+        preference == pymongo.ReadPreference.PRIMARY for preference in reference_reads
+    )
+
+
+def test_metadata_update_started_before_delete_cannot_recreate_waveform(
+    database, monkeypatch
+):
+    datum = save_original(database, make_timeseries)
+    waveform_id = datum["_id"]
+    datum["concurrent_metadata"] = "must-not-upsert"
+    original_sync = Database._sync_metadata_before_update
+    delete_completed = False
+
+    def delete_between_primary_read_and_write(handle, target):
+        nonlocal delete_completed
+        if not delete_completed:
+            delete_completed = True
+            database.delete_data(waveform_id, "TimeSeries")
+        return original_sync(target)
+
+    monkeypatch.setattr(
+        Database,
+        "_sync_metadata_before_update",
+        delete_between_primary_read_and_write,
+    )
+
+    with pytest.raises(MsPASSError, match="could not find the persisted waveform"):
+        database.update_metadata(datum, mode="promiscuous")
+
+    assert delete_completed
+    assert database["wf_TimeSeries"].find_one({"_id": waveform_id}) is None
+    assert database["fs.files"].count_documents({}) == 0
+
+
+def test_gridfs_replacement_cas_binds_persisted_auxiliary_pointers(
+    database, monkeypatch
+):
+    datum = database.save_data(
+        make_timeseries([1.0, 2.0, 3.0, 4.0]),
+        storage_mode="gridfs",
+        save_history=True,
+        return_data=True,
+    )
+    waveform_id = datum["_id"]
+    old_gridfs_id = datum["gridfs_id"]
+    concurrent_history_id = (
+        database["history_object"].insert_one({"concurrent": True}).inserted_id
+    )
+    datum.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    original_update_one = Collection.update_one
+    concurrent_change_applied = False
+
+    def change_auxiliary_pointer_before_sample_cas(
+        collection, query, update, *args, **kwargs
+    ):
+        nonlocal concurrent_change_applied
+        new_gridfs_id = update.get("$set", {}).get("gridfs_id")
+        if (
+            collection.name == "wf_TimeSeries"
+            and new_gridfs_id is not None
+            and new_gridfs_id != old_gridfs_id
+            and not concurrent_change_applied
+        ):
+            concurrent_change_applied = True
+            original_update_one(
+                collection,
+                {"_id": waveform_id},
+                {"$set": {"history_object_id": concurrent_history_id}},
+            )
+        return original_update_one(collection, query, update, *args, **kwargs)
+
+    monkeypatch.setattr(
+        Collection, "update_one", change_auxiliary_pointer_before_sample_cas
+    )
+
+    with pytest.raises(MsPASSError, match="could not commit the new GridFS"):
+        database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert concurrent_change_applied
+    document = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+    assert document["gridfs_id"] == old_gridfs_id
+    assert document["history_object_id"] == concurrent_history_id
+    assert database["history_object"].find_one({"_id": concurrent_history_id})
+    assert database["fs.files"].count_documents({}) == 1
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_metadata_update_cannot_restore_gridfs_pointer_after_concurrent_replace(
+    database, monkeypatch
+):
+    saved = save_original(database, make_timeseries)
+    waveform_id = saved["_id"]
+    old_gridfs_id = saved["gridfs_id"]
+    metadata_writer = database.read_data(waveform_id, collection="wf_TimeSeries")
+    metadata_writer["gridfs_id"] = old_gridfs_id
+    metadata_writer["concurrent_metadata"] = "safe"
+    sample_writer = database.read_data(waveform_id, collection="wf_TimeSeries")
+    sample_writer.data = make_timeseries([5.0, 6.0, 7.0, 8.0]).data
+    original_sync = Database._sync_metadata_before_update
+    replacement_committed = False
+
+    def replace_after_primary_read(target):
+        nonlocal replacement_committed
+        if not replacement_committed:
+            replacement_committed = True
+            database.update_data(
+                sample_writer,
+                mode="promiscuous",
+                save_history=False,
+            )
+        return original_sync(target)
+
+    monkeypatch.setattr(
+        Database,
+        "_sync_metadata_before_update",
+        staticmethod(replace_after_primary_read),
+    )
+
+    database.update_metadata(metadata_writer, mode="promiscuous")
+
+    assert replacement_committed
+    document = database["wf_TimeSeries"].find_one({"_id": waveform_id})
+    assert document["gridfs_id"] != old_gridfs_id
+    assert document["concurrent_metadata"] == "safe"
+    storage = gridfs.GridFS(database)
+    assert not storage.exists(old_gridfs_id)
+    assert storage.exists(document["gridfs_id"])
+
+
+def test_distributed_gridfs_preflight_rejects_excluded_pointer(database):
+    with pytest.raises(ValueError, match="gridfs_id is excluded"):
+        write_distributed_data(
+            None,
+            database,
+            storage_mode="gridfs",
+            exclude_keys=["gridfs_id"],
+        )
+
+    assert database["wf_TimeSeries"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_distributed_gridfs_failure_leaves_reconcilable_stage(database, monkeypatch):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    bag = dask.bag.from_sequence([datum], npartitions=1)
+    failure = pymongo.errors.AutoReconnect("distributed waveform result unknown")
+    original_insert_one = Collection.insert_one
+
+    def fail_waveform_insert(self, document, *args, **kwargs):
+        if self.name == "wf_TimeSeries":
+            raise failure
+        return original_insert_one(self, document, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "insert_one", fail_waveform_insert)
+    with dask.config.set(scheduler="synchronous"):
+        with pytest.raises(MsPASSError, match="could not determine whether"):
+            write_distributed_data(
+                bag,
+                database,
+                storage_mode="gridfs",
+                save_history=False,
+            )
+
+    stage = database["gridfs_staging"].find_one({})
+    assert stage is not None
+    assert gridfs.GridFS(database).exists(stage["new_gridfs_id"])

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -140,6 +140,114 @@ def test_successful_overwrite_commits_new_reference_before_removing_old_blob(
 
 
 @pytest.mark.parametrize("factory,collection", CASES)
+def test_update_legacy_gridfs_document_without_storage_mode_removes_old_blob(
+    database, factory, collection
+):
+    original = save_original(database, factory)
+    waveform_id = original["_id"]
+    old_gridfs_id = original["gridfs_id"]
+    database[collection].update_one(
+        {"_id": waveform_id}, {"$unset": {"storage_mode": ""}}
+    )
+    legacy_document = database[collection].find_one({"_id": waveform_id})
+    assert "storage_mode" not in legacy_document
+    datum = database.read_data(legacy_document, collection=collection)
+    datum.data = factory([5.0, 6.0, 7.0, 8.0]).data
+
+    database.update_data(datum, mode="promiscuous", save_history=False)
+
+    document = database[collection].find_one({"_id": waveform_id})
+    assert document["storage_mode"] == "gridfs"
+    assert document["gridfs_id"] != old_gridfs_id
+    storage = gridfs.GridFS(database)
+    assert not storage.exists(old_gridfs_id)
+    assert storage.exists(document["gridfs_id"])
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_delete_legacy_gridfs_document_without_storage_mode_removes_blob(
+    database, factory, collection
+):
+    datum = save_original(database, factory)
+    waveform_id = datum["_id"]
+    gridfs_id = datum["gridfs_id"]
+    database[collection].update_one(
+        {"_id": waveform_id}, {"$unset": {"storage_mode": ""}}
+    )
+
+    database.delete_data(
+        waveform_id,
+        "TimeSeries" if factory is make_timeseries else "Seismogram",
+        collection=collection,
+    )
+
+    assert database[collection].find_one({"_id": waveform_id}) is None
+    assert not gridfs.GridFS(database).exists(gridfs_id)
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_update_uses_persisted_gridfs_id_when_caller_metadata_loses_it(
+    database, factory, collection
+):
+    datum = save_original(database, factory)
+    old_gridfs_id = datum["gridfs_id"]
+    datum.erase("gridfs_id")
+    datum.data = factory([5.0, 6.0, 7.0, 8.0]).data
+
+    database.update_data(datum, mode="promiscuous", save_history=False)
+
+    document = database[collection].find_one({"_id": datum["_id"]})
+    assert document["gridfs_id"] == datum["gridfs_id"]
+    assert document["gridfs_id"] != old_gridfs_id
+    storage = gridfs.GridFS(database)
+    assert not storage.exists(old_gridfs_id)
+    assert storage.exists(document["gridfs_id"])
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
+def test_update_gridfs_cas_rejects_concurrent_reference_change(
+    database, monkeypatch, factory, collection
+):
+    datum = save_original(database, factory)
+    waveform_id = datum["_id"]
+    old_gridfs_id = datum["gridfs_id"]
+    datum.data = factory([5.0, 6.0, 7.0, 8.0]).data
+    storage = gridfs.GridFS(database)
+    concurrent_gridfs_id = storage.put(b"concurrent samples")
+    original_update_one = Collection.update_one
+    concurrent_change_applied = False
+
+    def change_reference_before_cas(self, query, update, *args, **kwargs):
+        nonlocal concurrent_change_applied
+        new_gridfs_id = update.get("$set", {}).get("gridfs_id")
+        if (
+            self.name == collection
+            and new_gridfs_id is not None
+            and new_gridfs_id not in (old_gridfs_id, concurrent_gridfs_id)
+            and not concurrent_change_applied
+        ):
+            concurrent_change_applied = True
+            original_update_one(
+                self,
+                {"_id": waveform_id},
+                {"$set": {"gridfs_id": concurrent_gridfs_id}},
+            )
+        return original_update_one(self, query, update, *args, **kwargs)
+
+    monkeypatch.setattr(Collection, "update_one", change_reference_before_cas)
+    with pytest.raises(MsPASSError, match="could not commit the new GridFS"):
+        database.update_data(datum, mode="promiscuous", save_history=False)
+
+    assert concurrent_change_applied
+    document = database[collection].find_one({"_id": waveform_id})
+    assert document["gridfs_id"] == concurrent_gridfs_id
+    assert datum["gridfs_id"] == old_gridfs_id
+    assert storage.exists(old_gridfs_id)
+    assert storage.exists(concurrent_gridfs_id)
+    assert database["fs.files"].count_documents({}) == 2
+
+
+@pytest.mark.parametrize("factory,collection", CASES)
 @pytest.mark.parametrize("entrypoint", ["update_data", "save_data"])
 def test_new_put_failure_preserves_old_reference_and_blob(
     database, factory, collection, entrypoint

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -230,7 +230,14 @@ def test_reference_compare_miss_removes_new_blob_without_overwriting_current_ref
             replace_samples(database, datum, entrypoint)
 
     assert error.value.severity == ErrorSeverity.Invalid
-    assert final_queries == [{"_id": waveform_id, "gridfs_id": old_gridfs_id}]
+    assert final_queries == [
+        {
+            "_id": waveform_id,
+            "storage_mode": "gridfs",
+            "object_store": {"$exists": False},
+            "gridfs_id": old_gridfs_id,
+        }
+    ]
     assert datum["gridfs_id"] == old_gridfs_id
     document = database[collection].find_one({"_id": waveform_id})
     assert document["gridfs_id"] == old_gridfs_id

--- a/python/tests/db/test_gridfs_overwrite_contract.py
+++ b/python/tests/db/test_gridfs_overwrite_contract.py
@@ -384,6 +384,106 @@ def test_gridfs_stage_insert_failure_restores_new_save_caller(database, monkeypa
     assert database["fs.files"].count_documents({}) == 0
 
 
+def test_initial_gridfs_put_uncertainty_detaches_source_owner(database, monkeypatch):
+    storage = gridfs.GridFS(database)
+    old_waveform_id = ObjectId()
+    old_gridfs_id = storage.put(b"old samples")
+    old_history_id = ObjectId()
+    old_elog_id = ObjectId()
+    old_delete_token = ObjectId()
+    old_waveform = {
+        "_id": old_waveform_id,
+        "storage_mode": "gridfs",
+        "gridfs_id": old_gridfs_id,
+        "history_object_id": old_history_id,
+        "elog_id": old_elog_id,
+        "_mspass_delete_token": old_delete_token,
+    }
+    database["wf_TimeSeries"].insert_one(copy.deepcopy(old_waveform))
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    for key, value in old_waveform.items():
+        datum[key] = value
+    original_put = gridfs.GridFS.put
+
+    def put_then_lose_result(handle, *args, **kwargs):
+        original_put(handle, *args, **kwargs)
+        raise pymongo.errors.AutoReconnect("initial GridFS put result unknown")
+
+    monkeypatch.setattr(gridfs.GridFS, "put", put_then_lose_result)
+    with pytest.raises(MsPASSError, match="staged GridFS write committed"):
+        database.save_data(
+            datum,
+            mode="promiscuous",
+            storage_mode="gridfs",
+            save_history=False,
+            return_data=True,
+        )
+
+    stage = database["gridfs_staging"].find_one(
+        {"waveform_id": datum["_id"], "new_gridfs_id": datum["gridfs_id"]}
+    )
+    assert stage is not None
+    assert datum["_id"] != old_waveform_id
+    assert datum["storage_mode"] == "gridfs"
+    assert datum["gridfs_id"] != old_gridfs_id
+    assert "history_object_id" not in datum
+    assert "elog_id" not in datum
+    assert "_mspass_delete_token" not in datum
+    assert database["wf_TimeSeries"].find_one({"_id": old_waveform_id}) == old_waveform
+    assert storage.exists(old_gridfs_id)
+    assert storage.exists(datum["gridfs_id"])
+
+    report = database.reconcile_gridfs_staging(delete_uncommitted=True)
+    assert report["deleted"] == [str(stage["new_gridfs_id"])]
+    assert database["gridfs_staging"].find_one({"_id": stage["_id"]}) is None
+    assert storage.exists(old_gridfs_id)
+    assert not storage.exists(stage["new_gridfs_id"])
+
+
+def test_delete_data_prefers_literal_collection_over_default_alias(database):
+    saved = database.save_data(
+        make_timeseries([1.0, 2.0, 3.0, 4.0]),
+        collection="wf",
+        storage_mode="gridfs",
+        mode="promiscuous",
+        save_history=False,
+        return_data=True,
+    )
+    storage = gridfs.GridFS(database)
+    literal_gridfs_id = saved["gridfs_id"]
+    default_gridfs_id = storage.put(b"default owner samples")
+    default_owner = {
+        "_id": saved["_id"],
+        "storage_mode": "gridfs",
+        "gridfs_id": default_gridfs_id,
+    }
+    database["wf_TimeSeries"].insert_one(copy.deepcopy(default_owner))
+
+    database.delete_data(saved["_id"], "TimeSeries", collection="wf")
+
+    assert database["wf"].find_one({"_id": saved["_id"]}) is None
+    assert database["wf_TimeSeries"].find_one({"_id": saved["_id"]}) == default_owner
+    assert not storage.exists(literal_gridfs_id)
+    assert storage.exists(default_gridfs_id)
+
+
+def test_delete_data_default_alias_fallback(database):
+    saved = database.save_data(
+        make_timeseries([1.0, 2.0, 3.0, 4.0]),
+        storage_mode="gridfs",
+        mode="promiscuous",
+        save_history=False,
+        return_data=True,
+    )
+    storage = gridfs.GridFS(database)
+    saved_gridfs_id = saved["gridfs_id"]
+
+    database.delete_data(saved["_id"], "TimeSeries", collection="wf")
+
+    assert database["wf_TimeSeries"].find_one({"_id": saved["_id"]}) is None
+    assert not storage.exists(saved_gridfs_id)
+
+
 def test_update_gridfs_pointer_lifecycle_forces_primary_and_majority(
     database, monkeypatch
 ):
@@ -410,7 +510,9 @@ def test_update_gridfs_pointer_lifecycle_forces_primary_and_majority(
             and args
             and "storage_mode" in args[0]
         ):
-            owner_read_options.append(collection.read_preference)
+            owner_read_options.append(
+                (collection.read_preference, collection.read_concern.level)
+            )
         return original_find_one(collection, query, *args, **kwargs)
 
     def capture_update(collection, query, update, *args, **kwargs):
@@ -419,6 +521,7 @@ def test_update_gridfs_pointer_lifecycle_forces_primary_and_majority(
             cas_options.append(
                 (
                     collection.read_preference,
+                    collection.read_concern.level,
                     collection.write_concern.document,
                 )
             )
@@ -428,6 +531,7 @@ def test_update_gridfs_pointer_lifecycle_forces_primary_and_majority(
         gridfs_write_options.append(
             (
                 handle._files.read_preference,
+                handle._files.read_concern.level,
                 handle._files.write_concern.document,
             )
         )
@@ -439,9 +543,13 @@ def test_update_gridfs_pointer_lifecycle_forces_primary_and_majority(
 
     configured_database.update_data(datum, mode="promiscuous", save_history=False)
 
-    assert owner_read_options == [pymongo.ReadPreference.PRIMARY]
-    assert cas_options == [(pymongo.ReadPreference.PRIMARY, {"w": "majority"})]
-    assert gridfs_write_options == [(pymongo.ReadPreference.PRIMARY, {"w": "majority"})]
+    assert owner_read_options == [(pymongo.ReadPreference.PRIMARY, "majority")]
+    assert cas_options == [
+        (pymongo.ReadPreference.PRIMARY, "majority", {"w": "majority"})
+    ]
+    assert gridfs_write_options == [
+        (pymongo.ReadPreference.PRIMARY, "majority", {"w": "majority"})
+    ]
     document = database["wf_TimeSeries"].find_one({"_id": datum["_id"]})
     assert document["gridfs_id"] == datum["gridfs_id"]
     assert document["gridfs_id"] != old_gridfs_id
@@ -1820,6 +1928,75 @@ def test_serial_gridfs_cremate_discards_live_zero_length(database):
 
     assert result.dead()
     assert database["cemetery"].count_documents({}) == 0
+    assert database["wf_TimeSeries"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_atomic_gridfs_zero_length_restores_source_owner(database):
+    datum = TimeSeries(0)
+    datum.set_live()
+    original_owner = {
+        "_id": ObjectId(),
+        "storage_mode": "file",
+        "dir": "/source",
+        "dfile": "source.bin",
+        "foff": 128,
+        "history_object_id": ObjectId(),
+        "elog_id": ObjectId(),
+        "_mspass_delete_token": ObjectId(),
+    }
+    for key, value in original_owner.items():
+        datum[key] = value
+
+    result = database.save_data(
+        datum,
+        storage_mode="gridfs",
+        mode="promiscuous",
+        cremate=True,
+        save_history=False,
+        return_data=True,
+    )
+
+    assert result.dead()
+    for key, value in original_owner.items():
+        assert result[key] == value
+    assert "gridfs_id" not in result
+    assert database["wf_TimeSeries"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_atomic_gridfs_metadata_rejection_restores_source_owner(database, monkeypatch):
+    datum = make_timeseries([1.0, 2.0, 3.0, 4.0])
+    original_owner = {
+        "_id": ObjectId(),
+        "storage_mode": "url",
+        "url": "https://example.invalid/source",
+        "history_object_id": ObjectId(),
+        "elog_id": ObjectId(),
+        "_mspass_delete_token": ObjectId(),
+    }
+    for key, value in original_owner.items():
+        datum[key] = value
+
+    def reject_metadata(*args, **kwargs):
+        return dict(datum), False, database_module.ErrorLogger()
+
+    monkeypatch.setattr(database_module, "md2doc", reject_metadata)
+    result = database.save_data(
+        datum,
+        storage_mode="gridfs",
+        mode="pedantic",
+        cremate=True,
+        save_history=False,
+        return_data=True,
+    )
+
+    assert result.dead()
+    for key, value in original_owner.items():
+        assert result[key] == value
+    assert "gridfs_id" not in result
     assert database["wf_TimeSeries"].count_documents({}) == 0
     assert database["fs.files"].count_documents({}) == 0
     assert database["gridfs_staging"].count_documents({}) == 0

--- a/python/tests/db/test_response_stream_contract.py
+++ b/python/tests/db/test_response_stream_contract.py
@@ -196,3 +196,24 @@ def test_url_read_error_is_preserved_when_close_also_fails(monkeypatch):
 
     assert raised.value.__cause__ is read_error
     assert response.close_calls == 1
+
+
+def test_object_store_read_error_is_preserved_when_close_also_fails():
+    read_error = OSError("read failed")
+    body = FakeBody(read_error=read_error, close_error=RuntimeError("close failed"))
+    client = FakeS3Client(body)
+
+    with pytest.raises(MsPASSError) as raised:
+        Database._read_data_from_object_store(
+            {},
+            {
+                "provider": "s3",
+                "bucket": "bucket",
+                "object_name": "waveform.bin",
+                "encoding": "float64-le-v1",
+            },
+            client,
+        )
+
+    assert raised.value.__cause__ is read_error
+    assert body.close_calls == 1

--- a/python/tests/db/test_schema.py
+++ b/python/tests/db/test_schema.py
@@ -12,6 +12,25 @@ from mspasspy.db.schema import (
 )
 
 
+@pytest.mark.parametrize(
+    "schema_file",
+    ["mspass.yaml", "mspass_lite.yaml", "mspass_fdsn.yaml", "mspass_s3.yaml"],
+)
+def test_shipped_schemas_support_object_store_writes(schema_file):
+    metadata_schema = MetadataSchema(schema_file)
+    required_attributes = {
+        "storage_mode": str,
+        "object_store": dict,
+        "format": str,
+        "nbytes": int,
+    }
+    for data_schema in (metadata_schema.TimeSeries, metadata_schema.Seismogram):
+        for key, expected_type in required_attributes.items():
+            assert data_schema.is_defined(key)
+            assert data_schema.type(key) is expected_type
+            assert data_schema.writeable(key)
+
+
 class TestSchema:
     def setup_class(self):
         self.mdschema = MetadataSchema()

--- a/python/tests/io/test_distributed_write_state_contract.py
+++ b/python/tests/io/test_distributed_write_state_contract.py
@@ -12,9 +12,10 @@ import pymongo
 import pytest
 
 from mspasspy.ccore.seismic import TimeSeries, TimeSeriesEnsemble
-from mspasspy.ccore.utility import AtomicType, ErrorLogger, ErrorSeverity
+from mspasspy.ccore.utility import AtomicType, ErrorLogger, ErrorSeverity, MsPASSError
 from mspasspy.db.client import DBClient
 from mspasspy.db.database import Database
+import mspasspy.db.database as database_module
 from mspasspy.db.serialization import decode_processing_history
 import mspasspy.io.distributed as distributed_module
 from mspasspy.util.Undertaker import Undertaker
@@ -95,18 +96,18 @@ def conversion_logger(enabled):
 
 
 def install_md2doc(monkeypatch, with_conversion_log):
-    def fake_md2doc(datum, **kwargs):
-        doc = {
-            "waveform_marker": datum["waveform_marker"],
-            "preserved_number": datum["preserved_number"],
-        }
+    def fake_md2doc(datum, *args, **kwargs):
+        doc = dict(datum)
+        doc["waveform_marker"] = datum["waveform_marker"]
+        doc["preserved_number"] = datum["preserved_number"]
         return doc, True, conversion_logger(with_conversion_log)
 
     monkeypatch.setattr(distributed_module, "md2doc", fake_md2doc)
+    monkeypatch.setattr(database_module, "md2doc", fake_md2doc)
 
 
 def install_rejected_md2doc(monkeypatch):
-    def fake_md2doc(datum, **kwargs):
+    def fake_md2doc(datum, *args, **kwargs):
         return (
             {
                 "waveform_marker": datum["waveform_marker"],
@@ -117,6 +118,7 @@ def install_rejected_md2doc(monkeypatch):
         )
 
     monkeypatch.setattr(distributed_module, "md2doc", fake_md2doc)
+    monkeypatch.setattr(database_module, "md2doc", fake_md2doc)
 
 
 def persist_distributed_document(
@@ -424,3 +426,123 @@ def test_elog_posting_matrix_preserves_every_entry_and_honors_flag(
         else:
             assert "elog_id" not in persisted
             assert database["elog"].count_documents({}) == 0
+
+
+def test_distributed_post_modes_retain_only_waveform_stage_on_uncertain_insert(
+    monkeypatch, database
+):
+    datum = make_datum("uncertain_post_modes")
+    datum.elog.log_error("datum_log", "datum diagnostic", ErrorSeverity.Complaint)
+    original_insert_one = database_module.Collection.insert_one
+
+    def fail_waveform_insert(collection, document, *args, **kwargs):
+        if collection.name == "wf_TimeSeries":
+            raise pymongo.errors.AutoReconnect("waveform result unknown")
+        return original_insert_one(collection, document, *args, **kwargs)
+
+    monkeypatch.setattr(database_module.Collection, "insert_one", fail_waveform_insert)
+
+    with pytest.raises(MsPASSError, match="could not determine whether"):
+        distributed_module._save_distributed_gridfs_item(
+            datum,
+            database,
+            mode="promiscuous",
+            exclude_keys=None,
+            collection="wf_TimeSeries",
+            data_tag=None,
+            post_elog=True,
+            save_history=True,
+            post_history=True,
+            cremate=False,
+            normalizing_collections=[],
+            alg_name="write_distributed_data",
+            alg_id="0",
+        )
+
+    stage = database["gridfs_staging"].find_one({})
+    assert stage is not None
+    assert database["history_object"].count_documents({}) == 0
+    assert database["elog"].count_documents({}) == 0
+    assert "history_object_id" not in datum
+    assert "elog_id" not in datum
+
+
+@pytest.mark.parametrize("path", ["atomic", "ensemble"])
+def test_distributed_gridfs_cremate_discards_metadata_rejections(
+    monkeypatch, database, path
+):
+    install_rejected_md2doc(monkeypatch)
+    datum = make_datum(path + "_cremate_rejected")
+    if path == "atomic":
+        item = datum
+    else:
+        item = TimeSeriesEnsemble()
+        item.member.append(datum)
+        item.set_live()
+
+    with dask.config.set(scheduler="synchronous"):
+        result = distributed_module.write_distributed_data(
+            dask.bag.from_sequence([item], npartitions=1),
+            database,
+            data_are_atomic=path == "atomic",
+            storage_mode="gridfs",
+            mode="pedantic",
+            cremate=True,
+        )
+
+    assert result == ([None] if path == "atomic" else [[]])
+    assert database["cemetery"].count_documents({}) == 0
+    assert database["wf_TimeSeries"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+@pytest.mark.parametrize("path", ["atomic", "ensemble"])
+def test_distributed_gridfs_cremate_discards_live_zero_length(database, path):
+    datum = TimeSeries(0)
+    datum.set_live()
+    datum["waveform_marker"] = path + "_zero_length"
+    if path == "atomic":
+        item = datum
+    else:
+        item = TimeSeriesEnsemble()
+        item.member.append(datum)
+        item.set_live()
+
+    with dask.config.set(scheduler="synchronous"):
+        result = distributed_module.write_distributed_data(
+            dask.bag.from_sequence([item], npartitions=1),
+            database,
+            data_are_atomic=path == "atomic",
+            storage_mode="gridfs",
+            mode="promiscuous",
+            cremate=True,
+        )
+
+    assert result == ([None] if path == "atomic" else [[]])
+    assert database["cemetery"].count_documents({}) == 0
+    assert database["wf_TimeSeries"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0
+    assert database["gridfs_staging"].count_documents({}) == 0
+
+
+def test_distributed_dead_ensemble_does_not_report_stale_member_ids(database):
+    member = make_datum("dead_ensemble_stale_id")
+    member["_id"] = ObjectId()
+    ensemble = TimeSeriesEnsemble()
+    ensemble.member.append(member)
+    ensemble.kill()
+
+    with dask.config.set(scheduler="synchronous"):
+        result = distributed_module.write_distributed_data(
+            dask.bag.from_sequence([ensemble], npartitions=1),
+            database,
+            data_are_atomic=False,
+            storage_mode="gridfs",
+            cremate=True,
+        )
+
+    assert result == [[]]
+    assert database["cemetery"].count_documents({}) == 0
+    assert database["wf_TimeSeries"].count_documents({}) == 0
+    assert database["fs.files"].count_documents({}) == 0


### PR DESCRIPTION
Fixes #758.
Closes #1013.

## Summary
- preserve the existing `storage_mode="url"` web-resource reader
- add blocking `storage_mode="object_store"` support to `Database.save_data`, `read_data`, and `delete_data`
- store one S3 object per atomic datum with an explicit caller-owned boto3-compatible client
- normalize mutually exclusive sample-location pointers and reject in-place object-store sample updates using persisted state
- make GridFS replacement CAS depend on the persisted mode and `gridfs_id`, including legacy documents without `storage_mode`
- preallocate waveform ids and write durable MongoDB staging records before S3 uploads
- provide `reconcile_object_store_staging`; it reports uncommitted objects by default and deletes them only when explicitly requested while writers are quiescent
- commit object-store ensemble members one at a time, bounding the uncommitted upload window to one member

## Compatibility and safety
- native `float64-le-v1` payloads define little-endian float64 and component-major C-order Seismogram layout
- cautious, pedantic, shipped-lite, and capable custom schemas retain the complete object-store pointer
- validation and serialization failures leave caller storage metadata unchanged
- an attempted waveform insert that ends with a connection, topology, write-concern, or retryable-write uncertainty is never compensated from a single negative reference query; S3 data, staging, and new caller metadata remain durable for reconciliation
- definite pre-insert or server-rejected failures retain the existing immediate compensation behavior
- reconciliation first checks the staging record's exact collection and waveform `_id`, including alternate collections, before scanning schema-defined waveform collections for shared references
- `delete_data` retains shared S3 samples, retains the waveform document on S3 or reference-check failure, and conditionally deletes it only if the persisted sample identity has not changed; callers sharing or editing identities must quiesce reference writers because the MongoDB check and S3 deletion are not atomic

## Validation
- object-store binary and formatted TimeSeries/Seismogram round trips
- object-store ensemble, alternate-schema, compensation, deletion, concurrent-change, and interrupted-write reconciliation tests
- regression tests for response-lost and synchronized in-flight waveform inserts, failed waveform rollback, alternate-collection owners, and shared object-store references
- GridFS legacy-document, missing caller pointer, and concurrent CAS regression tests
- full Python 3.10/3.13 GitHub integration suite, schema tests, Black, Python compilation, and `git diff --check`

The final lifecycle review is complete and the full required CI suite is green for head `98dcb769f`.
