### PR TITLE
Prevent unmanaged Mongo clients in Dask tasks

### DIFF
--- a/docs/source/user_manual/components.rst
+++ b/docs/source/user_manual/components.rst
@@ -260,6 +260,19 @@ custom processing function that has a database handle as an
 argument you need to deal with this issue.  The following
 skeleton example illustrates how to handle that situation:
 
+``DBClient``, ``Database``, and ``Collection`` instances must not be passed to
+Dask tasks, whether directly or indirectly through a closure, partial, bound
+method, or callable object.  MsPASS rejects that serialization before the task
+runs because unpickling the handle would create a client outside the worker
+plugin's lifecycle.  Pass the database name instead, as shown below.  The
+``MongoDBWorker`` plugin owns the one client stored on each worker, closes it
+during worker teardown, and creates one replacement when a worker restarts.
+
+Ordinary explicit Python pickle and the Spark compatibility path are separate
+from this Dask contract.  An explicitly unpickled client is owned by the code
+that unpickled it and must be closed by that code.  It must not then be embedded
+in a Dask task.
+
 .. code-block:: python
 
    from mspasspy.util.db_utils import fetch_dbhandle
@@ -284,7 +297,7 @@ The key point here is that with that construct ``myfunction`` can
 be run as a Dask task using a map operation or the Futures interface
 (see :ref:`parallel_processing`).   The essential thing to do is to send the
 function only the database name and then use ``fetch_dbhandle`` inside
-the function to create the database handle to the database the name references.
+the function to obtain a database handle backed by the plugin-owned client.
 
 .. note::
 

--- a/python/mspasspy/db/_dask_serialization.py
+++ b/python/mspasspy/db/_dask_serialization.py
@@ -1,0 +1,23 @@
+"""Internal guards for MongoDB handles embedded in Dask tasks."""
+
+import sys
+
+
+def is_dask_serializing():
+    """Return True while Dask Distributed is pickling a task payload."""
+    frame = sys._getframe(1)
+    while frame is not None:
+        if frame.f_globals.get("__name__") == "distributed.protocol.pickle":
+            return True
+        frame = frame.f_back
+    return False
+
+
+def reject_dask_serialization(value):
+    """Reject live MongoDB handles before Dask can recreate their clients."""
+    if is_dask_serializing():
+        raise TypeError(
+            f"{type(value).__name__} objects cannot be serialized into Dask tasks. "
+            "Register MongoDBWorker, pass the database name, and call "
+            "fetch_dbhandle inside the worker instead."
+        )

--- a/python/mspasspy/db/client.py
+++ b/python/mspasspy/db/client.py
@@ -2,6 +2,7 @@ import pymongo
 from pymongo import uri_parser
 from typing import Any
 from mspasspy.db.database import Database
+from mspasspy.db._dask_serialization import reject_dask_serialization
 
 
 class DBClient(pymongo.MongoClient):
@@ -79,6 +80,7 @@ class DBClient(pymongo.MongoClient):
         Pickle only connection parameters, not the active MongoClient internals.
         This prevents thread lock serialization issues.
         """
+        reject_dask_serialization(self)
         return {
             "host": self._mspass_db_host,
             "args": getattr(self, "_mspass_connection_args", ()),

--- a/python/mspasspy/db/collection.py
+++ b/python/mspasspy/db/collection.py
@@ -1,5 +1,7 @@
 import pymongo
 
+from mspasspy.db._dask_serialization import reject_dask_serialization
+
 
 class Collection(pymongo.database.Collection):
     """
@@ -15,6 +17,7 @@ class Collection(pymongo.database.Collection):
         super(Collection, self).__init__(*args, **kwargs)
 
     def __getstate__(self):
+        reject_dask_serialization(self)
         ret = self.__dict__.copy()
         ret["_BaseObject__codec_options"] = self.codec_options.__repr__()
 

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -70,6 +70,7 @@ from mspasspy.db.serialization import (
     inventory_subset,
     merge_inventories,
 )
+from mspasspy.db._dask_serialization import reject_dask_serialization
 from mspasspy.util.converter import Textfile2Dataframe
 
 _CURSOR_SESSION_REFRESH_INTERVAL_SECONDS = 300.0
@@ -191,6 +192,7 @@ class Database(pymongo.database.Database):
         self.stedronsky = Undertaker(self)
 
     def __getstate__(self):
+        reject_dask_serialization(self)
         ret = self.__dict__.copy()
         ret["_BaseObject__codec_options"] = self.codec_options.__repr__()
 

--- a/python/mspasspy/db/normalize.py
+++ b/python/mspasspy/db/normalize.py
@@ -9,6 +9,7 @@ from mspasspy.ccore.seismic import (
     SeismogramEnsemble,
 )
 from mspasspy.db.database import Database
+from mspasspy.db._dask_serialization import is_dask_serializing
 from mspasspy.util.decorators import mspass_func_wrapper
 
 from bson import ObjectId
@@ -326,6 +327,25 @@ class DatabaseMatcher(BasicMatcher):
         self.require_unique_match = require_unique_match
         self.prepend_collection_name = prepend_collection_name
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if is_dask_serializing():
+            dbhandle = state.pop("dbhandle", None)
+            if dbhandle is not None:
+                state["_mspass_db_name"] = dbhandle.database.name
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
+    def _get_dbhandle(self):
+        if not hasattr(self, "dbhandle"):
+            from mspasspy.util.db_utils import fetch_dbhandle
+
+            database = fetch_dbhandle(self._mspass_db_name)
+            self.dbhandle = database[self.collection]
+        return self.dbhandle
+
     @abstractmethod
     def query_generator(self, mspass_object) -> dict:
         """
@@ -384,13 +404,14 @@ class DatabaseMatcher(BasicMatcher):
             message = "query_generator method failed to generate a valid query - required attributes are probably missing"
             elog.log_error(message, ErrorSeverity.Invalid)
             return [None, elog]
-        number_hits = self.dbhandle.count_documents(query)
+        dbhandle = self._get_dbhandle()
+        number_hits = dbhandle.count_documents(query)
         if number_hits <= 0:
             elog = PyErrorLogger()
             message = "query = " + str(query) + " yielded no documents"
             elog.log_error(message, ErrorSeverity.Complaint)
             return [None, elog]
-        cursor = self.dbhandle.find(query)
+        cursor = dbhandle.find(query)
         elog = PyErrorLogger()
         metadata_list = []
         try:

--- a/python/mspasspy/io/distributed.py
+++ b/python/mspasspy/io/distributed.py
@@ -16,7 +16,7 @@ from mspasspy.db.normalize import BasicMatcher
 from mspasspy.db.normalize import normalize as normalize_function
 from mspasspy.util.Undertaker import Undertaker
 from mspasspy.db.client import DBClient
-from mspasspy.util.db_utils import fetch_dbhandle
+from mspasspy.util.db_utils import fetch_dbhandle, _WorkerDatabaseReference
 
 
 from mspasspy.ccore.utility import (
@@ -94,6 +94,31 @@ def read_ensemble_parallel(
     if kill_me:
         ensemble.kill()
     return ensemble
+
+
+def read_atomic_parallel(
+    document,
+    dbname_or_handle,
+    collection="wf_TimeSeries",
+    normalize=None,
+    load_history=False,
+    exclude_keys=None,
+    data_tag=None,
+    aws_access_key_id=None,
+    aws_secret_access_key=None,
+):
+    """Read one atomic datum using the worker-owned database client."""
+    db = fetch_dbhandle(dbname_or_handle)
+    return db.read_data(
+        document,
+        collection=collection,
+        normalize=normalize,
+        load_history=load_history,
+        exclude_keys=exclude_keys,
+        data_tag=data_tag,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+    )
 
 
 def _validate_sort_clause(sort_clause):
@@ -669,14 +694,14 @@ def read_distributed_data(
             )
 
         else:
-            # Dask path: extract dbname to avoid serializing Database object
-            # fetch_dbhandle in read_ensemble_parallel will get DBClient from worker plugin
-            dbname = db.name if isinstance(db, Database) else db
+            db_reference = (
+                _WorkerDatabaseReference(db) if isinstance(db, Database) else db
+            )
             # note same maintenance issue as with parallelize above
             plist = dask.bag.from_sequence(data, npartitions=npartitions)
             plist = plist.map(
                 read_ensemble_parallel,
-                dbname,  # Pass dbname string for Dask
+                db_reference,
                 collection=collection,
                 mode=mode,
                 normalize=normalize,
@@ -774,8 +799,10 @@ def read_distributed_data(
                 )
             )
         else:
+            db_reference = _WorkerDatabaseReference(db)
             plist = plist.map(
-                db.read_data,
+                read_atomic_parallel,
+                db_reference,
                 collection=collection,
                 normalize=normalize,
                 load_history=load_history,
@@ -927,6 +954,21 @@ def _partitioned_save_wfdoc(
         wfids = dbcol.insert_many(docarray).inserted_ids
 
     return wfids
+
+
+def _save_sample_data_parallel(datum, dbname_or_handle, **kwargs):
+    """Save sample data through the worker-owned database client."""
+    return fetch_dbhandle(dbname_or_handle)._save_sample_data(datum, **kwargs)
+
+
+def _handle_dead_data_parallel(
+    datum, dbname_or_handle, cremate=False, save_history=False
+):
+    """Run Undertaker operations through the worker-owned database client."""
+    undertaker = Undertaker(fetch_dbhandle(dbname_or_handle))
+    if cremate:
+        return undertaker.cremate(datum)
+    return undertaker.bury(datum, save_history=save_history)
 
 
 class pyspark_mappartition_interface:
@@ -1094,6 +1136,10 @@ def _save_ensemble_wfdocs(
     Default is None, but normal use should set it as an appropriate string
     defining what this dataset is.  D
     """
+    db = fetch_dbhandle(db)
+    if undertaker is None:
+        undertaker = Undertaker(db)
+
     if cremate:
         ensemble_data = undertaker.cremate(ensemble_data)
     else:
@@ -1212,6 +1258,7 @@ def _atomic_extract_wf_document(
     dead data are not store in a wf collection.
     """
 
+    db = fetch_dbhandle(db)
     if undertaker:
         stedronsky = undertaker
     else:
@@ -1365,7 +1412,10 @@ def write_distributed_data(
        mybag = read_distributed_data(db,collection='wf_TimeSeries')
        mybag = mybag.map(detrend)   # example
        # intermediate save
-       mybag = mybag.map(db.save_data,collection="wf_TimeSeries")
+       def save_intermediate(d, dbname):
+           worker_db = fetch_dbhandle(dbname)
+           return worker_db.save_data(d, collection="wf_TimeSeries")
+       mybag = mybag.map(save_intermediate, db.name)
        # more processing - trivial example
        mybag = mybag.map(filter,'lowpass',freq=1.0)
        # termination with this function
@@ -1678,11 +1728,13 @@ def write_distributed_data(
             )
             data = data.collect()
     else:
+        db_reference = _WorkerDatabaseReference(db)
         if data_are_atomic:
             # See comment at top of spark section  - this code is exactly
             # the same by in the dask dialect
             data = data.map(
-                db._save_sample_data,
+                _save_sample_data_parallel,
+                db_reference,
                 storage_mode=storage_mode,
                 dir=None,
                 dfile=None,
@@ -1691,7 +1743,7 @@ def write_distributed_data(
             )
             data = data.map(
                 _atomic_extract_wf_document,
-                db,
+                db_reference,
                 save_schema,
                 exclude_keys,
                 mode,
@@ -1700,11 +1752,14 @@ def write_distributed_data(
                 save_history=save_history,
                 post_history=post_history,
                 data_tag=data_tag,
-                undertaker=stedronsky,
+                undertaker=None,
                 cremate=cremate,
             )
             data = data.map_partitions(
-                _partitioned_save_wfdoc, db, collection=collection
+                _partitioned_save_wfdoc,
+                None,
+                collection=collection,
+                dbname=db_reference,
             )
             # necessary here or the map_partition function will fail
             # because it will receive a DAG structure instead of a list
@@ -1722,12 +1777,23 @@ def write_distributed_data(
             # cause some overhead if the number of bodies is large.
             # in both cases the ensemble has the bodies removed by the undertaker
             if cremate:
-                data = data.map(stedronsky.cremate)
+                data = data.map(
+                    _handle_dead_data_parallel,
+                    db_reference,
+                    cremate=True,
+                    save_history=save_history,
+                )
             else:
-                data = data.map(stedronsky.bury, save_history=save_history)
+                data = data.map(
+                    _handle_dead_data_parallel,
+                    db_reference,
+                    cremate=False,
+                    save_history=save_history,
+                )
             # important comment about this next line in the spark section
             data = data.map(
-                db._save_sample_data,
+                _save_sample_data_parallel,
+                db_reference,
                 storage_mode=storage_mode,
                 dir=None,
                 dfile=None,
@@ -1736,11 +1802,11 @@ def write_distributed_data(
             )
             data = data.map(
                 _save_ensemble_wfdocs,
-                db,
+                db_reference,
                 save_schema,
                 exclude_keys,
                 mode,
-                stedronsky,
+                None,
                 normalizing_collections,
                 cremate=cremate,
                 post_elog=post_elog,

--- a/python/mspasspy/util/db_utils.py
+++ b/python/mspasspy/util/db_utils.py
@@ -11,6 +11,21 @@ from mspasspy.db.database import Database
 from mspasspy.db.client import DBClient
 
 
+class _WorkerDatabaseReference:
+    """Keep a local Database handle but serialize only its name."""
+
+    def __init__(self, database):
+        self.name = database.name
+        self._local_database = database
+
+    def __getstate__(self):
+        return {"name": self.name}
+
+    def __setstate__(self, state):
+        self.name = state["name"]
+        self._local_database = None
+
+
 def fetch_dbhandle(dbname_or_handle):
     """
     Fetch a Database handle from dbname_or_handle.
@@ -27,6 +42,11 @@ def fetch_dbhandle(dbname_or_handle):
     :raises: ValueError if dbname_or_handle is neither a string nor a Database instance,
         or if called with a string outside of a Dask worker context.
     """
+
+    if isinstance(dbname_or_handle, _WorkerDatabaseReference):
+        if dbname_or_handle._local_database is not None:
+            return dbname_or_handle._local_database
+        dbname_or_handle = dbname_or_handle.name
 
     if isinstance(dbname_or_handle, str):
         try:
@@ -93,6 +113,10 @@ class MongoDBWorker(WorkerPlugin):
 
     def setup(self, worker):
         """Called when worker starts - create DBClient for this worker."""
+        if self.dbclient_key in worker.data:
+            previous_client = worker.data[self.dbclient_key]
+            del worker.data[self.dbclient_key]
+            previous_client.close()
         if self.connection_url is None:
             dbclient = DBClient()
         else:
@@ -101,6 +125,7 @@ class MongoDBWorker(WorkerPlugin):
 
     def teardown(self, worker):
         """Called when worker shuts down - cleanup if needed."""
-        dbclient = worker.data.get(self.dbclient_key)
-        if dbclient:
+        if self.dbclient_key in worker.data:
+            dbclient = worker.data[self.dbclient_key]
+            del worker.data[self.dbclient_key]
             dbclient.close()

--- a/python/tests/db/test_dask_database_serialization_contract.py
+++ b/python/tests/db/test_dask_database_serialization_contract.py
@@ -1,0 +1,325 @@
+import functools
+import os
+import pickle
+from types import SimpleNamespace
+
+import dask.bag
+import pandas as pd
+import pytest
+from distributed import Client, LocalCluster, get_worker
+from distributed.protocol import pickle as dask_pickle
+
+import mspasspy.util.db_utils as db_utils
+from mspasspy.db.client import DBClient
+from mspasspy.db.collection import Collection
+from mspasspy.db.database import Database
+from mspasspy.db.normalize import ObjectIdDBMatcher
+import mspasspy.io.distributed as distributed_io
+from mspasspy.util.db_utils import (
+    MongoDBWorker,
+    _WorkerDatabaseReference,
+    fetch_dbhandle,
+)
+from mspasspy.workflow import sliding_window_pipeline
+
+CONNECTION_URL = "mongodb://127.0.0.1:27017/?connect=false"
+ERROR_GUIDANCE = ("MongoDBWorker", "fetch_dbhandle")
+
+
+def _captured_closure(value):
+    def task():
+        return value
+
+    return task
+
+
+def _return_value(value):
+    return value
+
+
+def _captured_partial(value):
+    return functools.partial(_return_value, value)
+
+
+def _captured_bound_method(value):
+    return value.read_data
+
+
+class _CapturedCallable:
+    def __init__(self, value):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+
+def _must_not_run(value):
+    raise AssertionError(f"unsafe task ran with {value!r}")
+
+
+def _worker_client_identity(index, database_name):
+    database = fetch_dbhandle(database_name)
+    client = get_worker().data["dbclient"]
+    return os.getpid(), id(client), id(database.client)
+
+
+def _worker_database_sink(value, database_name):
+    database = fetch_dbhandle(database_name)
+    assert database.client is get_worker().data["dbclient"]
+
+
+def _exception_text(error):
+    messages = []
+    seen = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        messages.append(str(error))
+        error = error.__cause__ or error.__context__
+    return "\n".join(messages)
+
+
+@pytest.fixture
+def database_handles():
+    client = DBClient(CONNECTION_URL)
+    database = client.get_database("serialization_contract")
+    collection = database["wf_TimeSeries"]
+    try:
+        yield client, database, collection
+    finally:
+        client.close()
+
+
+def test_ordinary_pickle_compatibility_is_preserved(database_handles):
+    for handle in database_handles:
+        restored = pickle.loads(pickle.dumps(handle))
+        if isinstance(restored, DBClient):
+            restored.close()
+        elif isinstance(restored, Database):
+            restored.client.close()
+        elif isinstance(restored, Collection):
+            restored.database.client.close()
+
+
+@pytest.mark.parametrize("handle_index", range(3))
+def test_direct_dask_serialization_fails_with_worker_lookup_guidance(
+    database_handles, handle_index
+):
+    with pytest.raises(TypeError) as raised:
+        dask_pickle.dumps(database_handles[handle_index])
+
+    message = _exception_text(raised.value)
+    assert all(text in message for text in ERROR_GUIDANCE)
+
+
+@pytest.mark.parametrize(
+    "capture",
+    [
+        _captured_closure,
+        _captured_partial,
+        _captured_bound_method,
+        _CapturedCallable,
+    ],
+)
+def test_indirect_dask_serialization_fails_with_worker_lookup_guidance(
+    database_handles, capture
+):
+    payload = capture(database_handles[1])
+
+    with pytest.raises(TypeError) as raised:
+        dask_pickle.dumps(payload)
+
+    message = _exception_text(raised.value)
+    assert all(text in message for text in ERROR_GUIDANCE)
+
+
+def test_worker_database_reference_never_pickles_its_local_handle(
+    monkeypatch, database_handles
+):
+    database = database_handles[1]
+    reference = _WorkerDatabaseReference(database)
+    assert fetch_dbhandle(reference) is database
+
+    restored = pickle.loads(pickle.dumps(reference))
+    worker_database = object()
+
+    class FakeClient:
+        def get_database(self, name):
+            assert name == database.name
+            return worker_database
+
+    monkeypatch.setattr(
+        db_utils,
+        "get_worker",
+        lambda: SimpleNamespace(data={"dbclient": FakeClient()}),
+    )
+    assert fetch_dbhandle(restored) is worker_database
+
+
+def test_database_matcher_rebinds_to_the_worker_owned_client(
+    monkeypatch, database_handles
+):
+    database = database_handles[1]
+    matcher = ObjectIdDBMatcher(database)
+    restored = dask_pickle.loads(dask_pickle.dumps(matcher))
+    worker_collection = object()
+
+    class FakeDatabase:
+        def __getitem__(self, collection):
+            assert collection == "channel"
+            return worker_collection
+
+    class FakeClient:
+        def get_database(self, name):
+            assert name == database.name
+            return FakeDatabase()
+
+    monkeypatch.setattr(
+        db_utils,
+        "get_worker",
+        lambda: SimpleNamespace(data={"dbclient": FakeClient()}),
+    )
+    assert restored._get_dbhandle() is worker_collection
+
+
+def test_official_dask_read_graph_contains_only_worker_database_reference(
+    database_handles,
+):
+    database = database_handles[1]
+    matcher = ObjectIdDBMatcher(database)
+    bag = distributed_io.read_distributed_data(
+        pd.DataFrame([{"storage_mode": "file", "npts": 0}]),
+        db=database,
+        normalize=[matcher],
+        scheduler="dask",
+        npartitions=1,
+    )
+
+    dask_pickle.dumps(bag.__dask_graph__())
+
+
+def test_official_dask_write_graph_contains_only_worker_database_reference(
+    monkeypatch, database_handles
+):
+    captured = {}
+
+    def capture_compute(self, scheduler=None):
+        captured["graph"] = self.__dask_graph__()
+        return []
+
+    monkeypatch.setattr(dask.bag.Bag, "compute", capture_compute)
+    input_bag = dask.bag.from_sequence([object()], npartitions=1)
+
+    assert (
+        distributed_io.write_distributed_data(
+            input_bag,
+            database_handles[1],
+            scheduler="dask",
+        )
+        == []
+    )
+    dask_pickle.dumps(captured["graph"])
+
+
+def test_plugin_owns_exactly_one_client_for_each_worker_lifecycle(monkeypatch):
+    clients = []
+
+    class FakeClient:
+        def __init__(self, connection_url):
+            self.connection_url = connection_url
+            self.close_calls = 0
+            clients.append(self)
+
+        def close(self):
+            self.close_calls += 1
+
+    provider = SimpleNamespace(
+        get_database_client=lambda: SimpleNamespace(_mspass_db_host=CONNECTION_URL)
+    )
+    plugin = MongoDBWorker(provider)
+    monkeypatch.setattr(db_utils, "DBClient", FakeClient)
+
+    for _ in range(2):
+        worker = SimpleNamespace(data={})
+        plugin.setup(worker)
+        assert worker.data == {"dbclient": clients[-1]}
+        plugin.teardown(worker)
+        assert worker.data == {}
+        assert clients[-1].close_calls == 1
+
+    assert len(clients) == 2
+
+
+def test_process_workers_reject_live_handles_and_reuse_plugin_client(
+    database_handles,
+):
+    provider = SimpleNamespace(get_database_client=lambda: database_handles[0])
+    plugin = MongoDBWorker(provider)
+    with (
+        LocalCluster(
+            n_workers=1,
+            threads_per_worker=1,
+            processes=True,
+            dashboard_address=None,
+        ) as cluster,
+        Client(cluster) as client,
+    ):
+        client.register_plugin(plugin, name="mongodb-worker-contract")
+        before_restart = client.gather(
+            [
+                client.submit(
+                    _worker_client_identity,
+                    index,
+                    database_handles[1].name,
+                    pure=False,
+                )
+                for index in range(12)
+            ]
+        )
+        assert len(set(before_restart)) == 1
+        assert before_restart[0][1] == before_restart[0][2]
+
+        assert (
+            sliding_window_pipeline(
+                range(12),
+                _return_value,
+                client,
+                sliding_window_size=2,
+                completion_function=_worker_database_sink,
+                cfunc_args=[database_handles[1].name],
+                completion_on_worker=True,
+                retain_results=False,
+            )
+            is None
+        )
+        after_sink = client.submit(
+            _worker_client_identity,
+            0,
+            database_handles[1].name,
+            pure=False,
+        ).result()
+        assert after_sink == before_restart[0]
+
+        for _ in range(12):
+            with pytest.raises(Exception) as raised:
+                future = client.submit(_must_not_run, database_handles[1], pure=False)
+                future.result(timeout=5)
+            message = _exception_text(raised.value)
+            assert all(text in message for text in ERROR_GUIDANCE)
+
+        old_pid = before_restart[0][0]
+        worker_addresses = list(client.scheduler_info()["workers"])
+        client.restart_workers(worker_addresses, timeout=20)
+        after_restart = client.gather(
+            [
+                client.submit(
+                    _worker_client_identity,
+                    index,
+                    database_handles[1].name,
+                    pure=False,
+                )
+                for index in range(12)
+            ]
+        )
+        assert len(set(after_restart)) == 1
+        assert after_restart[0][1] == after_restart[0][2]
+        assert after_restart[0][0] != old_pid


### PR DESCRIPTION
Closes #1028.

## Contract
Dask Distributed now rejects DBClient, Database, and Collection objects before task execution, including handles captured through closures, partials, bound methods, and callable objects. The error directs callers to MongoDBWorker and fetch_dbhandle.

Ordinary explicit Python pickle and the Spark compatibility path remain supported. This is intentionally a Dask-specific guard rather than a new connection cache or serialization format.

## Supported paths
- official Dask atomic and ensemble reads pass an internal reference that keeps the driver handle only for local schedulers and serializes only the database name
- official Dask writes resolve all sample, Undertaker, metadata, and partition saves through the plugin-owned worker client
- DatabaseMatcher drops its Collection only during Dask serialization and lazily rebinds through the worker plugin
- MongoDBWorker replaces any prior owned client safely and removes/closes its client during teardown

## Verification
- 14 focused contract tests pass
- process-based LocalCluster repeatedly rejects unsafe submissions before task work
- repeated safe tasks and a worker-side sliding-window sink reuse the same plugin client
- worker restart creates one replacement client and teardown completes without SpillBuffer errors
- ordinary pickle round trips remain supported
- official read/write task graphs serialize without live handles, including a DatabaseMatcher normalizer
- 19 non-Spark distributed-read contract tests pass
- all 41 sliding-window workflow tests pass
- Black, py_compile, and git diff checks pass

MongoDB-backed read/write integration remains covered by the repository CI environment; no local mongod was available.