### PR TITLE
Allow sliding window results to be discarded

### DIFF
--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -21,6 +21,7 @@ def sliding_window_pipeline(
     a_kwargs=None,
     verbose=False,
     progress_report_interval=10000,
+    retain_results=True,
 ):
     """
     Run a processing function and optional completion function on an
@@ -87,8 +88,10 @@ def sliding_window_pipeline(
     that of the processing function in the returned list.  Without a
     completion function, processing results are returned directly.  Either
     list has the same size as `dlist` and follows Future completion order,
-    which is not necessarily input order.  For large numbers of inputs such
-    a giant list can be problematic for a variety of reasons.
+    which is not necessarily input order.  Set ``retain_results=False`` when
+    the processing or completion function is used only for side effects and
+    its per-item return values are not needed.  For large numbers of inputs
+    retaining the results can be problematic for a variety of reasons.
     For that reason this function has an optional `accumulator`
     argument.  As the name implies it should be an accumulation function
     that creates a summary of the output or some useful combination of
@@ -119,6 +122,9 @@ def sliding_window_pipeline(
       MongoDB documents.  Note although it should theoretically work we do not recommend
       using a MongoDB CommandCursor for this argument as it is subject to
       timeout errors if the processing function runs for a significant time.
+      The iterable is materialized in the driver, so its items should be small
+      specifications such as queries, dates, or document identifiers rather
+      than waveform data.
     :param processing_function:   symbol defining the function object
       (usually just the function name) to run on each component of dlist.
       If the function has required arguments you must define the related
@@ -187,6 +193,14 @@ def sliding_window_pipeline(
     :param progress_report_interval: positive integer defining how many
        completed items elapse between reports when ``verbose`` is True.
        The default is 10000.  The final item is always reported.
+    :param retain_results: boolean controlling whether per-item processing or
+       completion results are retained in a list in the driver when no
+       accumulator is supplied.  The default is True for backward
+       compatibility.  Set False for sink-style workflows that need the
+       processing/completion side effects but not their return values.  In
+       that mode this function returns None.  This argument has no effect when
+       an accumulator is supplied because only the accumulated value is
+       retained.
 
     :return:   When the completion_function is not defined (default), return
        a list of processing results.  With a completion function and no
@@ -201,7 +215,8 @@ def sliding_window_pipeline(
        boolean values.  If, however, the same function is run with
        `return_data=True` a memory overflow in the caller is likely
        unless the entire output of the processing fits in the memory
-       space of the caller.
+       space of the caller.  When ``retain_results=False`` and no accumulator
+       is supplied, return None.
     """
     # Materialize once so generators and other one-shot iterables have the same
     # behavior as lists throughout validation and submission.
@@ -223,6 +238,8 @@ def sliding_window_pipeline(
         or progress_report_interval <= 0
     ):
         raise ValueError("progress_report_interval must be a positive integer")
+    if not isinstance(retain_results, bool):
+        raise ValueError("retain_results must be a boolean")
     if pfunc_args is None:
         # this and the comparable logic with kwargs is needed or a type error will be thrown when we use it
         # this is how python accepts a null args
@@ -363,12 +380,13 @@ def sliding_window_pipeline(
             if run_completion_function:
                 result = completion_function(result, *cfunc_args, **cfunc_kwargs)
                 if accumulator is None:
-                    results.append(result)
+                    if retain_results:
+                        results.append(result)
                 else:
                     accumulated_output = accumulator(
                         accumulated_output, result, *a_args, **a_kwargs
                     )
-            else:
+            elif retain_results:
                 results.append(result)
 
             # Release scheduler/client references as soon as each result has
@@ -402,5 +420,7 @@ def sliding_window_pipeline(
         raise
 
     if accumulator is None:
-        return results
+        if retain_results:
+            return results
+        return None
     return accumulated_output

--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -200,7 +200,9 @@ def sliding_window_pipeline(
        processing/completion side effects but not their return values.  In
        that mode this function returns None.  This argument has no effect when
        an accumulator is supplied because only the accumulated value is
-       retained.
+       retained.  It controls retention only:  processing results are still
+       gathered to the driver so task failures propagate, even when no
+       completion function is defined.
 
     :return:   When the completion_function is not defined (default), return
        a list of processing results.  With a completion function and no
@@ -209,14 +211,14 @@ def sliding_window_pipeline(
        order and do not preserve input order.
        Be warned this list can get huge if the data set is large
        and anything but a tiny datum is returned by processing_function.
-       The definitive use of this function in MsPASS is a function
-       that runs `Database.save_data` returning the default output of that
-       method.   That is easily handled as the default is the a list of
-       boolean values.  If, however, the same function is run with
-       `return_data=True` a memory overflow in the caller is likely
-       unless the entire output of the processing fits in the memory
-       space of the caller.  When ``retain_results=False`` and no accumulator
-       is supplied, return None.
+       The default `Database.save_data(..., return_data=False)` output is a
+       small status/identifier dictionary.  Retaining one such dictionary per
+       input is normally much cheaper than retaining waveform objects, but the
+       list can still become significant for very large input collections.  If
+       the same function is run with `return_data=True`, a memory overflow in
+       the caller is likely unless the entire output of the processing fits in
+       the memory space of the caller.  When ``retain_results=False`` and no
+       accumulator is supplied, return None.
     """
     # Materialize once so generators and other one-shot iterables have the same
     # behavior as lists throughout validation and submission.
@@ -377,17 +379,22 @@ def sliding_window_pipeline(
 
         for future in completed_futures:
             result = future.result()
-            if run_completion_function:
-                result = completion_function(result, *cfunc_args, **cfunc_kwargs)
-                if accumulator is None:
-                    if retain_results:
-                        results.append(result)
-                else:
-                    accumulated_output = accumulator(
-                        accumulated_output, result, *a_args, **a_kwargs
-                    )
-            elif retain_results:
-                results.append(result)
+            try:
+                if run_completion_function:
+                    result = completion_function(result, *cfunc_args, **cfunc_kwargs)
+                    if accumulator is None:
+                        if retain_results:
+                            results.append(result)
+                    else:
+                        accumulated_output = accumulator(
+                            accumulated_output, result, *a_args, **a_kwargs
+                        )
+                elif retain_results:
+                    results.append(result)
+            finally:
+                # Do not keep the previous output while waiting for the next
+                # Future or gathering and deserializing its result.
+                del result
 
             # Release scheduler/client references as soon as each result has
             # been handled.

--- a/python/tests/test_workflow.py
+++ b/python/tests/test_workflow.py
@@ -1,9 +1,11 @@
 from collections import Counter
 from contextlib import contextmanager
+import gc
 from pathlib import Path
 import subprocess
 import sys
 import time
+import weakref
 
 import dask
 import pytest
@@ -96,6 +98,16 @@ def fail_completion(value):
 
 def fail_accumulator(old, value):
     raise RuntimeError("accumulator failed")
+
+
+class CompletionPayload:
+    pass
+
+
+def make_completion_payload(value, references):
+    payload = CompletionPayload()
+    references.append(weakref.ref(payload))
+    return payload
 
 
 class OneShotIterable:
@@ -387,6 +399,67 @@ def test_completion_order_and_return_modes(dask_client):
     assert result == [20, 10, 0]
 
 
+def test_results_can_be_discarded(dask_client):
+    retained_references = []
+    retained = sliding_window_pipeline(
+        [1, 2, 3],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        completion_function=make_completion_payload,
+        cfunc_args=[retained_references],
+    )
+
+    assert len(retained) == 3
+    assert all(
+        reference() is payload
+        for reference, payload in zip(retained_references, retained)
+    )
+
+    del retained
+    gc.collect()
+    assert all(reference() is None for reference in retained_references)
+
+    references = []
+    result = sliding_window_pipeline(
+        [1, 2, 3],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        completion_function=make_completion_payload,
+        cfunc_args=[references],
+        retain_results=False,
+    )
+
+    gc.collect()
+    assert result is None
+    assert len(references) == 3
+    assert all(reference() is None for reference in references)
+
+    result = sliding_window_pipeline(
+        [1, 2, 3],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        retain_results=False,
+    )
+    assert result is None
+
+
+def test_retain_results_does_not_disable_accumulator(dask_client):
+    result = sliding_window_pipeline(
+        [1, 2, 3],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        completion_function=simple_completion,
+        accumulator=simple_accumulator,
+        retain_results=False,
+    )
+
+    assert result == 12
+
+
 def test_empty_input_in_all_return_modes(dask_client):
     assert (
         sliding_window_pipeline([], simple_no_args, dask_client, sliding_window_size=1)
@@ -569,6 +642,8 @@ def test_swp_error_handlers(dask_client):
         sliding_window_pipeline(
             [], simple_no_args, dask_client, progress_report_interval=0
         )
+    with pytest.raises(ValueError, match="retain_results"):
+        sliding_window_pipeline([], simple_no_args, dask_client, retain_results="false")
     # test arg1 handling
     with pytest.raises(
         ValueError,

--- a/python/tests/test_workflow.py
+++ b/python/tests/test_workflow.py
@@ -4,6 +4,7 @@ import gc
 from pathlib import Path
 import subprocess
 import sys
+import threading
 import time
 import weakref
 
@@ -104,8 +105,15 @@ class CompletionPayload:
     pass
 
 
-def make_completion_payload(value, references):
-    payload = CompletionPayload()
+def make_or_block_payload(item, second_task_started, release_second_task):
+    if item == 1:
+        second_task_started.set()
+        if not release_second_task.wait(timeout=5):
+            raise TimeoutError("timed out waiting to release second task")
+    return CompletionPayload()
+
+
+def record_and_return_payload(payload, references):
     references.append(weakref.ref(payload))
     return payload
 
@@ -400,50 +408,65 @@ def test_completion_order_and_return_modes(dask_client):
 
 
 def test_results_can_be_discarded(dask_client):
-    retained_references = []
-    retained = sliding_window_pipeline(
+    result = sliding_window_pipeline(
         [1, 2, 3],
         simple_no_args,
         dask_client,
         sliding_window_size=1,
-        completion_function=make_completion_payload,
-        cfunc_args=[retained_references],
+        completion_function=simple_completion,
+        retain_results=False,
     )
 
-    assert len(retained) == 3
-    assert all(
-        reference() is payload
-        for reference, payload in zip(retained_references, retained)
+    assert result is None
+
+    result = sliding_window_pipeline(
+        [1, 2, 3],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        retain_results=False,
     )
+    assert result is None
 
-    del retained
-    gc.collect()
-    assert all(reference() is None for reference in retained_references)
 
+def test_discarded_result_is_released_while_pipeline_runs(dask_client):
+    second_task_started = ddist.Event()
+    release_second_task = ddist.Event()
     references = []
-    result = sliding_window_pipeline(
-        [1, 2, 3],
-        simple_no_args,
-        dask_client,
-        sliding_window_size=1,
-        completion_function=make_completion_payload,
-        cfunc_args=[references],
-        retain_results=False,
-    )
+    errors = []
 
-    gc.collect()
-    assert result is None
-    assert len(references) == 3
-    assert all(reference() is None for reference in references)
+    def run_pipeline():
+        try:
+            sliding_window_pipeline(
+                [0, 1],
+                make_or_block_payload,
+                dask_client,
+                sliding_window_size=1,
+                completion_function=record_and_return_payload,
+                pfunc_args=[second_task_started, release_second_task],
+                cfunc_args=[references],
+                retain_results=False,
+            )
+        except BaseException as error:
+            errors.append(error)
 
-    result = sliding_window_pipeline(
-        [1, 2, 3],
-        simple_no_args,
-        dask_client,
-        sliding_window_size=1,
-        retain_results=False,
-    )
-    assert result is None
+    pipeline_thread = threading.Thread(target=run_pipeline)
+    pipeline_thread.start()
+    second_started = False
+    first_result_released = False
+    try:
+        second_started = second_task_started.wait(timeout=5)
+        if second_started:
+            gc.collect()
+            first_result_released = len(references) == 1 and references[0]() is None
+    finally:
+        release_second_task.set()
+        pipeline_thread.join(timeout=5)
+
+    assert second_started
+    assert not pipeline_thread.is_alive()
+    assert errors == []
+    assert first_result_released
 
 
 def test_retain_results_does_not_disable_accumulator(dask_client):
@@ -483,6 +506,27 @@ def test_empty_input_in_all_return_modes(dask_client):
             sliding_window_size=1,
             completion_function=simple_completion,
             accumulator=simple_accumulator,
+        )
+        is None
+    )
+    assert (
+        sliding_window_pipeline(
+            [],
+            simple_no_args,
+            dask_client,
+            sliding_window_size=1,
+            retain_results=False,
+        )
+        is None
+    )
+    assert (
+        sliding_window_pipeline(
+            [],
+            simple_no_args,
+            dask_client,
+            sliding_window_size=1,
+            completion_function=simple_completion,
+            retain_results=False,
         )
         is None
     )


### PR DESCRIPTION
Closes #1014.

## Summary

- add a backward-compatible `retain_results` option to
  `sliding_window_pipeline`
- return `None` and avoid the driver-side results list when retention is
  disabled and no accumulator is supplied
- release the transient driver reference before waiting for or gathering the
  next Future
- document that `dlist` is materialized in the driver and should contain small
  specifications rather than waveform data
- document that processing results are still gathered even when retention is
  disabled
- verify with a blocked second task that the first completion output is
  reclaimed while the pipeline is still running

## Motivation

Completion functions run in the driver.  Previously, every completion return
value was appended to `results` until the pipeline finished.  A save completion
that returned a daily ensemble could therefore make driver memory grow after
each day even though Dask worker memory remained stable.  Cancelling the Future
does not release the separate reference in the driver's results list.

The existing accumulator workaround remains supported.  The new option gives
sink-style workflows a direct way to run completion side effects without
retaining per-item outputs.  Its default is `True`, preserving the current
return-list contract.

This option bounds pipeline-owned retention; it does not skip
`Future.result()` or its driver-side gather.  A processing-only sink can still
incur the communication and transient memory cost of one gathered result.

## Tests

```text
python -m pytest python/tests/test_workflow.py -q
35 passed, 1 warning in 4.48s
```

The warning reports that Dask dashboard port 8787 was occupied and that Dask
selected another port.

Both changed files pass Black's check, and `git diff --check` passes.
