### PR TITLE
Improve comments on a confusing section of code

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -10418,19 +10418,19 @@ class Database(pymongo.database.Database):
                     "Database._load_enemble_file", message, ErrorSeverity.Invalid
                 )
 
-        # Sort foff_list by file byte offset.  
+        # Sort foff_list by file byte offset.
         # Default for list sort is to use component 0 and sort in ascending
         # order which is what we want.
-        # That is done for efficiency as reading a file sequentially is almost always 
+        # That is done for efficiency as reading a file sequentially is almost always
         # faster than jumping around because fread is buffered io
         foff_list.sort()
         # pybind11 maps an array of int values to used as
-        # input to the fread function below.  That usage, however, is a bit weird 
-        # and potentially confusing.   The index required is the slot in the member array 
+        # input to the fread function below.  That usage, however, is a bit weird
+        # and potentially confusing.   The index required is the slot in the member array
         # to insert the array of sample data when fread is called.   It is NOT
-        # the foff (file byte offset) for the reader.   That works here only 
+        # the foff (file byte offset) for the reader.   That works here only
         # because the above builds a skeleton of the emsemble members with the arrays
-        # already allocated in memory.  That allows the C++ reader to call fread 
+        # already allocated in memory.  That allows the C++ reader to call fread
         # to push bytes in file into the member sample arrays
         index = []
         for x in foff_list:

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -10418,20 +10418,24 @@ class Database(pymongo.database.Database):
                     "Database._load_enemble_file", message, ErrorSeverity.Invalid
                 )
 
-        # default for list sort is to use component 0 and sort in ascending
-        # order.  That is waht we want for read efficiency
+        # Sort foff_list by file byte offset.  
+        # Default for list sort is to use component 0 and sort in ascending
+        # order which is what we want.
+        # That is done for efficiency as reading a file sequentially is almost always 
+        # faster than jumping around because fread is buffered io
         foff_list.sort()
-        # I think pybind11 maps a list of int values to used as
-        # input to the fread function below requiring an
-        # input of an std::vector<long int> container.  In C++ a vector
-        # and list are different concepts but I think that is what pybind11 does
+        # pybind11 maps an array of int values to used as
+        # input to the fread function below.  That usage, however, is a bit weird 
+        # and potentially confusing.   The index required is the slot in the member array 
+        # to insert the array of sample data when fread is called.   It is NOT
+        # the foff (file byte offset) for the reader.   That works here only 
+        # because the above builds a skeleton of the emsemble members with the arrays
+        # already allocated in memory.  That allows the C++ reader to call fread 
+        # to push bytes in file into the member sample arrays
         index = []
         for x in foff_list:
             index.append(x[1])
-
-        # note _fread_from_file extracs foff from each member using index
-        # to (potentially) skip around in the container
-        # it never throws an exception but can return a negative
+        # Note this C++ function never throws an exception but can return a negative
         # number used to signal file open error
         count = _fread_from_file(ensemble, dir, dfile, index)
         if count > 0:


### PR DESCRIPTION
While working on a different problem I was reading this section of code to recall how to use the _fread_from_file C++ function.  I was confused by what the code did until I dug back into the C code and realized the index used by that function is not what one would first guess.  The new comments should make this clear.   

Unless I accidentally did something dumb there should be no reason not to merge this immediately after the tests complete.