### PR TITLE
Allow sliding-window completion to run on workers

### DIFF
--- a/docs/source/user_manual/parallel_processing.rst
+++ b/docs/source/user_manual/parallel_processing.rst
@@ -623,7 +623,49 @@ The comparable code using `sliding_window_pipeline` is:
   data_out = sliding_window_pipeline(querylist,
                           process_ensemble,
                           dask_client,
-                          db.name)
+                          pfunc_args=[db.name])
+
+Worker-side sink completion
+---------------------------
+The default completion function runs serially in the driver.  That is useful
+when completion needs driver-local state, but it requires every processing
+result to be serialized and gathered first.  For a result as large as a day
+ensemble, that transfer and the simultaneous worker and driver copies can be
+the dominant memory cost.
+
+Use ``completion_on_worker=True`` when completion can run safely on workers.
+The processing and completion functions are then one Dask task, so the
+intermediate result never crosses the worker-to-driver boundary.  A sink-style
+workflow should also set ``retain_results=False`` so the completion return
+value is discarded before transport.  The save call below is schematic; a
+production sink should use a deterministic object key or an upsert so retrying
+the task does not duplicate data:
+
+.. code:: python
+
+  def save_ensemble(ensemble, dbname):
+      db = fetch_dbhandle(dbname)
+      db.save_data(ensemble, return_data=False)
+
+  sliding_window_pipeline(
+      querylist,
+      process_ensemble,
+      dask_client,
+      pfunc_args=[db.name],
+      completion_function=save_ensemble,
+      cfunc_args=[db.name],
+      completion_on_worker=True,
+      retain_results=False,
+      sliding_window_size=1,
+  )
+
+Worker completions may run concurrently and may run again if a worker is lost,
+so their side effects should be idempotent.  Completion functions and arguments
+must be serializable; use worker plugins or worker-side handle lookup for
+database and object-store access rather than passing live clients or secrets.
+This mode removes the driver transfer, but each combined task must still fit in
+one worker's memory.  Increase ``sliding_window_size`` only after measuring the
+per-task peak.
 
 HPC deployment
 --------------

--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -5,6 +5,27 @@ from numbers import Integral, Real
 import dask.distributed as ddist
 
 
+def _execute_pipeline_task(
+    data_item,
+    processing_function,
+    pfunc_args,
+    pfunc_kwargs,
+    completion_function=None,
+    cfunc_args=(),
+    cfunc_kwargs=None,
+    discard_result=False,
+):
+    """Execute pipeline stages that must not exchange their intermediate."""
+    result = processing_function(data_item, *pfunc_args, **pfunc_kwargs)
+    if completion_function is not None:
+        if cfunc_kwargs is None:
+            cfunc_kwargs = {}
+        result = completion_function(result, *cfunc_args, **cfunc_kwargs)
+    if discard_result:
+        return None
+    return result
+
+
 def sliding_window_pipeline(
     dlist,
     processing_function,
@@ -22,6 +43,7 @@ def sliding_window_pipeline(
     verbose=False,
     progress_report_interval=10000,
     retain_results=True,
+    completion_on_worker=False,
 ):
     """
     Run a processing function and optional completion function on an
@@ -82,9 +104,11 @@ def sliding_window_pipeline(
     may not be running on the same node.  See the MsPASS User Manual for
     more guidance on this issue.
 
-    The other element of this function is the optional "completion_function"
-    argument.  That function is run on the output of every instance of
-    the function returned by workers.  When defined, its output replaces
+    The other element of this function is the optional ``completion_function``
+    argument.  By default that function is run in the driver on the output of
+    every instance of the function returned by workers.  Set
+    ``completion_on_worker=True`` to compose the processing and completion
+    functions into one worker task.  When defined, its output replaces
     that of the processing function in the returned list.  Without a
     completion function, processing results are returned directly.  Either
     list has the same size as `dlist` and follows Future completion order,
@@ -158,6 +182,17 @@ def sliding_window_pipeline(
     :param completion_function:   if defined the result returned by each submit
        will be processed with this function.   When defined the function
        output will be the single output of this function.
+    :param completion_on_worker: boolean controlling where
+       ``completion_function`` runs.  The default is False, which gathers each
+       processing result and runs completion serially in the driver.  Set True
+       to run processing and completion in the same worker task, avoiding
+       serialization and transfer of the intermediate processing result.  This
+       also allows completions to run concurrently, and requires the completion
+       function and its arguments to be serializable and worker-safe.  When
+       ``retain_results=False`` and no accumulator is supplied, the completion
+       return value is discarded in the worker as well.  Configure database and
+       object-store access on workers rather than passing live clients or
+       credentials as completion arguments.
     :param accumulator: optional accumulator function applied to the
        output of the completion function.   In most cases the large list
        returned by this function with or without a completion function is
@@ -200,9 +235,11 @@ def sliding_window_pipeline(
        processing/completion side effects but not their return values.  In
        that mode this function returns None.  This argument has no effect when
        an accumulator is supplied because only the accumulated value is
-       retained.  It controls retention only:  processing results are still
-       gathered to the driver so task failures propagate, even when no
-       completion function is defined.
+       retained.  With no completion function, the processing return value is
+       discarded in the worker instead of being gathered.  With the default
+       driver-side completion, the processing result must still be gathered.
+       Set ``completion_on_worker=True`` to avoid that transfer.  Task failures
+       propagate in all modes.
 
     :return:   When the completion_function is not defined (default), return
        a list of processing results.  With a completion function and no
@@ -242,6 +279,8 @@ def sliding_window_pipeline(
         raise ValueError("progress_report_interval must be a positive integer")
     if not isinstance(retain_results, bool):
         raise ValueError("retain_results must be a boolean")
+    if not isinstance(completion_on_worker, bool):
+        raise ValueError("completion_on_worker must be a boolean")
     if pfunc_args is None:
         # this and the comparable logic with kwargs is needed or a type error will be thrown when we use it
         # this is how python accepts a null args
@@ -252,6 +291,7 @@ def sliding_window_pipeline(
                 alg
             )
             raise ValueError(message)
+        pfunc_args = tuple(pfunc_args)
     if pfunc_kwargs is None:
         pfunc_kwargs = {}
     else:
@@ -260,8 +300,11 @@ def sliding_window_pipeline(
                 alg
             )
             raise ValueError(message)
+        pfunc_kwargs = dict(pfunc_kwargs)
     if completion_function is None:
         run_completion_function = False
+        if completion_on_worker:
+            raise ValueError("completion_on_worker requires a completion_function")
         if accumulator is not None:
             raise ValueError("accumulator requires a completion_function")
     else:
@@ -280,6 +323,7 @@ def sliding_window_pipeline(
                     alg
                 )
                 raise ValueError(message)
+            cfunc_args = tuple(cfunc_args)
         if cfunc_kwargs is None:
             cfunc_kwargs = {}
         else:
@@ -288,6 +332,7 @@ def sliding_window_pipeline(
                     alg
                 )
                 raise ValueError(message)
+            cfunc_kwargs = dict(cfunc_kwargs)
         if accumulator is not None:
             if not callable(accumulator):
                 message = "{}:  Illegal value for accumulator argument\n".format(alg)
@@ -364,15 +409,39 @@ def sliding_window_pipeline(
     outstanding = []
     completed_futures = ddist.as_completed(loop=dask_client.loop)
 
+    run_completion_in_driver = run_completion_function and not completion_on_worker
+    run_combined_worker_task = completion_on_worker or (
+        not run_completion_function and not retain_results
+    )
+    discard_worker_result = (
+        not retain_results and accumulator is None and run_combined_worker_task
+    )
+
+    def submit_item(data_item):
+        if run_combined_worker_task:
+            return dask_client.submit(
+                _execute_pipeline_task,
+                data_item,
+                processing_function,
+                pfunc_args,
+                pfunc_kwargs,
+                completion_function if completion_on_worker else None,
+                cfunc_args if completion_on_worker else (),
+                cfunc_kwargs if completion_on_worker else {},
+                discard_worker_result,
+                pure=False,
+            )
+        return dask_client.submit(
+            processing_function,
+            data_item,
+            *pfunc_args,
+            pure=False,
+            **pfunc_kwargs,
+        )
+
     try:
         while next_item < swsize:
-            future = dask_client.submit(
-                processing_function,
-                data_items[next_item],
-                *pfunc_args,
-                pure=False,
-                **pfunc_kwargs,
-            )
+            future = submit_item(data_items[next_item])
             outstanding.append(future)
             completed_futures.add(future)
             next_item += 1
@@ -380,15 +449,16 @@ def sliding_window_pipeline(
         for future in completed_futures:
             result = future.result()
             try:
-                if run_completion_function:
+                # Request release of the remote result before running a
+                # potentially slow driver-side completion.  The local result
+                # remains valid until the finally block below.
+                dask_client.cancel(future)
+                if run_completion_in_driver:
                     result = completion_function(result, *cfunc_args, **cfunc_kwargs)
-                    if accumulator is None:
-                        if retain_results:
-                            results.append(result)
-                    else:
-                        accumulated_output = accumulator(
-                            accumulated_output, result, *a_args, **a_kwargs
-                        )
+                if accumulator is not None:
+                    accumulated_output = accumulator(
+                        accumulated_output, result, *a_args, **a_kwargs
+                    )
                 elif retain_results:
                     results.append(result)
             finally:
@@ -396,9 +466,6 @@ def sliding_window_pipeline(
                 # Future or gathering and deserializing its result.
                 del result
 
-            # Release scheduler/client references as soon as each result has
-            # been handled.
-            dask_client.cancel(future)
             outstanding.remove(future)
             number_handled += 1
             if verbose and (
@@ -407,13 +474,7 @@ def sliding_window_pipeline(
                 print(f"Handled {number_handled} of {N} items")
 
             if next_item < N:
-                future = dask_client.submit(
-                    processing_function,
-                    data_items[next_item],
-                    *pfunc_args,
-                    pure=False,
-                    **pfunc_kwargs,
-                )
+                future = submit_item(data_items[next_item])
                 outstanding.append(future)
                 completed_futures.add(future)
                 next_item += 1

--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -452,7 +452,12 @@ def sliding_window_pipeline(
                 # Request release of the remote result before running a
                 # potentially slow driver-side completion.  The local result
                 # remains valid until the finally block below.
-                dask_client.cancel(future)
+                try:
+                    dask_client.cancel(future)
+                except Exception:
+                    # Releasing remote memory is best-effort and must not
+                    # prevent the completion side effect from running.
+                    pass
                 if run_completion_in_driver:
                     result = completion_function(result, *cfunc_args, **cfunc_kwargs)
                 if accumulator is not None:

--- a/python/tests/test_workflow.py
+++ b/python/tests/test_workflow.py
@@ -105,6 +105,29 @@ class CompletionPayload:
     pass
 
 
+class WorkerOnlyPayload:
+    def __reduce__(self):
+        raise RuntimeError("worker-only payload was serialized")
+
+
+def make_worker_only_payload(_):
+    return WorkerOnlyPayload()
+
+
+def return_input(payload):
+    return payload
+
+
+def report_completion_location(value, prefix="", suffix=""):
+    try:
+        ddist.get_worker()
+    except ValueError:
+        location = "driver"
+    else:
+        location = "worker"
+    return f"{prefix}{location}{suffix}", value
+
+
 def make_or_block_payload(item, second_task_started, release_second_task):
     if item == 1:
         second_task_started.set()
@@ -146,6 +169,18 @@ def _local_dask_client():
 def dask_client():
     with _local_dask_client() as client:
         yield client
+
+
+@pytest.fixture
+def process_dask_client():
+    with ddist.LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=True,
+        dashboard_address=None,
+    ) as cluster:
+        with ddist.Client(cluster) as client:
+            yield client
 
 
 def test_import_does_not_install_a_default_dask_client():
@@ -429,6 +464,94 @@ def test_results_can_be_discarded(dask_client):
     assert result is None
 
 
+def test_discarded_processing_result_is_not_gathered(process_dask_client):
+    result = sliding_window_pipeline(
+        [1],
+        make_worker_only_payload,
+        process_dask_client,
+        sliding_window_size=1,
+        retain_results=False,
+    )
+
+    assert result is None
+
+
+def test_completion_can_run_and_discard_output_on_worker(process_dask_client):
+    result = sliding_window_pipeline(
+        [1],
+        make_worker_only_payload,
+        process_dask_client,
+        sliding_window_size=1,
+        completion_function=return_input,
+        retain_results=False,
+        completion_on_worker=True,
+    )
+
+    assert result is None
+
+
+def test_completion_location_and_worker_result_modes(dask_client):
+    driver_result = sliding_window_pipeline(
+        [1],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        completion_function=report_completion_location,
+    )
+    worker_result = sliding_window_pipeline(
+        [1],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        completion_function=report_completion_location,
+        cfunc_args=["on-"],
+        cfunc_kwargs={"suffix": "-side"},
+        completion_on_worker=True,
+    )
+    accumulated_result = sliding_window_pipeline(
+        [1, 2],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        completion_function=times_ten,
+        accumulator=simple_accumulator,
+        retain_results=False,
+        completion_on_worker=True,
+    )
+
+    assert driver_result == [("driver", 2)]
+    assert worker_result == [("on-worker-side", 2)]
+    assert accumulated_result == 50
+
+
+def test_future_cancel_is_requested_before_driver_completion(dask_client, monkeypatch):
+    submitted = []
+    statuses_during_completion = []
+    original_submit = dask_client.submit
+
+    def capture_submit(*args, **kwargs):
+        future = original_submit(*args, **kwargs)
+        submitted.append(future)
+        return future
+
+    def inspect_future_status(value):
+        statuses_during_completion.append(submitted[0].status)
+        return value
+
+    monkeypatch.setattr(dask_client, "submit", capture_submit)
+
+    result = sliding_window_pipeline(
+        [1],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        completion_function=inspect_future_status,
+    )
+
+    assert result == [2]
+    assert statuses_during_completion == ["cancelled"]
+
+
 def test_discarded_result_is_released_while_pipeline_runs(dask_client):
     second_task_started = ddist.Event()
     release_second_task = ddist.Event()
@@ -621,6 +744,7 @@ def _assert_all_cancelled(futures):
         ("submit", "submit failed"),
         ("processing", "processing failed"),
         ("completion", "completion failed"),
+        ("worker_completion", "completion failed"),
         ("accumulator", "accumulator failed"),
     ],
 )
@@ -653,8 +777,12 @@ def test_failures_cancel_all_outstanding_futures(
         items = [("fail", 0), ("slow-1", 0.3), ("slow-2", 0.3)]
         processing_function = delayed_value
         kwargs["completion_function"] = (
-            fail_completion if failure_stage == "completion" else lambda value: value
+            fail_completion
+            if failure_stage in ("completion", "worker_completion")
+            else lambda value: value
         )
+        if failure_stage == "worker_completion":
+            kwargs["completion_on_worker"] = True
         if failure_stage == "accumulator":
             kwargs["accumulator"] = fail_accumulator
 
@@ -688,6 +816,14 @@ def test_swp_error_handlers(dask_client):
         )
     with pytest.raises(ValueError, match="retain_results"):
         sliding_window_pipeline([], simple_no_args, dask_client, retain_results="false")
+    with pytest.raises(ValueError, match="completion_on_worker must be a boolean"):
+        sliding_window_pipeline(
+            [], simple_no_args, dask_client, completion_on_worker="true"
+        )
+    with pytest.raises(ValueError, match="requires a completion_function"):
+        sliding_window_pipeline(
+            [], simple_no_args, dask_client, completion_on_worker=True
+        )
     # test arg1 handling
     with pytest.raises(
         ValueError,

--- a/python/tests/test_workflow.py
+++ b/python/tests/test_workflow.py
@@ -552,6 +552,30 @@ def test_future_cancel_is_requested_before_driver_completion(dask_client, monkey
     assert statuses_during_completion == ["cancelled"]
 
 
+def test_cancel_failure_does_not_skip_driver_completion(dask_client, monkeypatch):
+    completion_inputs = []
+
+    def fail_cancel(*args, **kwargs):
+        raise RuntimeError("cancel failed")
+
+    def record_completion(value):
+        completion_inputs.append(value)
+        return value + 1
+
+    monkeypatch.setattr(dask_client, "cancel", fail_cancel)
+
+    result = sliding_window_pipeline(
+        [1],
+        simple_no_args,
+        dask_client,
+        sliding_window_size=1,
+        completion_function=record_completion,
+    )
+
+    assert result == [3]
+    assert completion_inputs == [2]
+
+
 def test_discarded_result_is_released_while_pipeline_runs(dask_client):
     second_task_started = ddist.Event()
     release_second_task = ddist.Event()


### PR DESCRIPTION
Closes #1016.

## Summary

- add an opt-in `completion_on_worker=False` argument to
  `sliding_window_pipeline`
- compose processing and completion into one worker task when enabled, so the
  processing output never becomes a Dask Future payload
- discard unused processing/completion returns inside the worker when
  `retain_results=False` and no accumulator is present
- request cancellation of a gathered Future before a slow driver completion,
  allowing the scheduler to release the worker copy earlier
- document concurrency, serialization, idempotency, credential, and per-task
  memory constraints for worker-side sinks

The default remains driver-side completion, so existing execution order and
return behavior are preserved.  This PR does not change the MsPASS pickle
format.

## Why

#1015 removed the unbounded driver `results` list, but a sink workflow still
called `Future.result()` for every large processing result before discarding
the completion output.  In the reported workflow, one Future contains all
station ensembles for a day.  The driver then deep-copies those members into a
new day ensemble and pickles it.  Avoiding O(N) retention therefore did not
remove serialization, network transfer, driver deserialization, or the
one-day multi-copy peak.

The worker-side mode keeps that intermediate local to one compound task.  In
sink mode the only successful result sent to the driver is `None`; processing
and completion exceptions still arrive through `Future.result()`.

## Tests

- `python/tests/test_workflow.py`: 40 passed
- workflow formatting/static gates: 6 passed, 2 skipped
- process-based Dask regressions use a payload whose `__reduce__` raises, so
  the tests fail if either discarded payload crosses the worker boundary
- failure coverage includes worker-side completion exceptions and outstanding
  Future cancellation

## Limits

This removes the worker-to-driver intermediate, but it cannot make an
arbitrarily large item fit in one worker.  Large sinks should begin with
`sliding_window_size=1` and write bounded, idempotent batches.  The existing
nested ensemble pickle representation is a separate memory-amplification and
compatibility issue.
