### PR TITLE
Add a bounded EarthScope S3 day-window workflow example

### DIFF
--- a/python/tests/test_earthscope_s3_example.py
+++ b/python/tests/test_earthscope_s3_example.py
@@ -134,6 +134,7 @@ def _holding(net, sta, year, jday, key):
 
 
 def test_paginated_index_is_complete_deduplicated_and_deterministic():
+    assert workflow.EARTHSCOPE_BUCKET == "earthscope-geophysical-data"
     prefix = "miniseed/TA/2014/001/"
     first = [{"Key": f"{prefix}S{i}.TA.2014.001"} for i in range(1000)]
     second = [

--- a/python/tests/test_earthscope_s3_example.py
+++ b/python/tests/test_earthscope_s3_example.py
@@ -1,6 +1,8 @@
+import sys
 from dataclasses import replace
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 
 from botocore.exceptions import ClientError
 import dask.distributed as ddist
@@ -427,7 +429,7 @@ def test_failed_worker_setup_has_safe_teardown(monkeypatch):
     worker = FakeWorker()
     plugin = EarthScopeS3Worker()
 
-    def fail_setup():
+    def fail_setup(**kwargs):
         raise RuntimeError("setup failed")
 
     monkeypatch.setattr(worker_support, "create_earthscope_s3_client", fail_setup)
@@ -440,6 +442,58 @@ def test_failed_worker_setup_has_safe_teardown(monkeypatch):
     plugin.teardown(worker)
     assert client.closed
     assert plugin.key not in worker.data
+
+
+def test_earthscope_sdk_session_owns_refresh_and_receives_role(monkeypatch):
+    captured = {}
+    s3_client = object()
+
+    class FakeSession:
+        def client(self, service, config=None):
+            captured["client"] = (service, config)
+            return s3_client
+
+    class FakeUser:
+        def get_boto3_session(self, *, role):
+            captured["scope"] = {"role": role}
+            return FakeSession()
+
+    class FakeEarthScopeClient:
+        def __init__(self):
+            self.user = FakeUser()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "earthscope_sdk",
+        SimpleNamespace(EarthScopeClient=FakeEarthScopeClient),
+    )
+
+    assert (
+        worker_support.create_earthscope_s3_client(role="s3-miniseed-v2") is s3_client
+    )
+    assert captured["scope"] == {"role": "s3-miniseed-v2"}
+    assert captured["client"] == ("s3", worker_support.S3_CONFIG)
+
+    assert worker_support.create_earthscope_s3_client() is s3_client
+    assert captured["scope"] == {"role": "s3-miniseed-v2"}
+
+
+def test_worker_plugin_forwards_role(monkeypatch):
+    captured = {}
+    client = CloseTracker()
+
+    def create_client(**kwargs):
+        captured.update(kwargs)
+        return client
+
+    monkeypatch.setattr(worker_support, "create_earthscope_s3_client", create_client)
+    worker = FakeWorker()
+    plugin = EarthScopeS3Worker(role="test-role")
+
+    plugin.setup(worker)
+
+    assert worker.data[plugin.key] is client
+    assert captured == {"role": "test-role"}
 
 
 def test_worker_completion_keeps_unpickleable_payload_in_process():

--- a/python/tests/test_earthscope_s3_example.py
+++ b/python/tests/test_earthscope_s3_example.py
@@ -1,0 +1,462 @@
+from dataclasses import replace
+from io import BytesIO
+from pathlib import Path
+
+from botocore.exceptions import ClientError
+import dask.distributed as ddist
+import numpy as np
+from obspy import Stream, Trace, UTCDateTime
+import pytest
+
+from mspasspy.workflow import sliding_window_pipeline
+from scripts.earthscope_s3_example import workflow
+from scripts.earthscope_s3_example import worker as worker_support
+from scripts.earthscope_s3_example.worker import EarthScopeS3Worker
+
+
+class FakePaginator:
+    def __init__(self, pages):
+        self.pages = pages
+        self.calls = []
+
+    def paginate(self, **kwargs):
+        self.calls.append(kwargs)
+        yield from self.pages
+
+
+class FakeIndexS3:
+    def __init__(self, pages):
+        self.paginator = FakePaginator(pages)
+
+    def get_paginator(self, name):
+        assert name == "list_objects_v2"
+        return self.paginator
+
+
+class FakeCollection:
+    def __init__(self, documents=()):
+        self.documents = [dict(document) for document in documents]
+
+    def find(self, query):
+        return [
+            document
+            for document in self.documents
+            if all(document.get(key) == value for key, value in query.items())
+        ]
+
+    def replace_one(self, query, document, upsert=False):
+        assert upsert
+        self.documents = [
+            existing
+            for existing in self.documents
+            if not all(existing.get(key) == value for key, value in query.items())
+        ]
+        self.documents.append(dict(document))
+
+
+class FakeBody:
+    def __init__(self, payload=b"miniSEED", error=None, close_error=None):
+        self.payload = payload
+        self.error = error
+        self.close_error = close_error
+        self.closed = False
+
+    def read(self):
+        if self.error is not None:
+            raise self.error
+        return self.payload
+
+    def close(self):
+        self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class FakeObjectS3:
+    def __init__(self, body):
+        self.body = body
+
+    def head_object(self, **kwargs):
+        return {}
+
+    def get_object(self, **kwargs):
+        return {"Body": self.body}
+
+
+class FakeRecord:
+    def __init__(self, name, live=True, npts=1):
+        self.name = name
+        self.live = live
+        self.npts = npts
+
+    def dead(self):
+        return not self.live
+
+
+class FakeUploadS3:
+    def __init__(self):
+        self.uploads = []
+
+    def upload_file(self, filename, bucket, key, Config=None):
+        self.uploads.append((bucket, key, Path(filename).read_bytes(), Config))
+
+
+class FakeWorker:
+    def __init__(self):
+        self.data = {}
+
+
+class CloseTracker:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class WorkerOnlyPayload:
+    def __reduce__(self):
+        raise RuntimeError("worker-only payload crossed the process boundary")
+
+
+def make_worker_only_payload(item):
+    return item, WorkerOnlyPayload()
+
+
+def consume_worker_only_payload(payload):
+    item, large_value = payload
+    assert isinstance(large_value, WorkerOnlyPayload)
+    return {"ok": True, "item": item}
+
+
+def _holding(net, sta, year, jday, key):
+    return {"net": net, "sta": sta, "year": year, "jday": jday, "s3key": key}
+
+
+def test_paginated_index_is_complete_deduplicated_and_deterministic():
+    prefix = "miniseed/TA/2014/001/"
+    first = [{"Key": f"{prefix}S{i}.TA.2014.001"} for i in range(1000)]
+    second = [
+        {"Key": f"{prefix}S1000.TA.2014.001#2"},
+        {"Key": f"{prefix}S1001.TA.2014.001"},
+        {"Key": f"{prefix}S1000.TA.2014.001#1"},
+    ]
+    client = FakeIndexS3([{"Contents": first}, {"Contents": second}])
+
+    keys = workflow.list_station_day_keys(client, "TA", 2014, 1)
+
+    assert len(keys) == 1002
+    assert keys == sorted(keys)
+    assert keys.count(f"{prefix}S1000.TA.2014.001") == 1
+    assert len(client.paginator.calls) == 1
+
+    collection = FakeCollection()
+    result = workflow.index_station_days(
+        client, collection, [None, "", "TA"], [(2014, 1)]
+    )
+    assert result == {"indexed": 1002}
+    assert len(collection.documents) == 1002
+
+
+def test_index_materializes_one_shot_days_for_every_network():
+    client = FakeIndexS3([{"Contents": []}])
+    collection = FakeCollection()
+
+    workflow.index_station_days(
+        client, collection, ["IU", "TA"], ((2014, day) for day in (1, 2))
+    )
+
+    assert len(client.paginator.calls) == 4
+
+
+def test_cross_midnight_batches_have_no_omissions_or_duplicate_arrivals():
+    day = UTCDateTime(year=2014, julday=1)
+    arrivals = [
+        {"arid": 1, "net": "TA", "sta": "TEST", "time": float(day + 43200)},
+        {"arid": 2, "net": "TA", "sta": "TEST", "time": float(day + 86390)},
+    ]
+    holdings = FakeCollection(
+        [
+            _holding("TA", "TEST", 2014, 1, "day-1"),
+            _holding("TA", "TEST", 2014, 2, "day-2"),
+        ]
+    )
+
+    batches = workflow.build_station_batches(
+        arrivals, holdings, -240, 300, pad=100, max_arrivals_per_batch=32
+    )
+
+    assert len(batches) == 1
+    batch = batches[0]
+    assert [request.arrival_id for request in batch.arrivals] == ["1", "2"]
+    assert batch.object_keys == ("day-1", "day-2")
+    assert batch.missing_days == ()
+
+    only_crossing = workflow.build_station_batches(
+        [arrivals[1]], holdings, -240, 300, pad=100
+    )
+    assert [request.arrival_id for request in only_crossing[0].arrivals] == ["2"]
+
+
+def test_year_and_station_preparation_boundaries():
+    query = workflow.year_query(2014)
+    assert "$lt" in query["Ptime"]
+    assert "$lte" not in query["Ptime"]
+    assert query["Ptime"]["$lt"] == float(UTCDateTime(2015, 1, 1))
+    days = list(workflow.index_days_for_year(2014))
+    assert days[0] == (2013, 365)
+    assert days[-1] == (2015, 1)
+    assert workflow.normalized_networks(["TA", None, "", "IU", "TA"]) == [
+        "IU",
+        "TA",
+    ]
+    normalized = workflow.normalize_station(
+        {"sta": "ORIGINAL", "arid": 1}, {}, default_network="TA"
+    )
+    assert normalized["net"] == "TA"
+    assert normalized["sta"] == "ORIGINAL"
+    matched = workflow.normalize_station(
+        {"sta": "ALIAS", "arid": 2}, {"ALIAS": ("IU", "ANMO")}
+    )
+    assert matched["net"] == "IU"
+    assert matched["sta"] == "ANMO"
+
+    year_boundary = UTCDateTime(year=2016, julday=366) + 86399
+    assert workflow.days_for_interval(
+        float(year_boundary), float(year_boundary + 2)
+    ) == ((2016, 366), (2017, 1))
+
+
+def test_object_body_closes_and_errors_are_not_masked():
+    body = FakeBody()
+    marker = object()
+    result = workflow.read_versioned_miniseed(
+        FakeObjectS3(body), "base", stream_reader=lambda *args, **kwargs: marker
+    )
+    assert result is marker
+    assert body.closed
+
+    original = RuntimeError("read failed")
+    body = FakeBody(error=original, close_error=RuntimeError("close failed"))
+    try:
+        workflow.read_versioned_miniseed(FakeObjectS3(body), "base")
+    except RuntimeError as error:
+        assert error is original
+    else:
+        raise AssertionError("read error was not propagated")
+    assert body.closed
+
+    interrupt = KeyboardInterrupt("stop")
+    body = FakeBody(error=interrupt)
+    try:
+        workflow.read_versioned_miniseed(FakeObjectS3(body), "base")
+    except KeyboardInterrupt as error:
+        assert error is interrupt
+    else:
+        raise AssertionError("control exception was not propagated")
+    assert body.closed
+
+
+def test_non_missing_head_error_propagates():
+    error = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "denied"}}, "HeadObject"
+    )
+
+    class DeniedS3:
+        def head_object(self, **kwargs):
+            raise error
+
+    try:
+        workflow.read_versioned_miniseed(DeniedS3(), "base")
+    except ClientError as raised:
+        assert raised is error
+    else:
+        raise AssertionError("access error was not propagated")
+
+
+def test_versioned_reader_checks_base_then_descending_suffixes():
+    body = FakeBody(payload=b"selected-version")
+
+    class VersionedS3:
+        def __init__(self):
+            self.head_calls = []
+            self.get_calls = []
+
+        def head_object(self, **kwargs):
+            self.head_calls.append(kwargs["Key"])
+            if kwargs["Key"] != "base#2":
+                raise ClientError(
+                    {"Error": {"Code": "404", "Message": "missing"}},
+                    "HeadObject",
+                )
+            return {}
+
+        def get_object(self, **kwargs):
+            self.get_calls.append(kwargs["Key"])
+            return {"Body": body}
+
+    client = VersionedS3()
+    result = workflow.read_versioned_miniseed(
+        client,
+        "base",
+        max_version=3,
+        stream_reader=lambda buffer, **kwargs: buffer.read(),
+    )
+
+    assert client.head_calls == ["base", "base#3", "base#2"]
+    assert client.get_calls == ["base#2"]
+    assert result == b"selected-version"
+    assert body.closed
+
+
+def test_multirate_stream_converts_once_and_detrends_decoded_data():
+    stream = Stream(
+        [
+            Trace(np.arange(8, dtype=float), {"channel": "BHZ", "sampling_rate": 1}),
+            Trace(np.arange(8, dtype=float), {"channel": "BHN", "sampling_rate": 2}),
+        ]
+    )
+    decoded = object()
+    converted = []
+    detrended = []
+
+    def converter(merged):
+        converted.append(merged)
+        return decoded
+
+    def apply_detrend(data, **kwargs):
+        detrended.append((data, kwargs))
+        return data
+
+    result = workflow.prepare_stream(
+        stream,
+        detrend_type="simple",
+        converter=converter,
+        detrend_function=apply_detrend,
+    )
+
+    assert result is decoded
+    assert len(converted) == 1
+    assert {trace.stats.sampling_rate for trace in converted[0]} == {1, 2}
+    assert detrended == [(decoded, {"type": "simple"})]
+
+
+def test_writer_filters_records_streams_incrementally_and_is_idempotent(monkeypatch):
+    request = workflow.WindowRequest("1", 1.0, 0.0, 2.0, {})
+    batch = workflow.StationBatch(
+        2014, 1, "TA", "TEST", 0, (request,), ("input",), (), "B*"
+    )
+    upload = FakeUploadS3()
+    monkeypatch.setattr(workflow, "fetch_s3_client", lambda **kwargs: upload)
+
+    station_stream = workflow.StationRecordStream(
+        batch,
+        iter(
+            [
+                FakeRecord("dead", live=False),
+                FakeRecord("empty", npts=0),
+                FakeRecord("kept"),
+            ]
+        ),
+    )
+    status = workflow.write_station_batch_records(
+        station_stream, output_bucket="output", multipart_chunk_bytes=1024
+    )
+
+    assert status["ok"]
+    assert status["records"] == 1
+    assert len(upload.uploads) == 1
+    bucket, key, payload, config = upload.uploads[0]
+    assert bucket == "output"
+    assert key == workflow.station_batch_object_key(batch)
+    assert config.max_request_concurrency == 1
+    objects = list(workflow.iter_record_stream(BytesIO(payload)))
+    assert objects[0]["format"] == "mspass-earthscope-station-batch-v1"
+    assert [record.name for record in objects[1:]] == ["kept"]
+
+    assert workflow.station_batch_object_key(batch) == key
+    assert workflow.station_batch_object_key(replace(batch, channel_select="H*")) != key
+
+
+def test_writer_reports_missing_holding_with_initialized_zero_counts(monkeypatch):
+    request = workflow.WindowRequest("1", 1.0, 0.0, 2.0, {})
+    batch = workflow.StationBatch(
+        2014,
+        1,
+        "TA",
+        "TEST",
+        0,
+        (request,),
+        (),
+        ((2014, 2),),
+        "B*",
+    )
+    upload = FakeUploadS3()
+    monkeypatch.setattr(workflow, "fetch_s3_client", lambda **kwargs: upload)
+
+    status = workflow.write_station_batch_records(
+        workflow.StationRecordStream(batch, iter(())), output_bucket="output"
+    )
+
+    assert status["ok"] is False
+    assert status["records"] == 0
+    assert status["missing_days"] == 1
+
+
+def test_run_station_batches_forwards_nondefault_version(monkeypatch):
+    captured = {}
+
+    def capture(*args, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(workflow, "sliding_window_pipeline", capture)
+    assert (
+        workflow.run_station_batches(
+            [], object(), output_bucket="output", max_version=3
+        )
+        == []
+    )
+    assert captured["pfunc_kwargs"]["max_version"] == 3
+    assert captured["sliding_window_size"] == 1
+    assert captured["completion_on_worker"] is True
+    assert captured["retain_results"] is True
+
+
+def test_failed_worker_setup_has_safe_teardown(monkeypatch):
+    worker = FakeWorker()
+    plugin = EarthScopeS3Worker()
+
+    def fail_setup():
+        raise RuntimeError("setup failed")
+
+    monkeypatch.setattr(worker_support, "create_earthscope_s3_client", fail_setup)
+    with pytest.raises(RuntimeError, match="setup failed"):
+        plugin.setup(worker)
+    plugin.teardown(worker)
+
+    client = CloseTracker()
+    worker.data[plugin.key] = client
+    plugin.teardown(worker)
+    assert client.closed
+    assert plugin.key not in worker.data
+
+
+def test_worker_completion_keeps_unpickleable_payload_in_process():
+    with ddist.LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=True,
+        dashboard_address=None,
+    ) as cluster:
+        with ddist.Client(cluster) as client:
+            result = sliding_window_pipeline(
+                [7],
+                make_worker_only_payload,
+                client,
+                sliding_window_size=1,
+                completion_function=consume_worker_only_payload,
+                completion_on_worker=True,
+            )
+
+    assert result == [{"ok": True, "item": 7}]

--- a/python/tests/test_earthscope_s3_example.py
+++ b/python/tests/test_earthscope_s3_example.py
@@ -1,8 +1,6 @@
-import sys
 from dataclasses import replace
 from io import BytesIO
 from pathlib import Path
-from types import SimpleNamespace
 
 from botocore.exceptions import ClientError
 import dask.distributed as ddist
@@ -432,7 +430,7 @@ def test_failed_worker_setup_has_safe_teardown(monkeypatch):
     def fail_setup(**kwargs):
         raise RuntimeError("setup failed")
 
-    monkeypatch.setattr(worker_support, "create_earthscope_s3_client", fail_setup)
+    monkeypatch.setattr(worker_support, "create_s3_client", fail_setup)
     with pytest.raises(RuntimeError, match="setup failed"):
         plugin.setup(worker)
     plugin.teardown(worker)
@@ -444,56 +442,31 @@ def test_failed_worker_setup_has_safe_teardown(monkeypatch):
     assert plugin.key not in worker.data
 
 
-def test_earthscope_sdk_session_owns_refresh_and_receives_role(monkeypatch):
-    captured = {}
+def test_worker_client_uses_standard_boto3_session(monkeypatch):
+    calls = []
     s3_client = object()
 
     class FakeSession:
         def client(self, service, config=None):
-            captured["client"] = (service, config)
+            calls.append((service, config))
             return s3_client
 
-    class FakeUser:
-        def get_boto3_session(self, *, role):
-            captured["scope"] = {"role": role}
-            return FakeSession()
+    monkeypatch.setattr(worker_support, "Session", FakeSession)
 
-    class FakeEarthScopeClient:
-        def __init__(self):
-            self.user = FakeUser()
-
-    monkeypatch.setitem(
-        sys.modules,
-        "earthscope_sdk",
-        SimpleNamespace(EarthScopeClient=FakeEarthScopeClient),
-    )
-
-    assert (
-        worker_support.create_earthscope_s3_client(role="s3-miniseed-v2") is s3_client
-    )
-    assert captured["scope"] == {"role": "s3-miniseed-v2"}
-    assert captured["client"] == ("s3", worker_support.S3_CONFIG)
-
-    assert worker_support.create_earthscope_s3_client() is s3_client
-    assert captured["scope"] == {"role": "s3-miniseed-v2"}
+    assert worker_support.create_s3_client() is s3_client
+    assert calls == [("s3", worker_support.S3_CONFIG)]
 
 
-def test_worker_plugin_forwards_role(monkeypatch):
-    captured = {}
+def test_worker_plugin_installs_shared_client(monkeypatch):
     client = CloseTracker()
 
-    def create_client(**kwargs):
-        captured.update(kwargs)
-        return client
-
-    monkeypatch.setattr(worker_support, "create_earthscope_s3_client", create_client)
+    monkeypatch.setattr(worker_support, "create_s3_client", lambda: client)
     worker = FakeWorker()
-    plugin = EarthScopeS3Worker(role="test-role")
+    plugin = EarthScopeS3Worker()
 
     plugin.setup(worker)
 
     assert worker.data[plugin.key] is client
-    assert captured == {"role": "test-role"}
 
 
 def test_worker_completion_keeps_unpickleable_payload_in_process():

--- a/scripts/earthscope_s3_example/README.md
+++ b/scripts/earthscope_s3_example/README.md
@@ -1,0 +1,93 @@
+# Bounded EarthScope S3 day-window example
+
+This directory is a maintained example for one specific workflow: index
+EarthScope station-day miniSEED objects, extract event windows, and write
+bounded station batches.  It is not a universal EarthScope data API.
+
+The example contains no credentials or notebook output.  Authentication must
+come from the EarthScope SDK at runtime.  Do not print, save, commit, or place
+short-lived credentials in Dask task arguments.  Register one refreshable
+client per worker instead:
+
+```python
+from scripts.earthscope_s3_example.worker import EarthScopeS3Worker
+
+dask_client.register_plugin(EarthScopeS3Worker())
+```
+
+For serial indexing, obtain an authenticated session at runtime and pass it to
+`fetch_s3_client(session=...)`.  Use `index_days_for_year(year)` when building
+the station-day index; it includes the adjacent December 31 and January 1
+needed by padded windows.  `year_query(year)` is half-open, so an arrival at
+exactly January 1 belongs to only the new year.  Filter network values with
+`normalized_networks` instead of deleting an arbitrary element returned by
+MongoDB `distinct`.  Normalize every arrival with `normalize_station`; a
+station absent from the cross-reference keeps its original station code and
+receives the configured default network instead of inheriting stale loop
+state:
+
+```python
+from scripts.earthscope_s3_example.workflow import normalize_station
+
+arrival_documents = [
+    normalize_station(document, station_cross_reference, default_network="TA")
+    for document in arrival_documents
+]
+```
+
+Build station batches with a finite `max_arrivals_per_batch`.  Each arrival
+identity appears once, while its batch unions every station-day object needed
+by its window:
+
+```python
+from scripts.earthscope_s3_example.workflow import build_station_batches
+
+batches = build_station_batches(
+    arrival_documents,
+    db.wf_s3,
+    -240,
+    300,
+    pad=100,
+    max_arrivals_per_batch=32,
+    auxiliary_keys=("evid", "orid", "iphase", "delta", "pick_channel"),
+)
+```
+
+The worker reader returns a local generator.  The completion consumes that
+generator in the same worker, writes independent pickle records to a bounded
+temporary file, and uploads with one multipart buffer.  It never constructs a
+second whole-day ensemble.  Output keys derive from the station, day, batch
+number, and window identities, so retrying the same batch overwrites the same
+object rather than duplicating it.
+
+```python
+import os
+
+from scripts.earthscope_s3_example.workflow import run_station_batches
+
+statuses = run_station_batches(
+    batches,
+    dask_client,
+    output_bucket=os.environ["SCRATCH_BUCKET"],
+    sliding_window_size=1,
+)
+```
+
+`output_bucket` is the plain S3 bucket name.  Put any directory-like portion
+in `output_prefix`; do not pass an `s3://` URI as the bucket argument.
+
+Keep `sliding_window_size=1` until the largest station batch has been measured
+on the target GeoLab deployment.  Increase it only when the measured worker
+and database headroom permits.  A station-day miniSEED image, one decoded
+station stream, and one event window can coexist in a worker; the batch limit
+must make that peak fit.
+
+The object format starts with a small header followed by independently pickled
+waveform records.  Read it incrementally with `iter_record_stream`; never load
+untrusted pickle data.  The first yielded object is the header and the
+remaining objects are waveform records.
+
+The automated tests use fake MongoDB and S3 implementations.  They do not
+validate EarthScope authorization, the live object-lambda endpoint, real CSS
+tables, GeoLab filesystem limits, or production multipart throughput.  Run a
+small measured day before a yearly import.

--- a/scripts/earthscope_s3_example/README.md
+++ b/scripts/earthscope_s3_example/README.md
@@ -4,12 +4,11 @@ This directory is a maintained example for one specific workflow: index
 EarthScope station-day miniSEED objects, extract event windows, and write
 bounded station batches.  It is not a universal EarthScope data API.
 
-The example contains no credentials or notebook output.  Authentication must
-come from the EarthScope SDK at runtime.  Do not print, save, commit, or place
-short-lived credentials in Dask task arguments.  Register one refreshable
-client per worker instead.  The SDK returns a refreshable boto3 session, so
-the worker plugin delegates credential refresh to the SDK and requests the
-current `s3-miniseed-v2` role:
+The example contains no credentials or notebook output.  Do not print, save,
+commit, or place short-lived credentials in Dask task arguments.  Register one
+client per worker instead.  The plugin uses boto3's standard credential chain,
+which lets the same GeoLab worker identity read the public input bucket and
+write its authorized scratch bucket:
 
 ```python
 from scripts.earthscope_s3_example.worker import EarthScopeS3Worker
@@ -20,22 +19,23 @@ dask_client.register_plugin(EarthScopeS3Worker())
 The input is intentionally limited to the AWS Open Data Program bucket,
 `earthscope-geophysical-data`, for networks AK, II, IU, N4, PB, TA, UU, and
 UW.  In particular, this is the correct current bucket for the 2014 TA data
-that motivated the example.  Other networks use a separately authorized
-EarthScope Repository access point and network-scoped credentials; adapt the
-example only after following the
+that motivated the example, and it does not require EarthScope temporary
+credentials.  Other networks use a separately authorized EarthScope
+Repository access point and network-scoped credentials; adapt the example only
+after following the
 [EarthScope direct-S3 guide](https://docs.earthscope.org/sdk/s3-direct-access-tutorial)
 for its current bucket, region, and credential rules.
 
-For serial indexing, obtain an authenticated session at runtime and pass it to
-`fetch_s3_client(session=...)`.  Use `index_days_for_year(year)` when building
-the station-day index; it includes the adjacent December 31 and January 1
-needed by padded windows.  `year_query(year)` is half-open, so an arrival at
-exactly January 1 belongs to only the new year.  Filter network values with
-`normalized_networks` instead of deleting an arbitrary element returned by
-MongoDB `distinct`.  Normalize every arrival with `normalize_station`; a
-station absent from the cross-reference keeps its original station code and
-receives the configured default network instead of inheriting stale loop
-state:
+For serial indexing, create a standard `boto3.Session` at runtime and pass it
+to `fetch_s3_client(session=...)`.  Use `index_days_for_year(year)` when
+building the station-day index; it includes the adjacent December 31 and
+January 1 needed by padded windows.  `year_query(year)` is half-open, so an
+arrival at exactly January 1 belongs to only the new year.  Filter network
+values with `normalized_networks` instead of deleting an arbitrary element
+returned by MongoDB `distinct`.  Normalize every arrival with
+`normalize_station`; a station absent from the cross-reference keeps its
+original station code and receives the configured default network instead of
+inheriting stale loop state:
 
 ```python
 from scripts.earthscope_s3_example.workflow import normalize_station

--- a/scripts/earthscope_s3_example/README.md
+++ b/scripts/earthscope_s3_example/README.md
@@ -7,13 +7,24 @@ bounded station batches.  It is not a universal EarthScope data API.
 The example contains no credentials or notebook output.  Authentication must
 come from the EarthScope SDK at runtime.  Do not print, save, commit, or place
 short-lived credentials in Dask task arguments.  Register one refreshable
-client per worker instead:
+client per worker instead.  The SDK returns a refreshable boto3 session, so
+the worker plugin delegates credential refresh to the SDK and requests the
+current `s3-miniseed-v2` role:
 
 ```python
 from scripts.earthscope_s3_example.worker import EarthScopeS3Worker
 
 dask_client.register_plugin(EarthScopeS3Worker())
 ```
+
+The input is intentionally limited to the AWS Open Data Program bucket,
+`earthscope-geophysical-data`, for networks AK, II, IU, N4, PB, TA, UU, and
+UW.  In particular, this is the correct current bucket for the 2014 TA data
+that motivated the example.  Other networks use a separately authorized
+EarthScope Repository access point and network-scoped credentials; adapt the
+example only after following the
+[EarthScope direct-S3 guide](https://docs.earthscope.org/sdk/s3-direct-access-tutorial)
+for its current bucket, region, and credential rules.
 
 For serial indexing, obtain an authenticated session at runtime and pass it to
 `fetch_s3_client(session=...)`.  Use `index_days_for_year(year)` when building
@@ -88,6 +99,6 @@ untrusted pickle data.  The first yielded object is the header and the
 remaining objects are waveform records.
 
 The automated tests use fake MongoDB and S3 implementations.  They do not
-validate EarthScope authorization, the live object-lambda endpoint, real CSS
+validate EarthScope authorization, the live repository endpoint, real CSS
 tables, GeoLab filesystem limits, or production multipart throughput.  Run a
 small measured day before a yearly import.

--- a/scripts/earthscope_s3_example/__init__.py
+++ b/scripts/earthscope_s3_example/__init__.py
@@ -1,0 +1,4 @@
+"""Bounded EarthScope S3 workflow example.
+
+This package is an example integration, not a general EarthScope data API.
+"""

--- a/scripts/earthscope_s3_example/worker.py
+++ b/scripts/earthscope_s3_example/worker.py
@@ -1,0 +1,84 @@
+"""Worker-local EarthScope S3 client support for the example workflow."""
+
+from datetime import datetime, timedelta, timezone
+
+from boto3 import Session
+from botocore.config import Config
+from botocore.credentials import RefreshableCredentials
+from botocore.session import get_session
+from dask.distributed import WorkerPlugin, get_worker
+
+S3_CONFIG = Config(
+    request_checksum_calculation="when_required",
+    response_checksum_validation="when_required",
+)
+
+
+def fetch_s3_client(session=None, worker_data_key="earthscope_s3_client"):
+    """Return a serial client or the client installed on the current worker."""
+    if session is not None:
+        return session.client("s3", config=S3_CONFIG)
+
+    try:
+        worker = get_worker()
+    except Exception as error:
+        raise ValueError(
+            "fetch_s3_client requires a boto3 session outside a Dask worker"
+        ) from error
+
+    try:
+        return worker.data[worker_data_key]
+    except KeyError as error:
+        raise ValueError(
+            f"worker has no S3 client under key {worker_data_key!r}; "
+            "register EarthScopeS3Worker before submitting the workflow"
+        ) from error
+
+
+def _fresh_earthscope_credentials():
+    """Fetch short-lived credentials at runtime without serializing them."""
+    from earthscope_sdk import EarthScopeClient
+
+    session = EarthScopeClient().user.get_boto3_session()
+    credentials = session.get_credentials()
+    frozen = credentials.get_frozen_credentials()
+    expiry = getattr(credentials, "_expiry_time", None)
+    if isinstance(expiry, datetime):
+        expiry_string = expiry.astimezone(timezone.utc).isoformat()
+    elif isinstance(expiry, str):
+        expiry_string = expiry
+    else:
+        expiry_string = (datetime.now(timezone.utc) + timedelta(minutes=55)).isoformat()
+    return {
+        "access_key": frozen.access_key,
+        "secret_key": frozen.secret_key,
+        "token": frozen.token,
+        "expiry_time": expiry_string,
+    }
+
+
+def create_earthscope_s3_client():
+    """Create a worker client whose EarthScope credentials refresh in place."""
+    credentials = RefreshableCredentials.create_from_metadata(
+        metadata=_fresh_earthscope_credentials(),
+        refresh_using=_fresh_earthscope_credentials,
+        method="sts-assume-role",
+    )
+    botocore_session = get_session()
+    botocore_session._credentials = credentials
+    return Session(botocore_session=botocore_session).client("s3", config=S3_CONFIG)
+
+
+class EarthScopeS3Worker(WorkerPlugin):
+    """Install one refreshable S3 client in each Dask worker."""
+
+    def __init__(self, key="earthscope_s3_client"):
+        self.key = key
+
+    def setup(self, worker):
+        worker.data[self.key] = create_earthscope_s3_client()
+
+    def teardown(self, worker):
+        client = worker.data.pop(self.key, None)
+        if client is not None:
+            client.close()

--- a/scripts/earthscope_s3_example/worker.py
+++ b/scripts/earthscope_s3_example/worker.py
@@ -1,11 +1,6 @@
 """Worker-local EarthScope S3 client support for the example workflow."""
 
-from datetime import datetime, timedelta, timezone
-
-from boto3 import Session
 from botocore.config import Config
-from botocore.credentials import RefreshableCredentials
-from botocore.session import get_session
 from dask.distributed import WorkerPlugin, get_worker
 
 S3_CONFIG = Config(
@@ -35,48 +30,23 @@ def fetch_s3_client(session=None, worker_data_key="earthscope_s3_client"):
         ) from error
 
 
-def _fresh_earthscope_credentials():
-    """Fetch short-lived credentials at runtime without serializing them."""
+def create_earthscope_s3_client(role="s3-miniseed-v2"):
+    """Create an S3 client from the SDK's refreshable boto3 session."""
     from earthscope_sdk import EarthScopeClient
 
-    session = EarthScopeClient().user.get_boto3_session()
-    credentials = session.get_credentials()
-    frozen = credentials.get_frozen_credentials()
-    expiry = getattr(credentials, "_expiry_time", None)
-    if isinstance(expiry, datetime):
-        expiry_string = expiry.astimezone(timezone.utc).isoformat()
-    elif isinstance(expiry, str):
-        expiry_string = expiry
-    else:
-        expiry_string = (datetime.now(timezone.utc) + timedelta(minutes=55)).isoformat()
-    return {
-        "access_key": frozen.access_key,
-        "secret_key": frozen.secret_key,
-        "token": frozen.token,
-        "expiry_time": expiry_string,
-    }
-
-
-def create_earthscope_s3_client():
-    """Create a worker client whose EarthScope credentials refresh in place."""
-    credentials = RefreshableCredentials.create_from_metadata(
-        metadata=_fresh_earthscope_credentials(),
-        refresh_using=_fresh_earthscope_credentials,
-        method="sts-assume-role",
-    )
-    botocore_session = get_session()
-    botocore_session._credentials = credentials
-    return Session(botocore_session=botocore_session).client("s3", config=S3_CONFIG)
+    session = EarthScopeClient().user.get_boto3_session(role=role)
+    return session.client("s3", config=S3_CONFIG)
 
 
 class EarthScopeS3Worker(WorkerPlugin):
     """Install one refreshable S3 client in each Dask worker."""
 
-    def __init__(self, key="earthscope_s3_client"):
+    def __init__(self, key="earthscope_s3_client", role="s3-miniseed-v2"):
         self.key = key
+        self.role = role
 
     def setup(self, worker):
-        worker.data[self.key] = create_earthscope_s3_client()
+        worker.data[self.key] = create_earthscope_s3_client(role=self.role)
 
     def teardown(self, worker):
         client = worker.data.pop(self.key, None)

--- a/scripts/earthscope_s3_example/worker.py
+++ b/scripts/earthscope_s3_example/worker.py
@@ -1,5 +1,6 @@
 """Worker-local EarthScope S3 client support for the example workflow."""
 
+from boto3 import Session
 from botocore.config import Config
 from dask.distributed import WorkerPlugin, get_worker
 
@@ -30,23 +31,20 @@ def fetch_s3_client(session=None, worker_data_key="earthscope_s3_client"):
         ) from error
 
 
-def create_earthscope_s3_client(role="s3-miniseed-v2"):
-    """Create an S3 client from the SDK's refreshable boto3 session."""
-    from earthscope_sdk import EarthScopeClient
-
-    session = EarthScopeClient().user.get_boto3_session(role=role)
+def create_s3_client():
+    """Create one client from the worker's standard AWS credential chain."""
+    session = Session()
     return session.client("s3", config=S3_CONFIG)
 
 
 class EarthScopeS3Worker(WorkerPlugin):
-    """Install one refreshable S3 client in each Dask worker."""
+    """Install one ambient-credential S3 client in each Dask worker."""
 
-    def __init__(self, key="earthscope_s3_client", role="s3-miniseed-v2"):
+    def __init__(self, key="earthscope_s3_client"):
         self.key = key
-        self.role = role
 
     def setup(self, worker):
-        worker.data[self.key] = create_earthscope_s3_client(role=self.role)
+        worker.data[self.key] = create_s3_client()
 
     def teardown(self, worker):
         client = worker.data.pop(self.key, None)

--- a/scripts/earthscope_s3_example/workflow.py
+++ b/scripts/earthscope_s3_example/workflow.py
@@ -1,0 +1,558 @@
+"""Bounded station-batch workflow for EarthScope station-day miniSEED."""
+
+import calendar
+from dataclasses import dataclass
+import hashlib
+import io
+import json
+from pathlib import Path
+import pickle
+import tempfile
+from urllib.parse import quote
+
+import obspy
+from obspy import UTCDateTime
+from boto3.s3.transfer import TransferConfig
+from botocore.exceptions import ClientError
+
+from mspasspy.algorithms.signals import detrend
+from mspasspy.algorithms.window import WindowData
+from mspasspy.util.converter import Stream2TimeSeriesEnsemble
+from mspasspy.workflow import sliding_window_pipeline
+
+from .worker import fetch_s3_client
+
+EARTHSCOPE_BUCKET = "earthscope-mseed-res-na3mtd4fq5kz7pntcyr1uh46use2a--ol-s3"
+RECORD_STREAM_MAGIC = b"MSPASS_EARTHSCOPE_STATION_BATCH_V1\n"
+IMMUTABLE_METADATA = {
+    "delta",
+    "endtime",
+    "npts",
+    "starttime",
+    "time_standard",
+    "utc_convertible",
+}
+
+
+@dataclass(frozen=True)
+class WindowRequest:
+    """One arrival window retained exactly once in a station batch."""
+
+    arrival_id: str
+    arrival_time: float
+    starttime: float
+    endtime: float
+    metadata: dict
+
+
+@dataclass(frozen=True)
+class StationBatch:
+    """A bounded set of windows for one station and arrival day."""
+
+    year: int
+    jday: int
+    net: str
+    sta: str
+    batch_index: int
+    arrivals: tuple
+    object_keys: tuple
+    missing_days: tuple
+    channel_select: str = "B*"
+
+
+@dataclass
+class StationRecordStream:
+    """Worker-local record iterator paired with its small batch description."""
+
+    batch: StationBatch
+    records: object
+
+
+def year_query(year, time_key="Ptime"):
+    """Return a half-open MongoDB time query for one calendar year."""
+    start = float(UTCDateTime(year=year, month=1, day=1))
+    end = float(UTCDateTime(year=year + 1, month=1, day=1))
+    return {time_key: {"$gte": start, "$lt": end}}
+
+
+def normalized_networks(values):
+    """Remove explicitly empty network values without relying on ordering."""
+    return sorted(
+        {
+            str(value).strip()
+            for value in values
+            if value is not None and str(value).strip()
+        }
+    )
+
+
+def normalize_station(document, station_cross_reference, default_network="TA"):
+    """Normalize network/station codes while preserving an unmatched station."""
+    result = dict(document)
+    station = result.get("sta")
+    if not station:
+        raise ValueError("arrival document is missing sta")
+    if station in station_cross_reference:
+        network, final_station = station_cross_reference[station]
+        result["net"] = network
+        result["sta"] = final_station
+    else:
+        result["net"] = result.get("net") or default_network
+        result["sta"] = station
+    return result
+
+
+def days_for_interval(starttime, endtime):
+    """Return every UTC year/julian-day pair touched by a closed interval."""
+    if endtime < starttime:
+        raise ValueError("endtime must not precede starttime")
+    first = UTCDateTime(starttime)
+    current = UTCDateTime(year=first.year, julday=first.julday)
+    stop = UTCDateTime(endtime)
+    days = []
+    while current <= stop:
+        days.append((current.year, current.julday))
+        current += 86400
+    return tuple(days)
+
+
+def index_days_for_year(year):
+    """Yield the target year plus the adjacent day needed by padded windows."""
+    previous_year_days = 366 if calendar.isleap(year - 1) else 365
+    yield year - 1, previous_year_days
+    days = 366 if calendar.isleap(year) else 365
+    for jday in range(1, days + 1):
+        yield year, jday
+    yield year + 1, 1
+
+
+def list_station_day_keys(
+    s3_client,
+    net,
+    year,
+    jday,
+    bucket=EARTHSCOPE_BUCKET,
+):
+    """List all station-day base keys using the S3 paginator."""
+    prefix = f"miniseed/{net}/{year}/{jday:03d}/"
+    paginator = s3_client.get_paginator("list_objects_v2")
+    keys = set()
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/"):
+        for item in page.get("Contents", ()):
+            keys.add(item["Key"].split("#", 1)[0])
+    return sorted(keys)
+
+
+def station_day_document(key):
+    """Convert a canonical EarthScope station-day key to an index document."""
+    parts = key.split("/")
+    if len(parts) < 5:
+        raise ValueError(f"invalid EarthScope station-day key: {key!r}")
+    filename = parts[-1].split(".")
+    if len(filename) < 4:
+        raise ValueError(f"invalid EarthScope station-day filename: {key!r}")
+    year = int(parts[-3])
+    jday = int(parts[-2])
+    starttime = float(UTCDateTime(year=year, julday=jday))
+    return {
+        "s3key": key,
+        "net": parts[-4],
+        "sta": filename[0],
+        "year": year,
+        "jday": jday,
+        "starttime": starttime,
+        "endtime": starttime + 86400.0,
+    }
+
+
+def index_station_days(
+    s3_client,
+    collection,
+    networks,
+    days,
+    bucket=EARTHSCOPE_BUCKET,
+):
+    """Upsert a deterministic station-day index into a Mongo-like collection."""
+    indexed = 0
+    indexed_days = tuple(days)
+    for net in normalized_networks(networks):
+        for year, jday in indexed_days:
+            keys = list_station_day_keys(s3_client, net, year, jday, bucket)
+            for key in keys:
+                document = station_day_document(key)
+                collection.replace_one({"s3key": key}, document, upsert=True)
+                indexed += 1
+    return {"indexed": indexed}
+
+
+def _anchor_day(timestamp):
+    time = UTCDateTime(timestamp)
+    return time.year, time.julday
+
+
+def _holding_keys(collection, net, sta, days):
+    keys = set()
+    missing = []
+    for year, jday in sorted(days):
+        query = {"net": net, "sta": sta, "year": year, "jday": jday}
+        day_keys = {document["s3key"] for document in collection.find(query)}
+        if day_keys:
+            keys.update(day_keys)
+        else:
+            missing.append((year, jday))
+    return tuple(sorted(keys)), tuple(missing)
+
+
+def build_station_batches(
+    arrivals,
+    holdings_collection,
+    start,
+    end,
+    *,
+    pad=100.0,
+    max_arrivals_per_batch=32,
+    arrival_id_key="arid",
+    time_key="time",
+    auxiliary_keys=(),
+    channel_select="B*",
+):
+    """Build bounded station batches without arrival/holding cross products."""
+    if max_arrivals_per_batch <= 0:
+        raise ValueError("max_arrivals_per_batch must be positive")
+    if end < start:
+        raise ValueError("end must not precede start")
+
+    groups = {}
+    identities = {}
+    for arrival in arrivals:
+        arrival_id = str(arrival[arrival_id_key])
+        net_value = arrival.get("net")
+        sta_value = arrival.get("sta")
+        if not net_value or not sta_value:
+            raise ValueError("arrival documents require nonempty net and sta")
+        net = str(net_value)
+        sta = str(sta_value)
+        arrival_time = float(arrival[time_key])
+        year, jday = _anchor_day(arrival_time)
+        group_key = (year, jday, net, sta)
+        identity_key = (net, sta, arrival_id)
+        request = WindowRequest(
+            arrival_id=arrival_id,
+            arrival_time=arrival_time,
+            starttime=arrival_time + start - pad,
+            endtime=arrival_time + end + pad,
+            metadata={key: arrival[key] for key in auxiliary_keys if key in arrival},
+        )
+        previous = identities.get(identity_key)
+        if previous is not None:
+            if previous != request:
+                raise ValueError(
+                    f"conflicting rows for arrival identity {arrival_id!r}"
+                )
+            continue
+        identities[identity_key] = request
+        groups.setdefault(group_key, []).append(request)
+
+    batches = []
+    for (year, jday, net, sta), requests in sorted(groups.items()):
+        requests.sort(key=lambda item: (item.arrival_time, item.arrival_id))
+        for batch_index, offset in enumerate(
+            range(0, len(requests), max_arrivals_per_batch)
+        ):
+            batch_requests = tuple(requests[offset : offset + max_arrivals_per_batch])
+            needed_days = {
+                day
+                for request in batch_requests
+                for day in days_for_interval(request.starttime, request.endtime)
+            }
+            object_keys, missing_days = _holding_keys(
+                holdings_collection, net, sta, needed_days
+            )
+            batches.append(
+                StationBatch(
+                    year=year,
+                    jday=jday,
+                    net=net,
+                    sta=sta,
+                    batch_index=batch_index,
+                    arrivals=batch_requests,
+                    object_keys=object_keys,
+                    missing_days=missing_days,
+                    channel_select=channel_select,
+                )
+            )
+    return batches
+
+
+def _not_found(error):
+    code = str(error.response.get("Error", {}).get("Code", ""))
+    return code in {"404", "NoSuchKey", "NotFound"}
+
+
+def read_versioned_miniseed(
+    s3_client,
+    base_key,
+    *,
+    bucket=EARTHSCOPE_BUCKET,
+    max_version=10,
+    stream_reader=None,
+):
+    """Read one versioned object, close its body, and preserve real failures."""
+    if (
+        isinstance(max_version, bool)
+        or not isinstance(max_version, int)
+        or max_version < 0
+    ):
+        raise ValueError("max_version must be a nonnegative integer")
+    selected_key = None
+    candidates = [base_key]
+    candidates.extend(f"{base_key}#{version}" for version in range(max_version, 0, -1))
+    for candidate in candidates:
+        try:
+            s3_client.head_object(Bucket=bucket, Key=candidate)
+        except ClientError as error:
+            if _not_found(error):
+                continue
+            raise
+        selected_key = candidate
+        break
+    if selected_key is None:
+        raise FileNotFoundError(f"no readable version found for S3 key {base_key!r}")
+
+    response = s3_client.get_object(Bucket=bucket, Key=selected_key)
+    body = response["Body"]
+    try:
+        data = body.read()
+    except BaseException:
+        try:
+            body.close()
+        except Exception:
+            pass
+        raise
+    else:
+        body.close()
+
+    reader = stream_reader or obspy.read
+    return reader(io.BytesIO(data), format="mseed")
+
+
+def prepare_stream(
+    stream,
+    *,
+    channel_select="B*",
+    detrend_type=None,
+    converter=None,
+    detrend_function=None,
+):
+    """Merge each sample rate, convert once, and detrend the decoded data."""
+    selected = stream.select(channel=channel_select) if channel_select else stream
+    merged = obspy.Stream()
+    rates = sorted({trace.stats.sampling_rate for trace in selected})
+    for rate in rates:
+        same_rate = selected.select(sampling_rate=rate).copy()
+        same_rate.merge(method=1)
+        merged += same_rate
+    convert = converter or Stream2TimeSeriesEnsemble
+    decoded = convert(merged)
+    if detrend_type is not None:
+        apply_detrend = detrend_function or detrend
+        decoded = apply_detrend(decoded, type=detrend_type)
+    return decoded
+
+
+def live_nonempty(record):
+    """Return True only for a live waveform with at least one sample."""
+    if hasattr(record, "dead") and record.dead():
+        return False
+    if hasattr(record, "live") and not record.live:
+        return False
+    npts = getattr(record, "npts", None)
+    if npts is not None:
+        return npts > 0
+    data = getattr(record, "data", None)
+    return data is None or len(data) > 0
+
+
+def iter_station_records(
+    batch,
+    *,
+    input_bucket=EARTHSCOPE_BUCKET,
+    detrend_type="simple",
+    short_segment_handling="kill",
+    worker_data_key="earthscope_s3_client",
+    max_version=10,
+):
+    """Yield live records for one bounded batch without making a day ensemble."""
+    s3_client = fetch_s3_client(worker_data_key=worker_data_key)
+    stream = obspy.Stream()
+    for key in batch.object_keys:
+        stream += read_versioned_miniseed(
+            s3_client,
+            key,
+            bucket=input_bucket,
+            max_version=max_version,
+        )
+    if not batch.object_keys:
+        return
+    decoded = prepare_stream(
+        stream,
+        channel_select=batch.channel_select,
+        detrend_type=detrend_type,
+    )
+    for request in batch.arrivals:
+        ensemble = WindowData(
+            decoded,
+            request.starttime,
+            request.endtime,
+            short_segment_handling=short_segment_handling,
+        )
+        for record in ensemble.member:
+            if not live_nonempty(record):
+                continue
+            record["arrival_id"] = request.arrival_id
+            record["arrival_time"] = request.arrival_time
+            for key, value in request.metadata.items():
+                if key not in IMMUTABLE_METADATA:
+                    record[key] = value
+            yield record
+        # Drop references into the previous window before constructing the
+        # next one.  pybind member wrappers can otherwise keep the ensemble's
+        # native vector alive across the next WindowData call.
+        record = None
+        del ensemble
+
+
+def read_station_batch(batch, **kwargs):
+    """Create an intentionally worker-local iterator for a station batch."""
+    return StationRecordStream(
+        batch=batch,
+        records=iter_station_records(batch, **kwargs),
+    )
+
+
+def station_batch_object_key(batch, prefix="earthscope-windowed"):
+    """Return the deterministic key used by every retry of the same batch."""
+    identity = {
+        "year": batch.year,
+        "jday": batch.jday,
+        "net": batch.net,
+        "sta": batch.sta,
+        "batch_index": batch.batch_index,
+        "channel_select": batch.channel_select,
+        "windows": [
+            [request.arrival_id, request.starttime, request.endtime]
+            for request in batch.arrivals
+        ],
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:16]
+    path = "/".join(
+        (
+            prefix.strip("/"),
+            str(batch.year),
+            f"{batch.jday:03d}",
+            quote(batch.net, safe=""),
+            quote(batch.sta, safe=""),
+            f"batch-{batch.batch_index:05d}-{digest}.pklstream",
+        )
+    )
+    return path.lstrip("/")
+
+
+def _record_header(batch):
+    return {
+        "format": "mspass-earthscope-station-batch-v1",
+        "year": batch.year,
+        "jday": batch.jday,
+        "net": batch.net,
+        "sta": batch.sta,
+        "batch_index": batch.batch_index,
+        "arrival_ids": [request.arrival_id for request in batch.arrivals],
+        "missing_days": list(batch.missing_days),
+    }
+
+
+def write_station_batch_records(
+    station_stream,
+    *,
+    output_bucket,
+    output_prefix="earthscope-windowed",
+    worker_data_key="earthscope_s3_client",
+    multipart_chunk_bytes=16 * 1024 * 1024,
+):
+    """Write independent records to disk, upload them, and return small status."""
+    batch = station_stream.batch
+    object_key = station_batch_object_key(batch, output_prefix)
+    record_count = 0
+    with tempfile.TemporaryDirectory(prefix="mspass-earthscope-") as directory:
+        output_path = Path(directory) / "station-batch.pklstream"
+        with output_path.open("wb") as output:
+            output.write(RECORD_STREAM_MAGIC)
+            pickle.dump(_record_header(batch), output, protocol=pickle.HIGHEST_PROTOCOL)
+            for record in station_stream.records:
+                if not live_nonempty(record):
+                    continue
+                pickle.dump(record, output, protocol=pickle.HIGHEST_PROTOCOL)
+                record_count += 1
+            # Do not retain the last member wrapper during multipart upload.
+            record = None
+        byte_count = output_path.stat().st_size
+        config = TransferConfig(
+            multipart_threshold=multipart_chunk_bytes,
+            multipart_chunksize=multipart_chunk_bytes,
+            max_concurrency=1,
+            use_threads=False,
+        )
+        s3_client = fetch_s3_client(worker_data_key=worker_data_key)
+        s3_client.upload_file(
+            str(output_path), output_bucket, object_key, Config=config
+        )
+
+    missing_count = len(batch.missing_days)
+    return {
+        "ok": missing_count == 0,
+        "bucket": output_bucket,
+        "key": object_key,
+        "records": record_count,
+        "bytes": byte_count,
+        "missing_days": missing_count,
+    }
+
+
+def iter_record_stream(stream):
+    """Yield a record-stream header and records without materializing the file."""
+    if stream.read(len(RECORD_STREAM_MAGIC)) != RECORD_STREAM_MAGIC:
+        raise ValueError("not an EarthScope station-batch record stream")
+    while True:
+        try:
+            yield pickle.load(stream)
+        except EOFError:
+            return
+
+
+def run_station_batches(
+    batches,
+    dask_client,
+    *,
+    output_bucket,
+    input_bucket=EARTHSCOPE_BUCKET,
+    output_prefix="earthscope-windowed",
+    sliding_window_size=1,
+    max_version=10,
+):
+    """Run the bounded worker-side reader/writer and return small statuses."""
+    return sliding_window_pipeline(
+        batches,
+        read_station_batch,
+        dask_client,
+        sliding_window_size=sliding_window_size,
+        pfunc_kwargs={"input_bucket": input_bucket, "max_version": max_version},
+        completion_function=write_station_batch_records,
+        cfunc_kwargs={
+            "output_bucket": output_bucket,
+            "output_prefix": output_prefix,
+        },
+        completion_on_worker=True,
+        retain_results=True,
+    )

--- a/scripts/earthscope_s3_example/workflow.py
+++ b/scripts/earthscope_s3_example/workflow.py
@@ -22,7 +22,7 @@ from mspasspy.workflow import sliding_window_pipeline
 
 from .worker import fetch_s3_client
 
-EARTHSCOPE_BUCKET = "earthscope-mseed-res-na3mtd4fq5kz7pntcyr1uh46use2a--ol-s3"
+EARTHSCOPE_BUCKET = "earthscope-geophysical-data"
 RECORD_STREAM_MAGIC = b"MSPASS_EARTHSCOPE_STATION_BATCH_V1\n"
 IMMUTABLE_METADATA = {
     "delta",


### PR DESCRIPTION
## Summary

Add a sanitized, maintained EarthScope S3 example that replaces the supplied
out-of-tree notebook path with a bounded worker-side workflow.

The example:

- paginates and deterministically indexes all station-day objects
- uses half-open year queries and includes adjacent days required by padded
  windows
- groups arrivals without an arrival-by-holding Cartesian product and unions
  every day required by each window
- preserves unmatched station codes and filters invalid network values without
  relying on MongoDB ordering
- reads versioned miniSEED with explicit body cleanup and original-exception
  propagation
- converts multi-rate streams once, detrends the decoded data, and filters
  dead/empty records
- processes bounded station/arrival batches, consumes the generator in the
  same worker, writes independent pickle records to a temporary file, and
  uploads with single-threaded multipart transfer
- returns only small status dictionaries and uses deterministic object keys so
  retries overwrite rather than duplicate output
- uses one worker-local boto3 default-chain client to read the public Open Data
  Program bucket required for TA and write the worker's authorized GeoLab
  scratch bucket
- defaults to `sliding_window_size=1`

The last record/window references are explicitly dropped before constructing
the next window or starting the upload, avoiding a transient overlap through
pybind member wrappers.

## Security and scope

No notebook, saved output, credential, CSS/Antelope table, or private data is
included.  AWS credentials, if needed for the output bucket, are resolved and
refreshed in the worker by boto3's standard provider chain; they are never task
arguments.  The README limits the input path to public ODP networks and labels
this as a focused example rather than a universal EarthScope API.

## Validation

- all 15 tests passed in one run
- the suite includes a real
  `LocalCluster(processes=True)` and an intentionally unpickleable intermediate,
  proving the station payload stays in the worker while the driver receives a
  small dictionary
- coverage includes >1,000 paginated objects, version fallback order,
  cross-midnight and leap-year boundaries, duplicate prevention, body cleanup,
  error/control-exception propagation, detrend/multi-rate behavior, idempotent
  keys, bounded writer behavior, default-chain client creation, and
  failed-plugin setup/teardown
- `py_compile`, Black's formatting check, credential-pattern scan, and
  `git diff --check` passed
- independently reviewed; no blocker remained

Live ODP/scratch access, real CSS/Mongo data, GeoLab disk limits, and production
multipart throughput are intentionally not claimed by the fake-backed tests.
The README requires a measured small-day run first.

Closes #1020
