### PR TITLE
Restore automatic Black formatting pull requests

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -2,16 +2,31 @@ name: Black formatting
 
 "on":
   pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: black-format-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
   black-format:
+    if: github.event.action != 'closed'
     name: black-format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Format the contributor's commit, not GitHub's synthetic merge.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
@@ -20,9 +35,116 @@ jobs:
         run: python -m pip install 'black[jupyter]==25.1.0' pytest pyyaml
       - name: Verify the formatting policy
         run: pytest -q python/tests/test_black_workflow.py
-      - name: Check formatting without modifying files
+      - name: Apply formatting and save a patch
+        id: format
         shell: bash
         run: |
           shopt -s globstar nullglob
           notebooks=(docs/**/*.ipynb)
-          black --workers 1 --check --diff python/mspasspy python/tests "${notebooks[@]}"
+          black --workers 1 python/mspasspy python/tests "${notebooks[@]}"
+          git diff --binary -- python/mspasspy python/tests docs > "$RUNNER_TEMP/black-format.patch"
+          if test -s "$RUNNER_TEMP/black-format.patch"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload formatting patch
+        if: steps.format.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: black-format-pr-${{ github.event.pull_request.number }}
+          path: ${{ runner.temp }}/black-format.patch
+          retention-days: 14
+      - name: Check source PR before publishing
+        if: >-
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          !startsWith(github.event.pull_request.head.ref, 'black-formatting/')
+        id: source
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {data: pr} = await github.rest.pulls.get({
+              ...context.repo, pull_number: context.issue.number
+            });
+            core.setOutput('current', pr.state === 'open' &&
+              pr.head.sha === context.payload.pull_request.head.sha &&
+              pr.head.ref === context.payload.pull_request.head.ref &&
+              pr.head.repo.full_name === context.repo.owner + '/' + context.repo.repo);
+      - name: Create or update the formatting PR
+        # Also run when clean: the action closes obsolete fixes and deletes
+        # their branches after a formatting PR is merged into the source PR.
+        if: steps.source.outputs.current == 'true'
+        id: fix
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          token: ${{ github.token }}
+          base: ${{ github.event.pull_request.head.ref }}
+          branch: black-formatting/pr-${{ github.event.pull_request.number }}
+          delete-branch: true
+          add-paths: |
+            python/mspasspy
+            python/tests
+            docs/**/*.ipynb
+          title: 'Apply Black formatting to PR #${{ github.event.pull_request.number }}'
+          commit-message: 'Apply Black 25.1.0 formatting'
+          body: |
+            Black 25.1.0 generated these formatting-only changes for #${{ github.event.pull_request.number }}.
+            Merge this PR into the contributor's branch to apply the fix. The original PR's CI will then rerun.
+
+            This PR is updated in place; it does not create further formatting PRs.
+            GitHub may require a maintainer to select **Approve workflows to run** for a bot-created PR.
+            The original run also provides a `black-format.patch` artifact that can be applied with `git apply`.
+      - name: Report formatting changes
+        if: steps.format.outputs.changed == 'true'
+        env:
+          FIX_URL: ${{ steps.fix.outputs.pull-request-url }}
+        run: |
+          if test -n "$FIX_URL"; then
+            echo "Formatting fix: $FIX_URL" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'Download the black-format.patch artifact and apply it with git apply.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo 'This commit needs formatting. Apply the generated fix, then CI will rerun.' >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+  cleanup:
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.event.pull_request.head.ref, 'black-formatting/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Close the source PR's formatting PR and remove its branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {data: source} = await github.rest.pulls.get({
+              ...context.repo, pull_number: context.issue.number
+            });
+            if (source.state !== 'closed') return;
+            const branch = `black-formatting/pr-${context.issue.number}`;
+            const fixes = await github.paginate(github.rest.pulls.list, {
+              ...context.repo, state: 'all',
+              head: `${context.repo.owner}:${branch}`,
+              base: context.payload.pull_request.head.ref
+            });
+            for (const fix of fixes) {
+              if (fix.head.ref !== branch || fix.user.login !== 'github-actions[bot]') continue;
+              if (fix.state === 'open') {
+                await github.rest.pulls.update({
+                  ...context.repo, pull_number: fix.number, state: 'closed'
+                });
+              }
+            }
+            if (fixes.some(fix => fix.head.ref === branch && fix.user.login === 'github-actions[bot]')) {
+              try {
+                await github.rest.git.deleteRef({...context.repo, ref: `heads/${branch}`});
+              } catch (error) {
+                if (error.status !== 404 &&
+                    !(error.status === 422 && error.message.includes('Reference does not exist'))) throw error;
+              }
+            }

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -84,7 +84,7 @@ jobs:
           add-paths: |
             python/mspasspy
             python/tests
-            docs/**/*.ipynb
+            docs
           title: 'Apply Black formatting to PR #${{ github.event.pull_request.number }}'
           commit-message: 'Apply Black 25.1.0 formatting'
           body: |

--- a/README.md
+++ b/README.md
@@ -135,8 +135,23 @@ Before opening a pull request:
 2. Run relevant tests locally when possible.
 3. Keep documentation in sync with user-facing behavior changes.
 
-CI checks Python, test, and documentation-notebook formatting with Black
-25.1.0.  Run the same read-only check from the repository root with:
+CI automatically formats Python, tests, and documentation notebooks with
+Black 25.1.0. For a PR from a branch in this repository, it creates or updates
+one formatting-only PR into that source branch, using
+`black-formatting/pr-<original PR number>`. Merge that fix to apply the changes;
+the original PR's CI then reruns. Formatting PRs do not create further formatting
+PRs, and obsolete fixes and their branches are cleaned up when the source PR is
+formatted or closed. A stale run cannot publish after its source PR has moved.
+
+The required `black-format` check stays red until the generated changes are
+applied to the actual source commit. Every run that finds changes also uploads
+a `black-format.patch` artifact; download it and run `git apply black-format.patch`
+on the source branch if preferred. Fork PRs use this patch because the repository
+token cannot write to contributors' forks. GitHub may require a maintainer to
+select **Approve workflows to run** on a bot-created formatting PR; no extra
+personal access token is required.
+
+Run the matching read-only check locally from the repository root with:
 
 ```bash
 python -m pip install 'black[jupyter]==25.1.0'

--- a/python/tests/test_black_workflow.py
+++ b/python/tests/test_black_workflow.py
@@ -244,7 +244,7 @@ def test_workflow_formats_real_files_and_emits_applicable_patch(
         check=True,
         timeout=10,
     )
-    # Model merging the fix into the contributor's branch and running again.  
+    # Model merging the fix into the contributor's branch and running again.
     # Exercise the action's literal pathspecs, including a tree with no notebooks.
     paths = next(
         step["with"]["add-paths"].splitlines()

--- a/python/tests/test_black_workflow.py
+++ b/python/tests/test_black_workflow.py
@@ -120,7 +120,7 @@ def test_black_workflow_generates_bounded_source_branch_fixes():
     assert fix["with"]["add-paths"].splitlines() == [
         "python/mspasspy",
         "python/tests",
-        "docs/**/*.ipynb",
+        "docs",
     ]
 
     report = next(
@@ -188,7 +188,10 @@ new AsyncFunction('github', 'context', 'core', script)(github, context, core);
     assert json.loads(result.stdout) is expected
 
 
-def test_workflow_formats_real_python_and_notebook_and_emits_applicable_patch(tmp_path):
+@pytest.mark.parametrize("with_notebook", [True, False])
+def test_workflow_formats_real_files_and_emits_applicable_patch(
+    tmp_path, with_notebook
+):
     black = shutil.which("black")
     if not black:
         pytest.skip("Black is installed by the black-format workflow")
@@ -209,7 +212,9 @@ def test_workflow_formats_real_python_and_notebook_and_emits_applicable_patch(tm
     source.write_text(original)
     (tests / "sample.py").write_text("assert 1==1\n")
     notebook = notebooks / "example notebook.ipynb"
-    _write_notebook(notebook, "result=  [1,2,3]\n")
+    if with_notebook:
+        _write_notebook(notebook, "result=  [1,2,3]\n")
+    (tmp_path / "docs" / "README.md").write_text("Documentation\n")
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, timeout=10)
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, timeout=10)
 
@@ -228,9 +233,10 @@ def test_workflow_formats_real_python_and_notebook_and_emits_applicable_patch(tm
     assert "changed=true" in output.read_text()
     assert ast.dump(ast.parse(source.read_text())) == ast.dump(ast.parse(original))
     assert "# Explain the file byte offset.\n" in source.read_text()
-    assert "result = [1, 2, 3]" in "".join(
-        json.loads(notebook.read_text())["cells"][0]["source"]
-    )
+    if with_notebook:
+        assert "result = [1, 2, 3]" in "".join(
+            json.loads(notebook.read_text())["cells"][0]["source"]
+        )
     patch = runner_temp / "black-format.patch"
     subprocess.run(
         ["git", "apply", "--reverse", "--check", str(patch)],
@@ -239,9 +245,13 @@ def test_workflow_formats_real_python_and_notebook_and_emits_applicable_patch(tm
         timeout=10,
     )
     # Model merging the fix into the contributor's branch and running again.  
-    subprocess.run(
-        ["git", "add", "python", "docs"], cwd=tmp_path, check=True, timeout=10
+    # Exercise the action's literal pathspecs, including a tree with no notebooks.
+    paths = next(
+        step["with"]["add-paths"].splitlines()
+        for step in _load_workflow()["jobs"]["black-format"]["steps"]
+        if step.get("id") == "fix"
     )
+    subprocess.run(["git", "add", "--", *paths], cwd=tmp_path, check=True, timeout=10)
     output.write_text("")
     _run_workflow_script(script, tmp_path, environment)
     assert output.read_text().strip() == "changed=false"

--- a/python/tests/test_black_workflow.py
+++ b/python/tests/test_black_workflow.py
@@ -1,7 +1,9 @@
+import ast
 import json
 import os
 from pathlib import Path
 import shutil
+import signal
 import subprocess
 
 import pytest
@@ -59,23 +61,42 @@ def _write_notebook(path, source):
     )
 
 
-def test_black_workflow_is_pinned_read_only_and_stably_named():
+def _run_workflow_script(script, cwd, environment):
+    with subprocess.Popen(
+        ["bash", "-e", "-o", "pipefail", "-c", script],
+        cwd=cwd,
+        env=environment,
+        start_new_session=True,
+    ) as process:
+        try:
+            returncode = process.wait(timeout=30)
+        finally:
+            # Black uses workers when it receives multiple input files.
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+    assert returncode == 0
+
+
+def test_black_workflow_generates_bounded_source_branch_fixes():
     workflow = _load_workflow()
     assert workflow["permissions"] == {"contents": "read"}
-    assert set(workflow["jobs"]) == {"black-format"}
+    assert set(workflow["on"]) == {"pull_request"}
+    assert "closed" in workflow["on"]["pull_request"]["types"]
+    assert workflow["concurrency"]["group"] == (
+        "black-format-${{ github.event.pull_request.number }}"
+    )
+    assert workflow["concurrency"]["cancel-in-progress"] is False
 
     job = workflow["jobs"]["black-format"]
     assert job["name"] == "black-format"
-    assert job["runs-on"] == "ubuntu-latest"
-    assert "permissions" not in job
+    assert job["permissions"] == {"contents": "write", "pull-requests": "write"}
     assert all("continue-on-error" not in step for step in job["steps"])
-    assert [step.get("uses", step.get("name")) for step in job["steps"]] == [
-        "actions/checkout@v4",
-        "actions/setup-python@v5",
-        "Install pinned Black",
-        "Verify the formatting policy",
-        "Check formatting without modifying files",
-    ]
+    checkout = job["steps"][0]["with"]
+    assert checkout["ref"] == "${{ github.event.pull_request.head.sha }}"
+    assert checkout["persist-credentials"] is False
 
     install = next(
         step for step in job["steps"] if step.get("name") == "Install pinned Black"
@@ -83,22 +104,34 @@ def test_black_workflow_is_pinned_read_only_and_stably_named():
     assert (
         install["run"] == "python -m pip install 'black[jupyter]==25.1.0' pytest pyyaml"
     )
-    policy = next(
-        step
-        for step in job["steps"]
-        if step.get("name") == "Verify the formatting policy"
+    source = next(step for step in job["steps"] if step.get("id") == "source")
+    assert "head.repo.full_name == github.repository" in source["if"]
+    assert "!startsWith(github.event.pull_request.head.ref, 'black-formatting/')" in (
+        source["if"]
     )
-    assert policy["run"] == "pytest -q python/tests/test_black_workflow.py"
-    check = next(
-        step
-        for step in job["steps"]
-        if step.get("name") == "Check formatting without modifying files"
+    fix = next(step for step in job["steps"] if step.get("id") == "fix")
+    assert fix["if"] == "steps.source.outputs.current == 'true'"
+    assert fix["with"]["base"] == "${{ github.event.pull_request.head.ref }}"
+    assert fix["with"]["branch"] == (
+        "black-formatting/pr-${{ github.event.pull_request.number }}"
     )
-    assert check["shell"] == "bash"
-    assert check["run"] == CHECK_SCRIPT
-    assert "push" not in workflow["on"]
-    assert all(
-        "create-pull-request" not in str(step.get("uses", "")) for step in job["steps"]
+    assert fix["with"]["delete-branch"] is True
+    assert "branch-suffix" not in fix["with"]
+    assert fix["with"]["add-paths"].splitlines() == [
+        "python/mspasspy",
+        "python/tests",
+        "docs/**/*.ipynb",
+    ]
+
+    report = next(
+        step for step in job["steps"] if step.get("name") == "Report formatting changes"
+    )
+    assert report["if"] == "steps.format.outputs.changed == 'true'"
+    assert "exit 1" in report["run"]
+    cleanup = workflow["jobs"]["cleanup"]
+    assert "github.event.action == 'closed'" in cleanup["if"]
+    assert "!startsWith(github.event.pull_request.head.ref, 'black-formatting/')" in (
+        cleanup["if"]
     )
 
 
@@ -107,6 +140,112 @@ def test_readme_documents_the_exact_check_and_format_commands():
     assert "python -m pip install 'black[jupyter]==25.1.0'" in readme
     assert CHECK_SCRIPT in readme
     assert FORMAT_SCRIPT in readme
+
+
+@pytest.mark.parametrize(
+    "state,sha,branch,repo,expected",
+    [
+        ("open", "expected", "feature", "owner/repo", True),
+        ("open", "new-commit", "feature", "owner/repo", False),
+        ("closed", "expected", "feature", "owner/repo", False),
+        ("open", "expected", "renamed", "owner/repo", False),
+        ("open", "expected", "feature", "fork/repo", False),
+    ],
+)
+def test_publishing_rechecks_source_pr_before_writing(
+    state, sha, branch, repo, expected
+):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node is provided by the GitHub Actions runner")
+    script = next(
+        step["with"]["script"]
+        for step in _load_workflow()["jobs"]["black-format"]["steps"]
+        if step.get("id") == "source"
+    )
+    current = {
+        "state": state,
+        "head": {"sha": sha, "ref": branch, "repo": {"full_name": repo}},
+    }
+    harness = """
+const [script, current] = process.argv.slice(1);
+const context = {
+  repo: {owner: 'owner', repo: 'repo'}, issue: {number: 1033},
+  payload: {pull_request: {head: {sha: 'expected', ref: 'feature'}}}
+};
+const github = {rest: {pulls: {get: async () => ({data: JSON.parse(current)})}}};
+const core = {setOutput: (name, value) => process.stdout.write(JSON.stringify(value))};
+const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
+new AsyncFunction('github', 'context', 'core', script)(github, context, core);
+"""
+    result = subprocess.run(
+        [node, "-e", harness, script, json.dumps(current)],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=10,
+    )
+    assert json.loads(result.stdout) is expected
+
+
+def test_workflow_formats_real_python_and_notebook_and_emits_applicable_patch(tmp_path):
+    black = shutil.which("black")
+    if not black:
+        pytest.skip("Black is installed by the black-format workflow")
+    version = subprocess.run(
+        [black, "--version"], capture_output=True, text=True, check=True, timeout=10
+    )
+    if "25.1.0" not in version.stdout:
+        pytest.skip("integration contract requires the workflow's Black 25.1.0")
+
+    package = tmp_path / "python" / "mspasspy"
+    tests = tmp_path / "python" / "tests"
+    notebooks = tmp_path / "docs" / "guide with spaces"
+    for directory in (package, tests, notebooks):
+        directory.mkdir(parents=True)
+    source = package / "sample.py"
+    # Reproduce #1033: useful comments have trailing spaces, but no code change.
+    original = "# Explain the file byte offset.  \nresult=  [1,2,3]\n"
+    source.write_text(original)
+    (tests / "sample.py").write_text("assert 1==1\n")
+    notebook = notebooks / "example notebook.ipynb"
+    _write_notebook(notebook, "result=  [1,2,3]\n")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, timeout=10)
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, timeout=10)
+
+    runner_temp = tmp_path / "runner"
+    runner_temp.mkdir()
+    output = runner_temp / "output"
+    environment = dict(
+        os.environ, RUNNER_TEMP=str(runner_temp), GITHUB_OUTPUT=str(output)
+    )
+    script = next(
+        step["run"]
+        for step in _load_workflow()["jobs"]["black-format"]["steps"]
+        if step.get("id") == "format"
+    )
+    _run_workflow_script(script, tmp_path, environment)
+    assert "changed=true" in output.read_text()
+    assert ast.dump(ast.parse(source.read_text())) == ast.dump(ast.parse(original))
+    assert "# Explain the file byte offset.\n" in source.read_text()
+    assert "result = [1, 2, 3]" in "".join(
+        json.loads(notebook.read_text())["cells"][0]["source"]
+    )
+    patch = runner_temp / "black-format.patch"
+    subprocess.run(
+        ["git", "apply", "--reverse", "--check", str(patch)],
+        cwd=tmp_path,
+        check=True,
+        timeout=10,
+    )
+    # Model merging the fix into the contributor's branch and running again.  
+    subprocess.run(
+        ["git", "add", "python", "docs"], cwd=tmp_path, check=True, timeout=10
+    )
+    output.write_text("")
+    _run_workflow_script(script, tmp_path, environment)
+    assert output.read_text().strip() == "changed=false"
+    assert patch.read_bytes() == b""
 
 
 def test_read_only_check_rejects_python_and_notebook_without_mutation(tmp_path):


### PR DESCRIPTION
Black CI currently rejects even comment-only trailing whitespace, as in #1033, but no longer generates the formatting fixes it provided before #945. Restore automatic formatting PRs so contributors can apply the generated fix without running Black themselves.

- Run pinned Black 25.1.0 on the source commit and create or update one formatting-only PR into its source branch, using `black-formatting/pr-<source PR number>`.
- Prevent nested formatting PRs, serialize runs per source PR, and recheck the source head before publishing. Clean up obsolete fixes and branches after formatting is applied or the source PR closes.
- Provide an applicable patch artifact for every formatting difference, including fork PRs where the repository token cannot write to the contributor's branch. Keep `black-format` required and red until the fix is actually applied.
- Retain the existing Black version and formatting scope. No Docker, Python build, or branch-protection changes.

Validation: 11 local tests passed, including real Python/notebook formatting, whitespace-only comment normalization, patch applicability, staging with and without notebooks, idempotence, and stale/closed/source-repository guards. Actionlint and diff checks passed.

GitHub end-to-end validation generated #1035 automatically with exactly one whitespace-only comment change. Rerunning the formatter reused #1035 without creating duplicates. The formatter PR's own Black check passed and its publishing steps were skipped, confirming the recursion guard. After #1035 was merged into this source branch, the source's Black check passed and the formatter branch was automatically deleted. GitHub's approval prompt for bot-created PR workflows is documented; no new token is required.
