### PR TITLE
Bound GridFS waveform conversion memory

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -7,7 +7,6 @@ import tempfile
 from time import monotonic
 import urllib.error
 import urllib.request
-from array import array
 from contextlib import contextmanager
 import pandas as pd
 
@@ -73,6 +72,98 @@ from mspasspy.db.serialization import (
 from mspasspy.util.converter import Textfile2Dataframe
 
 _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS = 300.0
+_GRIDFS_IO_CHUNK_BYTES = 1024 * 1024
+
+
+class _NativeSampleReader(io.RawIOBase):
+    """Expose native waveform samples as the existing row-major byte stream."""
+
+    def __init__(self, data):
+        super().__init__()
+        self._samples = np.asarray(data)
+        if self._samples.ndim not in (1, 2):
+            raise ValueError("waveform sample data must be one- or two-dimensional")
+        self._sample_count = self._samples.size
+        self._byte_offset = 0
+
+    def readable(self):
+        return True
+
+    def _sample_value(self, index):
+        if self._samples.ndim == 1:
+            return self._samples[index]
+        columns = self._samples.shape[1]
+        return self._samples[index // columns, index % columns]
+
+    def _copy_samples(self, destination, start_sample, count):
+        if self._samples.ndim == 1:
+            destination[:count] = self._samples[start_sample : start_sample + count]
+            return
+        columns = self._samples.shape[1]
+        copied = 0
+        while copied < count:
+            index = start_sample + copied
+            row, column = divmod(index, columns)
+            segment_size = min(count - copied, columns - column)
+            destination[copied : copied + segment_size] = self._samples[
+                row, column : column + segment_size
+            ]
+            copied += segment_size
+
+    def readinto(self, buffer):
+        destination = memoryview(buffer).cast("B")
+        remaining = self._sample_count * 8 - self._byte_offset
+        byte_count = min(len(destination), remaining)
+        if byte_count <= 0:
+            return 0
+
+        written = 0
+        sample_byte_offset = self._byte_offset % 8
+        if sample_byte_offset:
+            sample = np.float64(self._sample_value(self._byte_offset // 8)).tobytes()
+            segment_size = min(byte_count, 8 - sample_byte_offset)
+            destination[:segment_size] = sample[
+                sample_byte_offset : sample_byte_offset + segment_size
+            ]
+            written += segment_size
+
+        full_sample_count = (byte_count - written) // 8
+        if full_sample_count:
+            start_sample = (self._byte_offset + written) // 8
+            output = np.frombuffer(
+                destination,
+                dtype=np.float64,
+                count=full_sample_count,
+                offset=written,
+            )
+            self._copy_samples(output, start_sample, full_sample_count)
+            written += full_sample_count * 8
+
+        if written < byte_count:
+            sample_index = (self._byte_offset + written) // 8
+            sample = np.float64(self._sample_value(sample_index)).tobytes()
+            segment_size = byte_count - written
+            destination[written:byte_count] = sample[:segment_size]
+
+        self._byte_offset += byte_count
+        return byte_count
+
+
+def _store_sample_chunk(destination, start_sample, values):
+    """Copy flat row-major sample values into a native vector or matrix view."""
+    if destination.ndim == 1:
+        destination[start_sample : start_sample + len(values)] = values
+        return
+    columns = destination.shape[1]
+    copied = 0
+    while copied < len(values):
+        index = start_sample + copied
+        row, column = divmod(index, columns)
+        segment_size = min(len(values) - copied, columns - column)
+        destination[row, column : column + segment_size] = values[
+            copied : copied + segment_size
+        ]
+        copied += segment_size
 
 
 @contextmanager
@@ -4924,23 +5015,10 @@ class Database(pymongo.database.Database):
         """
         gfsh = gridfs.GridFS(self)
         fh = gfsh.get(file_id=gridfs_id)
-        if isinstance(mspass_object, (TimeSeries, Seismogram)):
-            if not mspass_object.is_defined("npts"):
-                message = (
-                    "Required key npts is not defined in the document for this datum"
-                )
-                mspass_object.elog.log_error(
-                    "Database._read_data_from_gridfs", message, ErrorSeverity.Invalid
-                )
-                mspass_object.kill()
-                return
-            else:
-                if mspass_object.npts != mspass_object["npts"]:
-                    message = "Database._read_data_from_gridfs: "
-                    message += "Metadata value for npts is {} but datum attribute npts is {}\n".format(
-                        mspass_object["npts"], mspass_object.npts
-                    )
-                    message += "Illegal inconsistency; sample data were not loaded"
+        try:
+            if isinstance(mspass_object, (TimeSeries, Seismogram)):
+                if not mspass_object.is_defined("npts"):
+                    message = "Required key npts is not defined in the document for this datum"
                     mspass_object.elog.log_error(
                         "Database._read_data_from_gridfs",
                         message,
@@ -4948,43 +5026,72 @@ class Database(pymongo.database.Database):
                     )
                     mspass_object.kill()
                     return
-            npts = mspass_object.npts
-        if isinstance(mspass_object, TimeSeries):
-            sample_count = npts
-        elif isinstance(mspass_object, Seismogram):
-            sample_count = 3 * npts
-        else:
-            message = "Database._read_data_from_gridfs:  arg0 must be a TimeSeries or Seismogram\n"
-            message += "Actual type=" + str(type(mspass_object))
-            raise TypeError(message)
-        expected_nbytes = sample_count * 8
-        payload = fh.read(expected_nbytes + 1)
-        if len(payload) != expected_nbytes:
-            message = "Size mismatch in sample data.\n"
-            message += "Read {} bytes from gridfs but expected exactly {} for {} samples".format(
-                len(payload), expected_nbytes, sample_count
-            )
-            mspass_object.elog.log_error(
-                "Database._read_data_from_gridfs",
-                message,
-                ErrorSeverity.Invalid,
-            )
-            mspass_object.kill()
-            return
-        if isinstance(mspass_object, TimeSeries):
-            float_array = array("d")
-            float_array.frombytes(payload)
-            mspass_object.data = DoubleVector(float_array)
-        else:
-            np_arr = np.frombuffer(payload)
-            # v1 did a transpose on write that this reversed - unnecessary
-            # np_arr = np_arr.reshape(npts, 3).transpose()
-            np_arr = np_arr.reshape(3, npts)
-            mspass_object.data = dmatrix(np_arr)
-        if mspass_object.npts > 0:
-            mspass_object.set_live()
-        else:
-            mspass_object.kill()
+                else:
+                    if mspass_object.npts != mspass_object["npts"]:
+                        message = "Database._read_data_from_gridfs: "
+                        message += "Metadata value for npts is {} but datum attribute npts is {}\n".format(
+                            mspass_object["npts"], mspass_object.npts
+                        )
+                        message += "Illegal inconsistency; sample data were not loaded"
+                        mspass_object.elog.log_error(
+                            "Database._read_data_from_gridfs",
+                            message,
+                            ErrorSeverity.Invalid,
+                        )
+                        mspass_object.kill()
+                        return
+                npts = mspass_object.npts
+            if isinstance(mspass_object, TimeSeries):
+                sample_count = npts
+            elif isinstance(mspass_object, Seismogram):
+                sample_count = 3 * npts
+            else:
+                message = "Database._read_data_from_gridfs:  arg0 must be a TimeSeries or Seismogram\n"
+                message += "Actual type=" + str(type(mspass_object))
+                raise TypeError(message)
+            expected_nbytes = sample_count * 8
+            if fh.length != expected_nbytes:
+                message = "Size mismatch in sample data.\n"
+                message += "GridFS object contains {} bytes but expected exactly {} for {} samples".format(
+                    fh.length, expected_nbytes, sample_count
+                )
+                mspass_object.elog.log_error(
+                    "Database._read_data_from_gridfs", message, ErrorSeverity.Invalid
+                )
+                mspass_object.kill()
+                return
+            destination = np.asarray(mspass_object.data)
+            byte_offset = 0
+            while byte_offset < expected_nbytes:
+                request_size = min(
+                    _GRIDFS_IO_CHUNK_BYTES, expected_nbytes - byte_offset
+                )
+                payload = fh.read(request_size)
+                if len(payload) != request_size:
+                    message = "Size mismatch in sample data.\n"
+                    message += (
+                        "Read {} bytes from gridfs at offset {} but expected {}".format(
+                            len(payload), byte_offset, request_size
+                        )
+                    )
+                    mspass_object.elog.log_error(
+                        "Database._read_data_from_gridfs",
+                        message,
+                        ErrorSeverity.Invalid,
+                    )
+                    mspass_object.kill()
+                    return
+                values = np.frombuffer(payload, dtype=np.float64)
+                _store_sample_chunk(destination, byte_offset // 8, values)
+                byte_offset += request_size
+                del values
+                del payload
+            if mspass_object.npts > 0:
+                mspass_object.set_live()
+            else:
+                mspass_object.kill()
+        finally:
+            fh.close()
 
     @staticmethod
     def _read_data_from_s3_continuous(
@@ -7126,12 +7233,17 @@ class Database(pymongo.database.Database):
         gfsh = gridfs.GridFS(self)
 
         if isinstance(mspass_object, (TimeSeries, Seismogram)):
-            # verdion 2 had a transpose here that seemed unncessary
-            ub = bytes(np.array(mspass_object.data))
+            sample_reader = _NativeSampleReader(mspass_object.data)
             if gridfs_id is None:
-                gridfs_id = gfsh.put(ub)
-            else:
-                gridfs_id = gfsh.put(ub, _id=gridfs_id)
+                gridfs_id = ObjectId()
+            try:
+                gridfs_id = gfsh.put(sample_reader, _id=gridfs_id)
+            except BaseException:
+                try:
+                    gfsh.delete(gridfs_id)
+                except BaseException:
+                    pass
+                raise
             mspass_object["gridfs_id"] = gridfs_id
             mspass_object["storage_mode"] = "gridfs"
         elif isinstance(mspass_object, (TimeSeriesEnsemble, SeismogramEnsemble)):

--- a/python/tests/db/test_database_gridfs_payload_contract.py
+++ b/python/tests/db/test_database_gridfs_payload_contract.py
@@ -11,8 +11,8 @@ from bson import ObjectId
 
 import mspasspy.ccore.seismic as seismic_binding
 import mspasspy.db.database as database_module
-from mspasspy.ccore.seismic import Seismogram, TimeSeries
-from mspasspy.ccore.utility import AtomicType, ErrorSeverity
+from mspasspy.ccore.seismic import DoubleVector, Seismogram, TimeSeries
+from mspasspy.ccore.utility import AtomicType, ErrorSeverity, dmatrix
 from mspasspy.db.database import Database
 
 NPTS = 3
@@ -21,11 +21,17 @@ NPTS = 3
 class _TrackingBytesIO(io.BytesIO):
     def __init__(self, payload):
         super().__init__(payload)
+        self.length = len(payload)
         self.read_sizes = []
+        self.close_calls = 0
 
     def read(self, size=-1):
         self.read_sizes.append(size)
         return super().read(size)
+
+    def close(self):
+        self.close_calls += 1
+        super().close()
 
 
 def _datum_with_sentinel_samples(atomic_type):
@@ -87,7 +93,8 @@ def _assert_metadata_and_history_unchanged(datum, snapshot):
 def _assert_read_is_bounded(payload_reader, expected_nbytes):
     assert payload_reader.read_sizes
     assert all(size >= 0 for size in payload_reader.read_sizes)
-    assert sum(payload_reader.read_sizes) <= expected_nbytes + 1
+    assert sum(payload_reader.read_sizes) == expected_nbytes
+    assert max(payload_reader.read_sizes) <= database_module._GRIDFS_IO_CHUNK_BYTES
 
 
 def _read_payload(monkeypatch, datum, payload):
@@ -142,6 +149,7 @@ def test_exact_gridfs_payload_loads_all_samples(monkeypatch, atomic_type):
     payload_reader = _read_payload(monkeypatch, datum, payload)
 
     _assert_read_is_bounded(payload_reader, len(payload))
+    assert payload_reader.close_calls == 1
     assert datum.live
     assert datum.npts == NPTS
     assert datum.elog.size() == 0
@@ -178,7 +186,8 @@ def test_invalid_gridfs_payload_is_atomic_dead_and_logged(
 
     payload_reader = _read_payload(monkeypatch, datum, payload)
 
-    _assert_read_is_bounded(payload_reader, len(exact_payload))
+    assert payload_reader.read_sizes == []
+    assert payload_reader.close_calls == 1
     assert datum.dead()
     assert datum.npts == NPTS
     assert np.array_equal(np.asarray(datum.data), original_samples)
@@ -192,3 +201,108 @@ def test_invalid_gridfs_payload_is_atomic_dead_and_logged(
     assert len(errors) == 1
     assert errors[0].badness == ErrorSeverity.Invalid
     assert "Size mismatch in sample data" in errors[0].message
+
+
+@pytest.mark.parametrize("atomic_type", (TimeSeries, Seismogram))
+def test_zero_length_gridfs_payload_preserves_empty_dead_datum(
+    monkeypatch, atomic_type
+):
+    datum = atomic_type()
+    datum.npts = 0
+    datum.set_live()
+
+    payload_reader = _read_payload(monkeypatch, datum, b"")
+
+    assert payload_reader.read_sizes == []
+    assert payload_reader.close_calls == 1
+    assert datum.dead()
+    assert datum.npts == 0
+    assert datum.elog.size() == 0
+
+
+@pytest.mark.parametrize("atomic_type", (TimeSeries, Seismogram))
+def test_native_sample_reader_preserves_layout_for_unaligned_reads(atomic_type):
+    datum = _datum_with_sentinel_samples(atomic_type)
+    values, expected = _exact_payload(atomic_type)
+    if atomic_type is TimeSeries:
+        datum.data = DoubleVector(values)
+    else:
+        datum.data = dmatrix(values.reshape(3, NPTS))
+    reader = database_module._NativeSampleReader(datum.data)
+    payload = bytearray()
+    request_sizes = (1, 3, 7, 13)
+    request_index = 0
+    while True:
+        chunk = reader.read(request_sizes[request_index % len(request_sizes)])
+        if not chunk:
+            break
+        payload.extend(chunk)
+        request_index += 1
+
+    assert bytes(payload) == expected
+
+
+@pytest.mark.parametrize("atomic_type", (TimeSeries, Seismogram))
+def test_gridfs_save_streams_from_native_reader(monkeypatch, atomic_type):
+    datum = _datum_with_sentinel_samples(atomic_type)
+    values, expected = _exact_payload(atomic_type)
+    if atomic_type is TimeSeries:
+        datum.data = DoubleVector(values)
+    else:
+        datum.data = dmatrix(values.reshape(3, NPTS))
+    gridfs_id = ObjectId()
+    captured = {}
+
+    class FakeGridFS:
+        def put(self, source, **kwargs):
+            captured["source"] = source
+            captured["kwargs"] = kwargs
+            payload = bytearray()
+            while True:
+                chunk = source.read(11)
+                if not chunk:
+                    break
+                payload.extend(chunk)
+            captured["payload"] = bytes(payload)
+            return kwargs.get("_id", gridfs_id)
+
+    monkeypatch.setattr(database_module.gridfs, "GridFS", lambda database: FakeGridFS())
+
+    result = Database._save_sample_data_to_gridfs(object(), datum, gridfs_id=gridfs_id)
+
+    assert result is datum
+    assert isinstance(captured["source"], database_module._NativeSampleReader)
+    assert captured["kwargs"] == {"_id": gridfs_id}
+    assert captured["payload"] == expected
+    assert datum["gridfs_id"] == gridfs_id
+    assert datum["storage_mode"] == "gridfs"
+
+
+def test_gridfs_stream_failure_removes_partial_blob_and_preserves_error(monkeypatch):
+    datum = _datum_with_sentinel_samples(TimeSeries)
+    write_error = RuntimeError("injected streaming failure")
+    deleted_ids = []
+    written_id = None
+
+    class FailingGridFS:
+        def put(self, source, **kwargs):
+            nonlocal written_id
+            written_id = kwargs["_id"]
+            assert source.read(8)
+            raise write_error
+
+        def delete(self, gridfs_id):
+            deleted_ids.append(gridfs_id)
+            raise RuntimeError("injected cleanup failure")
+
+    monkeypatch.setattr(
+        database_module.gridfs, "GridFS", lambda database: FailingGridFS()
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        Database._save_sample_data_to_gridfs(object(), datum)
+
+    assert raised.value is write_error
+    assert deleted_ids == [written_id]
+    assert "gridfs_id" not in datum
+    assert "storage_mode" not in datum

--- a/python/tests/db/test_gridfs_memory_contract.py
+++ b/python/tests/db/test_gridfs_memory_contract.py
@@ -1,0 +1,117 @@
+import json
+import os
+import resource
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from bson import ObjectId
+
+import mspasspy.db.database as database_module
+from mspasspy.ccore.seismic import Seismogram, TimeSeries
+from mspasspy.db.database import Database
+
+PAYLOAD_BYTES = 32 * 1024 * 1024
+MAX_TRANSIENT_BYTES = 12 * 1024 * 1024
+
+
+def _peak_rss_bytes():
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+
+
+def _make_datum(atomic_type):
+    samples_per_point = 1 if atomic_type is TimeSeries else 3
+    npts = PAYLOAD_BYTES // (8 * samples_per_point)
+    datum = atomic_type(npts)
+    np.asarray(datum.data).fill(1.0)
+    datum.set_live()
+    return datum
+
+
+class _DiscardingGridFS:
+    def put(self, source, **kwargs):
+        byte_count = 0
+        while True:
+            chunk = source.read(database_module._GRIDFS_IO_CHUNK_BYTES)
+            if not chunk:
+                break
+            byte_count += len(chunk)
+        self.byte_count = byte_count
+        return ObjectId()
+
+
+class _ZeroGridOut:
+    def __init__(self, length):
+        self.length = length
+        self.remaining = length
+
+    def read(self, size):
+        byte_count = min(size, self.remaining)
+        self.remaining -= byte_count
+        return bytes(byte_count)
+
+    def close(self):
+        pass
+
+
+class _ReadingGridFS:
+    def __init__(self, length):
+        self.reader = _ZeroGridOut(length)
+
+    def get(self, file_id):
+        return self.reader
+
+
+def _run_probe(operation, atomic_name):
+    atomic_type = TimeSeries if atomic_name == "TimeSeries" else Seismogram
+    datum = _make_datum(atomic_type)
+    baseline_peak = _peak_rss_bytes()
+    database = object()
+    if operation == "write":
+        storage = _DiscardingGridFS()
+        database_module.gridfs.GridFS = lambda actual_database: storage
+        Database._save_sample_data_to_gridfs(database, datum)
+        byte_count = storage.byte_count
+    else:
+        byte_count = datum.npts * (8 if atomic_type is TimeSeries else 24)
+        storage = _ReadingGridFS(byte_count)
+        database_module.gridfs.GridFS = lambda actual_database: storage
+        Database._read_data_from_gridfs(database, datum, ObjectId())
+    print(
+        json.dumps(
+            {
+                "operation": operation,
+                "atomic_type": atomic_name,
+                "payload_bytes": byte_count,
+                "peak_transient_bytes": max(0, _peak_rss_bytes() - baseline_peak),
+            }
+        )
+    )
+
+
+@pytest.mark.parametrize("operation", ("read", "write"))
+@pytest.mark.parametrize("atomic_name", ("TimeSeries", "Seismogram"))
+def test_large_gridfs_conversion_has_bounded_rss(operation, atomic_name):
+    environment = os.environ.copy()
+    source_root = str(Path(__file__).resolve().parents[2])
+    environment["PYTHONPATH"] = (
+        source_root + os.pathsep + environment.get("PYTHONPATH", "")
+    )
+    completed = subprocess.run(
+        [sys.executable, __file__, "--probe", operation, atomic_name],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=60,
+    )
+    measurement = json.loads(completed.stdout.strip().splitlines()[-1])
+
+    assert measurement["payload_bytes"] >= PAYLOAD_BYTES - 24
+    assert measurement["peak_transient_bytes"] <= MAX_TRANSIENT_BYTES
+
+
+if __name__ == "__main__" and sys.argv[1:2] == ["--probe"]:
+    _run_probe(sys.argv[2], sys.argv[3])

--- a/python/tests/db/test_gridfs_memory_contract.py
+++ b/python/tests/db/test_gridfs_memory_contract.py
@@ -3,7 +3,6 @@ import os
 import resource
 import subprocess
 import sys
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -95,18 +94,15 @@ def _run_probe(operation, atomic_name):
 @pytest.mark.parametrize("atomic_name", ("TimeSeries", "Seismogram"))
 def test_large_gridfs_conversion_has_bounded_rss(operation, atomic_name):
     environment = os.environ.copy()
-    source_root = str(Path(__file__).resolve().parents[2])
-    environment["PYTHONPATH"] = (
-        source_root + os.pathsep + environment.get("PYTHONPATH", "")
-    )
     completed = subprocess.run(
         [sys.executable, __file__, "--probe", operation, atomic_name],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         env=environment,
         timeout=60,
     )
+    assert completed.returncode == 0, completed.stderr
     measurement = json.loads(completed.stdout.strip().splitlines()[-1])
 
     assert measurement["payload_bytes"] >= PAYLOAD_BYTES - 24


### PR DESCRIPTION
Closes #1027.

## What changed
- stream native TimeSeries and Seismogram samples into GridFS without first materializing a waveform-sized Python bytes object
- read GridFS samples in fixed 1 MiB chunks directly into native sample storage
- reject truncated or oversized GridFS payloads from the stored length before mutating waveform samples
- close GridOut handles and remove a partially written blob without masking the original write failure

The serialized native-float64 byte layout and public Database APIs are unchanged.

## Verification
- 22 focused payload, lifecycle, and memory-contract tests pass
- exact TimeSeries and Seismogram byte-layout checks, including unaligned reader boundaries
- zero-length, normal, truncated, and oversized payload coverage
- subprocess RSS probes on 32 MiB payloads measured fixed transient overhead below the 12 MiB test cap for both reads and writes
- Black, py_compile, and git diff checks pass

MongoDB-backed integration coverage remains in the existing CI suite; the focused local tests use deterministic GridFS doubles so they do not require a local mongod.