### PR TITLE
Stream native ensemble pickle state without a nested payload

### DIFF
--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -812,11 +812,14 @@ PYBIND11_MODULE(seismic, m) {
           stringstream sselog;
           boost::archive::text_oarchive arelog(sselog);
           arelog << self.elog;
-          pybind11::module pickle = pybind11::module::import("pickle");
-          pybind11::object dumps = pickle.attr("dumps");
-          pybind11::object dbuf = dumps(py::list(pybind11::cast(self.member)));
+          /* The default copy policy is intentional.  A pickle state can
+          outlive this call or the source vector can be resized after a user
+          calls __getstate__ directly.  References into self.member would be
+          invalidated by vector reallocation. */
+          py::list members(pybind11::cast(self.member));
           bool is_live=self.live();
-          pybind11::tuple r_tuple = py::make_tuple(sbuf, sselog.str(), is_live, dbuf);
+          pybind11::tuple r_tuple = py::make_tuple(
+            sbuf, sselog.str(), is_live, members);
           pybind11::gil_scoped_release release;
           return r_tuple;
         }catch(...){pybind11::gil_scoped_release release;throw;};
@@ -832,18 +835,31 @@ PYBIND11_MODULE(seismic, m) {
           stringstream sselog(t[1].cast<std::string>());
           boost::archive::text_iarchive arelog(sselog);;
           arelog>>elog;
-          pybind11::module pickle = pybind11::module::import("pickle");
-          pybind11::object loads = pickle.attr("loads");
-          /* This algorithm is a horrible memory pig because it has to
-          hold both a copy of the monster list of strings of pickled
-          data members and the reconstituted C++ data objects (ensemble
-          members).  Need to see if we can find a way to handle that
-          in a more memory efficient way.
-          wangyinz: The new implementation below should be better. */
-          py::list dlist = loads(t[3]);
-          LoggingEnsemble<Seismogram> result(md, elog, 0);
-          pybind11::object member_py = pybind11::module_::import("mspasspy.ccore.seismic").attr("SeismogramVector")(dlist);
-          result.member = member_py.cast<vector<Seismogram>>();
+          py::object member_state=t[3];
+          py::list dlist;
+          if(py::isinstance<py::bytes>(member_state)) {
+            pybind11::module pickle = pybind11::module::import("pickle");
+            member_state = pickle.attr("loads")(member_state);
+          }
+          if(!py::isinstance<py::list>(member_state))
+            throw py::value_error(
+              "Invalid SeismogramEnsemble pickle state: members must be a list or legacy bytes");
+          dlist=py::reinterpret_borrow<py::list>(member_state);
+          for(const auto item : dlist) {
+            if(!py::isinstance<Seismogram>(item))
+              throw py::value_error(
+                "Invalid SeismogramEnsemble pickle state: invalid member type");
+          }
+          LoggingEnsemble<Seismogram> result(md, elog, dlist.size());
+          for(py::ssize_t i=0; i<dlist.size(); ++i) {
+            const Seismogram& member=dlist[i].cast<const Seismogram&>();
+            result.member.push_back(member);
+            /* Python's unpickler passes a private, disposable state list.
+            Consume it incrementally so reconstructed members do not remain
+            live beside the growing final vector.  A caller invoking
+            __setstate__ directly must likewise treat that list as consumed. */
+            dlist[i]=py::none();
+          }
           bool is_live = t[2].cast<bool>();
           if(is_live)
             result.set_live();
@@ -897,11 +913,14 @@ PYBIND11_MODULE(seismic, m) {
           stringstream sselog;
           boost::archive::text_oarchive arelog(sselog);
           arelog << self.elog;
-          pybind11::module pickle = pybind11::module::import("pickle");
-          pybind11::object dumps = pickle.attr("dumps");
-          pybind11::object dbuf = dumps(py::list(pybind11::cast(self.member)));
+          /* The default copy policy is intentional.  A pickle state can
+          outlive this call or the source vector can be resized after a user
+          calls __getstate__ directly.  References into self.member would be
+          invalidated by vector reallocation. */
+          py::list members(pybind11::cast(self.member));
           bool is_live = self.live();
-          pybind11::tuple r_tuple = py::make_tuple(sbuf, sselog.str(), is_live, dbuf);
+          pybind11::tuple r_tuple = py::make_tuple(
+            sbuf, sselog.str(), is_live, members);
           pybind11::gil_scoped_release release;
           return r_tuple;
         }catch(...){pybind11::gil_scoped_release release;throw;};
@@ -917,18 +936,31 @@ PYBIND11_MODULE(seismic, m) {
           stringstream sselog(t[1].cast<std::string>());
           boost::archive::text_iarchive arelog(sselog);;
           arelog>>elog;
-          pybind11::module pickle = pybind11::module::import("pickle");
-          pybind11::object loads = pickle.attr("loads");
-          /* This algorithm is a horrible memory pig because it has to
-          hold both a copy of the monster list of strings of pickled
-          data members and the reconstituted C++ data objects (ensemble
-          members).  Need to see if we can find a way to handle that
-          in a more memory efficient way.
-          wangyinz: The new implementation below should be better. */
-          py::list dlist = loads(t[3]);
-          LoggingEnsemble<TimeSeries> result(md, elog, 0);
-          pybind11::object member_py = pybind11::module_::import("mspasspy.ccore.seismic").attr("TimeSeriesVector")(dlist);
-          result.member = member_py.cast<vector<TimeSeries>>();
+          py::object member_state=t[3];
+          py::list dlist;
+          if(py::isinstance<py::bytes>(member_state)) {
+            pybind11::module pickle = pybind11::module::import("pickle");
+            member_state = pickle.attr("loads")(member_state);
+          }
+          if(!py::isinstance<py::list>(member_state))
+            throw py::value_error(
+              "Invalid TimeSeriesEnsemble pickle state: members must be a list or legacy bytes");
+          dlist=py::reinterpret_borrow<py::list>(member_state);
+          for(const auto item : dlist) {
+            if(!py::isinstance<TimeSeries>(item))
+              throw py::value_error(
+                "Invalid TimeSeriesEnsemble pickle state: invalid member type");
+          }
+          LoggingEnsemble<TimeSeries> result(md, elog, dlist.size());
+          for(py::ssize_t i=0; i<dlist.size(); ++i) {
+            const TimeSeries& member=dlist[i].cast<const TimeSeries&>();
+            result.member.push_back(member);
+            /* Python's unpickler passes a private, disposable state list.
+            Consume it incrementally so reconstructed members do not remain
+            live beside the growing final vector.  A caller invoking
+            __setstate__ directly must likewise treat that list as consumed. */
+            dlist[i]=py::none();
+          }
           bool is_live = t[2].cast<bool>();
           if(is_live)
             result.set_live();

--- a/python/tests/test_native_ensemble_pickle.py
+++ b/python/tests/test_native_ensemble_pickle.py
@@ -1,0 +1,144 @@
+import gc
+import pickle
+
+import numpy as np
+import pytest
+
+from mspasspy.ccore.seismic import (
+    Seismogram,
+    SeismogramEnsemble,
+    TimeReferenceType,
+    TimeSeries,
+    TimeSeriesEnsemble,
+)
+from mspasspy.ccore.utility import AtomicType, ErrorSeverity
+
+
+@pytest.mark.parametrize(
+    "ensemble_type,member_type",
+    [
+        (TimeSeriesEnsemble, TimeSeries),
+        (SeismogramEnsemble, Seismogram),
+    ],
+)
+@pytest.mark.parametrize("protocol", [4, 5])
+def test_ensemble_pickle_direct_members_and_legacy_state(
+    ensemble_type, member_type, protocol
+):
+    atomic_type = (
+        AtomicType.TIMESERIES if member_type is TimeSeries else AtomicType.SEISMOGRAM
+    )
+    ensemble = ensemble_type(3)
+    ensemble["pickle_format"] = "direct-members"
+    ensemble.elog.log_error(
+        "test_ensemble_pickle",
+        "preserve ensemble error log",
+        ErrorSeverity.Complaint,
+    )
+    for index in range(3):
+        member = member_type(8)
+        member["member_index"] = index
+        member.dt = 0.05
+        member.t0 = float(index)
+        member.tref = TimeReferenceType.UTC
+        np.asarray(member.data)[...] = index + 0.5
+        member.set_as_origin(
+            "native-ensemble-pickle", "1", f"member-{index}", atomic_type
+        )
+        member.elog.log_error(
+            "native-ensemble-pickle",
+            f"member error {index}",
+            ErrorSeverity.Complaint,
+        )
+        member.set_live()
+        if index == 1:
+            member.kill()
+        ensemble.member.append(member)
+    ensemble.set_live()
+
+    state = ensemble.__getstate__()
+    assert len(state) == 4
+    assert isinstance(state[3], list)
+    assert [member["member_index"] for member in state[3]] == [0, 1, 2]
+
+    # The returned state owns an independent member snapshot.  References
+    # into the source vector would become invalid when the vector reallocates.
+    np.asarray(state[3][0].data)[...] = 17.5
+    assert np.all(np.asarray(ensemble.member[0].data) == 0.5)
+    for _ in range(8):
+        ensemble.member.append(member_type(1))
+    assert np.all(np.asarray(state[3][0].data) == 17.5)
+    for _ in range(8):
+        ensemble.member.pop()
+
+    restored = pickle.loads(pickle.dumps(ensemble, protocol=protocol))
+    _assert_ensemble_state(restored, ensemble, ensemble_type)
+
+    legacy_state = list(ensemble.__getstate__())
+    legacy_state[3] = pickle.dumps(legacy_state[3], protocol=protocol)
+    legacy = ensemble_type.__new__(ensemble_type)
+    legacy.__setstate__(tuple(legacy_state))
+    _assert_ensemble_state(legacy, ensemble, ensemble_type)
+
+    consumed_state = ensemble.__getstate__()
+    external_member_alias = consumed_state[3][0]
+    consumed = ensemble_type.__new__(ensemble_type)
+    consumed.__setstate__(consumed_state)
+    assert consumed_state[3] == [None, None, None]
+    assert external_member_alias["member_index"] == 0
+    assert np.all(np.asarray(external_member_alias.data) == 0.5)
+
+    lifetime_state = ensemble.__getstate__()
+    del ensemble
+    gc.collect()
+    after_source_collection = ensemble_type.__new__(ensemble_type)
+    after_source_collection.__setstate__(lifetime_state)
+    assert [member["member_index"] for member in after_source_collection.member] == [
+        0,
+        1,
+        2,
+    ]
+
+
+def _assert_ensemble_state(actual, expected, ensemble_type):
+    assert type(actual) is ensemble_type
+    assert actual.live
+    assert actual["pickle_format"] == "direct-members"
+    assert actual.elog.size() == 1
+    assert [member.live for member in actual.member] == [True, False, True]
+    for index, member in enumerate(actual.member):
+        expected_member = expected.member[index]
+        assert member["member_index"] == index
+        assert member.dt == 0.05
+        assert member.t0 == float(index)
+        assert member.tref == TimeReferenceType.UTC
+        assert member.number_of_stages() == expected_member.number_of_stages()
+        assert member.current_nodedata().uuid == expected_member.current_nodedata().uuid
+        assert member.elog.size() == 1
+        assert np.all(np.asarray(member.data) == index + 0.5)
+
+
+@pytest.mark.parametrize(
+    "ensemble_type,other_member_type",
+    [
+        (TimeSeriesEnsemble, Seismogram),
+        (SeismogramEnsemble, TimeSeries),
+    ],
+)
+def test_ensemble_pickle_rejects_invalid_member_payload(
+    ensemble_type, other_member_type
+):
+    ensemble = ensemble_type()
+    state = list(ensemble.__getstate__())
+
+    for invalid_payload in (None, (), {}, [other_member_type()]):
+        malformed = ensemble_type.__new__(ensemble_type)
+        state[3] = invalid_payload
+        with pytest.raises(ValueError, match="Invalid .*Ensemble pickle state"):
+            malformed.__setstate__(tuple(state))
+
+    empty = ensemble_type.__new__(ensemble_type)
+    state[3] = []
+    empty.__setstate__(tuple(state))
+    assert empty.dead()
+    assert len(empty.member) == 0


### PR DESCRIPTION
## Summary

- replace the native ensemble pickle state's nested `pickle.dumps(member_list)`
  byte payload with a direct owned member list
- accept both the new list and legacy nested-byte states when loading
- validate all member types before reconstruction
- pre-reserve the final ensemble and consume the private unpickle-state list
  incrementally, releasing each temporary member after its required copy

The getstate member list is intentionally an owned deep snapshot, not a
zero-copy view.  Adversarial tests demonstrated that references into the source
`std::vector` become invalid after reallocation; the owned snapshot remains
valid after source mutation or destruction.

Direct calls to `__setstate__` must treat the member list as disposable.  The
standard unpickler already supplies a private temporary state.  Tests lock down
that the list is consumed while external member aliases, source data, and the
new target remain valid.

## Compatibility

- Real legacy TimeSeriesEnsemble and SeismogramEnsemble pickles generated by
  the previous binary load successfully with Metadata, ErrorLogger, lifecycle,
  member data/metadata/error log, and processing history intact.
- Protocols 2–5 round-trip.  Protocols 0/1 also abort with the old baseline
  because of the existing atomic NumPy pickle implementation; this PR does not
  introduce that limitation.
- Older MsPASS binaries are not expected to read the new direct-list state.
  New-code-reads-old-data backward compatibility is preserved.

## Measured tradeoff

For six 1,000,000-sample TimeSeries members (48 MB of samples), protocol-5
`pickle.dump` produced essentially the same 48 MB file.  In separate processes,
the old nested-byte path increased peak RSS by about 195 MB, while the direct
list path increased it by about 99 MB (about 49% lower); elapsed time was
approximately 0.159 s versus 0.162 s.

For 1,000 ten-sample members, output was about 385 KB versus 380 KB and the new
path was slower in this development run (about 0.099 s versus 0.053 s), while
incremental peak RSS was similar.  The change targets large-member ensembles,
not a promise that every member distribution becomes faster.

## Validation

- combined #1018 + #1021 native build succeeded
- 43 focused native-safety/pickle tests passed; the new file alone has 6 tests
- old-binary compatibility fixtures for both ensemble types passed
- 64 repeated eight-thread round trips, cloudpickle, protocol-5 out-of-band
  buffers, and future Dask-serializer smoke tests passed
- Black and `git diff --check` passed
- independently adversarially reviewed; no blocker remained

This PR is stacked on #1022 so its tuple/array state validation is retained.

Closes #1021

