### PR TITLE
Harden native seismic pickle state

### DIFF
--- a/cxx/include/mspass/seismic/Ensemble.h
+++ b/cxx/include/mspass/seismic/Ensemble.h
@@ -180,7 +180,7 @@ public:
   LoggingEnsemble(const mspass::utility::Metadata &md,
                   const mspass::utility::ErrorLogger &elogin,
                   const size_t ndata)
-      : Ensemble<T>(md, ndata), elog(elogin) {};
+      : Ensemble<T>(md, ndata), elog(elogin), ensemble_is_live(false) {};
   /*! Standard copy constructor.   */
   LoggingEnsemble(const LoggingEnsemble<T> &parent)
       : Ensemble<T>(parent), elog(parent.elog) {
@@ -266,6 +266,7 @@ template <typename T> bool LoggingEnsemble<T>::validate() {
     if (dptr->live())
       return true;
   }
+  this->kill();
   return false;
 }
 

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -41,6 +41,24 @@ using namespace mspass::utility;
 using namespace mspass::seismic;
 using mspass::algorithms::TimeWindow;
 
+static py::buffer_info validate_pickle_sample_array(
+    const py::handle value, const char *data_type) {
+  const string prefix = string("Invalid ") + data_type + " pickle state: ";
+  if (!py::isinstance<py::array>(value))
+    throw py::value_error(prefix + "sample data must be a NumPy array");
+
+  const py::array samples = py::reinterpret_borrow<py::array>(value);
+  if (samples.ndim() != 1)
+    throw py::value_error(prefix +
+                          "sample array must be one-dimensional");
+  if (!samples.dtype().equal(py::dtype::of<double>()))
+    throw py::value_error(prefix + "sample array must have dtype float64");
+  if (!(samples.flags() & py::array::c_style) &&
+      !(samples.flags() & py::array::f_style))
+    throw py::value_error(prefix + "sample array must be contiguous");
+  return samples.request();
+}
+
 /* Trampoline class for BasicTimeSeries */
 class PyBasicTimeSeries : public BasicTimeSeries
 {
@@ -484,11 +502,11 @@ PYBIND11_MODULE(seismic, m) {
         stringstream sstm;
         boost::archive::text_oarchive artm(sstm);
         artm<<tmatrix;
-        //This creates a numpy array alias from the vector container
-        //without a move or copy of the data
+        // Without a base object, pybind11 copies the matrix data into an
+        // owning NumPy array.
         size_t u_size = self.u.rows()*self.u.columns();
         if(u_size==0){
-          py::array_t<double, py::array::f_style> darr(u_size,NULL);
+          py::array_t<double, py::array::f_style> darr(u_size,nullptr);
           return py::make_tuple(sbuf,ssbts.str(),sscorets.str(),
             cardinal, orthogonal,sstm.str(),
             u_size, darr);
@@ -500,6 +518,8 @@ PYBIND11_MODULE(seismic, m) {
         }
       },
       [](py::tuple t) {
+        if(t.size()!=8)
+          throw py::value_error("Invalid Seismogram pickle state");
         pybind11::object sbuf=t[0];
         Metadata md=restore_serialized_metadata_py(sbuf);
         stringstream ssbts(t[1].cast<std::string>());
@@ -517,15 +537,18 @@ PYBIND11_MODULE(seismic, m) {
         dmatrix tmatrix;
         artm>>tmatrix;
         size_t u_size = t[6].cast<size_t>();
-        py::array_t<double, py::array::f_style> darr;
-        darr=t[7].cast<py::array_t<double, py::array::f_style>>();
-        py::buffer_info info = darr.request();
+        py::buffer_info info = validate_pickle_sample_array(t[7], "Seismogram");
+        if((u_size%3)!=0 || static_cast<size_t>(info.size)!=u_size ||
+           (u_size/3)!=bts.npts())
+          throw py::value_error(
+            "Invalid Seismogram pickle state: inconsistent sample array size");
         if(u_size==0) {
           dmatrix u;
           return Seismogram(bts,md,corets,cardinal,orthogonal,tmatrix,u);
         } else {
           dmatrix u(3, u_size/3);
-          memcpy(u.get_address(0,0), info.ptr, sizeof(double) * u_size);
+          const double *sample_data = static_cast<const double *>(info.ptr);
+          memcpy(u.get_address(0,0), sample_data, sizeof(double) * u_size);
           return Seismogram(bts,md,corets,cardinal,orthogonal,tmatrix,u);
         }
      }
@@ -579,7 +602,8 @@ PYBIND11_MODULE(seismic, m) {
         bts.set_tref(TimeReferenceType::UTC);
         ProcessingHistory emptyph;
         vector<double> sbuf(npts);
-        memcpy(&sbuf[0], info.ptr, npts*sizeof(double));
+        if(npts>0)
+          memcpy(sbuf.data(), info.ptr, npts*sizeof(double));
         auto v = new TimeSeries(bts,md,emptyph,sbuf);
         return v;
       }))
@@ -611,12 +635,14 @@ PYBIND11_MODULE(seismic, m) {
           stringstream sscorets;
           boost::archive::text_oarchive arcorets(sscorets);
           arcorets<<dynamic_cast<const ProcessingHistory&>(self);
-          //This creates a numpy array alias from the vector container
-          //without a move or copy of the data
-          py::array_t<double, py::array::f_style> darr(self.s.size(),&(self.s[0]));
+          // Without a base object, pybind11 copies the vector data into an
+          // owning NumPy array.
+          py::array_t<double, py::array::f_style> darr(self.s.size(),self.s.data());
           return py::make_tuple(sbuf,ssbts.str(),sscorets.str(),darr);
         },
         [](py::tuple t) {
+         if(t.size()!=4)
+           throw py::value_error("Invalid TimeSeries pickle state");
          pybind11::object sbuf=t[0];
          Metadata md=restore_serialized_metadata_py(sbuf);
          stringstream ssbts(t[1].cast<std::string>());
@@ -630,12 +656,16 @@ PYBIND11_MODULE(seismic, m) {
          // There might be a faster way to do this than a copy like
          //this but for now this, like Seismogram, is make it work before you
          //make it fast
-         py::array_t<double, py::array::f_style> darr;
-         darr=t[3].cast<py::array_t<double, py::array::f_style>>();
-         py::buffer_info info = darr.request();
+         py::buffer_info info = validate_pickle_sample_array(t[3], "TimeSeries");
+         if(static_cast<size_t>(info.size)!=bts.npts())
+           throw py::value_error(
+             "Invalid TimeSeries pickle state: inconsistent sample array size");
          std::vector<double> d;
-         d.resize(info.shape[0]);
-         memcpy(d.data(), info.ptr, sizeof(double) * d.size());
+         d.resize(static_cast<size_t>(info.size));
+         if(!d.empty()) {
+           const double *sample_data = static_cast<const double *>(info.ptr);
+           memcpy(d.data(), sample_data, sizeof(double) * d.size());
+         }
          return TimeSeries(bts,md,corets,d);;
        }
      ))
@@ -792,6 +822,8 @@ PYBIND11_MODULE(seismic, m) {
         }catch(...){pybind11::gil_scoped_release release;throw;};
       },
       [](py::tuple t) {
+        if(t.size()!=4)
+          throw py::value_error("Invalid SeismogramEnsemble pickle state");
         pybind11::gil_scoped_acquire acquire;
         try{
           pybind11::object sbuf=t[0];
@@ -875,6 +907,8 @@ PYBIND11_MODULE(seismic, m) {
         }catch(...){pybind11::gil_scoped_release release;throw;};
       },
       [](py::tuple t) {
+        if(t.size()!=4)
+          throw py::value_error("Invalid TimeSeriesEnsemble pickle state");
         pybind11::gil_scoped_acquire acquire;
         try{
           pybind11::object sbuf=t[0];
@@ -978,17 +1012,20 @@ PYBIND11_MODULE(seismic, m) {
           pybind11::object sbuf;
           sbuf=serialize_metadata_py(dynamic_cast<const Metadata&>(self));
           py::array_t<double, py::array::f_style> darr(self.spectrum.size(),
-                              &(self.spectrum[0]));
+                              self.spectrum.data());
           stringstream ss_elog;
           boost::archive::text_oarchive ar(ss_elog);
           ar << self.elog;
-          pybind11::tuple r_tuple = py::make_tuple(sbuf,self.df(),self.f0(),self.spectrum_type,
-              ss_elog.str(),darr,self.dt(),self.timeseries_npts());
+          pybind11::tuple r_tuple = py::make_tuple(
+              sbuf,self.df(),self.f0(),self.spectrum_type,ss_elog.str(),darr,
+              self.dt(),self.timeseries_npts(),self.live());
           pybind11::gil_scoped_release release;
           return r_tuple;
         },
         [](py::tuple t)
         {
+          if(t.size()!=8 && t.size()!=9)
+            throw py::value_error("Invalid PowerSpectrum pickle state");
           pybind11::gil_scoped_acquire acquire;
           /* Deserialize Metadata*/
           pybind11::object sbuf=t[0];
@@ -1000,16 +1037,20 @@ PYBIND11_MODULE(seismic, m) {
           boost::archive::text_iarchive ar(ss_elog);
           ErrorLogger elog;
           ar >> elog;
-          py::array_t<double, py::array::f_style> darr;
-          darr=t[5].cast<py::array_t<double, py::array::f_style>>();
-          py::buffer_info info = darr.request();
+          py::buffer_info info =
+              validate_pickle_sample_array(t[5], "PowerSpectrum");
           std::vector<double> d;
-          d.resize(info.shape[0]);
-          memcpy(d.data(), info.ptr, sizeof(double) * d.size());
+          d.resize(static_cast<size_t>(info.size));
+          if(!d.empty()) {
+            const double *sample_data = static_cast<const double *>(info.ptr);
+            memcpy(d.data(), sample_data, sizeof(double) * d.size());
+          }
           double dt=t[6].cast<double>();
-          double parent_npts=t[7].cast<double>();
+          int parent_npts=t[7].cast<int>();
           PowerSpectrum restored(md,d,df,spectrum_type,f0,dt,parent_npts);
           restored.elog=elog;
+          if(t.size()==9 && !t[8].cast<bool>())
+            restored.kill();
           pybind11::gil_scoped_release release;
           return restored;
         }

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -10,6 +10,7 @@ from mspasspy.ccore.seismic import (
     _CoreSeismogram,
     _CoreTimeSeries,
     DataGap,
+    DoubleVector,
     PowerSpectrum,
     Seismogram,
     SeismogramEnsemble,
@@ -102,6 +103,13 @@ def make_constant_data_seis(d, t0=0.0, dt=0.1, nsamp=5, val=1.0):
         for k in range(3):
             d.data[k, i] = val
     return d
+
+
+def restore_pickle_state(data_type, state):
+    """Invoke a native pickle loader on a newly allocated instance."""
+    restored = data_type.__new__(data_type)
+    restored.__setstate__(state)
+    return restored
 
 
 def setup_function(function):
@@ -1142,6 +1150,184 @@ def test_Ensemble(Ensemble):
         assert (es.member[1].data[:] == escopy.member[1].data[:]).all()
 
 
+@pytest.mark.parametrize("protocol", [4, 5])
+def test_empty_atomic_pickle_round_trip(protocol):
+    ts = TimeSeries()
+    ts["pickle_test"] = "empty"
+    ts_copy = pickle.loads(pickle.dumps(ts, protocol=protocol))
+    assert ts_copy.npts == 0
+    assert len(ts_copy.data) == 0
+    assert ts_copy.dead()
+    assert ts_copy["pickle_test"] == "empty"
+
+    seis = Seismogram()
+    seis["pickle_test"] = "empty"
+    seis_copy = pickle.loads(pickle.dumps(seis, protocol=protocol))
+    assert seis_copy.npts == 0
+    assert seis_copy.data.size == 0
+    assert seis_copy.dead()
+    assert seis_copy["pickle_test"] == "empty"
+
+    spectrum = PowerSpectrum()
+    spectrum["pickle_test"] = "empty"
+    spectrum_copy = pickle.loads(pickle.dumps(spectrum, protocol=protocol))
+    assert spectrum_copy.nf() == 0
+    assert spectrum_copy.dead()
+    assert spectrum_copy["pickle_test"] == "empty"
+
+
+def test_empty_TimeSeries_numpy_constructor():
+    ts = TimeSeries({"delta": 0.1, "starttime": 0.0}, np.array([], dtype=np.float64))
+    assert ts.npts == 0
+    assert len(ts.data) == 0
+
+
+@pytest.mark.parametrize("protocol", [4, 5])
+@pytest.mark.parametrize(
+    "ensemble_type,member_type",
+    [
+        (TimeSeriesEnsemble, TimeSeries),
+        (SeismogramEnsemble, Seismogram),
+    ],
+)
+def test_empty_and_killed_ensemble_member_pickle_round_trip(
+    protocol, ensemble_type, member_type
+):
+    empty_ensemble = ensemble_type()
+    empty_copy = pickle.loads(pickle.dumps(empty_ensemble, protocol=protocol))
+    assert len(empty_copy.member) == 0
+    assert empty_copy.dead()
+
+    ensemble = ensemble_type()
+    ensemble["pickle_test"] = "members"
+    ensemble.member.append(member_type())
+    killed = member_type(2)
+    killed.set_live()
+    killed.kill()
+    ensemble.member.append(killed)
+
+    restored = pickle.loads(pickle.dumps(ensemble, protocol=protocol))
+    assert len(restored.member) == 2
+    assert restored.member[0].npts == 0
+    assert restored.member[0].dead()
+    assert restored.member[1].npts == 2
+    assert restored.member[1].dead()
+    assert restored.dead()
+    assert restored["pickle_test"] == "members"
+
+
+@pytest.mark.parametrize(
+    "ensemble_type,member_type",
+    [
+        (TimeSeriesEnsemble, TimeSeries),
+        (SeismogramEnsemble, Seismogram),
+    ],
+)
+def test_LoggingEnsemble_validate_and_pickle_kill_all_dead_members(
+    ensemble_type, member_type
+):
+    ensemble = ensemble_type()
+    member = member_type(2)
+    member.set_live()
+    ensemble.member.append(member)
+    assert ensemble.set_live()
+    ensemble.member[0].kill()
+    assert ensemble.live
+    assert not ensemble.validate()
+    assert ensemble.dead()
+
+    inconsistent = ensemble_type()
+    member = member_type(2)
+    member.set_live()
+    inconsistent.member.append(member)
+    assert inconsistent.set_live()
+    inconsistent.member[0].kill()
+    assert inconsistent.live
+
+    restored = pickle.loads(pickle.dumps(inconsistent, protocol=5))
+    assert restored.member[0].dead()
+    assert restored.dead()
+
+
+@pytest.mark.parametrize(
+    "data_type,minimum_state_size",
+    [
+        (TimeSeries, 4),
+        (Seismogram, 8),
+        (TimeSeriesEnsemble, 4),
+        (SeismogramEnsemble, 4),
+        (PowerSpectrum, 8),
+    ],
+)
+def test_native_pickle_rejects_invalid_state_lengths(data_type, minimum_state_size):
+    state = data_type().__getstate__()
+    for invalid_state in (state[: minimum_state_size - 1], state + (None,)):
+        with pytest.raises(
+            ValueError, match=f"Invalid {data_type.__name__} pickle state"
+        ):
+            restore_pickle_state(data_type, invalid_state)
+
+
+@pytest.mark.parametrize(
+    "data_type,array_index",
+    [(TimeSeries, 3), (PowerSpectrum, 5)],
+)
+def test_native_pickle_rejects_non_vector_sample_array(data_type, array_index):
+    state = list(data_type().__getstate__())
+    state[array_index] = np.asfortranarray(np.zeros((2, 2)))
+    with pytest.raises(ValueError, match="sample array must be one-dimensional"):
+        restore_pickle_state(data_type, tuple(state))
+
+
+@pytest.mark.parametrize(
+    "data_type,array_index",
+    [(TimeSeries, 3), (Seismogram, 7), (PowerSpectrum, 5)],
+)
+@pytest.mark.parametrize(
+    "invalid_samples,error",
+    [
+        ([1.0], "sample data must be a NumPy array"),
+        (np.zeros((2, 2), dtype=np.float64, order="C"), "one-dimensional"),
+        (np.zeros(4, dtype=np.float32), "dtype float64"),
+        (np.arange(8, dtype=np.float64)[::2], "contiguous"),
+    ],
+)
+def test_native_pickle_rejects_invalid_sample_array(
+    data_type, array_index, invalid_samples, error
+):
+    state = list(data_type().__getstate__())
+    state[array_index] = invalid_samples
+    with pytest.raises(ValueError, match=error):
+        restore_pickle_state(data_type, tuple(state))
+
+
+def test_Seismogram_pickle_rejects_invalid_sample_array_shape():
+    state = list(Seismogram(2).__getstate__())
+
+    non_vector = list(state)
+    non_vector[7] = np.asfortranarray(np.zeros((3, 2)))
+    with pytest.raises(ValueError, match="sample array must be one-dimensional"):
+        restore_pickle_state(Seismogram, tuple(non_vector))
+
+    wrong_size = list(state)
+    wrong_size[7] = np.zeros(3)
+    with pytest.raises(ValueError, match="inconsistent sample array size"):
+        restore_pickle_state(Seismogram, tuple(wrong_size))
+
+    non_multiple_of_three = list(state)
+    non_multiple_of_three[6] = 4
+    non_multiple_of_three[7] = np.zeros(4)
+    with pytest.raises(ValueError, match="inconsistent sample array size"):
+        restore_pickle_state(Seismogram, tuple(non_multiple_of_three))
+
+
+def test_TimeSeries_pickle_rejects_inconsistent_sample_array_size():
+    state = list(TimeSeries(2).__getstate__())
+    state[3] = np.zeros(3)
+    with pytest.raises(ValueError, match="inconsistent sample array size"):
+        restore_pickle_state(TimeSeries, tuple(state))
+
+
 def test_operators():
     d = _CoreTimeSeries(10)
     d1 = make_constant_data_ts(d, nsamp=10)
@@ -1863,6 +2049,49 @@ def test_MsPASSError():
         tm[2, 2] = 1.0
         d.transform(tm)
         d.rotate_to_standard()
+
+
+def make_test_power_spectrum():
+    return PowerSpectrum(
+        Metadata({"pickle_test": "spectrum"}),
+        DoubleVector([1.0, 4.0, 9.0]),
+        0.25,
+        "pickle-test",
+        0.0,
+        0.1,
+        20,
+    )
+
+
+@pytest.mark.parametrize("protocol", [4, 5])
+@pytest.mark.parametrize("lifecycle", ["live", "killed", "default-empty"])
+def test_PowerSpectrum_pickle_preserves_lifecycle_state(protocol, lifecycle):
+    if lifecycle == "default-empty":
+        spectrum = PowerSpectrum()
+    else:
+        spectrum = make_test_power_spectrum()
+        if lifecycle == "killed":
+            spectrum.kill()
+
+    restored = pickle.loads(pickle.dumps(spectrum, protocol=protocol))
+    assert restored.live() == spectrum.live()
+    assert restored.dead() == spectrum.dead()
+    assert restored.nf() == spectrum.nf()
+    assert list(restored.spectrum) == list(spectrum.spectrum)
+    assert restored.timeseries_npts() == spectrum.timeseries_npts()
+
+
+def test_PowerSpectrum_pickle_loads_eight_field_legacy_state_as_live():
+    spectrum = make_test_power_spectrum()
+    spectrum.kill()
+    state = spectrum.__getstate__()
+    assert len(state) == 9
+    assert state[8] is False
+
+    restored = restore_pickle_state(PowerSpectrum, state[:8])
+    assert restored.live()
+    assert restored.timeseries_npts() == spectrum.timeseries_npts()
+    assert list(restored.spectrum) == list(spectrum.spectrum)
 
 
 def test_PowerSpectrum():


### PR DESCRIPTION
## Summary

- remove undefined behavior from empty native seismic sample buffers
- validate pickle tuple and ndarray state before conversion, allocation, or copy
- preserve `PowerSpectrum` live/dead state while accepting legacy eight-field states
- make all-dead ensemble lifecycle state deterministic

The ndarray validation intentionally borrows the original `py::array` first.
It rejects non-arrays, non-1-D input, non-native-`float64` dtype,
noncontiguous layouts, and inconsistent sample counts before acquiring a typed
pointer or calling `memcpy`; malformed state cannot trigger an implicit
pybind11 conversion copy first.

## Compatibility

- Existing eight-field `PowerSpectrum` states remain readable with their
  historical live fallback.
- New nine-field states preserve killed/default-empty spectra.
- Old readers can read the new tuple but, as before, ignore the added lifecycle
  field and therefore resurrect killed spectra; this is an unavoidable legacy
  reader limitation.
- Ensemble member payload format is deliberately unchanged here.  #1021
  handles that separate persistence-format optimization.

## Validation

- 35 focused tests passed with the normal extension
- the same 35 tests passed under ASan
- the same 35 tests passed under UBSan
- full `test_ccore.py`: 63 passed; 3 unrelated packaged-data/`MSPASS_HOME`
  failures in the isolated worktree
- Black check and `git diff --check` passed
- independently reviewed after the validation-order fix

Closes #1018

